### PR TITLE
8320798: Console read line with zero out should zero out underlying buffer

### DIFF
--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,6 +195,9 @@ public final class JdkConsoleImpl implements JdkConsole {
             System.arraycopy(rcb, 0, b, 0, len);
             if (zeroOut) {
                 Arrays.fill(rcb, 0, len, ' ');
+                if (reader instanceof LineReader lr) {
+                    lr.zeroOut();
+                }
             }
         }
         return b;
@@ -227,6 +230,11 @@ public final class JdkConsoleImpl implements JdkConsole {
             cb = new char[1024];
             nextChar = nChars = 0;
             leftoverLF = false;
+        }
+        public void zeroOut() throws IOException {
+            if (in instanceof StreamDecoder sd) {
+                sd.fillZeroToPosition();
+            }
         }
         public void close () {}
         public boolean ready() throws IOException {

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -42,6 +42,8 @@ import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.Arrays;
+
 import jdk.internal.misc.InternalLock;
 
 public class StreamDecoder extends Reader {
@@ -271,6 +273,25 @@ public class StreamDecoder extends Reader {
         return !closed;
     }
 
+    public void fillZeroToPosition() throws IOException {
+        Object lock = this.lock;
+        if (lock instanceof InternalLock locker) {
+            locker.lock();
+            try {
+                lockedFillZeroToPosition();
+            } finally {
+                locker.unlock();
+            }
+        } else {
+            synchronized (lock) {
+                lockedFillZeroToPosition();
+            }
+        }
+    }
+
+    private void lockedFillZeroToPosition() {
+        Arrays.fill(bb.array(), bb.arrayOffset(), bb.arrayOffset() + bb.position(), (byte)0);
+    }
 
     // -- Charset-based stream decoder impl --
 


### PR DESCRIPTION
This issue should be fixed in 21, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320798](https://bugs.openjdk.org/browse/JDK-8320798) needs maintainer approval

### Issue
 * [JDK-8320798](https://bugs.openjdk.org/browse/JDK-8320798): Console read line with zero out should zero out underlying buffer (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3.diff">https://git.openjdk.org/jdk21u-dev/pull/3.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3#issuecomment-1853552277)