### PR TITLE
8314990: Generational ZGC: Strong OopStorage stats reported as weak roots

### DIFF
--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -101,7 +101,7 @@ void ZParallelApply<Iterator>::apply(ClosureType* cl) {
 }
 
 void ZOopStorageSetIteratorStrong::apply(OopClosure* cl) {
-  ZRootStatTimer timer(ZSubPhaseConcurrentWeakRootsOopStorageSet, _generation);
+  ZRootStatTimer timer(ZSubPhaseConcurrentRootsOopStorageSet, _generation);
   _iter.oops_do(cl);
 }
 


### PR DESCRIPTION
Transplanted from https://github.com/openjdk/jdk21u/pull/421

Clean and trivial backport to improve ZGC diagnostics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314990](https://bugs.openjdk.org/browse/JDK-8314990) needs maintainer approval

### Issue
 * [JDK-8314990](https://bugs.openjdk.org/browse/JDK-8314990): Generational ZGC: Strong OopStorage stats reported as weak roots (**Bug** - P3 - Approved)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/10.diff">https://git.openjdk.org/jdk21u-dev/pull/10.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/10#issuecomment-1853693558)