### PR TITLE
8305971: NPE in JavacProcessingEnvironment for missing enum constructor body

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -1650,7 +1650,7 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
             public void visitMethodDef(JCMethodDecl node) {
                 // remove super constructor call that may have been added during attribution:
                 if (TreeInfo.isConstructor(node) && node.sym != null && node.sym.owner.isEnum() &&
-                    node.body.stats.nonEmpty() && TreeInfo.isSuperCall(node.body.stats.head) &&
+                    node.body != null && node.body.stats.nonEmpty() && TreeInfo.isSuperCall(node.body.stats.head) &&
                     node.body.stats.head.pos == node.body.pos) {
                     node.body.stats = node.body.stats.tail;
                 }

--- a/test/langtools/tools/javac/annotations/crash_empty_enum_const/CrashEmptyEnumConstructorTest.java
+++ b/test/langtools/tools/javac/annotations/crash_empty_enum_const/CrashEmptyEnumConstructorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8305971
+ * @summary NPE in JavacProcessingEnvironment for missing enum constructor body
+ * @library /tools/lib /tools/javac/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main CrashEmptyEnumConstructorTest
+ */
+
+import java.io.IOException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.Task.Mode;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class CrashEmptyEnumConstructorTest extends TestRunner {
+    protected ToolBox tb;
+
+    CrashEmptyEnumConstructorTest() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String... args) throws Exception {
+        new CrashEmptyEnumConstructorTest().runTests();
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[]{Paths.get(m.getName())});
+    }
+
+    Path[] findJavaFiles(Path... paths) throws IOException {
+        return tb.findJavaFiles(paths);
+    }
+
+    @Test
+    public void testEmptyEnumConstructor(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path r = src.resolve("E");
+
+        Path classes = base.resolve("classes");
+
+        Files.createDirectories(classes);
+
+        tb.writeJavaFiles(r,
+                """
+                enum E {
+                    ONE("");
+                    E(String one);
+                }
+                """);
+
+        List<String> expected = List.of(
+            "E.java:3: error: missing method body, or declare abstract",
+            "    E(String one);",
+            "    ^",
+            "1 error");
+
+        List<String> log = new JavacTask(tb)
+                .options("-processor", SimpleProcessor.class.getName())
+                .files(findJavaFiles(src))
+                .outdir(classes)
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        if (log.size() != expected.size()) {
+            throw new AssertionError("Unexpected output: " + log);
+        } else {
+            for (int i = 0; i < expected.size(); i++) {
+                if (!log.get(i).contains(expected.get(i))) {
+                    throw new AssertionError("Unexpected output: " + log);
+                }
+            }
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    public static final class SimpleProcessor extends AbstractProcessor {
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to resolve javac crash. The patch is simple, and fixes the path where the alternative is NPE.

Additional testing:
 - [x] New test fails without the fix, passes with it
 - [x] `langtools_all` still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305971](https://bugs.openjdk.org/browse/JDK-8305971) needs maintainer approval

### Issue
 * [JDK-8305971](https://bugs.openjdk.org/browse/JDK-8305971): NPE in JavacProcessingEnvironment for missing enum constructor body (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/25.diff">https://git.openjdk.org/jdk21u-dev/pull/25.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/25#issuecomment-1854517118)