### PR TITLE
8316594: C2 SuperWord: wrong result with hand unrolled loops

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2704,15 +2704,12 @@ bool SuperWord::output() {
         // Set the memory dependency of the LoadVector as early as possible.
         // Walk up the memory chain, and ignore any StoreVector that provably
         // does not have any memory dependency.
-        SWPointer p1(n->as_Mem(), this, nullptr, false);
         while (mem->is_StoreVector()) {
-          SWPointer p2(mem->as_Mem(), this, nullptr, false);
-          if (p1.not_equal(p2)) {
-            // Either Less or Greater -> provably no overlap between the two memory regions.
-            mem = mem->in(MemNode::Memory);
-          } else {
-            // No proof that there is no overlap. Stop here.
+          SWPointer p_store(mem->as_Mem(), this, nullptr, false);
+          if (p_store.overlap_possible_with_any_in(this, p)) {
             break;
+          } else {
+            mem = mem->in(MemNode::Memory);
           }
         }
         Node* adr = first->in(MemNode::Address);

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -722,6 +722,20 @@ class SWPointer : public ArenaObj {
     }
   }
 
+  bool overlap_possible_with_any_in(SuperWord* sw, Node_List* p) {
+    for (uint k = 0; k < p->size(); k++) {
+      MemNode* mem = p->at(k)->as_Mem();
+      SWPointer p_mem(mem, sw, nullptr, false);
+      // Only if we know that we have Less or Greater can we
+      // be sure that there can never be an overlap between
+      // the two memory regions.
+      if (!not_equal(p_mem)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool not_equal(SWPointer& q)    { return not_equal(cmp(q)); }
   bool equal(SWPointer& q)        { return equal(cmp(q)); }
   bool comparable(SWPointer& q)   { return comparable(cmp(q)); }


### PR DESCRIPTION
Semi-clean backport to fix another corner case in auto-vectorization.

The patch is unclean because JDK 21u does not have [JDK-8312332](https://bugs.openjdk.org/browse/JDK-8312332) refactoring, that I do not want to backport. I have reapplied the patch by renaming SWPointer again. Plus, I had to pass `SuperWord*` pointer into `SWPointer::overlap_possible_with_any_in`.

Additional testing:
 - [ ] New regression test passes with and without the fix
 - [ ] Linux x86_64 server fastdebug `tier{1,2,3,4}`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8316594](https://bugs.openjdk.org/browse/JDK-8316594) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316594](https://bugs.openjdk.org/browse/JDK-8316594): C2 SuperWord: wrong result with hand unrolled loops (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/21.diff">https://git.openjdk.org/jdk21u-dev/pull/21.diff</a>

</details>
