### PR TITLE
8314612: TestUnorderedReduction.java fails with -XX:MaxVectorSize=32 and -XX:+AlignVector

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -4237,6 +4237,12 @@ void PhaseIdealLoop::move_unordered_reduction_out_of_loop(IdealLoopTree* loop) {
         break; // Chain traversal fails.
       }
 
+      assert(current->vect_type() != nullptr, "must have vector type");
+      if (current->vect_type() != last_ur->vect_type()) {
+        // Reductions do not have the same vector type (length and element type).
+        break; // Chain traversal fails.
+      }
+
       // Expect single use of UnorderedReduction, except for last_ur.
       if (current == last_ur) {
         // Expect all uses to be outside the loop, except phi.

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
@@ -22,11 +22,39 @@
  */
 
 /**
- * @test
- * @bug 8302652
+ * @test id=Vanilla-Unaligned
+ * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
- * @run driver compiler.loopopts.superword.TestUnorderedReduction
+ * @run driver compiler.loopopts.superword.TestUnorderedReduction Vanilla-Unaligned
+ */
+
+/**
+ * @test id=Vanilla-Aligned
+ * @bug 8302652 8314612
+ * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ * @requires vm.compiler2.enabled
+ * @library /test/lib /
+ * @run driver compiler.loopopts.superword.TestUnorderedReduction Vanilla-Aligned
+ */
+
+/**
+ * @test id=MaxVectorSize16-Unaligned
+ * @bug 8302652 8314612
+ * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ * @requires vm.compiler2.enabled
+ * @library /test/lib /
+ * @run driver compiler.loopopts.superword.TestUnorderedReduction MaxVectorSize16-Unaligned
+ */
+
+/**
+ * @test id=MaxVectorSize32-Aligned
+ * @bug 8302652 8314612
+ * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ * @requires vm.compiler2.enabled
+ * @library /test/lib /
+ * @run driver compiler.loopopts.superword.TestUnorderedReduction MaxVectorSize32-Aligned
  */
 
 package compiler.loopopts.superword;
@@ -38,9 +66,22 @@ public class TestUnorderedReduction {
     static final int ITER  = 10;
 
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-Xbatch",
-                                   "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestUnorderedReduction::test*",
-                                   "-XX:MaxVectorSize=16");
+        TestFramework framework = new TestFramework(TestUnorderedReduction.class);
+        framework.addFlags("-Xbatch",
+                           "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestUnorderedReduction::test*");
+
+        if (args.length != 1) {
+            throw new RuntimeException("Test requires exactly one argument!");
+        }
+
+        switch (args[0]) {
+            case "Vanilla-Unaligned"         -> { framework.addFlags("-XX:-AlignVector"); }
+            case "Vanilla-Aligned"           -> { framework.addFlags("-XX:+AlignVector"); }
+            case "MaxVectorSize16-Unaligned" -> { framework.addFlags("-XX:-AlignVector", "-XX:MaxVectorSize=16"); }
+            case "MaxVectorSize32-Aligned"   -> { framework.addFlags("-XX:+AlignVector", "-XX:MaxVectorSize=32"); }
+            default -> { throw new RuntimeException("Test argument not recognized: " + args[0]); }
+        }
+        framework.start();
     }
 
     @Run(test = {"test1", "test2", "test3"})
@@ -78,6 +119,7 @@ public class TestUnorderedReduction {
     @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
                   IRNode.ADD_VI, "= 0",
                   IRNode.ADD_REDUCTION_VI, "> 0"}, // count can be high
+        applyIfAnd = {"MaxVectorSize", "=16", "AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static int test1(int[] data, int sum) {
         // Vectorizes, but the UnorderedReduction cannot be moved out of the loop,
@@ -118,6 +160,7 @@ public class TestUnorderedReduction {
                   IRNode.ADD_VI, "> 0",
                   IRNode.ADD_REDUCTION_VI, "> 0",
                   IRNode.ADD_REDUCTION_VI, "<= 2"}, // count must be low
+        applyIfAnd = {"MaxVectorSize", "=16", "AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static int test2(int[] data, int sum) {
         for (int i = 0; i < RANGE; i+=8) {
@@ -153,6 +196,7 @@ public class TestUnorderedReduction {
                   IRNode.MUL_VI, "> 0",
                   IRNode.ADD_VI, "= 0", // reduction not moved out of loop
                   IRNode.ADD_REDUCTION_VI, "> 0",},
+        applyIfAnd = {"MaxVectorSize", "=16", "AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static int test3(int[] data, int sum) {
         for (int i = 0; i < RANGE; i+=8) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f804f865](https://github.com/openjdk/jdk/commit/f804f8652da71b18cc654c08c12d07d6fd43c2a7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Emanuel Peter on 13 Sep 2023 and was reviewed by Christian Hagedorn and Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314612](https://bugs.openjdk.org/browse/JDK-8314612) needs maintainer approval

### Issue
 * [JDK-8314612](https://bugs.openjdk.org/browse/JDK-8314612): TestUnorderedReduction.java fails with -XX:MaxVectorSize=32 and -XX:+AlignVector (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/24.diff">https://git.openjdk.org/jdk21u-dev/pull/24.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/24#issuecomment-1854497165)