### PR TITLE
8314578: Non-verifiable code is emitted when two guards declare pattern variables in colon-switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4635,11 +4635,11 @@ public class Check {
                 if (previousCompletessNormally &&
                     c.stats.nonEmpty() &&
                     c.labels.head instanceof JCPatternCaseLabel patternLabel &&
-                    hasBindings(patternLabel.pat)) {
+                    (hasBindings(patternLabel.pat) || hasBindings(c.guard))) {
                     log.error(c.labels.head.pos(), Errors.FlowsThroughToPattern);
                 } else if (c.stats.isEmpty() &&
                            c.labels.head instanceof JCPatternCaseLabel patternLabel &&
-                           hasBindings(patternLabel.pat) &&
+                           (hasBindings(patternLabel.pat) || hasBindings(c.guard)) &&
                            hasStatements(l.tail)) {
                     log.error(c.labels.head.pos(), Errors.FlowsThroughFromPattern);
                 }
@@ -4648,7 +4648,7 @@ public class Check {
         }
     }
 
-    boolean hasBindings(JCPattern p) {
+    boolean hasBindings(JCTree p) {
         boolean[] bindings = new boolean[1];
 
         new TreeScanner() {

--- a/test/langtools/tools/javac/patterns/T8314578.java
+++ b/test/langtools/tools/javac/patterns/T8314578.java
@@ -1,0 +1,43 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8314578
+ * @enablePreview
+ * @summary Parsing of erroneous patterns succeeds
+ * @compile/fail/ref=T8314578.out -XDrawDiagnostics T8314578.java
+ */
+public class T8314578 {
+    record R1() {}
+    record R2() {}
+
+    static void test(Object o) {
+        switch (o) {
+            case R1() when o instanceof String s:
+            case R2() when o instanceof Integer i:
+                System.out.println("hello: " + i);
+                break;
+            default:
+                break;
+        }
+    }
+
+    static void test2(Object o) {
+        switch (o) {
+            case R1() when o instanceof String s:
+                System.out.println("hello: " + s);
+            case R2() when o instanceof Integer i:
+                System.out.println("hello: " + i);
+                break;
+            default:
+                break;
+        }
+    }
+
+    static int unnamedInGuardsOK(String s) {
+        return switch (s) {
+            case String _ when s instanceof String _ ->  // should be OK
+                    1;
+            default ->
+                    -1;
+        };
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8314578.out
+++ b/test/langtools/tools/javac/patterns/T8314578.out
@@ -1,0 +1,6 @@
+T8314578.java:14:18: compiler.err.flows.through.from.pattern
+T8314578.java:15:18: compiler.err.flows.through.to.pattern
+T8314578.java:27:18: compiler.err.flows.through.to.pattern
+- compiler.note.preview.filename: T8314578.java, DEFAULT
+- compiler.note.preview.recompile
+3 errors


### PR DESCRIPTION
Clean backport to resolve javac compilation bug.

Additional testing:
 - [x] New test fails without the fix, passes with it
 - [x] `langtools_all` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8314578](https://bugs.openjdk.org/browse/JDK-8314578) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314578](https://bugs.openjdk.org/browse/JDK-8314578): Non-verifiable code is emitted when two guards declare pattern variables in colon-switch (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/26.diff">https://git.openjdk.org/jdk21u-dev/pull/26.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/26#issuecomment-1854547023)