### PR TITLE
8310308: IR Framework: check for type and size of vector nodes

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
@@ -61,7 +61,7 @@ public class TestMinMaxSubword {
     // as Java APIs for Math.min/max do not support integer subword types and superword
     // should not generate vectorized Min/Max nodes for them.
     @Test
-    @IR(failOn = {IRNode.MIN_V})
+    @IR(failOn = {IRNode.MIN_VI, IRNode.MIN_VF, IRNode.MIN_VD})
     public static void testMinShort() {
         for (int i = 0; i < LENGTH; i++) {
            sb[i] = (short) Math.min(sa[i], val);
@@ -77,7 +77,7 @@ public class TestMinMaxSubword {
     }
 
     @Test
-    @IR(failOn = {IRNode.MAX_V})
+    @IR(failOn = {IRNode.MAX_VI, IRNode.MAX_VF, IRNode.MAX_VD})
     public static void testMaxShort() {
         for (int i = 0; i < LENGTH; i++) {
             sb[i] = (short) Math.max(sa[i], val);
@@ -92,7 +92,7 @@ public class TestMinMaxSubword {
     }
 
     @Test
-    @IR(failOn = {IRNode.MIN_V})
+    @IR(failOn = {IRNode.MIN_VI, IRNode.MIN_VF, IRNode.MIN_VD})
     public static void testMinByte() {
         for (int i = 0; i < LENGTH; i++) {
            bb[i] = (byte) Math.min(ba[i], val);
@@ -108,7 +108,7 @@ public class TestMinMaxSubword {
     }
 
     @Test
-    @IR(failOn = {IRNode.MAX_V})
+    @IR(failOn = {IRNode.MAX_VI, IRNode.MAX_VF, IRNode.MAX_VD})
     public static void testMaxByte() {
         for (int i = 0; i < LENGTH; i++) {
             bb[i] = (byte) Math.max(ba[i], val);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVecCountingDownLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVecCountingDownLoop.java
@@ -46,7 +46,7 @@ public class TestAutoVecCountingDownLoop {
 
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,  " >0 "})
     @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
     private static void testCountingDown(int[] a, int[] b) {
         for (int i = 2000; i > 0; i--) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestAutoVectorization2DArray.java
@@ -48,9 +48,12 @@ public class TestAutoVectorization2DArray {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR,  " >0 " })
-    @IR(counts = { IRNode.ADD_VD,       " >0 " })
-    @IR(counts = { IRNode.STORE_VECTOR, " >0 " })
+    // Given small iteration count, the unrolling factor is not very predictable,
+    // hence it is difficult to exactly predict the vector size. But let's at least
+    // check that there is some vectorization of any size.
+    @IR(counts = { IRNode.LOAD_VECTOR_D, IRNode.VECTOR_SIZE_ANY, " >0 " })
+    @IR(counts = { IRNode.ADD_VD,        IRNode.VECTOR_SIZE_ANY, " >0 " })
+    @IR(counts = { IRNode.STORE_VECTOR,                          " >0 " })
     private static void testDouble(double[][] a , double[][] b, double[][] c) {
         for(int i = 0; i < a.length; i++) {
             for (int j = 0; j < a[0].length; j++) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestDisableAutoVectOpcodes.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestDisableAutoVectOpcodes.java
@@ -53,7 +53,7 @@ public class TestDisableAutoVectOpcodes {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_CAST_D2X})
+    @IR(failOn = {IRNode.VECTOR_CAST_D2I})
     private static void testConvD2I() {
         for(int i = 0; i < SIZE; i++) {
             inta[i] = (int) (doublea[i]);
@@ -61,7 +61,7 @@ public class TestDisableAutoVectOpcodes {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_CAST_L2X})
+    @IR(failOn = {IRNode.VECTOR_CAST_L2F})
     private static void testConvL2F() {
         for(int i = 0; i < SIZE; i++) {
             floata[i] = (float) (longa[i]);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorConditionalMove.java
@@ -206,7 +206,10 @@ public class TestVectorConditionalMove {
 
     // Compare 2 values, and pick one of them
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVFGT(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -215,7 +218,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVFGTSwap(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -224,7 +230,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVFLT(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -233,7 +242,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVFLTSwap(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -242,7 +254,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVFEQ(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -251,7 +266,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVDLE(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -260,7 +278,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVDLESwap(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -269,7 +290,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVDGE(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -278,7 +302,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVDGESwap(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -287,7 +314,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveVDNE(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -297,7 +327,10 @@ public class TestVectorConditionalMove {
 
     // Extensions: compare 2 values, and pick from 2 consts
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFGTforFConst(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -306,7 +339,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFGEforFConst(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -315,7 +351,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFLTforFConst(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -324,7 +363,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFLEforFConst(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -333,7 +375,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFEQforFConst(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -342,7 +387,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFNEQforFConst(float[] a, float[] b, float[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -351,7 +399,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveDGTforDConst(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -360,7 +411,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveDGEforDConst(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -369,7 +423,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveDLTforDConst(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -378,7 +435,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveDLEforDConst(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -387,7 +447,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveDEQforDConst(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -396,7 +459,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveDNEQforDConst(double[] a, double[] b, double[] c) {
         for (int i = 0; i < a.length; i++) {
@@ -411,7 +477,7 @@ public class TestVectorConditionalMove {
     //   compilation does not know that).
     //   So far, vectorization only works for CMoveF/D, with same data-width comparison (F/I for F, D/L for D).
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveIGTforI(int[] a, int[] b, int[] c, int[] d, int[] r, int[] r2) {
         for (int i = 0; i < a.length; i++) {
             int cc = c[i];
@@ -422,7 +488,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveIGTforL(int[] a, int[] b, long[] c, long[] d, long[] r, long[] r2) {
         for (int i = 0; i < a.length; i++) {
             long cc = c[i];
@@ -433,7 +499,11 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I,     IRNode.VECTOR_SIZE + "min(max_int, max_float)", ">0",
+                  IRNode.LOAD_VECTOR_F,     IRNode.VECTOR_SIZE + "min(max_int, max_float)", ">0",
+                  IRNode.VECTOR_MASK_CMP_I, IRNode.VECTOR_SIZE + "min(max_int, max_float)", ">0",
+                  IRNode.VECTOR_BLEND_F,    IRNode.VECTOR_SIZE + "min(max_int, max_float)", ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveIGTforF(int[] a, int[] b, float[] c, float[] d, float[] r, float[] r2) {
         for (int i = 0; i < a.length; i++) {
@@ -445,7 +515,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveIGTforD(int[] a, int[] b, double[] c, double[] d, double[] r, double[] r2) {
         for (int i = 0; i < a.length; i++) {
             double cc = c[i];
@@ -456,7 +526,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveLGTforI(long[] a, long[] b, int[] c, int[] d, int[] r, int[] r2) {
         for (int i = 0; i < a.length; i++) {
             int cc = c[i];
@@ -467,7 +537,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveLGTforL(long[] a, long[] b, long[] c, long[] d, long[] r, long[] r2) {
         for (int i = 0; i < a.length; i++) {
             long cc = c[i];
@@ -478,7 +548,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveLGTforF(long[] a, long[] b, float[] c, float[] d, float[] r, float[] r2) {
         for (int i = 0; i < a.length; i++) {
             float cc = c[i];
@@ -489,7 +559,11 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L,     IRNode.VECTOR_SIZE + "min(max_long, max_double)", ">0",
+                  IRNode.LOAD_VECTOR_D,     IRNode.VECTOR_SIZE + "min(max_long, max_double)", ">0",
+                  IRNode.VECTOR_MASK_CMP_L, IRNode.VECTOR_SIZE + "min(max_long, max_double)", ">0",
+                  IRNode.VECTOR_BLEND_D,    IRNode.VECTOR_SIZE + "min(max_long, max_double)", ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
     // Requires avx2, else L is restricted to 16 byte, and D has 32. That leads to a vector elements mismatch of 2 to 4.
     private static void testCMoveLGTforD(long[] a, long[] b, double[] c, double[] d, double[] r, double[] r2) {
@@ -502,7 +576,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveFGTforI(float[] a, float[] b, int[] c, int[] d, int[] r, int[] r2) {
         for (int i = 0; i < a.length; i++) {
             int cc = c[i];
@@ -513,7 +587,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveFGTforL(float[] a, float[] b, long[] c, long[] d, long[] r, long[] r2) {
         for (int i = 0; i < a.length; i++) {
             long cc = c[i];
@@ -524,7 +598,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFGTforF(float[] a, float[] b, float[] c, float[] d, float[] r, float[] r2) {
         for (int i = 0; i < a.length; i++) {
@@ -536,7 +613,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveFGTforD(float[] a, float[] b, double[] c, double[] d, double[] r, double[] r2) {
         for (int i = 0; i < a.length; i++) {
             double cc = c[i];
@@ -547,7 +624,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveDGTforI(double[] a, double[] b, int[] c, int[] d, int[] r, int[] r2) {
         for (int i = 0; i < a.length; i++) {
             int cc = c[i];
@@ -558,7 +635,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveDGTforL(double[] a, double[] b, long[] c, long[] d, long[] r, long[] r2) {
         for (int i = 0; i < a.length; i++) {
             long cc = c[i];
@@ -569,7 +646,7 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveDGTforF(double[] a, double[] b, float[] c, float[] d, float[] r, float[] r2) {
         for (int i = 0; i < a.length; i++) {
             float cc = c[i];
@@ -580,7 +657,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, ">0",
+                  IRNode.VECTOR_MASK_CMP_D, ">0",
+                  IRNode.VECTOR_BLEND_D, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveDGTforD(double[] a, double[] b, double[] c, double[] d, double[] r, double[] r2) {
         for (int i = 0; i < a.length; i++) {
@@ -593,7 +673,10 @@ public class TestVectorConditionalMove {
 
     // Use some constants in the comparison
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFGTforFCmpCon1(float a, float[] b, float[] c, float[] d, float[] r, float[] r2) {
         for (int i = 0; i < b.length; i++) {
@@ -605,7 +688,10 @@ public class TestVectorConditionalMove {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.VECTOR_MASK_CMP, ">0", IRNode.VECTOR_BLEND, ">0", IRNode.STORE_VECTOR, ">0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, ">0",
+                  IRNode.VECTOR_MASK_CMP_F, ">0",
+                  IRNode.VECTOR_BLEND_F, ">0",
+                  IRNode.STORE_VECTOR, ">0"},
         applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     private static void testCMoveFGTforFCmpCon2(float[] a, float b, float[] c, float[] d, float[] r, float[] r2) {
         for (int i = 0; i < a.length; i++) {
@@ -618,7 +704,7 @@ public class TestVectorConditionalMove {
 
     // A case that is currently not supported and is not expected to vectorize
     @Test
-    @IR(failOn = {IRNode.VECTOR_MASK_CMP, IRNode.VECTOR_BLEND})
+    @IR(failOn = {IRNode.STORE_VECTOR})
     private static void testCMoveVDUnsupported() {
         double[] doublec = new double[SIZE];
         int seed = 1001;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -150,7 +150,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteLong1(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i, src[i]);
@@ -163,7 +163,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteLong2(byte[] dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), src[i]);
@@ -176,7 +176,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteLong3(byte[] dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + 1), src[i]);
@@ -189,7 +189,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteLong4(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
             UNSAFE.putLongUnaligned(dest, 8 * i + baseOffset, src[i]);
@@ -203,7 +203,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteLong5(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + baseOffset), src[i]);
@@ -217,7 +217,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteByte1(byte[] dest, byte[] src) {
         for (int i = 0; i < src.length / 8; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i, UNSAFE.getLongUnaligned(src, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i));
@@ -229,9 +229,8 @@ public class TestVectorizationMismatchedAccess {
         runAndVerify2(() -> testByteByte1(byteArray, byteArray), 0);
     }
 
-    // It would be legal to vectorize this one but it's not currently
     @Test
-    //@IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteByte2(byte[] dest, byte[] src) {
         for (int i = 1; i < src.length / 8; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), UNSAFE.getLongUnaligned(src, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i));
@@ -244,7 +243,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(failOn = { IRNode.LOAD_VECTOR, IRNode.STORE_VECTOR })
+    @IR(failOn = { IRNode.LOAD_VECTOR_L, IRNode.STORE_VECTOR })
     public static void testByteByte3(byte[] dest, byte[] src) {
         for (int i = 0; i < src.length / 8 - 1; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + 1), UNSAFE.getLongUnaligned(src, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i));
@@ -257,7 +256,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(failOn = { IRNode.LOAD_VECTOR, IRNode.STORE_VECTOR })
+    @IR(failOn = { IRNode.LOAD_VECTOR_L, IRNode.STORE_VECTOR })
     public static void testByteByte4(byte[] dest, byte[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
             UNSAFE.putLongUnaligned(dest, 8 * i + baseOffset, UNSAFE.getLongUnaligned(src, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i));
@@ -271,7 +270,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(failOn = { IRNode.LOAD_VECTOR, IRNode.STORE_VECTOR })
+    @IR(failOn = { IRNode.LOAD_VECTOR_L, IRNode.STORE_VECTOR })
     public static void testByteByte5(byte[] dest, byte[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + baseOffset), UNSAFE.getLongUnaligned(src, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i));
@@ -285,7 +284,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testOffHeapLong1(long dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
             UNSAFE.putLongUnaligned(null, dest + 8 * i, src[i]);
@@ -298,7 +297,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testOffHeapLong2(long dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
             UNSAFE.putLongUnaligned(null, dest + 8 * (i - 1), src[i]);
@@ -311,7 +310,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testOffHeapLong3(long dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
             UNSAFE.putLongUnaligned(null, dest + 8 * (i + 1), src[i]);
@@ -324,7 +323,7 @@ public class TestVectorizationMismatchedAccess {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testOffHeapLong4(long dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
             UNSAFE.putLongUnaligned(null, dest + 8 * i + baseOffset, src[i]);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -229,8 +229,9 @@ public class TestVectorizationMismatchedAccess {
         runAndVerify2(() -> testByteByte1(byteArray, byteArray), 0);
     }
 
+    // It would be legal to vectorize this one but it's not currently
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    //@IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteByte2(byte[] dest, byte[] src) {
         for (int i = 1; i < src.length / 8; i++) {
             UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), UNSAFE.getLongUnaligned(src, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i));

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMultiInvar.java
@@ -60,7 +60,7 @@ public class TestVectorizationMultiInvar {
     static long baseOffset = 0;
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteLong1(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
             long j = Objects.checkIndex(i * 8, (long)(src.length * 8));
@@ -75,7 +75,7 @@ public class TestVectorizationMultiInvar {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_B, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testLoopNest1(byte[] dest, byte[] src,
                                      long start1, long stop1,
                                      long start2, long stop2,
@@ -106,7 +106,7 @@ public class TestVectorizationMultiInvar {
     }
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_I, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testLoopNest2(int[] dest, int[] src,
                                      long start1, long stop1,
                                      long start2, long stop2,

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
@@ -51,7 +51,7 @@ public class TestVectorizationNotRun {
     static long[] longArray = new long[size];
 
     @Test
-    @IR(counts = { IRNode.LOAD_VECTOR, ">=1", IRNode.STORE_VECTOR, ">=1" })
+    @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void test(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
             if ((i < 0) || (8 > sizeBytes - i)) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -55,8 +55,9 @@ public class TestVectorizeTypeConversion {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0",
-                  IRNode.VECTOR_CAST_I2X, ">0",
+    // Mixing types of different sizes has the effect that some vectors are shorter than the type allows.
+    @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0",
+                  IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0",
                   IRNode.STORE_VECTOR, ">0"},
         // The vectorization of some conversions may fail when `+AlignVector`.
         // We can remove the condition after JDK-8303827.
@@ -68,9 +69,11 @@ public class TestVectorizeTypeConversion {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0",
-                  IRNode.VECTOR_CAST_I2X, ">0",
-                  IRNode.VECTOR_CAST_L2X, ">0",
+    // Mixing types of different sizes has the effect that some vectors are shorter than the type allows.
+    @IR(counts = {IRNode.LOAD_VECTOR_L,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", ">0",
+                  IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", ">0",
+                  IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", ">0",
+                  IRNode.VECTOR_CAST_L2I, IRNode.VECTOR_SIZE + "min(max_int, max_long)", ">0",
                   IRNode.STORE_VECTOR, ">0"})
     private static void testConvI2L(int[] d1, int d2[], long[] a1, long[] a2) {
         for(int i = 0; i < d1.length; i++) {
@@ -80,9 +83,11 @@ public class TestVectorizeTypeConversion {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0",
-                  IRNode.VECTOR_CAST_D2X, ">0",
-                  IRNode.VECTOR_CAST_F2X, ">0",
+    // Mixing types of different sizes has the effect that some vectors are shorter than the type allows.
+    @IR(counts = {IRNode.LOAD_VECTOR_F,   IRNode.VECTOR_SIZE + "min(max_float, max_double)", ">0",
+                  IRNode.LOAD_VECTOR_D,   IRNode.VECTOR_SIZE + "min(max_float, max_double)", ">0",
+                  IRNode.VECTOR_CAST_D2F, IRNode.VECTOR_SIZE + "min(max_float, max_double)", ">0",
+                  IRNode.VECTOR_CAST_F2D, IRNode.VECTOR_SIZE + "min(max_float, max_double)", ">0",
                   IRNode.STORE_VECTOR, ">0"})
     private static void testConvF2D(double[] d1, double[] d2, float[] a1, float[] a2) {
         for(int i = 0; i < d1.length; i++) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
@@ -70,7 +70,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VB, ">0", IRNode.STORE_VECTOR, ">0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_B, ">0", IRNode.RSHIFT_VB, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testByte0() {
         for(int i = 0; i < NUM; i++) {
             byteb[i] = (byte) (bytea[i] >>> 3);
@@ -78,7 +78,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VB, ">0", IRNode.STORE_VECTOR, ">0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_B, ">0", IRNode.RSHIFT_VB, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testByte1() {
         for(int i = 0; i < NUM; i++) {
             byteb[i] = (byte) (bytea[i] >>> 24);
@@ -86,7 +86,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.RSHIFT_VB, IRNode.STORE_VECTOR})
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.RSHIFT_VB, IRNode.STORE_VECTOR})
     public void testByte2() {
         for(int i = 0; i < NUM; i++) {
             byteb[i] = (byte) (bytea[i] >>> 25);
@@ -94,7 +94,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VS, ">0", IRNode.STORE_VECTOR, ">0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_S, ">0", IRNode.RSHIFT_VS, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testShort0() {
         for(int i = 0; i < NUM; i++) {
             shortb[i] = (short) (shorta[i] >>> 10);
@@ -102,7 +102,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, ">0", IRNode.RSHIFT_VS, ">0", IRNode.STORE_VECTOR, ">0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_S, ">0", IRNode.RSHIFT_VS, ">0", IRNode.STORE_VECTOR, ">0"})
     public void testShort1() {
         for(int i = 0; i < NUM; i++) {
             shortb[i] = (short) (shorta[i] >>> 16);
@@ -110,7 +110,7 @@ public class TestVectorizeURShiftSubword {
     }
 
     @Test
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.RSHIFT_VS, IRNode.STORE_VECTOR})
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.RSHIFT_VS, IRNode.STORE_VECTOR})
     public void testShort2() {
         for(int i = 0; i < NUM; i++) {
             shortb[i] = (short) (shorta[i] >>> 17);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -24,6 +24,7 @@
 package compiler.lib.ir_framework;
 
 import compiler.lib.ir_framework.driver.irmatching.mapping.*;
+import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
 import compiler.lib.ir_framework.shared.CheckedTestFrameworkException;
 import compiler.lib.ir_framework.shared.TestFormat;
 import compiler.lib.ir_framework.shared.TestFormatException;
@@ -69,6 +70,17 @@ import java.util.Map;
  *                                 Using this IR node expects another user provided string in the constraint list of
  *                                 {@link IR#failOn()} and {@link IR#counts()}. They cannot be used as normal IR nodes.
  *                                 Trying to do so will result in a format violation error.</li>
+ *     <li><p>Vector IR nodes:  The IR node placeholder string contains an additional {@link #VECTOR_PREFIX}.
+ *                              Using this IR node, one can check for the type and size of a vector. The type must
+ *                              be directly specified in {@link #vectorNode}. The size can be specified directly with
+ *                              an additional argument using {@link #VECTOR_SIZE}, followed by a size tag or a comma
+ *                              separated list of sizes. If the size argument is not given, then a default size of
+ *                              {@link #VECTOR_SIZE_MAX} is taken, which is the number of elements that can fit in a
+ *                              vector of the specified type (depends on the VM flag MaxVectorSize and CPU features).
+ *                              However, when using {@link IR#failOn} or {@link IR#counts()} with comparison {@code <},
+ *                              or {@code <=} or {@code =0}, the default size is {@link #VECTOR_SIZE_ANY}, allowing any
+ *                              size. The motivation for these default values is that in most cases one wants to have
+ *                              vectorization with maximal vector width, or no vectorization of any vector width.
  * </ul>
  */
 public class IRNode {
@@ -80,6 +92,11 @@ public class IRNode {
      * Prefix for composite IR nodes.
      */
     private static final String COMPOSITE_PREFIX = PREFIX + "C#";
+    /**
+     * Prefix for vector IR nodes.
+     */
+    private static final String VECTOR_PREFIX = PREFIX + "V#";
+
     private static final String POSTFIX = "#_";
 
     private static final String START = "(\\d+(\\s){2}(";
@@ -90,20 +107,44 @@ public class IRNode {
 
     public static final String IS_REPLACED = "#IS_REPLACED#"; // Is replaced by an additional user-defined string.
 
+    public static final String VECTOR_SIZE = "_@";
+    public static final String VECTOR_SIZE_TAG_ANY = "any";
+    public static final String VECTOR_SIZE_TAG_MAX = "max_for_type";
+    public static final String VECTOR_SIZE_ANY = VECTOR_SIZE + VECTOR_SIZE_TAG_ANY; // default for counts "=0" and failOn
+    public static final String VECTOR_SIZE_MAX = VECTOR_SIZE + VECTOR_SIZE_TAG_MAX; // default in counts
+    public static final String VECTOR_SIZE_2   = VECTOR_SIZE + "2";
+    public static final String VECTOR_SIZE_4   = VECTOR_SIZE + "4";
+    public static final String VECTOR_SIZE_8   = VECTOR_SIZE + "8";
+    public static final String VECTOR_SIZE_16  = VECTOR_SIZE + "16";
+    public static final String VECTOR_SIZE_32  = VECTOR_SIZE + "32";
+    public static final String VECTOR_SIZE_64  = VECTOR_SIZE + "64";
+
+    private static final String TYPE_BYTE   = "byte";
+    private static final String TYPE_CHAR   = "char";
+    private static final String TYPE_SHORT  = "short";
+    private static final String TYPE_INT    = "int";
+    private static final String TYPE_LONG   = "long";
+    private static final String TYPE_FLOAT  = "float";
+    private static final String TYPE_DOUBLE = "double";
 
     /**
      * IR placeholder string to regex-for-compile-phase map.
      */
     private static final Map<String, IRNodeMapEntry> IR_NODE_MAPPINGS = new HashMap<>();
 
+    /**
+     * Map every vectorNode to a type string.
+     */
+    private static final Map<String, String> VECTOR_NODE_TYPE = new HashMap<>();
+
     /*
      * Start of IR placeholder string definitions followed by a static block defining the regex-for-compile-phase mapping.
      * An IR node placeholder string must start with PREFIX for normal IR nodes or COMPOSITE_PREFIX for composite IR
-     * nodes (see class description above).
+     * nodes, or VECTOR_PREFIX for vector nodes (see class description above).
      *
      * An IR node definition looks like this:
      *
-     * public static final String IR_NODE = [PREFIX|COMPOSITE_PREFIX] + "IR_NODE" + POSTFIX;
+     * public static final String IR_NODE = [PREFIX|COMPOSITE_PREFIX|VECTOR_PREFIX] + "IR_NODE" + POSTFIX;
      * static {
      *    // Define IR_NODE to regex-for-compile-phase mapping. Create a new IRNodeMapEntry object and add it to
      *    // IR_NODE_MAPPINGS. This can be done by using the helper methods defined after all IR node placeholder string
@@ -131,9 +172,36 @@ public class IRNode {
         beforeMatchingNameRegex(ABS_L, "AbsL");
     }
 
-    public static final String ABS_V = PREFIX + "ABS_V" + POSTFIX;
+    public static final String ABS_VB = VECTOR_PREFIX + "ABS_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(ABS_V, "AbsV(B|S|I|L|F|D)");
+        vectorNode(ABS_VB, "AbsVB", TYPE_BYTE);
+    }
+
+    // ABS_VC / AbsVC does not exist (char is 2 byte unsigned)
+
+    public static final String ABS_VS = VECTOR_PREFIX + "ABS_VS" + POSTFIX;
+    static {
+        vectorNode(ABS_VS, "AbsVS", TYPE_SHORT);
+    }
+
+    public static final String ABS_VI = VECTOR_PREFIX + "ABS_VI" + POSTFIX;
+    static {
+        vectorNode(ABS_VI, "AbsVI", TYPE_INT);
+    }
+
+    public static final String ABS_VL = VECTOR_PREFIX + "ABS_VL" + POSTFIX;
+    static {
+        vectorNode(ABS_VL, "AbsVL", TYPE_LONG);
+    }
+
+    public static final String ABS_VF = VECTOR_PREFIX + "ABS_VF" + POSTFIX;
+    static {
+        vectorNode(ABS_VF, "AbsVF", TYPE_FLOAT);
+    }
+
+    public static final String ABS_VD = VECTOR_PREFIX + "ABS_VD" + POSTFIX;
+    static {
+        vectorNode(ABS_VD, "AbsVD", TYPE_DOUBLE);
     }
 
     public static final String ADD = PREFIX + "ADD" + POSTFIX;
@@ -151,24 +219,34 @@ public class IRNode {
         beforeMatchingNameRegex(ADD_L, "AddL");
     }
 
-    public static final String ADD_V = PREFIX + "ADD_V" + POSTFIX;
+    public static final String ADD_VD = VECTOR_PREFIX + "ADD_VD" + POSTFIX;
     static {
-        beforeMatchingNameRegex(ADD_V, "AddV(B|S|I|L|F|D)");
+        vectorNode(ADD_VD, "AddVD", TYPE_DOUBLE);
     }
 
-    public static final String ADD_VD = PREFIX + "ADD_VD" + POSTFIX;
+    public static final String ADD_VI = VECTOR_PREFIX + "ADD_VI" + POSTFIX;
     static {
-        beforeMatchingNameRegex(ADD_VD, "AddVD");
+        vectorNode(ADD_VI, "AddVI", TYPE_INT);
     }
 
-    public static final String ADD_VI = PREFIX + "ADD_VI" + POSTFIX;
+    public static final String ADD_VF = VECTOR_PREFIX + "ADD_VF" + POSTFIX;
     static {
-        beforeMatchingNameRegex(ADD_VI, "AddVI");
+        vectorNode(ADD_VF, "AddVF", TYPE_FLOAT);
     }
 
-    public static final String ADD_VF = PREFIX + "ADD_VF" + POSTFIX;
+    public static final String ADD_VB = VECTOR_PREFIX + "ADD_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(ADD_VF, "AddVF");
+        vectorNode(ADD_VB, "AddVB", TYPE_BYTE);
+    }
+
+    public static final String ADD_VS = VECTOR_PREFIX + "ADD_VS" + POSTFIX;
+    static {
+        vectorNode(ADD_VS, "AddVS", TYPE_SHORT);
+    }
+
+    public static final String ADD_VL = VECTOR_PREFIX + "ADD_VL" + POSTFIX;
+    static {
+        vectorNode(ADD_VL, "AddVL", TYPE_LONG);
     }
 
     public static final String ADD_REDUCTION_V = PREFIX + "ADD_REDUCTION_V" + POSTFIX;
@@ -235,9 +313,29 @@ public class IRNode {
         beforeMatchingNameRegex(AND_L, "AndL");
     }
 
-    public static final String AND_V = PREFIX + "AND_V" + POSTFIX;
+    public static final String AND_VB = VECTOR_PREFIX + "AND_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(AND_V, "AndV");
+        vectorNode(AND_VB, "AndV", TYPE_BYTE);
+    }
+
+    public static final String AND_VC = VECTOR_PREFIX + "AND_VC" + POSTFIX;
+    static {
+        vectorNode(AND_VC, "AndV", TYPE_CHAR);
+    }
+
+    public static final String AND_VS = VECTOR_PREFIX + "AND_VS" + POSTFIX;
+    static {
+        vectorNode(AND_VS, "AndV", TYPE_SHORT);
+    }
+
+    public static final String AND_VI = VECTOR_PREFIX + "AND_VI" + POSTFIX;
+    static {
+        vectorNode(AND_VI, "AndV", TYPE_INT);
+    }
+
+    public static final String AND_VL = VECTOR_PREFIX + "AND_VL" + POSTFIX;
+    static {
+        vectorNode(AND_VL, "AndV", TYPE_LONG);
     }
 
     public static final String AND_V_MASK = PREFIX + "AND_V_MASK" + POSTFIX;
@@ -386,9 +484,14 @@ public class IRNode {
         beforeMatchingNameRegex(DIV_L, "DivL");
     }
 
-    public static final String DIV_V = PREFIX + "DIV_V" + POSTFIX;
+    public static final String DIV_VF = VECTOR_PREFIX + "DIV_VF" + POSTFIX;
     static {
-        beforeMatchingNameRegex(DIV_V, "DivV(F|D)");
+        vectorNode(DIV_VF, "DivVF", TYPE_FLOAT);
+    }
+
+    public static final String DIV_VD = VECTOR_PREFIX + "DIV_VD" + POSTFIX;
+    static {
+        vectorNode(DIV_VD, "DivVD", TYPE_DOUBLE);
     }
 
     public static final String DYNAMIC_CALL_OF_METHOD = COMPOSITE_PREFIX + "DYNAMIC_CALL_OF_METHOD" + POSTFIX;
@@ -418,9 +521,14 @@ public class IRNode {
         optoOnly(FIELD_ACCESS, regex);
     }
 
-    public static final String FMA_V = PREFIX + "FMA_V" + POSTFIX;
+    public static final String FMA_VF = VECTOR_PREFIX + "FMA_VF" + POSTFIX;
     static {
-        beforeMatchingNameRegex(FMA_V, "FmaV(F|D)");
+        vectorNode(FMA_VF, "FmaVF", TYPE_FLOAT);
+    }
+
+    public static final String FMA_VD = VECTOR_PREFIX + "FMA_VD" + POSTFIX;
+    static {
+        vectorNode(FMA_VD, "FmaVD", TYPE_DOUBLE);
     }
 
     public static final String IF = PREFIX + "IF" + POSTFIX;
@@ -582,9 +690,39 @@ public class IRNode {
         loadOfNodes(LOAD_US_OF_CLASS, "LoadUS");
     }
 
-    public static final String LOAD_VECTOR = PREFIX + "LOAD_VECTOR" + POSTFIX;
+    public static final String LOAD_VECTOR_B = VECTOR_PREFIX + "LOAD_VECTOR_B" + POSTFIX;
     static {
-        beforeMatchingNameRegex(LOAD_VECTOR, "LoadVector");
+        vectorNode(LOAD_VECTOR_B, "LoadVector", TYPE_BYTE);
+    }
+
+    public static final String LOAD_VECTOR_C = VECTOR_PREFIX + "LOAD_VECTOR_C" + POSTFIX;
+    static {
+        vectorNode(LOAD_VECTOR_C, "LoadVector", TYPE_CHAR);
+    }
+
+    public static final String LOAD_VECTOR_S = VECTOR_PREFIX + "LOAD_VECTOR_S" + POSTFIX;
+    static {
+        vectorNode(LOAD_VECTOR_S, "LoadVector", TYPE_SHORT);
+    }
+
+    public static final String LOAD_VECTOR_I = VECTOR_PREFIX + "LOAD_VECTOR_I" + POSTFIX;
+    static {
+        vectorNode(LOAD_VECTOR_I, "LoadVector", TYPE_INT);
+    }
+
+    public static final String LOAD_VECTOR_L = VECTOR_PREFIX + "LOAD_VECTOR_L" + POSTFIX;
+    static {
+        vectorNode(LOAD_VECTOR_L, "LoadVector", TYPE_LONG);
+    }
+
+    public static final String LOAD_VECTOR_F = VECTOR_PREFIX + "LOAD_VECTOR_F" + POSTFIX;
+    static {
+        vectorNode(LOAD_VECTOR_F, "LoadVector", TYPE_FLOAT);
+    }
+
+    public static final String LOAD_VECTOR_D = VECTOR_PREFIX + "LOAD_VECTOR_D" + POSTFIX;
+    static {
+        vectorNode(LOAD_VECTOR_D, "LoadVector", TYPE_DOUBLE);
     }
 
     public static final String LOAD_VECTOR_GATHER = PREFIX + "LOAD_VECTOR_GATHER" + POSTFIX;
@@ -624,9 +762,29 @@ public class IRNode {
         beforeMatchingNameRegex(LSHIFT_L, "LShiftL");
     }
 
-    public static final String LSHIFT_V = PREFIX + "LSHIFT_V" + POSTFIX;
+    public static final String LSHIFT_VB = VECTOR_PREFIX + "LSHIFT_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(LSHIFT_V, "LShiftV(B|S|I|L)");
+        vectorNode(LSHIFT_VB, "LShiftVB", TYPE_BYTE);
+    }
+
+    public static final String LSHIFT_VS = VECTOR_PREFIX + "LSHIFT_VS" + POSTFIX;
+    static {
+        vectorNode(LSHIFT_VS, "LShiftVS", TYPE_SHORT);
+    }
+
+    public static final String LSHIFT_VC = VECTOR_PREFIX + "LSHIFT_VC" + POSTFIX;
+    static {
+        vectorNode(LSHIFT_VC, "LShiftVS", TYPE_CHAR); // using short op with char type
+    }
+
+    public static final String LSHIFT_VI = VECTOR_PREFIX + "LSHIFT_VI" + POSTFIX;
+    static {
+        vectorNode(LSHIFT_VI, "LShiftVI", TYPE_INT);
+    }
+
+    public static final String LSHIFT_VL = VECTOR_PREFIX + "LSHIFT_VL" + POSTFIX;
+    static {
+        vectorNode(LSHIFT_VL, "LShiftVL", TYPE_LONG);
     }
 
     public static final String MACRO_LOGIC_V = PREFIX + "MACRO_LOGIC_V" + POSTFIX;
@@ -669,9 +827,19 @@ public class IRNode {
         beforeMatchingNameRegex(MAX_L, "MaxL");
     }
 
-    public static final String MAX_V = PREFIX + "MAX_V" + POSTFIX;
+    public static final String MAX_VI = VECTOR_PREFIX + "MAX_VI" + POSTFIX;
     static {
-        beforeMatchingNameRegex(MAX_V, "MaxV");
+        vectorNode(MAX_VI, "MaxV", TYPE_INT);
+    }
+
+    public static final String MAX_VF = VECTOR_PREFIX + "MAX_VF" + POSTFIX;
+    static {
+        vectorNode(MAX_VF, "MaxV", TYPE_FLOAT);
+    }
+
+    public static final String MAX_VD = VECTOR_PREFIX + "MAX_VD" + POSTFIX;
+    static {
+        vectorNode(MAX_VD, "MaxV", TYPE_DOUBLE);
     }
 
     public static final String MEMBAR = PREFIX + "MEMBAR" + POSTFIX;
@@ -719,9 +887,19 @@ public class IRNode {
         beforeMatchingNameRegex(MIN_L, "MinL");
     }
 
-    public static final String MIN_V = PREFIX + "MIN_V" + POSTFIX;
+    public static final String MIN_VI = VECTOR_PREFIX + "MIN_VI" + POSTFIX;
     static {
-        beforeMatchingNameRegex(MIN_V, "MinV");
+        vectorNode(MIN_VI, "MinV", TYPE_INT);
+    }
+
+    public static final String MIN_VF = VECTOR_PREFIX + "MIN_VF" + POSTFIX;
+    static {
+        vectorNode(MIN_VF, "MinV", TYPE_FLOAT);
+    }
+
+    public static final String MIN_VD = VECTOR_PREFIX + "MIN_VD" + POSTFIX;
+    static {
+        vectorNode(MIN_VD, "MinV", TYPE_DOUBLE);
     }
 
     public static final String MUL = PREFIX + "MUL" + POSTFIX;
@@ -749,29 +927,34 @@ public class IRNode {
         beforeMatchingNameRegex(MUL_L, "MulL");
     }
 
-    public static final String MUL_V = PREFIX + "MUL_V" + POSTFIX;
+    public static final String MUL_VL = VECTOR_PREFIX + "MUL_VL" + POSTFIX;
     static {
-        beforeMatchingNameRegex(MUL_V, "MulV(B|S|I|L|F|D)");
+        vectorNode(MUL_VL, "MulVL", TYPE_LONG);
     }
 
-    public static final String MUL_VL = PREFIX + "MUL_VL" + POSTFIX;
+    public static final String MUL_VI = VECTOR_PREFIX + "MUL_VI" + POSTFIX;
     static {
-        beforeMatchingNameRegex(MUL_VL, "MulVL");
+        vectorNode(MUL_VI, "MulVI", TYPE_INT);
     }
 
-    public static final String MUL_VI = PREFIX + "MUL_VI" + POSTFIX;
+    public static final String MUL_VF = VECTOR_PREFIX + "MUL_VF" + POSTFIX;
     static {
-        beforeMatchingNameRegex(MUL_VI, "MulVI");
+        vectorNode(MUL_VF, "MulVF", TYPE_FLOAT);
     }
 
-    public static final String MUL_VF = PREFIX + "MUL_VF" + POSTFIX;
+    public static final String MUL_VD = VECTOR_PREFIX + "MUL_VD" + POSTFIX;
     static {
-        beforeMatchingNameRegex(MUL_VF, "MulVF");
+        vectorNode(MUL_VD, "MulVD", TYPE_DOUBLE);
     }
 
-    public static final String MUL_VD = PREFIX + "MUL_VD" + POSTFIX;
+    public static final String MUL_VB = VECTOR_PREFIX + "MUL_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(MUL_VD, "MulVD");
+        vectorNode(MUL_VB, "MulVB", TYPE_BYTE);
+    }
+
+    public static final String MUL_VS = VECTOR_PREFIX + "MUL_VS" + POSTFIX;
+    static {
+        vectorNode(MUL_VS, "MulVS", TYPE_SHORT);
     }
 
     public static final String MUL_REDUCTION_VD = PREFIX + "MUL_REDUCTION_VD" + POSTFIX;
@@ -804,9 +987,14 @@ public class IRNode {
         superWordNodes(MAX_REDUCTION_V, "MaxReductionV");
     }
 
-    public static final String NEG_V = PREFIX + "NEG_V" + POSTFIX;
+    public static final String NEG_VF = VECTOR_PREFIX + "NEG_VF" + POSTFIX;
     static {
-        beforeMatchingNameRegex(NEG_V, "NegV(F|D)");
+        vectorNode(NEG_VF, "NegVF", TYPE_FLOAT);
+    }
+
+    public static final String NEG_VD = VECTOR_PREFIX + "NEG_VD" + POSTFIX;
+    static {
+        vectorNode(NEG_VD, "NegVD", TYPE_DOUBLE);
     }
 
     public static final String NULL_ASSERT_TRAP = PREFIX + "NULL_ASSERT_TRAP" + POSTFIX;
@@ -819,9 +1007,24 @@ public class IRNode {
         trapNodes(NULL_CHECK_TRAP,"null_check");
     }
 
-    public static final String OR_V = PREFIX + "OR_V" + POSTFIX;
+    public static final String OR_VB = VECTOR_PREFIX + "OR_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(OR_V, "OrV");
+        vectorNode(OR_VB, "OrV", TYPE_BYTE);
+    }
+
+    public static final String OR_VS = VECTOR_PREFIX + "OR_VS" + POSTFIX;
+    static {
+        vectorNode(OR_VS, "OrV", TYPE_SHORT);
+    }
+
+    public static final String OR_VI = VECTOR_PREFIX + "OR_VI" + POSTFIX;
+    static {
+        vectorNode(OR_VI, "OrV", TYPE_INT);
+    }
+
+    public static final String OR_VL = VECTOR_PREFIX + "OR_VL" + POSTFIX;
+    static {
+        vectorNode(OR_VL, "OrV", TYPE_LONG);
     }
 
     public static final String OR_V_MASK = PREFIX + "OR_V_MASK" + POSTFIX;
@@ -850,24 +1053,24 @@ public class IRNode {
         beforeMatchingNameRegex(POPCOUNT_L, "PopCountL");
     }
 
-    public static final String POPCOUNT_VI = PREFIX + "POPCOUNT_VI" + POSTFIX;
+    public static final String POPCOUNT_VI = VECTOR_PREFIX + "POPCOUNT_VI" + POSTFIX;
     static {
-        superWordNodes(POPCOUNT_VI, "PopCountVI");
+        vectorNode(POPCOUNT_VI, "PopCountVI", TYPE_INT);
     }
 
-    public static final String POPCOUNT_VL = PREFIX + "POPCOUNT_VL" + POSTFIX;
+    public static final String POPCOUNT_VL = VECTOR_PREFIX + "POPCOUNT_VL" + POSTFIX;
     static {
-        superWordNodes(POPCOUNT_VL, "PopCountVL");
+        vectorNode(POPCOUNT_VL, "PopCountVL", TYPE_LONG);
     }
 
-    public static final String COUNTTRAILINGZEROS_VL = PREFIX + "COUNTTRAILINGZEROS_VL" + POSTFIX;
+    public static final String COUNTTRAILINGZEROS_VL = VECTOR_PREFIX + "COUNTTRAILINGZEROS_VL" + POSTFIX;
     static {
-        superWordNodes(COUNTTRAILINGZEROS_VL, "CountTrailingZerosV");
+        vectorNode(COUNTTRAILINGZEROS_VL, "CountTrailingZerosV", TYPE_LONG);
     }
 
-    public static final String COUNTLEADINGZEROS_VL = PREFIX + "COUNTLEADINGZEROS_VL" + POSTFIX;
+    public static final String COUNTLEADINGZEROS_VL = VECTOR_PREFIX + "COUNTLEADINGZEROS_VL" + POSTFIX;
     static {
-        superWordNodes(COUNTLEADINGZEROS_VL, "CountLeadingZerosV");
+        vectorNode(COUNTLEADINGZEROS_VL, "CountLeadingZerosV", TYPE_LONG);
     }
 
     public static final String POPULATE_INDEX = PREFIX + "POPULATE_INDEX" + POSTFIX;
@@ -936,9 +1139,24 @@ public class IRNode {
                                                                     CompilePhase.BEFORE_MATCHING));
     }
 
-    public static final String REVERSE_BYTES_V = PREFIX + "REVERSE_BYTES_V" + POSTFIX;
+    public static final String REVERSE_BYTES_VB = VECTOR_PREFIX + "REVERSE_BYTES_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(REVERSE_BYTES_V, "ReverseBytesV");
+        vectorNode(REVERSE_BYTES_VB, "ReverseBytesV", TYPE_BYTE);
+    }
+
+    public static final String REVERSE_BYTES_VS = VECTOR_PREFIX + "REVERSE_BYTES_VS" + POSTFIX;
+    static {
+        vectorNode(REVERSE_BYTES_VS, "ReverseBytesV", TYPE_SHORT);
+    }
+
+    public static final String REVERSE_BYTES_VI = VECTOR_PREFIX + "REVERSE_BYTES_VI" + POSTFIX;
+    static {
+        vectorNode(REVERSE_BYTES_VI, "ReverseBytesV", TYPE_INT);
+    }
+
+    public static final String REVERSE_BYTES_VL = VECTOR_PREFIX + "REVERSE_BYTES_VL" + POSTFIX;
+    static {
+        vectorNode(REVERSE_BYTES_VL, "ReverseBytesV", TYPE_LONG);
     }
 
     public static final String REVERSE_I = PREFIX + "REVERSE_I" + POSTFIX;
@@ -951,19 +1169,24 @@ public class IRNode {
         beforeMatchingNameRegex(REVERSE_L, "ReverseL");
     }
 
-    public static final String REVERSE_V = PREFIX + "REVERSE_V" + POSTFIX;
+    public static final String REVERSE_VI = VECTOR_PREFIX + "REVERSE_VI" + POSTFIX;
     static {
-        beforeMatchingNameRegex(REVERSE_V, "ReverseV");
+        vectorNode(REVERSE_VI, "ReverseV", TYPE_INT);
     }
 
-    public static final String ROUND_VD = PREFIX + "ROUND_VD" + POSTFIX;
+    public static final String REVERSE_VL = VECTOR_PREFIX + "REVERSE_VL" + POSTFIX;
     static {
-        beforeMatchingNameRegex(ROUND_VD, "RoundVD");
+        vectorNode(REVERSE_VL, "ReverseV", TYPE_LONG);
     }
 
-    public static final String ROUND_VF = PREFIX + "ROUND_VF" + POSTFIX;
+    public static final String ROUND_VD = VECTOR_PREFIX + "ROUND_VD" + POSTFIX;
     static {
-        beforeMatchingNameRegex(ROUND_VF, "RoundVF");
+        vectorNode(ROUND_VD, "RoundVD", TYPE_LONG);
+    }
+
+    public static final String ROUND_VF = VECTOR_PREFIX + "ROUND_VF" + POSTFIX;
+    static {
+        vectorNode(ROUND_VF, "RoundVF", TYPE_INT);
     }
 
     public static final String ROTATE_LEFT = PREFIX + "ROTATE_LEFT" + POSTFIX;
@@ -986,9 +1209,9 @@ public class IRNode {
         beforeMatchingNameRegex(ROTATE_RIGHT_V, "RotateRightV");
     }
 
-    public static final String ROUND_DOUBLE_MODE_V = PREFIX + "ROUND_DOUBLE_MODE_V" + POSTFIX;
+    public static final String ROUND_DOUBLE_MODE_V = VECTOR_PREFIX + "ROUND_DOUBLE_MODE_V" + POSTFIX;
     static {
-        beforeMatchingNameRegex(ROUND_DOUBLE_MODE_V, "RoundDoubleModeV");
+        vectorNode(ROUND_DOUBLE_MODE_V, "RoundDoubleModeV", TYPE_DOUBLE);
     }
 
     public static final String RSHIFT = PREFIX + "RSHIFT" + POSTFIX;
@@ -1006,19 +1229,29 @@ public class IRNode {
         beforeMatchingNameRegex(RSHIFT_L, "RShiftL");
     }
 
-    public static final String RSHIFT_VB = PREFIX + "RSHIFT_VB" + POSTFIX;
+    public static final String RSHIFT_VB = VECTOR_PREFIX + "RSHIFT_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(RSHIFT_VB, "RShiftVB");
+        vectorNode(RSHIFT_VB, "RShiftVB", TYPE_BYTE);
     }
 
-    public static final String RSHIFT_VS = PREFIX + "RSHIFT_VS" + POSTFIX;
+    public static final String RSHIFT_VS = VECTOR_PREFIX + "RSHIFT_VS" + POSTFIX;
     static {
-        beforeMatchingNameRegex(RSHIFT_VS, "RShiftVS");
+        vectorNode(RSHIFT_VS, "RShiftVS", TYPE_SHORT);
     }
 
-    public static final String RSHIFT_V = PREFIX + "RSHIFT_V" + POSTFIX;
+    public static final String RSHIFT_VC = VECTOR_PREFIX + "RSHIFT_VC" + POSTFIX;
     static {
-        beforeMatchingNameRegex(RSHIFT_V, "RShiftV(B|S|I|L)");
+        vectorNode(RSHIFT_VC, "RShiftVS", TYPE_CHAR); // short computation with char type
+    }
+
+    public static final String RSHIFT_VI = VECTOR_PREFIX + "RSHIFT_VI" + POSTFIX;
+    static {
+        vectorNode(RSHIFT_VI, "RShiftVI", TYPE_INT);
+    }
+
+    public static final String RSHIFT_VL = VECTOR_PREFIX + "RSHIFT_VL" + POSTFIX;
+    static {
+        vectorNode(RSHIFT_VL, "RShiftVL", TYPE_LONG);
     }
 
     public static final String SAFEPOINT = PREFIX + "SAFEPOINT" + POSTFIX;
@@ -1032,19 +1265,24 @@ public class IRNode {
         optoOnly(SCOPE_OBJECT, regex);
     }
 
-    public static final String SIGNUM_VD = PREFIX + "SIGNUM_VD" + POSTFIX;
+    public static final String SIGNUM_VD = VECTOR_PREFIX + "SIGNUM_VD" + POSTFIX;
     static {
-        beforeMatchingNameRegex(SIGNUM_VD, "SignumVD");
+        vectorNode(SIGNUM_VD, "SignumVD", TYPE_DOUBLE);
     }
 
-    public static final String SIGNUM_VF = PREFIX + "SIGNUM_VF" + POSTFIX;
+    public static final String SIGNUM_VF = VECTOR_PREFIX + "SIGNUM_VF" + POSTFIX;
     static {
-        beforeMatchingNameRegex(SIGNUM_VF, "SignumVF");
+        vectorNode(SIGNUM_VF, "SignumVF", TYPE_FLOAT);
     }
 
-    public static final String SQRT_V = PREFIX + "SQRT_V" + POSTFIX;
+    public static final String SQRT_VF = VECTOR_PREFIX + "SQRT_VF" + POSTFIX;
     static {
-        beforeMatchingNameRegex(SQRT_V, "SqrtV(F|D)");
+        vectorNode(SQRT_VF, "SqrtVF", TYPE_FLOAT);
+    }
+
+    public static final String SQRT_VD = VECTOR_PREFIX + "SQRT_VD" + POSTFIX;
+    static {
+        vectorNode(SQRT_VD, "SqrtVD", TYPE_DOUBLE);
     }
 
     public static final String STORE = PREFIX + "STORE" + POSTFIX;
@@ -1183,9 +1421,34 @@ public class IRNode {
         beforeMatchingNameRegex(SUB_L, "SubL");
     }
 
-    public static final String SUB_V = PREFIX + "SUB_V" + POSTFIX;
+    public static final String SUB_VB = VECTOR_PREFIX + "SUB_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(SUB_V, "SubV(B|S|I|L|F|D)");
+        vectorNode(SUB_VB, "SubVB", TYPE_BYTE);
+    }
+
+    public static final String SUB_VS = VECTOR_PREFIX + "SUB_VS" + POSTFIX;
+    static {
+        vectorNode(SUB_VS, "SubVS", TYPE_SHORT);
+    }
+
+    public static final String SUB_VI = VECTOR_PREFIX + "SUB_VI" + POSTFIX;
+    static {
+        vectorNode(SUB_VI, "SubVI", TYPE_INT);
+    }
+
+    public static final String SUB_VL = VECTOR_PREFIX + "SUB_VL" + POSTFIX;
+    static {
+        vectorNode(SUB_VL, "SubVL", TYPE_LONG);
+    }
+
+    public static final String SUB_VF = VECTOR_PREFIX + "SUB_VF" + POSTFIX;
+    static {
+        vectorNode(SUB_VF, "SubVF", TYPE_FLOAT);
+    }
+
+    public static final String SUB_VD = VECTOR_PREFIX + "SUB_VD" + POSTFIX;
+    static {
+        vectorNode(SUB_VD, "SubVD", TYPE_DOUBLE);
     }
 
     public static final String SUBTYPE_CHECK = PREFIX + "SUBTYPE_CHECK" + POSTFIX;
@@ -1263,9 +1526,29 @@ public class IRNode {
         beforeMatchingNameRegex(URSHIFT_S, "URShiftS");
     }
 
-    public static final String URSHIFT_V = PREFIX + "URSHIFT_V" + POSTFIX;
+    public static final String URSHIFT_VB = VECTOR_PREFIX + "URSHIFT_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(URSHIFT_V, "URShiftV(B|S|I|L)");
+        vectorNode(URSHIFT_VB, "URShiftVB", TYPE_BYTE);
+    }
+
+    public static final String URSHIFT_VS = VECTOR_PREFIX + "URSHIFT_VS" + POSTFIX;
+    static {
+        vectorNode(URSHIFT_VS, "URShiftVS", TYPE_SHORT);
+    }
+
+    public static final String URSHIFT_VC = VECTOR_PREFIX + "URSHIFT_VC" + POSTFIX;
+    static {
+        vectorNode(URSHIFT_VC, "URShiftVS", TYPE_CHAR); // short computation with char type
+    }
+
+    public static final String URSHIFT_VI = VECTOR_PREFIX + "URSHIFT_VI" + POSTFIX;
+    static {
+        vectorNode(URSHIFT_VI, "URShiftVI", TYPE_INT);
+    }
+
+    public static final String URSHIFT_VL = VECTOR_PREFIX + "URSHIFT_VL" + POSTFIX;
+    static {
+        vectorNode(URSHIFT_VL, "URShiftVL", TYPE_LONG);
     }
 
     public static final String VAND_NOT_I = PREFIX + "VAND_NOT_I" + POSTFIX;
@@ -1278,54 +1561,199 @@ public class IRNode {
         machOnlyNameRegex(VAND_NOT_L, "vand_notL");
     }
 
-    public static final String VECTOR_BLEND = PREFIX + "VECTOR_BLEND" + POSTFIX;
+    public static final String VECTOR_BLEND_B = VECTOR_PREFIX + "VECTOR_BLEND_B" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_BLEND, "VectorBlend");
+        vectorNode(VECTOR_BLEND_B, "VectorBlend", TYPE_BYTE);
     }
 
-    public static final String VECTOR_MASK_CMP = PREFIX + "VECTOR_MASK_CMP" + POSTFIX;
+    public static final String VECTOR_BLEND_F = VECTOR_PREFIX + "VECTOR_BLEND_F" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_MASK_CMP, "VectorMaskCmp");
+        vectorNode(VECTOR_BLEND_F, "VectorBlend", TYPE_FLOAT);
     }
 
-    public static final String VECTOR_CAST_B2X = PREFIX + "VECTOR_CAST_B2X" + POSTFIX;
+    public static final String VECTOR_BLEND_D = VECTOR_PREFIX + "VECTOR_BLEND_D" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_CAST_B2X, "VectorCastB2X");
+        vectorNode(VECTOR_BLEND_D, "VectorBlend", TYPE_DOUBLE);
     }
 
-    public static final String VECTOR_CAST_D2X = PREFIX + "VECTOR_CAST_D2X" + POSTFIX;
+    public static final String VECTOR_MASK_CMP_I = VECTOR_PREFIX + "VECTOR_MASK_CMP_I" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_CAST_D2X, "VectorCastD2X");
+        vectorNode(VECTOR_MASK_CMP_I, "VectorMaskCmp", TYPE_INT);
     }
 
-    public static final String VECTOR_CAST_F2X = PREFIX + "VECTOR_CAST_F2X" + POSTFIX;
+    public static final String VECTOR_MASK_CMP_L = VECTOR_PREFIX + "VECTOR_MASK_CMP_L" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_CAST_F2X, "VectorCastF2X");
+        vectorNode(VECTOR_MASK_CMP_L, "VectorMaskCmp", TYPE_LONG);
     }
 
-    public static final String VECTOR_CAST_I2X = PREFIX + "VECTOR_CAST_I2X" + POSTFIX;
+    public static final String VECTOR_MASK_CMP_F = VECTOR_PREFIX + "VECTOR_MASK_CMP_F" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_CAST_I2X, "VectorCastI2X");
+        vectorNode(VECTOR_MASK_CMP_F, "VectorMaskCmp", TYPE_FLOAT);
     }
 
-    public static final String VECTOR_CAST_L2X = PREFIX + "VECTOR_CAST_L2X" + POSTFIX;
+    public static final String VECTOR_MASK_CMP_D = VECTOR_PREFIX + "VECTOR_MASK_CMP_D" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_CAST_L2X, "VectorCastL2X");
+        vectorNode(VECTOR_MASK_CMP_D, "VectorMaskCmp", TYPE_DOUBLE);
     }
 
-    public static final String VECTOR_CAST_S2X = PREFIX + "VECTOR_CAST_S2X" + POSTFIX;
+    public static final String VECTOR_CAST_B2S = VECTOR_PREFIX + "VECTOR_CAST_B2S" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_CAST_S2X, "VectorCastS2X");
+        vectorNode(VECTOR_CAST_B2S, "VectorCastB2X", TYPE_SHORT);
     }
 
-    public static final String VECTOR_CAST_F2HF = PREFIX + "VECTOR_CAST_F2HF" + POSTFIX;
+    public static final String VECTOR_CAST_B2I = VECTOR_PREFIX + "VECTOR_CAST_B2I" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_CAST_F2HF, "VectorCastF2HF");
+        vectorNode(VECTOR_CAST_B2I, "VectorCastB2X", TYPE_INT);
     }
 
-    public static final String VECTOR_CAST_HF2F = PREFIX + "VECTOR_CAST_HF2F" + POSTFIX;
+    public static final String VECTOR_CAST_B2L = VECTOR_PREFIX + "VECTOR_CAST_B2L" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_CAST_HF2F, "VectorCastHF2F");
+        vectorNode(VECTOR_CAST_B2L, "VectorCastB2X", TYPE_LONG);
+    }
+
+    public static final String VECTOR_CAST_B2F = VECTOR_PREFIX + "VECTOR_CAST_B2F" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_B2F, "VectorCastB2X", TYPE_FLOAT);
+    }
+
+    public static final String VECTOR_CAST_B2D = VECTOR_PREFIX + "VECTOR_CAST_B2D" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_B2D, "VectorCastB2X", TYPE_DOUBLE);
+    }
+
+    public static final String VECTOR_CAST_D2B = VECTOR_PREFIX + "VECTOR_CAST_D2B" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_D2B, "VectorCastD2X", TYPE_BYTE);
+    }
+
+    public static final String VECTOR_CAST_D2S = VECTOR_PREFIX + "VECTOR_CAST_D2S" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_D2S, "VectorCastD2X", TYPE_SHORT);
+    }
+
+    public static final String VECTOR_CAST_D2I = VECTOR_PREFIX + "VECTOR_CAST_D2I" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_D2I, "VectorCastD2X", TYPE_INT);
+    }
+
+    public static final String VECTOR_CAST_D2L = VECTOR_PREFIX + "VECTOR_CAST_D2L" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_D2L, "VectorCastD2X", TYPE_LONG);
+    }
+
+    public static final String VECTOR_CAST_D2F = VECTOR_PREFIX + "VECTOR_CAST_D2F" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_D2F, "VectorCastD2X", TYPE_FLOAT);
+    }
+
+    public static final String VECTOR_CAST_F2B = VECTOR_PREFIX + "VECTOR_CAST_F2B" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_F2B, "VectorCastF2X", TYPE_BYTE);
+    }
+
+    public static final String VECTOR_CAST_F2S = VECTOR_PREFIX + "VECTOR_CAST_F2S" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_F2S, "VectorCastF2X", TYPE_SHORT);
+    }
+
+    public static final String VECTOR_CAST_F2I = VECTOR_PREFIX + "VECTOR_CAST_F2I" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_F2I, "VectorCastF2X", TYPE_INT);
+    }
+
+    public static final String VECTOR_CAST_F2L = VECTOR_PREFIX + "VECTOR_CAST_F2L" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_F2L, "VectorCastF2X", TYPE_LONG);
+    }
+
+    public static final String VECTOR_CAST_F2D = VECTOR_PREFIX + "VECTOR_CAST_F2D" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_F2D, "VectorCastF2X", TYPE_DOUBLE);
+    }
+
+    public static final String VECTOR_CAST_I2B = VECTOR_PREFIX + "VECTOR_CAST_I2B" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_I2B, "VectorCastI2X", TYPE_BYTE);
+    }
+
+    public static final String VECTOR_CAST_I2S = VECTOR_PREFIX + "VECTOR_CAST_I2S" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_I2S, "VectorCastI2X", TYPE_SHORT);
+    }
+
+    public static final String VECTOR_CAST_I2L = VECTOR_PREFIX + "VECTOR_CAST_I2L" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_I2L, "VectorCastI2X", TYPE_LONG);
+    }
+
+    public static final String VECTOR_CAST_I2F = VECTOR_PREFIX + "VECTOR_CAST_I2F" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_I2F, "VectorCastI2X", TYPE_FLOAT);
+    }
+
+    public static final String VECTOR_CAST_I2D = VECTOR_PREFIX + "VECTOR_CAST_I2D" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_I2D, "VectorCastI2X", TYPE_DOUBLE);
+    }
+
+    public static final String VECTOR_CAST_L2B = VECTOR_PREFIX + "VECTOR_CAST_L2B" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_L2B, "VectorCastL2X", TYPE_BYTE);
+    }
+
+    public static final String VECTOR_CAST_L2S = VECTOR_PREFIX + "VECTOR_CAST_L2S" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_L2S, "VectorCastL2X", TYPE_SHORT);
+    }
+
+    public static final String VECTOR_CAST_L2I = VECTOR_PREFIX + "VECTOR_CAST_L2I" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_L2I, "VectorCastL2X", TYPE_INT);
+    }
+
+    public static final String VECTOR_CAST_L2F = VECTOR_PREFIX + "VECTOR_CAST_L2F" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_L2F, "VectorCastL2X", TYPE_FLOAT);
+    }
+
+    public static final String VECTOR_CAST_L2D = VECTOR_PREFIX + "VECTOR_CAST_L2D" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_L2D, "VectorCastL2X", TYPE_DOUBLE);
+    }
+
+    public static final String VECTOR_CAST_S2B = VECTOR_PREFIX + "VECTOR_CAST_S2B" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_S2B, "VectorCastS2X", TYPE_BYTE);
+    }
+
+    public static final String VECTOR_CAST_S2I = VECTOR_PREFIX + "VECTOR_CAST_S2I" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_S2I, "VectorCastS2X", TYPE_INT);
+    }
+
+    public static final String VECTOR_CAST_S2L = VECTOR_PREFIX + "VECTOR_CAST_S2L" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_S2L, "VectorCastS2X", TYPE_LONG);
+    }
+
+    public static final String VECTOR_CAST_S2F = VECTOR_PREFIX + "VECTOR_CAST_S2F" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_S2F, "VectorCastS2X", TYPE_FLOAT);
+    }
+
+    public static final String VECTOR_CAST_S2D = VECTOR_PREFIX + "VECTOR_CAST_S2D" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_S2D, "VectorCastS2X", TYPE_DOUBLE);
+    }
+
+    public static final String VECTOR_CAST_F2HF = VECTOR_PREFIX + "VECTOR_CAST_F2HF" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_F2HF, "VectorCastF2HF", TYPE_SHORT);
+    }
+
+    public static final String VECTOR_CAST_HF2F = VECTOR_PREFIX + "VECTOR_CAST_HF2F" + POSTFIX;
+    static {
+        vectorNode(VECTOR_CAST_HF2F, "VectorCastHF2F", TYPE_FLOAT);
     }
 
     public static final String VECTOR_MASK_CAST = PREFIX + "VECTOR_MASK_CAST" + POSTFIX;
@@ -1338,19 +1766,34 @@ public class IRNode {
         beforeMatchingNameRegex(VECTOR_REINTERPRET, "VectorReinterpret");
     }
 
-    public static final String VECTOR_UCAST_B2X = PREFIX + "VECTOR_UCAST_B2X" + POSTFIX;
+    public static final String VECTOR_UCAST_B2S = VECTOR_PREFIX + "VECTOR_UCAST_B2S" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_UCAST_B2X, "VectorUCastB2X");
+        vectorNode(VECTOR_UCAST_B2S, "VectorUCastB2X", TYPE_SHORT);
     }
 
-    public static final String VECTOR_UCAST_I2X = PREFIX + "VECTOR_UCAST_I2X" + POSTFIX;
+    public static final String VECTOR_UCAST_B2I = VECTOR_PREFIX + "VECTOR_UCAST_B2I" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_UCAST_I2X, "VectorUCastI2X");
+        vectorNode(VECTOR_UCAST_B2I, "VectorUCastB2X", TYPE_INT);
     }
 
-    public static final String VECTOR_UCAST_S2X = PREFIX + "VECTOR_UCAST_S2X" + POSTFIX;
+    public static final String VECTOR_UCAST_B2L = VECTOR_PREFIX + "VECTOR_UCAST_B2L" + POSTFIX;
     static {
-        beforeMatchingNameRegex(VECTOR_UCAST_S2X, "VectorUCastS2X");
+        vectorNode(VECTOR_UCAST_B2L, "VectorUCastB2X", TYPE_LONG);
+    }
+
+    public static final String VECTOR_UCAST_I2L = VECTOR_PREFIX + "VECTOR_UCAST_I2L" + POSTFIX;
+    static {
+        vectorNode(VECTOR_UCAST_I2L, "VectorUCastI2X", TYPE_LONG);
+    }
+
+    public static final String VECTOR_UCAST_S2I = VECTOR_PREFIX + "VECTOR_UCAST_S2I" + POSTFIX;
+    static {
+        vectorNode(VECTOR_UCAST_S2I, "VectorUCastS2X", TYPE_INT);
+    }
+
+    public static final String VECTOR_UCAST_S2L = VECTOR_PREFIX + "VECTOR_UCAST_S2L" + POSTFIX;
+    static {
+        vectorNode(VECTOR_UCAST_S2L, "VectorUCastS2X", TYPE_LONG);
     }
 
     public static final String VECTOR_TEST = PREFIX + "VECTOR_TEST" + POSTFIX;
@@ -1498,9 +1941,24 @@ public class IRNode {
         beforeMatchingNameRegex(XOR_L, "XorL");
     }
 
-    public static final String XOR_V = PREFIX + "XOR_V" + POSTFIX;
+    public static final String XOR_VB = VECTOR_PREFIX + "XOR_VB" + POSTFIX;
     static {
-        beforeMatchingNameRegex(XOR_V, "XorV");
+        vectorNode(XOR_VB, "XorV", TYPE_BYTE);
+    }
+
+    public static final String XOR_VS = VECTOR_PREFIX + "XOR_VS" + POSTFIX;
+    static {
+        vectorNode(XOR_VS, "XorV", TYPE_SHORT);
+    }
+
+    public static final String XOR_VI = VECTOR_PREFIX + "XOR_VI" + POSTFIX;
+    static {
+        vectorNode(XOR_VI, "XorV", TYPE_INT);
+    }
+
+    public static final String XOR_VL = VECTOR_PREFIX + "XOR_VL" + POSTFIX;
+    static {
+        vectorNode(XOR_VL, "XorV", TYPE_LONG);
     }
 
     public static final String XOR_V_MASK = PREFIX + "XOR_V_MASK" + POSTFIX;
@@ -1523,14 +1981,24 @@ public class IRNode {
         machOnlyNameRegex(XOR3_SVE, "veor3_sve");
     }
 
-    public static final String COMPRESS_BITSV = PREFIX + "COMPRESS_BITSV" + POSTFIX;
+    public static final String COMPRESS_BITS_VI = VECTOR_PREFIX + "COMPRESS_BITS_VI" + POSTFIX;
     static {
-        beforeMatchingNameRegex(COMPRESS_BITSV, "CompressBitsV");
+        vectorNode(COMPRESS_BITS_VI, "CompressBitsV", TYPE_INT);
     }
 
-    public static final String EXPAND_BITSV = PREFIX + "EXPAND_BITSV" + POSTFIX;
+    public static final String COMPRESS_BITS_VL = VECTOR_PREFIX + "COMPRESS_BITS_VL" + POSTFIX;
     static {
-        beforeMatchingNameRegex(EXPAND_BITSV, "ExpandBitsV");
+        vectorNode(COMPRESS_BITS_VL, "CompressBitsV", TYPE_LONG);
+    }
+
+    public static final String EXPAND_BITS_VI = VECTOR_PREFIX + "EXPAND_BITS_VI" + POSTFIX;
+    static {
+        vectorNode(EXPAND_BITS_VI, "ExpandBitsV", TYPE_INT);
+    }
+
+    public static final String EXPAND_BITS_VL = VECTOR_PREFIX + "EXPAND_BITS_VL" + POSTFIX;
+    static {
+        vectorNode(EXPAND_BITS_VL, "ExpandBitsV", TYPE_LONG);
     }
 
     public static final String Z_LOAD_P_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "Z_LOAD_P_WITH_BARRIER_FLAG" + POSTFIX;
@@ -1570,6 +2038,20 @@ public class IRNode {
     private static void beforeMatchingNameRegex(String irNodePlaceholder, String irNodeRegex) {
         String regex = START + irNodeRegex + MID + END;
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new RegexTypeEntry(RegexType.IDEAL_INDEPENDENT, regex));
+    }
+
+    /**
+     * Apply {@code irNodeRegex} as regex for the IR vector node name on all machine independent ideal graph phases up to and
+     * including {@link CompilePhase#BEFORE_MATCHING}. Since this is a vector node, we can also check the vector element
+     * type {@code typeString} and the vector size (number of elements), {@see VECTOR_SIZE}.
+     */
+    private static void vectorNode(String irNodePlaceholder, String irNodeRegex, String typeString) {
+        TestFramework.check(isVectorIRNode(irNodePlaceholder), "vectorNode: failed prefix check for irNodePlaceholder "
+                                                               + irNodePlaceholder + " -> did you use VECTOR_PREFIX?");
+        // IS_REPLACED is later replaced with the specific type and size of the vector.
+        String regex = START + irNodeRegex + MID  + IS_REPLACED + END;
+        IR_NODE_MAPPINGS.put(irNodePlaceholder, new RegexTypeEntry(RegexType.IDEAL_INDEPENDENT, regex));
+        VECTOR_NODE_TYPE.put(irNodePlaceholder, typeString);
     }
 
     private static void allocNodes(String irNode, String irNodeName, String optoRegex) {
@@ -1688,6 +2170,149 @@ public class IRNode {
     }
 
     /**
+     * Is {@code irVectorNodeString} an IR vector node placeholder string?
+     */
+    public static boolean isVectorIRNode(String irVectorNodeString) {
+        return irVectorNodeString.startsWith(VECTOR_PREFIX);
+    }
+
+    /**
+     * Is {@code irVectorSizeString} a vector size string?
+     */
+    public static boolean isVectorSize(String irVectorSizeString) {
+        return irVectorSizeString.startsWith(VECTOR_SIZE);
+    }
+
+    /**
+     * Parse {@code sizeString} and generate a regex pattern to match for the size in the IR dump.
+     */
+    public static String parseVectorNodeSize(String sizeString, String typeString, VMInfo vmInfo) {
+        if (sizeString.equals(VECTOR_SIZE_TAG_ANY)) {
+            return "\\\\d+"; // match with any number
+        }
+        // Try to parse any tags, convert to comma separated list of ints
+        sizeString = parseVectorNodeSizeTag(sizeString, typeString, vmInfo);
+        // Parse comma separated list of numbers
+        String[] sizes = sizeString.split(",");
+        String regex = "";
+        for (int i = 0; i < sizes.length; i++) {
+            int size = 0;
+            try {
+                size = Integer.parseInt(sizes[i]);
+            } catch (NumberFormatException e) {
+                throw new TestFormatException("Vector node has invalid size \"" + sizes[i] + "\", in \"" + sizeString + "\"");
+            }
+            TestFormat.checkNoReport(size > 1, "Vector node size must be 2 or larger, but got \"" + sizes[i] + "\", in \"" + sizeString + "\"");
+            regex += ((i > 0) ? "|" : "") + size;
+        }
+        if (sizes.length > 1) {
+           regex = "(" + regex + ")";
+        }
+        return regex;
+    }
+
+    /**
+     * If {@code sizeTagString} is a size tag, return the list of accepted sizes, else return sizeTagString.
+     */
+    public static String parseVectorNodeSizeTag(String sizeTagString, String typeString, VMInfo vmInfo) {
+        // Parse out "min(a,b,c,...)"
+        if (sizeTagString.startsWith("min(") && sizeTagString.endsWith(")")) {
+            return parseVectorNodeSizeTagMin(sizeTagString, typeString, vmInfo);
+        }
+
+        // Parse individual tags
+        return switch (sizeTagString) {
+            case VECTOR_SIZE_TAG_MAX -> String.valueOf(getMaxElementsForType(typeString, vmInfo));
+            case "max_byte"          -> String.valueOf(getMaxElementsForType(TYPE_BYTE, vmInfo));
+            case "max_char"          -> String.valueOf(getMaxElementsForType(TYPE_CHAR, vmInfo));
+            case "max_short"         -> String.valueOf(getMaxElementsForType(TYPE_SHORT, vmInfo));
+            case "max_int"           -> String.valueOf(getMaxElementsForType(TYPE_INT, vmInfo));
+            case "max_long"          -> String.valueOf(getMaxElementsForType(TYPE_LONG, vmInfo));
+            case "max_float"         -> String.valueOf(getMaxElementsForType(TYPE_FLOAT, vmInfo));
+            case "max_double"        -> String.valueOf(getMaxElementsForType(TYPE_DOUBLE, vmInfo));
+            case "LoopMaxUnroll"     -> String.valueOf(vmInfo.getLongValue("LoopMaxUnroll"));
+            default                  -> sizeTagString;
+        };
+    }
+
+    /**
+     * Parse {@code sizeTagString}, which must be a min-clause.
+     */
+    public static String parseVectorNodeSizeTagMin(String sizeTagString, String typeString, VMInfo vmInfo) {
+        String[] tags = sizeTagString.substring(4, sizeTagString.length() - 1).split(",");
+        TestFormat.checkNoReport(tags.length > 1, "Vector node size \"min(...)\" must have at least 2 comma separated arguments, got \"" + sizeTagString + "\"");
+        int minVal = 1024;
+        for (int i = 0; i < tags.length; i++) {
+            String tag = parseVectorNodeSizeTag(tags[i].trim(), typeString, vmInfo);
+            int tag_val = 0;
+            try {
+                tag_val = Integer.parseInt(tag);
+            } catch (NumberFormatException e) {
+                throw new TestFormatException("Vector node has invalid size in \"min(...)\", argument " + i + ", \"" + tag + "\", in \"" + sizeTagString + "\"");
+            }
+            minVal = Math.min(minVal, tag_val);
+        }
+        return String.valueOf(minVal);
+    }
+
+    /**
+     * Return maximal number of elements that can fit in a vector of the specified type.
+     */
+    public static long getMaxElementsForType(String typeString, VMInfo vmInfo) {
+        long maxVectorSize = vmInfo.getLongValue("MaxVectorSize");
+        TestFormat.checkNoReport(maxVectorSize > 0, "VMInfo: MaxVectorSize is not larger than zero");
+        long maxBytes = maxVectorSize;
+
+        if (Platform.isX64() || Platform.isX86()) {
+            maxBytes = Math.min(maxBytes, getMaxElementsForTypeOnX86(typeString, vmInfo));
+        }
+
+        // compute elements per vector: vector bytes divided by bytes per element
+        int bytes = getTypeSizeInBytes(typeString);
+        return maxBytes / bytes;
+    }
+
+    /**
+     * Return maximal number of elements that can fit in a vector of the specified type, on x86 / x64.
+     */
+    public static long getMaxElementsForTypeOnX86(String typeString, VMInfo vmInfo) {
+        // restrict maxBytes for specific features, see Matcher::vector_width_in_bytes in x86.ad:
+        boolean avx1 = vmInfo.hasCPUFeature("avx");
+        boolean avx2 = vmInfo.hasCPUFeature("avx2");
+        boolean avx512 = vmInfo.hasCPUFeature("avx512f");
+        boolean avx512bw = vmInfo.hasCPUFeature("avx512bw");
+        long maxBytes;
+        if (avx512) {
+            maxBytes = 64;
+        } else if (avx2) {
+            maxBytes = 32;
+        } else {
+            maxBytes = 16;
+        }
+        if (avx1 && (typeString.equals(TYPE_FLOAT) || typeString.equals(TYPE_DOUBLE))) {
+            maxBytes = avx512 ? 64 : 32;
+        }
+        if (avx512 && (typeString.equals(TYPE_BYTE) || typeString.equals(TYPE_SHORT) || typeString.equals(TYPE_CHAR))) {
+            maxBytes = avx512bw ? 64 : 32;
+        }
+
+        return maxBytes;
+    }
+
+    /**
+     * Return size in bytes of type named by {@code typeString}, return 0 if it does not name a type.
+     */
+    public static int getTypeSizeInBytes(String typeString) {
+        return switch (typeString) {
+            case TYPE_BYTE              -> 1;
+            case TYPE_CHAR, TYPE_SHORT  -> 2;
+            case TYPE_INT, TYPE_FLOAT   -> 4;
+            case TYPE_LONG, TYPE_DOUBLE -> 8;
+            default                     -> 0;
+        };
+    }
+
+    /**
      * Returns "IRNode.XYZ", where XYZ is one of the IR node placeholder variable names defined above.
      */
     public static String getIRNodeAccessString(String irNodeString) {
@@ -1696,6 +2321,10 @@ public class IRNode {
             TestFramework.check(irNodeString.length() > COMPOSITE_PREFIX.length() + POSTFIX.length(),
                                 "Invalid composite node placeholder: " + irNodeString);
             prefixLength = COMPOSITE_PREFIX.length();
+        } else if (isVectorIRNode(irNodeString)) {
+            TestFramework.check(irNodeString.length() > VECTOR_PREFIX.length() + POSTFIX.length(),
+                                "Invalid vector node placeholder: " + irNodeString);
+            prefixLength = VECTOR_PREFIX.length();
         } else {
             prefixLength = PREFIX.length();
         }
@@ -1769,5 +2398,12 @@ public class IRNode {
                          "   Violation";
         TestFormat.checkNoReport(entry != null, failMsg);
         return entry.defaultCompilePhase();
+    }
+
+    public static String getVectorNodeType(String irNode) {
+        String typeString = VECTOR_NODE_TYPE.get(irNode);
+        String failMsg = "\"" + irNode + "\" is not a Vector IR node defined in class IRNode";
+        TestFormat.check(typeString != null, failMsg);
+        return typeString;
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -71,6 +71,26 @@ public void test() {
 }
 ```
 
+#### Vector IR Nodes
+For vector nodes, we not only check for the presence of the node, but also its type and size (number of elements in the vector). Every node has an associated type, for example `IRNode.LOAD_VECTOR_I` has type `int` and `IRNode.LOAD_VECTOR_F` has type `float`. The size can be explicitly specified as an additional argument. For example:
+
+```
+@IR(counts = {IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_16, "> 0"},
+    applyIf = {"MaxVectorSize", "=64"},
+    applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+static float[] test() {
+    float[] a = new float[1024*8];
+    for (int i = 0; i < a.length; i++) {
+        a[i]++;
+    }
+    return a;
+}
+```
+
+However, the size does not have to be specified. In most cases, one either wants to have vectorization at the maximal possible vector width, or no vectorization at all. Hence, for lower bound counts ('>' or '>=') and equal count comparisons with strictly positive count (e.g. "=2") the default size is `IRNode.VECTOR_SIZE_MAX`, and for upper bound counts ('<' or '<=' or '=0' or failOn) the default is `IRNode.VECTOR_SIZE_ANY`. On machines with 'canTrustVectorSize == false' (default Cascade Lake) the maximal vector width is not predictable currently (32 byte for SuperWord and 64 byte for VectorAPI). Hence, on such a machine we have to automatically weaken the IR rules. All lower bound counts are performed checking with `IRNode.VECTOR_SIZE_ANY`. Upper bound counts with no user specified size are performed with `IRNode.VECTOR_SIZE_ANY` but upper bound counts with a user specified size are not checked at all. Equal count comparisons with strictly positive count are also not checked at all. Details and reasoning can be found in [RawIRNode](./driver/irmatching/irrule/checkattribute/parsing/RawIRNode.java).
+
+More examples can be found in [IRExample](../../../testlibrary_tests/ir_framework/examples/IRExample.java). You can also find many examples in the Vector API and SuperWord tests, when searching for `IRNode.VECTOR_SIZE` or `IRNode.LOAD_VECTOR`.
+
 #### User-defined Regexes
 
 The user can also directly specify user-defined regexes in combination with a required compile phase (there is no default compile phase known by the framework for custom regexes). If such a user-defined regex represents a not yet supported C2 IR node, it is highly encouraged to directly add a new IR node placeholder string definition to [IRNode](./IRNode.java) for it instead together with a static regex mapping block.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/SuccessOnlyConstraintException.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/SuccessOnlyConstraintException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework.driver;
+
+import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
+
+/**
+ * Exception used to signal that a {@link Constraint} should always succeed.
+ */
+public class SuccessOnlyConstraintException extends RuntimeException {
+    public SuccessOnlyConstraintException(String message) {
+        super("Unhandled SuccessOnlyConstraintException, should have created a Constraint that always succeeds:" + System.lineSeparator() + message);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irmethod/IRMethod.java
@@ -31,6 +31,7 @@ import compiler.lib.ir_framework.driver.irmatching.MatchResult;
 import compiler.lib.ir_framework.driver.irmatching.Matchable;
 import compiler.lib.ir_framework.driver.irmatching.MatchableMatcher;
 import compiler.lib.ir_framework.driver.irmatching.irrule.IRRule;
+import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
 import compiler.lib.ir_framework.shared.TestFormat;
 import compiler.lib.ir_framework.shared.TestFormatException;
 
@@ -50,16 +51,16 @@ public class IRMethod implements IRMethodMatchable {
     private final Method method;
     private final MatchableMatcher matcher;
 
-    public IRMethod(Method method, int[] ruleIds, IR[] irAnnos, Compilation compilation) {
+    public IRMethod(Method method, int[] ruleIds, IR[] irAnnos, Compilation compilation, VMInfo vmInfo) {
         this.method = method;
-        this.matcher = new MatchableMatcher(createIRRules(method, ruleIds, irAnnos, compilation));
+        this.matcher = new MatchableMatcher(createIRRules(method, ruleIds, irAnnos, compilation, vmInfo));
     }
 
-    private List<Matchable> createIRRules(Method method, int[] ruleIds, IR[] irAnnos, Compilation compilation) {
+    private List<Matchable> createIRRules(Method method, int[] ruleIds, IR[] irAnnos, Compilation compilation, VMInfo vmInfo) {
         List<Matchable> irRules = new ArrayList<>();
         for (int ruleId : ruleIds) {
             try {
-                irRules.add(new IRRule(ruleId, irAnnos[ruleId - 1], compilation));
+                irRules.add(new IRRule(ruleId, irAnnos[ruleId - 1], compilation, vmInfo));
             } catch (TestFormatException e) {
                 String postfixErrorMsg = " for IR rule " + ruleId + " at " + method + ".";
                 TestFormat.failNoThrow(e.getMessage() + postfixErrorMsg);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/IRRule.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/IRRule.java
@@ -31,6 +31,7 @@ import compiler.lib.ir_framework.driver.irmatching.Matchable;
 import compiler.lib.ir_framework.driver.irmatching.MatchableMatcher;
 import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseIRRule;
 import compiler.lib.ir_framework.driver.irmatching.irrule.phase.CompilePhaseIRRuleBuilder;
+import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
 
 /**
  * This class represents a generic {@link IR @IR} rule of an IR method. It contains a list of compile phase specific
@@ -44,10 +45,10 @@ public class IRRule implements Matchable {
     private final IR irAnno;
     private final MatchableMatcher matcher;
 
-    public IRRule(int ruleId, IR irAnno, Compilation compilation) {
+    public IRRule(int ruleId, IR irAnno, Compilation compilation, VMInfo vmInfo) {
         this.ruleId = ruleId;
         this.irAnno = irAnno;
-        this.matcher = new MatchableMatcher(new CompilePhaseIRRuleBuilder(irAnno, compilation).build());
+        this.matcher = new MatchableMatcher(new CompilePhaseIRRuleBuilder(irAnno, compilation).build(vmInfo));
     }
 
     @Override

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/checkattribute/parsing/CheckAttributeReader.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/checkattribute/parsing/CheckAttributeReader.java
@@ -60,16 +60,34 @@ public class CheckAttributeReader<R> {
 
     public final CheckAttributeString readUserPostfix(String node) {
         if (IRNode.isCompositeIRNode(node)) {
-            String irNode = IRNode.getIRNodeAccessString(node);
-            int nextIndex = iterator.nextIndex();
-            TestFormat.checkNoReport(iterator.hasNext(), "Must provide additional value at index " +
-                                                         nextIndex + " right after " + irNode);
-            CheckAttributeString userPostfix = new CheckAttributeString(iterator.next());
-            TestFormat.checkNoReport(userPostfix.isValidUserPostfix(), "Provided empty string for composite node " +
-                                                                       irNode + " at index " + nextIndex);
-            return userPostfix;
+            return readUserPostfixForCompositeIRNode(node);
+        } else if (IRNode.isVectorIRNode(node)) {
+            return readUserPostfixForVectorIRNode(node);
         } else {
             return CheckAttributeString.invalid();
         }
+    }
+
+    private final CheckAttributeString readUserPostfixForCompositeIRNode(String node) {
+        String irNode = IRNode.getIRNodeAccessString(node);
+        int nextIndex = iterator.nextIndex();
+        TestFormat.checkNoReport(iterator.hasNext(), "Must provide additional value at index " +
+                                                     nextIndex + " right after " + irNode);
+        CheckAttributeString userPostfix = new CheckAttributeString(iterator.next());
+        TestFormat.checkNoReport(userPostfix.isValidUserPostfix(), "Provided empty string for composite node " +
+                                                                   irNode + " at index " + nextIndex);
+        return userPostfix;
+    }
+
+    private final CheckAttributeString readUserPostfixForVectorIRNode(String node) {
+        if (iterator.hasNext()) {
+            String maybeVectorType = iterator.next();
+            if (IRNode.isVectorSize(maybeVectorType)) {
+                return new CheckAttributeString(maybeVectorType);
+            }
+            // If we do not find that pattern, then revert the iterator once
+            iterator.previous();
+        }
+        return CheckAttributeString.invalid();
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/checkattribute/parsing/RawIRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/checkattribute/parsing/RawIRNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,10 @@ package compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.parsin
 
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IRNode;
+import compiler.lib.ir_framework.shared.Comparison;
+import compiler.lib.ir_framework.shared.TestFormat;
+import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
+import compiler.lib.ir_framework.driver.SuccessOnlyConstraintException;
 
 /**
  * This class represents a "raw IR node" as read from a check attribute. It has a node part that either represents an
@@ -51,14 +55,85 @@ public class RawIRNode {
         return IRNode.getDefaultPhase(node);
     }
 
-    public String regex(CompilePhase compilePhase) {
+    public String regex(CompilePhase compilePhase, VMInfo vmInfo, Comparison.Bound bound) {
         String nodeRegex = node;
         if (IRNode.isIRNode(node)) {
             nodeRegex = IRNode.getRegexForCompilePhase(node, compilePhase);
-            if (userPostfix.isValid()) {
+            if (IRNode.isVectorIRNode(node)) {
+                nodeRegex = regexForVectorIRNode(nodeRegex, vmInfo, bound);
+            } else if (userPostfix.isValid()) {
                 nodeRegex = nodeRegex.replaceAll(IRNode.IS_REPLACED, userPostfix.value());
             }
         }
         return nodeRegex;
+    }
+
+    private String regexForVectorIRNode(String nodeRegex, VMInfo vmInfo, Comparison.Bound bound) {
+        String type = IRNode.getVectorNodeType(node);
+        TestFormat.checkNoReport(IRNode.getTypeSizeInBytes(type) > 0,
+                                 "Vector node's type must have valid type, got \"" + type + "\" for \"" + node + "\"");
+        String size = null;
+        if (userPostfix.isValid()) {
+            // Size is explicitly stated
+            String value = userPostfix.value();
+            TestFormat.checkNoReport(value.startsWith(IRNode.VECTOR_SIZE),
+                                     "Vector node's vector size must start with IRNode.VECTOR_SIZE, got: \"" + value + "\"");
+            size = value.substring(2);
+
+            if (!vmInfo.canTrustVectorSize()) {
+                // Parse it already just to get errors before we overwrite size
+                IRNode.parseVectorNodeSize(size, type, vmInfo);
+            }
+        }
+
+        // Set default values in some cases:
+        if (!userPostfix.isValid() || !vmInfo.canTrustVectorSize()) {
+            switch (bound) {
+                case LOWER -> {
+                    // For lower bound we check for the maximal size by default. But if we cannot trust the
+                    // vector size we at least check there are vectors of any size.
+                    if (vmInfo.canTrustVectorSize()) {
+                        // No size specified, so assume maximal size
+                        size = IRNode.VECTOR_SIZE_TAG_MAX;
+                    } else {
+                        System.out.println("WARNING: you are on a system with \"canTrustVectorSize == false\" (default Cascade Lake).");
+                        System.out.println("         The lower bound rule for \"" + node + "\" is now performed with");
+                        System.out.println("         \"IRNode.VECTOR_SIZE_TAG_ANY\" instead of \"IRNode.VECTOR_SIZE_TAG_MAX\".");
+                        size = IRNode.VECTOR_SIZE_TAG_ANY;
+                    }
+                }
+                case UPPER -> {
+                    if (userPostfix.isValid()) {
+                        TestFormat.checkNoReport(!vmInfo.canTrustVectorSize(), "sanity");
+                        // If we have a size specified but cannot trust the size, and must check an upper
+                        // bound, this can be impossible to count correctly - if we have an incorrect size
+                        // we may count either too many nodes. We just create an impossible regex which will
+                        // always have count zero and make the upper bound rule pass.
+                        System.out.println("WARNING: you are on a system with \"canTrustVectorSize == false\" (default Cascade Lake).");
+                        System.out.println("         The upper bound rule for \"" + node + "\" cannot be checked.");
+                        throw new SuccessOnlyConstraintException("upper bound with specified size");
+                    } else {
+                        // For upper bound we check for vectors of any size by default.
+                        size = IRNode.VECTOR_SIZE_TAG_ANY;
+                    }
+                }
+                case EQUAL -> {
+                    if (vmInfo.canTrustVectorSize()) {
+                        // No size specified, so assume maximal size
+                        size = IRNode.VECTOR_SIZE_TAG_MAX;
+                    } else {
+                        // Equal comparison to a strictly positive number would lead us to an impossible
+                        // situation: we might have to know the exact vector size or else we count too many
+                        // or too few cases. We therefore skip such a constraint and treat it as success.
+                        System.out.println("WARNING: you are on a system with \"canTrustVectorSize == false\" (default Cascade Lake).");
+                        System.out.println("         The equal count comparison rule for \"" + node + "\" cannot be checked.");
+                        throw new SuccessOnlyConstraintException("equal count comparison");
+                    }
+                }
+            }
+        }
+        String sizeRegex = IRNode.parseVectorNodeSize(size, type, vmInfo);
+        return nodeRegex.replaceAll(IRNode.IS_REPLACED,
+                                    "vector[A-Za-z]\\\\[" + sizeRegex + "\\\\]:\\\\{" + type + "\\\\}");
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/Constraint.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/Constraint.java
@@ -61,6 +61,12 @@ public class Constraint implements Matchable {
         return new Constraint(new CountsConstraintCheck(nodeRegex, constraintId, comparison), nodeRegex, compilationOutput);
     }
 
+    public static Constraint createSuccess() {
+        String nodeRegex = "impossible_regex";
+        String compilationOutput = ""; // empty
+        return new Constraint(new SuccessConstraintCheck(), nodeRegex, compilationOutput);
+    }
+
     public String nodeRegex() {
         return nodeRegex;
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/SuccessConstraintCheck.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/SuccessConstraintCheck.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework.driver.irmatching.irrule.constraint;
+
+import compiler.lib.ir_framework.driver.irmatching.MatchResult;
+
+import java.util.List;
+
+/**
+ * This class provides a check that always succeeds.
+ *
+ * @see Constraint
+ */
+class SuccessConstraintCheck implements ConstraintCheck {
+
+    @Override
+    public MatchResult check(List<String> matchedNodes) {
+        return SuccessResult.getInstance();
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawConstraint.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawConstraint.java
@@ -27,6 +27,7 @@ import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IR;
 import compiler.lib.ir_framework.IRNode;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
+import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
 
 /**
  * Interface to represent a single raw constraint as found in the {@link IR @IR} annotation (i.e. {@link IRNode}
@@ -38,5 +39,5 @@ import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
  */
 public interface RawConstraint {
     CompilePhase defaultCompilePhase();
-    Constraint parse(CompilePhase compilePhase, String compilationOutput);
+    Constraint parse(CompilePhase compilePhase, String compilationOutput, VMInfo vmInfo);
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawCountsConstraint.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawCountsConstraint.java
@@ -26,10 +26,15 @@ package compiler.lib.ir_framework.driver.irmatching.irrule.constraint.raw;
 
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.IRNode;
 import compiler.lib.ir_framework.TestFramework;
 import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.parsing.RawIRNode;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
+import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
+import compiler.lib.ir_framework.driver.SuccessOnlyConstraintException;
 import compiler.lib.ir_framework.shared.Comparison;
+import compiler.lib.ir_framework.shared.TestFormat;
+import compiler.lib.ir_framework.shared.TestFormatException;
 
 /**
  * This class represents a raw constraint of a {@link IR#counts()} attribute.
@@ -52,9 +57,49 @@ public class RawCountsConstraint implements RawConstraint {
         return rawIRNode.defaultCompilePhase();
     }
 
+    private Comparison.Bound getComparisonBound() {
+        switch (comparison.getComparator()) {
+            case "<" -> {
+                TestFormat.checkNoReport(comparison.getGivenValue() > 0, "Node count comparison \"<" +
+                                         comparison.getGivenValue() + "\" is not allowed: always false.");
+                TestFormat.checkNoReport(comparison.getGivenValue() > 1, "Node count comparison \"<" +
+                                         comparison.getGivenValue() + "\" should be rewritten as \"=0\"");
+                return Comparison.Bound.UPPER;
+            }
+            case "<=" -> {
+                TestFormat.checkNoReport(comparison.getGivenValue() >= 0, "Node count comparison \"<=" +
+                                         comparison.getGivenValue() + "\" is not allowed: always false.");
+                TestFormat.checkNoReport(comparison.getGivenValue() >= 1, "Node count comparison \"<=" +
+                                         comparison.getGivenValue() + "\" should be rewritten as \"=0\"");
+                return Comparison.Bound.UPPER;
+            }
+            case "=" -> {
+                // "=0" is same as setting upper bound - just like for failOn. But if we compare equals a
+                // strictly positive number it is like setting both upper and lower bound (equal).
+                return comparison.getGivenValue() > 0 ? Comparison.Bound.EQUAL : Comparison.Bound.UPPER;
+            }
+            case ">" -> {
+                TestFormat.checkNoReport(comparison.getGivenValue() >= 0, "Node count comparison \">" +
+                                         comparison.getGivenValue() + "\" is useless, please only use positive numbers.");
+                return Comparison.Bound.LOWER;
+            }
+            case ">=" -> {
+                TestFormat.checkNoReport(comparison.getGivenValue() > 0, "Node count comparison \">=" +
+                                         comparison.getGivenValue() + "\" is useless, please only use strictly positive numbers with greater-equal.");
+                return Comparison.Bound.LOWER;
+            }
+            case "!=" -> throw new TestFormatException("Not-equal comparator not supported. Please rewrite the rule.");
+            default -> throw new TestFormatException("Comparator not handled: " + comparison.getComparator());
+        }
+    }
+
     @Override
-    public Constraint parse(CompilePhase compilePhase, String compilationOutput) {
+    public Constraint parse(CompilePhase compilePhase, String compilationOutput, VMInfo vmInfo) {
         TestFramework.check(compilePhase != CompilePhase.DEFAULT, "must not be default");
-        return Constraint.createCounts(rawIRNode.regex(compilePhase), constraintIndex, comparison, compilationOutput);
+        try {
+            return Constraint.createCounts(rawIRNode.regex(compilePhase, vmInfo, getComparisonBound()), constraintIndex, comparison, compilationOutput);
+        } catch (SuccessOnlyConstraintException e) {
+            return Constraint.createSuccess();
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawFailOnConstraint.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawFailOnConstraint.java
@@ -25,9 +25,12 @@ package compiler.lib.ir_framework.driver.irmatching.irrule.constraint.raw;
 
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.IRNode;
 import compiler.lib.ir_framework.TestFramework;
+import compiler.lib.ir_framework.shared.Comparison;
 import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.parsing.RawIRNode;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
+import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
 
 /**
  * This class represents a raw constraint of a {@link IR#failOn()} attribute.
@@ -49,9 +52,9 @@ public class RawFailOnConstraint implements RawConstraint {
     }
 
     @Override
-    public Constraint parse(CompilePhase compilePhase, String compilationOutput) {
+    public Constraint parse(CompilePhase compilePhase, String compilationOutput, VMInfo vmInfo) {
         TestFramework.check(compilePhase != CompilePhase.DEFAULT, "must not be default");
-        return Constraint.createFailOn(rawIRNode.regex(compilePhase), constraintIndex, compilationOutput);
+        return Constraint.createFailOn(rawIRNode.regex(compilePhase, vmInfo, Comparison.Bound.UPPER), constraintIndex, compilationOutput);
     }
 }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawFailOnConstraint.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawFailOnConstraint.java
@@ -25,12 +25,12 @@ package compiler.lib.ir_framework.driver.irmatching.irrule.constraint.raw;
 
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IR;
-import compiler.lib.ir_framework.IRNode;
 import compiler.lib.ir_framework.TestFramework;
-import compiler.lib.ir_framework.shared.Comparison;
+import compiler.lib.ir_framework.driver.SuccessOnlyConstraintException;
 import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.parsing.RawIRNode;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
 import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
+import compiler.lib.ir_framework.shared.Comparison;
 
 /**
  * This class represents a raw constraint of a {@link IR#failOn()} attribute.
@@ -54,7 +54,11 @@ public class RawFailOnConstraint implements RawConstraint {
     @Override
     public Constraint parse(CompilePhase compilePhase, String compilationOutput, VMInfo vmInfo) {
         TestFramework.check(compilePhase != CompilePhase.DEFAULT, "must not be default");
-        return Constraint.createFailOn(rawIRNode.regex(compilePhase, vmInfo, Comparison.Bound.UPPER), constraintIndex, compilationOutput);
+        try {
+            return Constraint.createFailOn(rawIRNode.regex(compilePhase, vmInfo, Comparison.Bound.UPPER), constraintIndex, compilationOutput);
+        } catch (SuccessOnlyConstraintException e) {
+            return Constraint.createSuccess();
+        }
     }
 }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/phase/DefaultPhaseRawConstraintParser.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/phase/DefaultPhaseRawConstraintParser.java
@@ -31,6 +31,7 @@ import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.Counts;
 import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.FailOn;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.raw.RawConstraint;
+import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
 import compiler.lib.ir_framework.shared.TestFrameworkException;
 
 import java.util.ArrayList;
@@ -52,22 +53,26 @@ class DefaultPhaseRawConstraintParser {
     }
 
     public Map<CompilePhase, List<Matchable>> parse(List<RawConstraint> rawFailOnConstraints,
-                                                    List<RawConstraint> rawCountsConstraints) {
+                                                    List<RawConstraint> rawCountsConstraints,
+                                                    VMInfo vmInfo) {
         Map<CompilePhase, Matchable> failOnForCompilePhase = parseRawConstraints(rawFailOnConstraints,
-                                                                                 CheckAttributeType.FAIL_ON);
+                                                                                 CheckAttributeType.FAIL_ON,
+                                                                                 vmInfo);
         Map<CompilePhase, Matchable> countsForCompilePhase = parseRawConstraints(rawCountsConstraints,
-                                                                                 CheckAttributeType.COUNTS);
+                                                                                 CheckAttributeType.COUNTS,
+                                                                                 vmInfo);
         return mergeCheckAttributesForCompilePhase(failOnForCompilePhase, countsForCompilePhase);
     }
 
     private Map<CompilePhase, Matchable> parseRawConstraints(List<RawConstraint> rawConstraints,
-                                                             CheckAttributeType checkAttributeType) {
+                                                             CheckAttributeType checkAttributeType,
+                                                             VMInfo vmInfo) {
         Map<CompilePhase, List<Constraint>> matchableForCompilePhase = new HashMap<>();
         for (RawConstraint rawConstraint : rawConstraints) {
             CompilePhase compilePhase = rawConstraint.defaultCompilePhase();
             List<Constraint> checkAttribute =
                     matchableForCompilePhase.computeIfAbsent(compilePhase, k -> new ArrayList<>());
-            checkAttribute.add(rawConstraint.parse(compilePhase, compilation.output(compilePhase)));
+            checkAttribute.add(rawConstraint.parse(compilePhase, compilation.output(compilePhase), vmInfo));
         }
         return replaceConstraintsWithCheckAttribute(matchableForCompilePhase, checkAttributeType);
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/IRMethodBuilder.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/IRMethodBuilder.java
@@ -51,18 +51,18 @@ class IRMethodBuilder {
      * Create IR methods for all test methods identified by {@link IREncodingParser} by combining them with the parsed
      * compilation output from {@link HotSpotPidFileParser}.
      */
-    public SortedSet<IRMethodMatchable> build() {
+    public SortedSet<IRMethodMatchable> build(VMInfo vmInfo) {
         SortedSet<IRMethodMatchable> irMethods = new TreeSet<>();
         testMethods.testMethods().forEach(
-                (methodName, testMethod) -> irMethods.add(createIRMethod(methodName, testMethod)));
+                (methodName, testMethod) -> irMethods.add(createIRMethod(methodName, testMethod, vmInfo)));
         return irMethods;
     }
 
-    private IRMethodMatchable createIRMethod(String methodName, TestMethod testMethod) {
+    private IRMethodMatchable createIRMethod(String methodName, TestMethod testMethod, VMInfo vmInfo) {
         LoggedMethod loggedMethod = loggedMethods.get(methodName);
         if (loggedMethod != null) {
             return new IRMethod(testMethod.method(), testMethod.irRuleIds(), testMethod.irAnnos(),
-                                new Compilation(loggedMethod.compilationOutput()));
+                                new Compilation(loggedMethod.compilationOutput()), vmInfo);
         } else {
             return new NotCompiledIRMethod(testMethod.method(), testMethod.irRuleIds().length);
         }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/TestClassParser.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/TestClassParser.java
@@ -54,10 +54,11 @@ public class TestClassParser {
     public Matchable parse(String hotspotPidFileName, String irEncoding) {
         IREncodingParser irEncodingParser = new IREncodingParser(testClass);
         TestMethods testMethods = irEncodingParser.parse(irEncoding);
+        VMInfo vmInfo = VMInfoParser.parseVMInfo(irEncoding);
         if (testMethods.hasTestMethods()) {
             HotSpotPidFileParser hotSpotPidFileParser = new HotSpotPidFileParser(testClass.getName(), testMethods);
             LoggedMethods loggedMethods = hotSpotPidFileParser.parse(hotspotPidFileName);
-            return createTestClass(testMethods, loggedMethods);
+            return createTestClass(testMethods, loggedMethods, vmInfo);
         }
         return new NonIRTestClass();
     }
@@ -66,9 +67,9 @@ public class TestClassParser {
      * Create test class with IR methods for all test methods identified by {@link IREncodingParser} by combining them
      * with the parsed compilation output from {@link HotSpotPidFileParser}.
      */
-    private Matchable createTestClass(TestMethods testMethods, LoggedMethods loggedMethods) {
+    private Matchable createTestClass(TestMethods testMethods, LoggedMethods loggedMethods, VMInfo vmInfo) {
         IRMethodBuilder irMethodBuilder = new IRMethodBuilder(testMethods, loggedMethods);
-        SortedSet<IRMethodMatchable> irMethods = irMethodBuilder.build();
+        SortedSet<IRMethodMatchable> irMethods = irMethodBuilder.build(vmInfo);
         TestFormat.throwIfAnyFailures();
         return new TestClass(irMethods);
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/VMInfo.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/VMInfo.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework.driver.irmatching.parser;
+
+import compiler.lib.ir_framework.TestFramework;
+import compiler.lib.ir_framework.shared.TestFrameworkException;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class stores the key value mapping from the VMInfo.
+ *
+ * @see IREncodingParser
+ */
+public class VMInfo {
+    /**
+     * Stores the key-value mapping.
+     */
+    private final Map<String, String> keyValueMap;
+
+    private static final Pattern CPU_SKYLAKE_PATTERN =
+            Pattern.compile("family 6 model 85 stepping (\\d) ");
+
+    public VMInfo(Map<String, String> map) {
+        this.keyValueMap = map;
+
+        TestFramework.check(isKey("cpuFeatures"),   "VMInfo does not contain cpuFeatures");
+        TestFramework.check(isKey("MaxVectorSize"), "VMInfo does not contain MaxVectorSize");
+        TestFramework.check(isKey("MaxVectorSizeIsDefault"), "VMInfo does not contain MaxVectorSizeIsDefault");
+        TestFramework.check(isKey("LoopMaxUnroll"), "VMInfo does not contain LoopMaxUnroll");
+        TestFramework.check(isKey("UseAVX"), "VMInfo does not contain UseAVX");
+        TestFramework.check(isKey("UseAVXIsDefault"), "VMInfo does not contain UseAVXIsDefault");
+    }
+
+    public String getStringValue(String key) {
+        TestFramework.check(isKey(key), "VMInfo does not contain \"" + key + "\"");
+        return keyValueMap.get(key);
+    }
+
+    public long getLongValue(String key) {
+        try {
+            return Long.parseLong(getStringValue(key));
+        } catch (NumberFormatException e) {
+            throw new TestFrameworkException("VMInfo value for \"" + key + "\" is not a long, got \"" + getStringValue(key) + "\"");
+        }
+    }
+
+    public boolean hasCPUFeature(String feature) {
+        String features = getStringValue("cpuFeatures") + ",";
+        return features.contains(" " + feature + ",");
+    }
+
+    public boolean isCascadeLake() {
+        Matcher matcher = CPU_SKYLAKE_PATTERN.matcher(getStringValue("cpuFeatures"));
+        if (!matcher.find()) {
+            return false; // skylake pattern not found
+        }
+        String stepping = matcher.group(1).trim();
+        return Long.parseLong(stepping) >= 5; // this makes it Cascade Lake
+    }
+
+    public boolean isDefaultCascadeLake() {
+        // See VM_Version::is_default_intel_cascade_lake
+        return isCascadeLake() &&
+               getLongValue("MaxVectorSizeIsDefault") == 1 &&
+               getLongValue("UseAVXIsDefault") == 1 &&
+               getLongValue("UseAVX") > 2;
+    }
+
+    /**
+     * Some platforms do not behave as expected, and one cannot trust that the vectors
+     * make use of the full MaxVectorSize. For Cascade Lake, we only use 32 bytes for
+     * SuperWord by default even though MaxVectorSize is 64. But the VectorAPI still
+     * uses 64 bytes. Thus MaxVectorSize is not a reliable indicator for the expected
+     * maximal vector size on that platform.
+     */
+    public boolean canTrustVectorSize() {
+        return !isDefaultCascadeLake();
+    }
+
+    public boolean isKey(String key) {
+        return keyValueMap.containsKey(key);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/VMInfoParser.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/VMInfoParser.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework.driver.irmatching.parser;
+
+import compiler.lib.ir_framework.TestFramework;
+import compiler.lib.ir_framework.shared.TestFrameworkException;
+import compiler.lib.ir_framework.test.VMInfoPrinter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Class to parse the VMInfo emitted by the test VM and creating {@link VMInfo} objects for each entry.
+ *
+ * @see VMInfo
+ */
+public class VMInfoParser {
+
+    private static final Pattern VM_INFO_PATTERN =
+            Pattern.compile("(?<=" + VMInfoPrinter.START_VM_INFO + "\r?\n).*\\R([\\s\\S]*)(?=" + VMInfoPrinter.END_VM_INFO + ")");
+
+    /**
+     * Extract VMInfo from the irEncoding.
+     */
+    public static VMInfo parseVMInfo(String irEncoding) {
+        Map<String, String> map = new HashMap<>();
+        String[] lines = getVMInfoLines(irEncoding);
+        for (String s : lines) {
+            String line = s.trim();
+            String[] splitLine = line.split(":", 2);
+            if (splitLine.length != 2) {
+                throw new TestFrameworkException("Invalid VMInfo key:value encoding. Found: " + splitLine[0]);
+            }
+            String key = splitLine[0];
+            String value = splitLine[1];
+            map.put(key, value);
+        }
+        return new VMInfo(map);
+    }
+
+    /**
+     * Extract the VMInfo from the irEncoding string, strip away the header and return the individual key-value lines.
+     */
+    private static String[] getVMInfoLines(String irEncoding) {
+        Matcher matcher = VM_INFO_PATTERN.matcher(irEncoding);
+        TestFramework.check(matcher.find(), "Did not find VMInfo in:" + System.lineSeparator() + irEncoding);
+        String lines = matcher.group(1).trim();
+        if (lines.isEmpty()) {
+            // Nothing to IR match.
+            return new String[0];
+        }
+        return lines.split("\\R");
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/Comparison.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/Comparison.java
@@ -38,6 +38,12 @@ public class Comparison<T extends Comparable<T>> {
     private final BiPredicate<T, T> comparisonPredicate;
     private final String comparator;
 
+    public enum Bound {
+        LOWER,
+        UPPER,
+        EQUAL,
+    }
+
     public Comparison(T givenValue, String comparator, BiPredicate<T, T> comparisonPredicate) {
         this.givenValue = givenValue;
         this.comparator = comparator;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -266,6 +266,7 @@ public class TestVM {
         addBaseTests();
         if (PRINT_VALID_IR_RULES) {
             irMatchRulePrinter.emit();
+            VMInfoPrinter.emit();
         }
         TestFormat.throwIfAnyFailures();
         declaredTests.clear();

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/VMInfoPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/VMInfoPrinter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.lib.ir_framework.test;
+
+import compiler.lib.ir_framework.shared.TestFrameworkSocket;
+import jdk.test.whitebox.WhiteBox;
+
+/**
+ * Prints some test VM info to the socket.
+ */
+public class VMInfoPrinter {
+    public static final String START_VM_INFO = "##### IRMatchingVMInfo - used by TestFramework #####";
+    public static final String END_VM_INFO = "----- END VMInfo -----";
+
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    public static void emit() {
+        StringBuilder vmInfo = new StringBuilder();
+        vmInfo.append(START_VM_INFO).append(System.lineSeparator());
+        vmInfo.append("<key>:<value>").append(System.lineSeparator());
+
+        // CPU feature independent info
+        String cpuFeatures = WHITE_BOX.getCPUFeatures();
+        vmInfo.append("cpuFeatures:").append(cpuFeatures).append(System.lineSeparator());
+        long maxVectorSize = WHITE_BOX.getIntxVMFlag("MaxVectorSize");
+        vmInfo.append("MaxVectorSize:").append(maxVectorSize).append(System.lineSeparator());
+        boolean maxVectorSizeIsDefault = WHITE_BOX.isDefaultVMFlag("MaxVectorSize");
+        vmInfo.append("MaxVectorSizeIsDefault:")
+              .append(maxVectorSizeIsDefault ? 1 : 0)
+              .append(System.lineSeparator());
+        long loopMaxUnroll = WHITE_BOX.getIntxVMFlag("LoopMaxUnroll");
+        vmInfo.append("LoopMaxUnroll:").append(loopMaxUnroll).append(System.lineSeparator());
+
+        // CPU feature dependent info
+        long useAVX = 0;
+        boolean useAVXIsDefault = true;
+        if (cpuFeatures.contains(" sse, ")) {
+            useAVX = WHITE_BOX.getIntVMFlag("UseAVX");
+            useAVXIsDefault = WHITE_BOX.isDefaultVMFlag("UseAVX");
+        }
+        vmInfo.append("UseAVX:").append(useAVX).append(System.lineSeparator());
+        vmInfo.append("UseAVXIsDefault:")
+              .append(useAVXIsDefault ? 1 : 0)
+              .append(System.lineSeparator());
+
+        vmInfo.append(END_VM_INFO);
+        TestFrameworkSocket.write(vmInfo.toString(), "VMInfo");
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/superword/SumRedAbsNeg_Double.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/SumRedAbsNeg_Double.java
@@ -92,7 +92,7 @@ public class SumRedAbsNeg_Double {
        (with or without store) in SuperWord::profitable. */
     @Test
     @IR(applyIf = {"SuperWordReductions", "false"},
-        failOn = {IRNode.ADD_REDUCTION_VD, IRNode.ABS_V, IRNode.NEG_V})
+        failOn = {IRNode.ADD_REDUCTION_VD, IRNode.ABS_VD, IRNode.NEG_VD})
     public static double sumReductionImplement(
             double[] a,
             double[] b,

--- a/test/hotspot/jtreg/compiler/loopopts/superword/SumRedAbsNeg_Float.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/SumRedAbsNeg_Float.java
@@ -90,10 +90,12 @@ public class SumRedAbsNeg_Float {
 
     @Test
     @IR(applyIf = {"SuperWordReductions", "false"},
-        failOn = {IRNode.ADD_REDUCTION_VF, IRNode.ABS_V, IRNode.NEG_V})
+        failOn = {IRNode.ADD_REDUCTION_VF, IRNode.ABS_VF, IRNode.NEG_VF})
     @IR(applyIfCPUFeature = {"sse2", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
-        counts = {IRNode.ADD_REDUCTION_VF, ">= 1", IRNode.ABS_V, ">= 1", IRNode.NEG_V, ">= 1"})
+        counts = {IRNode.ADD_REDUCTION_VF, ">= 1",
+                  IRNode.ABS_VF, IRNode.VECTOR_SIZE + "min(LoopMaxUnroll, max_float)", ">= 1",
+                  IRNode.NEG_VF, IRNode.VECTOR_SIZE + "min(LoopMaxUnroll, max_float)", ">= 1"})
     public static float sumReductionImplement(
             float[] a,
             float[] b,

--- a/test/hotspot/jtreg/compiler/loopopts/superword/SumRedSqrt_Double.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/SumRedSqrt_Double.java
@@ -87,10 +87,10 @@ public class SumRedSqrt_Double {
        Require avx for SQRT_VD. */
     @Test
     @IR(applyIf = {"SuperWordReductions", "false"},
-        failOn = {IRNode.ADD_REDUCTION_VD, IRNode.SQRT_V})
+        failOn = {IRNode.ADD_REDUCTION_VD, IRNode.SQRT_VD})
     @IR(applyIfCPUFeature = {"avx", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
-        counts = {IRNode.ADD_REDUCTION_VD, ">= 1", IRNode.SQRT_V, ">= 1"})
+        counts = {IRNode.ADD_REDUCTION_VD, ">= 1", IRNode.SQRT_VD, ">= 1"})
     public static double sumReductionWithStoreImplement(
             double[] a,
             double[] b,

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestCyclicDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestCyclicDependency.java
@@ -240,7 +240,7 @@ public class TestCyclicDependency {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.ADD_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test0(int[] dataI, float[] dataF) {
         for (int i = 0; i < RANGE; i++) {
@@ -346,7 +346,7 @@ public class TestCyclicDependency {
     }
 
     @Test
-    @IR(counts = {IRNode.ADD_VF, "> 0"},
+    @IR(counts = {IRNode.ADD_VF, IRNode.VECTOR_SIZE + "min(max_int, max_float)", "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     // Some aarch64 machines have AlignVector == true, like ThunderX2

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -28,7 +28,7 @@
  *   Note: CompileCommand Option Vectorize is enabled.
  *
  * Note: this test is auto-generated. Please modify / generate with script:
- *       https://bugs.openjdk.org/browse/JDK-8298935
+ *       https://bugs.openjdk.org/browse/JDK-8310308
  *
  * Types: int, long, short, char, byte, float, double
  * Offsets: 0, -1, 1, -2, 2, -3, 3, -4, 4, -7, 7, -8, 8, -14, 14, -16, 16, -18, 18, -20, 20, -31, 31, -32, 32, -63, 63, -64, 64, -65, 65, -128, 128, -129, 129, -192, 192
@@ -1391,19 +1391,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP0(int[] data) {
@@ -1423,35 +1423,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM1(int[] data) {
@@ -1499,19 +1499,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM2(int[] data) {
@@ -1532,22 +1532,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP2(int[] data) {
@@ -1567,35 +1567,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM3(int[] data) {
@@ -1616,22 +1616,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
     //   positive byte_offset 12 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 12"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 12 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 12"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 12 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 12"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 12 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 12"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP3(int[] data) {
@@ -1651,19 +1651,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM4(int[] data) {
@@ -1683,26 +1683,26 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP4(int[] data) {
@@ -1722,35 +1722,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM7(int[] data) {
@@ -1770,22 +1770,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 28"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 28"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 28"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP7(int[] data) {
@@ -1805,19 +1805,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM8(int[] data) {
@@ -1837,32 +1837,32 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 32 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 32"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP8(int[] data) {
@@ -1882,19 +1882,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM14(int[] data) {
@@ -1914,20 +1914,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 56 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 56"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP14(int[] data) {
@@ -1947,19 +1947,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM16(int[] data) {
@@ -1979,35 +1979,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP16(int[] data) {
@@ -2027,19 +2027,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM18(int[] data) {
@@ -2059,19 +2059,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP18(int[] data) {
@@ -2091,19 +2091,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM20(int[] data) {
@@ -2123,23 +2123,23 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP20(int[] data) {
@@ -2159,35 +2159,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM31(int[] data) {
@@ -2207,19 +2207,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP31(int[] data) {
@@ -2239,19 +2239,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM32(int[] data) {
@@ -2271,35 +2271,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP32(int[] data) {
@@ -2319,35 +2319,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM63(int[] data) {
@@ -2367,19 +2367,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP63(int[] data) {
@@ -2399,19 +2399,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM64(int[] data) {
@@ -2431,35 +2431,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP64(int[] data) {
@@ -2479,35 +2479,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM65(int[] data) {
@@ -2527,19 +2527,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP65(int[] data) {
@@ -2559,19 +2559,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM128(int[] data) {
@@ -2591,35 +2591,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP128(int[] data) {
@@ -2639,35 +2639,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_I, IRNode.MUL_VI, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM129(int[] data) {
@@ -2687,19 +2687,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP129(int[] data) {
@@ -2719,19 +2719,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntM192(int[] data) {
@@ -2751,35 +2751,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testIntP192(int[] data) {
@@ -2799,19 +2799,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP0(long[] data) {
@@ -2831,35 +2831,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM1(long[] data) {
@@ -2907,19 +2907,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM2(long[] data) {
@@ -2939,26 +2939,26 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP2(long[] data) {
@@ -2978,35 +2978,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM3(long[] data) {
@@ -3026,22 +3026,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
     //   positive byte_offset 24 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 24"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
     //   positive byte_offset 24 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 24"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
     //   positive byte_offset 24 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 24"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP3(long[] data) {
@@ -3061,19 +3061,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM4(long[] data) {
@@ -3093,32 +3093,32 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
     //   positive byte_offset 32 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 32"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP4(long[] data) {
@@ -3138,35 +3138,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM7(long[] data) {
@@ -3186,20 +3186,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
     //   positive byte_offset 56 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 56"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP7(long[] data) {
@@ -3219,19 +3219,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM8(long[] data) {
@@ -3251,35 +3251,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP8(long[] data) {
@@ -3299,19 +3299,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM14(long[] data) {
@@ -3331,23 +3331,23 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP14(long[] data) {
@@ -3367,19 +3367,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM16(long[] data) {
@@ -3399,35 +3399,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP16(long[] data) {
@@ -3447,19 +3447,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM18(long[] data) {
@@ -3479,23 +3479,23 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP18(long[] data) {
@@ -3515,19 +3515,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM20(long[] data) {
@@ -3547,31 +3547,31 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP20(long[] data) {
@@ -3591,35 +3591,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM31(long[] data) {
@@ -3639,19 +3639,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP31(long[] data) {
@@ -3671,19 +3671,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM32(long[] data) {
@@ -3703,35 +3703,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP32(long[] data) {
@@ -3751,35 +3751,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM63(long[] data) {
@@ -3799,19 +3799,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP63(long[] data) {
@@ -3831,19 +3831,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM64(long[] data) {
@@ -3863,35 +3863,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP64(long[] data) {
@@ -3911,35 +3911,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM65(long[] data) {
@@ -3959,19 +3959,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP65(long[] data) {
@@ -3991,19 +3991,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM128(long[] data) {
@@ -4023,35 +4023,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP128(long[] data) {
@@ -4071,35 +4071,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.ADD_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_L, IRNode.ADD_VL, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM129(long[] data) {
@@ -4119,19 +4119,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP129(long[] data) {
@@ -4151,19 +4151,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongM192(long[] data) {
@@ -4183,35 +4183,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testLongP192(long[] data) {
@@ -4231,19 +4231,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP0(short[] data) {
@@ -4263,35 +4263,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM1(short[] data) {
@@ -4339,19 +4339,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM2(short[] data) {
@@ -4372,22 +4372,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP2(short[] data) {
@@ -4407,35 +4407,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM3(short[] data) {
@@ -4456,22 +4456,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
     //   positive byte_offset 6 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 6"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 6 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 6"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 6 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 6"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 6 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 6"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP3(short[] data) {
@@ -4491,19 +4491,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM4(short[] data) {
@@ -4524,22 +4524,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP4(short[] data) {
@@ -4559,35 +4559,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM7(short[] data) {
@@ -4608,22 +4608,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP7(short[] data) {
@@ -4643,19 +4643,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM8(short[] data) {
@@ -4675,26 +4675,26 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP8(short[] data) {
@@ -4714,19 +4714,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM14(short[] data) {
@@ -4746,22 +4746,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 28"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 28"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 28"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP14(short[] data) {
@@ -4781,19 +4781,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM16(short[] data) {
@@ -4813,32 +4813,32 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 32 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 32"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP16(short[] data) {
@@ -4858,19 +4858,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM18(short[] data) {
@@ -4890,20 +4890,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 36 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 36"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP18(short[] data) {
@@ -4923,19 +4923,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM20(short[] data) {
@@ -4955,20 +4955,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 40 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 40"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP20(short[] data) {
@@ -4988,35 +4988,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM31(short[] data) {
@@ -5036,20 +5036,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 62 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 62"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP31(short[] data) {
@@ -5069,19 +5069,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM32(short[] data) {
@@ -5101,35 +5101,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP32(short[] data) {
@@ -5149,35 +5149,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM63(short[] data) {
@@ -5197,19 +5197,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP63(short[] data) {
@@ -5229,19 +5229,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM64(short[] data) {
@@ -5261,35 +5261,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP64(short[] data) {
@@ -5309,35 +5309,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM65(short[] data) {
@@ -5357,19 +5357,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP65(short[] data) {
@@ -5389,19 +5389,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM128(short[] data) {
@@ -5421,35 +5421,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP128(short[] data) {
@@ -5469,35 +5469,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_S, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM129(short[] data) {
@@ -5517,19 +5517,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP129(short[] data) {
@@ -5549,19 +5549,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortM192(short[] data) {
@@ -5581,35 +5581,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testShortP192(short[] data) {
@@ -5629,19 +5629,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP0(char[] data) {
@@ -5661,35 +5661,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM1(char[] data) {
@@ -5737,19 +5737,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM2(char[] data) {
@@ -5770,22 +5770,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP2(char[] data) {
@@ -5805,35 +5805,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM3(char[] data) {
@@ -5854,22 +5854,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
     //   positive byte_offset 6 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 6"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 6 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 6"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 6 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 6"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 6 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 6"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP3(char[] data) {
@@ -5889,19 +5889,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM4(char[] data) {
@@ -5922,22 +5922,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP4(char[] data) {
@@ -5957,35 +5957,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM7(char[] data) {
@@ -6006,22 +6006,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP7(char[] data) {
@@ -6041,19 +6041,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM8(char[] data) {
@@ -6073,26 +6073,26 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP8(char[] data) {
@@ -6112,19 +6112,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM14(char[] data) {
@@ -6144,22 +6144,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 28"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 28"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 28"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP14(char[] data) {
@@ -6179,19 +6179,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM16(char[] data) {
@@ -6211,32 +6211,32 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 32 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 32"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP16(char[] data) {
@@ -6256,19 +6256,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM18(char[] data) {
@@ -6288,20 +6288,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 36 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 36"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP18(char[] data) {
@@ -6321,19 +6321,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM20(char[] data) {
@@ -6353,20 +6353,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 40 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 40"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP20(char[] data) {
@@ -6386,35 +6386,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM31(char[] data) {
@@ -6434,20 +6434,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
     //   positive byte_offset 62 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 62"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP31(char[] data) {
@@ -6467,19 +6467,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM32(char[] data) {
@@ -6499,35 +6499,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP32(char[] data) {
@@ -6547,35 +6547,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM63(char[] data) {
@@ -6595,19 +6595,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP63(char[] data) {
@@ -6627,19 +6627,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM64(char[] data) {
@@ -6659,35 +6659,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP64(char[] data) {
@@ -6707,35 +6707,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM65(char[] data) {
@@ -6755,19 +6755,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP65(char[] data) {
@@ -6787,19 +6787,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM128(char[] data) {
@@ -6819,35 +6819,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP128(char[] data) {
@@ -6867,35 +6867,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_C, IRNode.MUL_VS, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM129(char[] data) {
@@ -6915,19 +6915,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP129(char[] data) {
@@ -6947,19 +6947,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharM192(char[] data) {
@@ -6979,35 +6979,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.MUL_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testCharP192(char[] data) {
@@ -7027,19 +7027,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP0(byte[] data) {
@@ -7059,35 +7059,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM1(byte[] data) {
@@ -7135,35 +7135,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM2(byte[] data) {
@@ -7211,35 +7211,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM3(byte[] data) {
@@ -7287,19 +7287,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM4(byte[] data) {
@@ -7320,22 +7320,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 4 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP4(byte[] data) {
@@ -7355,35 +7355,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM7(byte[] data) {
@@ -7404,22 +7404,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
     //   positive byte_offset 7 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 7"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 7 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 7"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 7 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 7"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 7 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 7"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP7(byte[] data) {
@@ -7439,19 +7439,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM8(byte[] data) {
@@ -7472,22 +7472,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP8(byte[] data) {
@@ -7507,35 +7507,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM14(byte[] data) {
@@ -7556,22 +7556,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 14 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 14"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP14(byte[] data) {
@@ -7591,19 +7591,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM16(byte[] data) {
@@ -7623,26 +7623,26 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP16(byte[] data) {
@@ -7662,35 +7662,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM18(byte[] data) {
@@ -7710,22 +7710,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 18 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 18"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 18 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 18"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 18 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 18"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP18(byte[] data) {
@@ -7745,19 +7745,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM20(byte[] data) {
@@ -7777,22 +7777,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 20 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 20"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 20 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 20"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 20 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 20"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP20(byte[] data) {
@@ -7812,35 +7812,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM31(byte[] data) {
@@ -7860,22 +7860,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 31 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 31"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 31 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 31"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
     //   positive byte_offset 31 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 31"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP31(byte[] data) {
@@ -7895,19 +7895,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM32(byte[] data) {
@@ -7927,32 +7927,32 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 32 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 32"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP32(byte[] data) {
@@ -7972,35 +7972,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM63(byte[] data) {
@@ -8020,20 +8020,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
     //   positive byte_offset 63 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4", "MaxVectorSize", "<= 63"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP63(byte[] data) {
@@ -8053,19 +8053,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM64(byte[] data) {
@@ -8085,35 +8085,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP64(byte[] data) {
@@ -8133,35 +8133,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM65(byte[] data) {
@@ -8181,19 +8181,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP65(byte[] data) {
@@ -8213,19 +8213,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM128(byte[] data) {
@@ -8245,35 +8245,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP128(byte[] data) {
@@ -8293,35 +8293,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_B, IRNode.MUL_VB, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM129(byte[] data) {
@@ -8341,19 +8341,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP129(byte[] data) {
@@ -8373,19 +8373,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteM192(byte[] data) {
@@ -8405,35 +8405,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 to avx -> vector_width: 16 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "false"})
     // CPU: avx2 to avx512 without avx512bw -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeatureAnd = {"avx2", "true", "avx512bw", "false"})
     // CPU: avx512bw -> vector_width: 64 -> elements in vector: 64
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"avx512bw", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 32
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.MUL_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 4"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testByteP192(byte[] data) {
@@ -8453,19 +8453,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP0(float[] data) {
@@ -8485,35 +8485,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM1(float[] data) {
@@ -8561,19 +8561,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM2(float[] data) {
@@ -8594,22 +8594,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 8 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP2(float[] data) {
@@ -8629,35 +8629,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM3(float[] data) {
@@ -8678,22 +8678,22 @@ public class TestDependencyOffsets {
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
     //   positive byte_offset 12 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 12"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 12 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 12"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 12 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 12"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 12 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 12"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP3(float[] data) {
@@ -8713,19 +8713,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM4(float[] data) {
@@ -8745,26 +8745,26 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP4(float[] data) {
@@ -8784,35 +8784,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM7(float[] data) {
@@ -8832,22 +8832,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 28"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 28"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
     //   positive byte_offset 28 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 28"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP7(float[] data) {
@@ -8867,19 +8867,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM8(float[] data) {
@@ -8899,32 +8899,32 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 32 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 32"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP8(float[] data) {
@@ -8944,19 +8944,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM14(float[] data) {
@@ -8976,20 +8976,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
     //   positive byte_offset 56 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8", "MaxVectorSize", "<= 56"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP14(float[] data) {
@@ -9009,19 +9009,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM16(float[] data) {
@@ -9041,35 +9041,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP16(float[] data) {
@@ -9089,19 +9089,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM18(float[] data) {
@@ -9121,19 +9121,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP18(float[] data) {
@@ -9153,19 +9153,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM20(float[] data) {
@@ -9185,23 +9185,23 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP20(float[] data) {
@@ -9221,35 +9221,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM31(float[] data) {
@@ -9269,19 +9269,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP31(float[] data) {
@@ -9301,19 +9301,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM32(float[] data) {
@@ -9333,35 +9333,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP32(float[] data) {
@@ -9381,35 +9381,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM63(float[] data) {
@@ -9429,19 +9429,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP63(float[] data) {
@@ -9461,19 +9461,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM64(float[] data) {
@@ -9493,35 +9493,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP64(float[] data) {
@@ -9541,35 +9541,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM65(float[] data) {
@@ -9589,19 +9589,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP65(float[] data) {
@@ -9621,19 +9621,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM128(float[] data) {
@@ -9653,35 +9653,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP128(float[] data) {
@@ -9701,35 +9701,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.MUL_VF, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM129(float[] data) {
@@ -9749,19 +9749,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP129(float[] data) {
@@ -9781,19 +9781,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatM192(float[] data) {
@@ -9813,35 +9813,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 16
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.MUL_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 8"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testFloatP192(float[] data) {
@@ -9861,19 +9861,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP0(double[] data) {
@@ -9893,35 +9893,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM1(double[] data) {
@@ -9969,19 +9969,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM2(double[] data) {
@@ -10001,26 +10001,26 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
     //   positive byte_offset 16 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP2(double[] data) {
@@ -10040,35 +10040,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM3(double[] data) {
@@ -10088,22 +10088,22 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
     //   positive byte_offset 24 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 24"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
     //   positive byte_offset 24 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 24"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
     //   positive byte_offset 24 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 24"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP3(double[] data) {
@@ -10123,19 +10123,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM4(double[] data) {
@@ -10155,32 +10155,32 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
     //   positive byte_offset 32 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 32"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP4(double[] data) {
@@ -10200,35 +10200,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM7(double[] data) {
@@ -10248,20 +10248,20 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
     //   positive byte_offset 56 can lead to cyclic dependency
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16", "MaxVectorSize", "<= 56"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP7(double[] data) {
@@ -10281,19 +10281,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM8(double[] data) {
@@ -10313,35 +10313,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP8(double[] data) {
@@ -10361,19 +10361,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM14(double[] data) {
@@ -10393,23 +10393,23 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP14(double[] data) {
@@ -10429,19 +10429,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM16(double[] data) {
@@ -10461,35 +10461,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP16(double[] data) {
@@ -10509,19 +10509,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM18(double[] data) {
@@ -10541,23 +10541,23 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP18(double[] data) {
@@ -10577,19 +10577,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM20(double[] data) {
@@ -10609,31 +10609,31 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP20(double[] data) {
@@ -10653,35 +10653,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM31(double[] data) {
@@ -10701,19 +10701,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP31(double[] data) {
@@ -10733,19 +10733,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM32(double[] data) {
@@ -10765,35 +10765,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP32(double[] data) {
@@ -10813,35 +10813,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM63(double[] data) {
@@ -10861,19 +10861,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP63(double[] data) {
@@ -10893,19 +10893,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM64(double[] data) {
@@ -10925,35 +10925,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP64(double[] data) {
@@ -10973,35 +10973,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM65(double[] data) {
@@ -11021,19 +11021,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP65(double[] data) {
@@ -11053,19 +11053,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM128(double[] data) {
@@ -11085,35 +11085,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP128(double[] data) {
@@ -11133,35 +11133,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Strict alignment not possible.
-    @IR(failOn = {IRNode.LOAD_VECTOR, IRNode.MUL_V, IRNode.STORE_VECTOR},
+    @IR(failOn = {IRNode.LOAD_VECTOR_D, IRNode.MUL_VD, IRNode.STORE_VECTOR},
         applyIf = {"AlignVector", "true"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM129(double[] data) {
@@ -11181,19 +11181,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP129(double[] data) {
@@ -11213,19 +11213,19 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleM192(double[] data) {
@@ -11245,35 +11245,35 @@ public class TestDependencyOffsets {
 
     @Test
     // CPU: sse4.1 -> vector_width: 16 -> elements in vector: 2
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx", "false"})
     // CPU: avx and avx2 -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeatureAnd = {"avx", "true", "avx512", "false"})
     // CPU: avx512 -> vector_width: 64 -> elements in vector: 8
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"avx512", "true"})
     // CPU: asimd -> vector_width: 32 -> elements in vector: 4
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     //   Vectorize when strict alignment guaranteed.
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.MUL_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.MUL_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIfAnd = {"AlignVector", "true", "MaxVectorSize", ">= 16"},
         applyIfCPUFeature = {"asimd", "true"})
     public static void testDoubleP192(double[] data) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java
@@ -143,7 +143,7 @@ public class TestIndependentPacksWithCyclicDependency {
     }
 
     @Test
-    @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VF, "> 0", IRNode.VECTOR_CAST_F2X, "> 0", IRNode.VECTOR_CAST_I2X, "> 0"},
+    @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VF, "> 0", IRNode.VECTOR_CAST_F2I, "> 0", IRNode.VECTOR_CAST_I2F, "> 0"},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
     static void test1(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
@@ -75,7 +75,7 @@ public class TestUnorderedReduction {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0",
                   IRNode.ADD_VI, "= 0",
                   IRNode.ADD_REDUCTION_VI, "> 0"}, // count can be high
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
@@ -114,7 +114,7 @@ public class TestUnorderedReduction {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0",
                   IRNode.ADD_VI, "> 0",
                   IRNode.ADD_REDUCTION_VI, "> 0",
                   IRNode.ADD_REDUCTION_VI, "<= 2"}, // count must be low
@@ -149,7 +149,7 @@ public class TestUnorderedReduction {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0",
                   IRNode.MUL_VI, "> 0",
                   IRNode.ADD_VI, "= 0", // reduction not moved out of loop
                   IRNode.ADD_REDUCTION_VI, "> 0",},

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -59,8 +59,9 @@ public class TestUnorderedReductionPartialVectorization {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
-                  IRNode.OR_REDUCTION_V, "> 0",},
+    @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.OR_REDUCTION_V,                                                 "> 0",},
         applyIfCPUFeatureOr = {"avx2", "true"})
     static long test1(int[] data, long sum) {
         for (int i = 0; i < data.length; i++) {
@@ -75,7 +76,7 @@ public class TestUnorderedReductionPartialVectorization {
             // PhaseIdealLoop::move_unordered_reduction_out_of_loop
             int v = data[i]; // int read
             data[0] = 0;     // ruin the first pack
-            sum |= v;        // long reduction
+            sum |= v;        // long reduction (and implicit cast from int to long)
         }
         return sum;
     }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java
@@ -280,17 +280,23 @@ public class TestMaskedMacroLogicVector {
     }
 
     @Test
-    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "}, counts = {IRNode.AND_V, " > 0 ", IRNode.XOR_V, " > 0 "})
+    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "},
+        counts = {IRNode.AND_VI, IRNode.VECTOR_SIZE_4, " > 0 ",
+                  IRNode.XOR_VI, IRNode.VECTOR_SIZE_4, " > 0 "})
     public void testInt4_Int128(int[] r, int[] a, int[] b, int[] c, boolean [] mask) {
         testInt4Kernel(IntVector.SPECIES_128, r, a, b, c, mask);
     }
     @Test
-    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "}, counts = {IRNode.AND_V, " > 0 ", IRNode.XOR_V, " > 0 "})
+    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "},
+        counts = {IRNode.AND_VI, IRNode.VECTOR_SIZE_8, " > 0 ",
+                  IRNode.XOR_VI, IRNode.VECTOR_SIZE_8, " > 0 "})
     public void testInt4_Int256(int[] r, int[] a, int[] b, int[] c, boolean [] mask) {
         testInt4Kernel(IntVector.SPECIES_256, r, a, b, c, mask);
     }
     @Test
-    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "}, counts = {IRNode.AND_V, " > 0 ", IRNode.XOR_V, " > 0 "})
+    @IR(applyIfAnd = {"UseAVX", "3", "UseSSE", " > 3 "},
+        counts = {IRNode.AND_VI, IRNode.VECTOR_SIZE_16, " > 0 ",
+                  IRNode.XOR_VI, IRNode.VECTOR_SIZE_16, " > 0 "})
     public void testInt4_Int512(int[] r, int[] a, int[] b, int[] c, boolean [] mask) {
         testInt4Kernel(IntVector.SPECIES_512, r, a, b, c, mask);
     }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransforms.java
@@ -81,7 +81,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_VL, " > 0 "})
     public void test_reversebytes_long_transform1(long[] lout, long[] linp) {
         VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
@@ -100,7 +100,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_VL, " > 0 "})
     public void test_reversebytes_long_transform2(long[] lout, long[] linp) {
         VectorMask<Long> mask1 = VectorMask.fromLong(LSPECIES, 3);
         VectorMask<Long> mask2 = VectorMask.fromLong(LSPECIES, 3);
@@ -120,7 +120,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_VL})
     public void test_reversebytes_long_transform3(long[] lout, long[] linp) {
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
             LongVector.fromArray(LSPECIES, linp, i)
@@ -138,7 +138,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_VI, " > 0 "})
     public void test_reversebytes_int_transform1(int[] iout, int[] iinp) {
         VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
@@ -157,7 +157,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_VI, " > 0 "})
     public void test_reversebytes_int_transform2(int[] iout, int[] iinp) {
         VectorMask<Integer> mask1 = VectorMask.fromLong(ISPECIES, 3);
         VectorMask<Integer> mask2 = VectorMask.fromLong(ISPECIES, 3);
@@ -177,7 +177,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_VI})
     public void test_reversebytes_int_transform3(int[] iout, int[] iinp) {
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
             IntVector.fromArray(ISPECIES, iinp, i)
@@ -195,7 +195,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_VS, " > 0 "})
     public void test_reversebytes_short_transform1(short[] sout, short[] sinp) {
         VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
@@ -214,7 +214,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_V , " > 0 "})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, counts = {IRNode.REVERSE_BYTES_VS, " > 0 "})
     public void test_reversebytes_short_transform2(short[] sout, short[] sinp) {
         VectorMask<Short> mask1 = VectorMask.fromLong(SSPECIES, 3);
         VectorMask<Short> mask2 = VectorMask.fromLong(SSPECIES, 3);
@@ -234,7 +234,7 @@ public class TestReverseByteTransforms {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"}, failOn = {IRNode.REVERSE_BYTES_VS})
     public void test_reversebytes_short_transform3(short[] sout, short[] sinp) {
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {
             ShortVector.fromArray(SSPECIES, sinp, i)

--- a/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransformsSVE.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestReverseByteTransformsSVE.java
@@ -78,7 +78,7 @@ public class TestReverseByteTransformsSVE {
     }
 
     @Test
-    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_VL})
     public void test_reversebytes_long_transform(long[] lout, long[] linp) {
         VectorMask<Long> mask = VectorMask.fromLong(LSPECIES, 3);
         for (int i = 0; i < LSPECIES.loopBound(linp.length); i+=LSPECIES.length()) {
@@ -97,7 +97,7 @@ public class TestReverseByteTransformsSVE {
     }
 
     @Test
-    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_VI})
     public void test_reversebytes_int_transform(int[] iout, int[] iinp) {
         VectorMask<Integer> mask = VectorMask.fromLong(ISPECIES, 3);
         for (int i = 0; i < ISPECIES.loopBound(iinp.length); i+=ISPECIES.length()) {
@@ -116,7 +116,7 @@ public class TestReverseByteTransformsSVE {
     }
 
     @Test
-    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(applyIf = {"UseSVE", " > 0"}, failOn = {IRNode.REVERSE_BYTES_VS})
     public void test_reversebytes_short_transform(short[] sout, short[] sinp) {
         VectorMask<Short> mask = VectorMask.fromLong(SSPECIES, 3);
         for (int i = 0; i < SSPECIES.loopBound(sinp.length); i+=SSPECIES.length()) {

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorCompressExpandBits.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorCompressExpandBits.java
@@ -77,7 +77,7 @@ public class TestVectorCompressExpandBits {
 
     // Test for vectorized Integer.compress operation in SVE2
     @Test
-    @IR(counts = {IRNode.COMPRESS_BITSV, "> 0"})
+    @IR(counts = {IRNode.COMPRESS_BITS_VI, "> 0"})
     public static void testIntCompress() {
         for (int i = 0; i < LENGTH; i += I_SPECIES.length()) {
             IntVector av = IntVector.fromArray(I_SPECIES, ia, i);
@@ -96,7 +96,7 @@ public class TestVectorCompressExpandBits {
 
     // Test for vectorized Integer.expand operation in SVE2
     @Test
-    @IR(counts = {IRNode.EXPAND_BITSV, "> 0"})
+    @IR(counts = {IRNode.EXPAND_BITS_VI, "> 0"})
     public static void testIntExpand() {
         for (int i = 0; i < LENGTH; i += I_SPECIES.length()) {
             IntVector av = IntVector.fromArray(I_SPECIES, ia, i);
@@ -115,7 +115,7 @@ public class TestVectorCompressExpandBits {
 
     // Test for vectorized Long.compress operation in SVE2
     @Test
-    @IR(counts = {IRNode.COMPRESS_BITSV, "> 0"})
+    @IR(counts = {IRNode.COMPRESS_BITS_VL, "> 0"})
     public static void testLongCompress() {
         for (int i = 0; i < LENGTH; i += L_SPECIES.length()) {
             LongVector av = LongVector.fromArray(L_SPECIES, la, i);
@@ -134,7 +134,7 @@ public class TestVectorCompressExpandBits {
 
     // Test for vectorized Long.expand operation in SVE2
     @Test
-    @IR(counts = {IRNode.EXPAND_BITSV, "> 0"})
+    @IR(counts = {IRNode.EXPAND_BITS_VL, "> 0"})
     public static void testLongExpand() {
         for (int i = 0; i < LENGTH; i += L_SPECIES.length()) {
             LongVector av = LongVector.fromArray(L_SPECIES, la, i);

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorFPtoIntCastTest.java
@@ -86,7 +86,8 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_F2X, "> 0"}, applyIfCPUFeature = {"avx512f", "true"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2I, IRNode.VECTOR_SIZE_16, "> 0"},
+        applyIfCPUFeature = {"avx512f", "true"})
     public void float2int() {
         var cvec = (IntVector)fvec512.convertShape(VectorOperators.F2I, ispec512, 0);
         cvec.intoArray(int_arr, 0);
@@ -103,7 +104,8 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_F2X, "> 0"}, applyIfCPUFeature = {"avx512dq", "true"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE_8, "> 0"},
+        applyIfCPUFeature = {"avx512dq", "true"})
     public void float2long() {
         var cvec = (LongVector)fvec512.convertShape(VectorOperators.F2L, lspec512, 0);
         cvec.intoArray(long_arr, 0);
@@ -120,7 +122,8 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_F2X, "> 0"}, applyIfCPUFeature = {"avx512f", "true"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE_16, "> 0"},
+        applyIfCPUFeature = {"avx512f", "true"})
     public void float2short() {
         var cvec = (ShortVector)fvec512.convertShape(VectorOperators.F2S, sspec256, 0);
         cvec.intoArray(short_arr, 0);
@@ -137,7 +140,8 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_F2X, "> 0"}, applyIfCPUFeature = {"avx512f", "true"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2B, IRNode.VECTOR_SIZE_16, "> 0"},
+        applyIfCPUFeature = {"avx512f", "true"})
     public void float2byte() {
         var cvec = (ByteVector)fvec512.convertShape(VectorOperators.F2B, bspec128, 0);
         cvec.intoArray(byte_arr, 0);
@@ -154,7 +158,8 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_D2X, "> 0"}, applyIfCPUFeature = {"avx512f", "true"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2I, IRNode.VECTOR_SIZE_8, "> 0"},
+        applyIfCPUFeature = {"avx512f", "true"})
     public void double2int() {
         var cvec = (IntVector)dvec512.convertShape(VectorOperators.D2I, ispec256, 0);
         cvec.intoArray(int_arr, 0);
@@ -171,7 +176,8 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_D2X, "> 0"}, applyIfCPUFeature = {"avx512dq", "true"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE_8, "> 0"},
+        applyIfCPUFeature = {"avx512dq", "true"})
     public void double2long() {
         var cvec = (LongVector)dvec512.convertShape(VectorOperators.D2L, lspec512, 0);
         cvec.intoArray(long_arr, 0);
@@ -188,7 +194,8 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_D2X, "> 0"}, applyIfCPUFeature = {"avx512f", "true"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE_8, "> 0"},
+        applyIfCPUFeature = {"avx512f", "true"})
     public void double2short() {
         var cvec = (ShortVector)dvec512.convertShape(VectorOperators.D2S, sspec128, 0);
         cvec.intoArray(short_arr, 0);
@@ -205,7 +212,8 @@ public class VectorFPtoIntCastTest {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_D2X, "> 0"}, applyIfCPUFeature = {"avx512f", "true"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2B, IRNode.VECTOR_SIZE_8, "> 0"},
+        applyIfCPUFeature = {"avx512f", "true"})
     public void double2byte() {
         var cvec = (ByteVector)dvec512.convertShape(VectorOperators.D2B, bspec64, 0);
         cvec.intoArray(byte_arr, 0);

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorLogicalOpIdentityTest.java
@@ -104,7 +104,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.AND_V, counts = {IRNode.LOAD_VECTOR, ">=1"})
+    @IR(failOn = IRNode.AND_VB, counts = {IRNode.LOAD_VECTOR_B, ">=1"})
     public static void testAndMinusOne() {
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
         av.and((byte) -1).intoArray(br, 0);
@@ -117,7 +117,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.AND_V, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = IRNode.AND_VS, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testAndZero() {
         ShortVector av = ShortVector.fromArray(S_SPECIES, sa, 0);
         av.and((short) 0).intoArray(sr, 0);
@@ -130,7 +130,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.AND_V, counts = {IRNode.LOAD_VECTOR, ">=1"})
+    @IR(failOn = IRNode.AND_VI, counts = {IRNode.LOAD_VECTOR_I, ">=1"})
     public static void testAndSame() {
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
         av.and(av).intoArray(ir, 0);
@@ -143,7 +143,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.AND_V, counts = {IRNode.LOAD_VECTOR, ">=1"})
+    @IR(failOn = IRNode.AND_VL, counts = {IRNode.LOAD_VECTOR_L, ">=1"})
     public static void testMaskedAndMinusOne1() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -163,8 +163,8 @@ public class VectorLogicalOpIdentityTest {
     // Masked AndV in this test should not be optimized out on SVE.
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.LOAD_VECTOR, ">=1"})
-    @IR(failOn = IRNode.AND_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
+    @IR(counts = {IRNode.LOAD_VECTOR_B, ">=1"})
+    @IR(failOn = IRNode.AND_VB, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedAndMinusOne2() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
@@ -185,7 +185,7 @@ public class VectorLogicalOpIdentityTest {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.STORE_VECTOR, ">=1"})
-    @IR(failOn = IRNode.AND_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
+    @IR(failOn = IRNode.AND_VS, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedAndZero1() {
         VectorMask<Short> mask = VectorMask.fromArray(S_SPECIES, m, 0);
         ShortVector av = ShortVector.fromArray(S_SPECIES, sa, 0);
@@ -204,7 +204,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.AND_V, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = IRNode.AND_VI, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskedAndZero2() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -223,7 +223,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.AND_V, counts = {IRNode.LOAD_VECTOR, ">=1"})
+    @IR(failOn = IRNode.AND_VL, counts = {IRNode.LOAD_VECTOR_L, ">=1"})
     public static void testMaskedAndSame() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -242,7 +242,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(AndV(a, b), b) ==> AndV(a, b)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"})
+    @IR(counts = {IRNode.AND_VI, "1"})
     public static void testAndSameValue1() {
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
         IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
@@ -257,7 +257,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(AndV(a, b), a) ==> AndV(a, b)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"})
+    @IR(counts = {IRNode.AND_VL, "1"})
     public static void testAndSameValue2() {
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
         LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
@@ -272,7 +272,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(b, AndV(a, b)) ==> AndV(a, b)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"})
+    @IR(counts = {IRNode.AND_VI, "1"})
     public static void testAndSameValue3() {
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
         IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
@@ -287,7 +287,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(a, AndV(a, b)) ==> AndV(a, b)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"})
+    @IR(counts = {IRNode.AND_VL, "1"})
     public static void testAndSameValue4() {
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
         LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
@@ -302,7 +302,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(AndV(a, b, m), b, m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
+    @IR(counts = {IRNode.AND_VI, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testAndMaskSameValue1() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -323,7 +323,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(AndV(a, b, m), a, m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
+    @IR(counts = {IRNode.AND_VL, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testAndMaskSameValue2() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -344,7 +344,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform AndV(a, AndV(a, b, m), m) ==> AndV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.AND_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
+    @IR(counts = {IRNode.AND_VI, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testAndMaskSameValue3() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -368,7 +368,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.OR_V, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = IRNode.OR_VB, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testOrMinusOne() {
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
         av.or((byte) -1).intoArray(br, 0);
@@ -381,7 +381,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.OR_V, counts = {IRNode.LOAD_VECTOR, ">=1"})
+    @IR(failOn = IRNode.OR_VS, counts = {IRNode.LOAD_VECTOR_S, ">=1"})
     public static void testOrZero() {
         ShortVector av = ShortVector.fromArray(S_SPECIES, sa, 0);
         av.or((short) 0).intoArray(sr, 0);
@@ -394,7 +394,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.OR_V, counts = {IRNode.LOAD_VECTOR, ">=1"})
+    @IR(failOn = IRNode.OR_VI, counts = {IRNode.LOAD_VECTOR_I, ">=1"})
     public static void testOrSame() {
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
         av.or(av).intoArray(ir, 0);
@@ -409,7 +409,7 @@ public class VectorLogicalOpIdentityTest {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.STORE_VECTOR, ">=1"})
-    @IR(failOn = IRNode.OR_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
+    @IR(failOn = IRNode.OR_VB, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedOrMinusOne1() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
@@ -428,7 +428,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.OR_V, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = IRNode.OR_VB, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskedOrMinusOne2() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
@@ -447,7 +447,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.OR_V, counts = {IRNode.LOAD_VECTOR, ">=1"})
+    @IR(failOn = IRNode.OR_VS, counts = {IRNode.LOAD_VECTOR_S, ">=1"})
     public static void testMaskedOrZero1() {
         VectorMask<Short> mask = VectorMask.fromArray(S_SPECIES, m, 0);
         ShortVector av = ShortVector.fromArray(S_SPECIES, sa, 0);
@@ -467,8 +467,8 @@ public class VectorLogicalOpIdentityTest {
     // Masked OrV in this test should not be optimized out on SVE.
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.LOAD_VECTOR, ">=1"})
-    @IR(failOn = IRNode.OR_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
+    @IR(counts = {IRNode.LOAD_VECTOR_B, ">=1"})
+    @IR(failOn = IRNode.OR_VB, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedOrZero2() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
@@ -487,7 +487,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.OR_V, counts = {IRNode.LOAD_VECTOR, ">=1"})
+    @IR(failOn = IRNode.OR_VL, counts = {IRNode.LOAD_VECTOR_L, ">=1"})
     public static void testMaskedOrSame() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -506,7 +506,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(OrV(a, b), b) ==> OrV(a, b)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"})
+    @IR(counts = {IRNode.OR_VI, "1"})
     public static void testOrSameValue1() {
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
         IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
@@ -521,7 +521,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(OrV(a, b), a) ==> OrV(a, b)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"})
+    @IR(counts = {IRNode.OR_VL, "1"})
     public static void testOrSameValue2() {
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
         LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
@@ -536,7 +536,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(b, OrV(a, b)) ==> OrV(a, b)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"})
+    @IR(counts = {IRNode.OR_VI, "1"})
     public static void testOrSameValue3() {
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
         IntVector bv = IntVector.fromArray(I_SPECIES, ib, 0);
@@ -551,7 +551,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(a, OrV(a, b)) ==> OrV(a, b)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"})
+    @IR(counts = {IRNode.OR_VL, "1"})
     public static void testOrSameValue4() {
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
         LongVector bv = LongVector.fromArray(L_SPECIES, lb, 0);
@@ -566,7 +566,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(OrV(a, b, m), b, m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
+    @IR(counts = {IRNode.OR_VI, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testOrMaskSameValue1() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -587,7 +587,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(OrV(a, b, m), a, m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
+    @IR(counts = {IRNode.OR_VL, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testOrMaskSameValue2() {
         VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
         LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
@@ -608,7 +608,7 @@ public class VectorLogicalOpIdentityTest {
     // Transform OrV(a, OrV(a, b, m), m) ==> OrV(a, b, m)
     @Test
     @Warmup(10000)
-    @IR(counts = {IRNode.OR_V, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
+    @IR(counts = {IRNode.OR_VI, "1"}, applyIfCPUFeatureOr = {"sve", "true", "avx512", "true"})
     public static void testOrMaskSameValue3() {
         VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
         IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
@@ -632,7 +632,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = IRNode.XOR_V, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = IRNode.XOR_VB, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testXorSame() {
         ByteVector av = ByteVector.fromArray(B_SPECIES, ba, 0);
         av.lanewise(VectorOperators.XOR, av).intoArray(br, 0);
@@ -647,7 +647,7 @@ public class VectorLogicalOpIdentityTest {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.STORE_VECTOR, ">=1"})
-    @IR(failOn = IRNode.XOR_V, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
+    @IR(failOn = IRNode.XOR_VS, applyIfCPUFeatureAnd = {"asimd", "true", "sve", "false"})
     public static void testMaskedXorSame() {
         VectorMask<Short> mask = VectorMask.fromArray(S_SPECIES, m, 0);
         ShortVector av = ShortVector.fromArray(S_SPECIES, sa, 0);
@@ -666,7 +666,7 @@ public class VectorLogicalOpIdentityTest {
     // Following are the vector mask logic operations tests
     @Test
     @Warmup(10000)
-    @IR(failOn = {IRNode.AND_V, IRNode.AND_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = {IRNode.AND_VI, IRNode.AND_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskAndMinusOne() {
         VectorMask<Integer> ma = VectorMask.fromArray(I_SPECIES, m, 0);
         VectorMask<Integer> mb = I_SPECIES.maskAll(true);
@@ -680,7 +680,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = {IRNode.AND_V, IRNode.AND_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = {IRNode.AND_VS, IRNode.AND_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskAndZero() {
         VectorMask<Short> ma = VectorMask.fromArray(S_SPECIES, m, 0);
         VectorMask<Short> mb = S_SPECIES.maskAll(false);
@@ -694,7 +694,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = {IRNode.AND_V, IRNode.AND_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = {IRNode.AND_VB, IRNode.AND_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskAndSame() {
         VectorMask<Byte> ma = VectorMask.fromArray(B_SPECIES, m, 0);
         ma.and(ma).intoArray(mr, 0);
@@ -707,7 +707,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = {IRNode.OR_V, IRNode.OR_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = {IRNode.OR_VS, IRNode.OR_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskOrMinusOne() {
         VectorMask<Short> ma = VectorMask.fromArray(S_SPECIES, m, 0);
         VectorMask<Short> mb = S_SPECIES.maskAll(true);
@@ -721,7 +721,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = {IRNode.OR_V, IRNode.OR_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = {IRNode.OR_VI, IRNode.OR_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskOrZero() {
         VectorMask<Integer> ma = VectorMask.fromArray(I_SPECIES, m, 0);
         VectorMask<Integer> mb = I_SPECIES.maskAll(false);
@@ -735,7 +735,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = {IRNode.OR_V, IRNode.OR_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = {IRNode.OR_VB, IRNode.OR_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskOrSame() {
         VectorMask<Byte> ma = VectorMask.fromArray(B_SPECIES, m, 0);
         ma.or(ma).intoArray(mr, 0);
@@ -748,7 +748,7 @@ public class VectorLogicalOpIdentityTest {
 
     @Test
     @Warmup(10000)
-    @IR(failOn = {IRNode.XOR_V, IRNode.XOR_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
+    @IR(failOn = {IRNode.XOR_VI, IRNode.XOR_V_MASK}, counts = {IRNode.STORE_VECTOR, ">=1"})
     public static void testMaskXorSame() {
         VectorMask<Integer> ma = I_SPECIES.maskAll(true);
         ma.not().intoArray(mr, 0);

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorReverseBytesTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorReverseBytesTest.java
@@ -70,7 +70,7 @@ public class VectorReverseBytesTest {
     }
 
     @Test
-    @IR(failOn = IRNode.REVERSE_BYTES_V)
+    @IR(failOn = IRNode.REVERSE_BYTES_VB)
     public static void testReverseBytesV() {
         for (int i = 0; i < LENGTH; i += B_SPECIES.length()) {
             ByteVector v = ByteVector.fromArray(B_SPECIES, input, i);
@@ -84,8 +84,8 @@ public class VectorReverseBytesTest {
     }
 
     @Test
-    @IR(failOn = IRNode.REVERSE_BYTES_V)
-    @IR(failOn = IRNode.VECTOR_BLEND)
+    @IR(failOn = IRNode.REVERSE_BYTES_VB)
+    @IR(failOn = IRNode.VECTOR_BLEND_B)
     public static void testReverseBytesVMasked() {
         VectorMask<Byte> mask = VectorMask.fromArray(B_SPECIES, m, 0);
         for (int i = 0; i < LENGTH; i += B_SPECIES.length()) {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorCast.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorCast.java
@@ -26,6 +26,7 @@ package compiler.vectorapi.reshape.tests;
 import compiler.lib.ir_framework.IR;
 import compiler.lib.ir_framework.Run;
 import compiler.lib.ir_framework.Test;
+import compiler.lib.ir_framework.IRNode;
 
 import static compiler.vectorapi.reshape.utils.VectorReshapeHelper.*;
 import static jdk.incubator.vector.VectorOperators.*;
@@ -44,7 +45,7 @@ import static jdk.incubator.vector.VectorOperators.*;
  */
 public class TestVectorCast {
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2S, IRNode.VECTOR_SIZE_4, "1"})
     public static void testB64toS64(byte[] input, short[] output) {
         vectorCast(B2S, BSPEC64, SSPEC64, input, output);
     }
@@ -55,7 +56,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2S, IRNode.VECTOR_SIZE_8, "1"})
     public static void testB64toS128(byte[] input, short[] output) {
         vectorCast(B2S, BSPEC64, SSPEC128, input, output);
     }
@@ -66,7 +67,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2S, IRNode.VECTOR_SIZE_16, "1"})
     public static void testB128toS256(byte[] input, short[] output) {
         vectorCast(B2S, BSPEC128, SSPEC256, input, output);
     }
@@ -77,7 +78,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2S, IRNode.VECTOR_SIZE_32, "1"})
     public static void testB256toS512(byte[] input, short[] output) {
         vectorCast(B2S, BSPEC256, SSPEC512, input, output);
     }
@@ -88,7 +89,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testB64toI64(byte[] input, int[] output) {
         vectorCast(B2I, BSPEC64, ISPEC64, input, output);
     }
@@ -99,7 +100,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2I, IRNode.VECTOR_SIZE_4, "1"})
     public static void testB64toI128(byte[] input, int[] output) {
         vectorCast(B2I, BSPEC64, ISPEC128, input, output);
     }
@@ -110,7 +111,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2I, IRNode.VECTOR_SIZE_8, "1"})
     public static void testB64toI256(byte[] input, int[] output) {
         vectorCast(B2I, BSPEC64, ISPEC256, input, output);
     }
@@ -121,7 +122,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2I, IRNode.VECTOR_SIZE_16, "1"})
     public static void testB128toI512(byte[] input, int[] output) {
         vectorCast(B2I, BSPEC128, ISPEC512, input, output);
     }
@@ -132,7 +133,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testB64toL64(byte[] input, long[] output) {
         vectorCast(B2L, BSPEC64, LSPEC64, input, output);
     }
@@ -143,7 +144,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testB64toL128(byte[] input, long[] output) {
         vectorCast(B2L, BSPEC64, LSPEC128, input, output);
     }
@@ -154,7 +155,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2L, IRNode.VECTOR_SIZE_4, "1"})
     public static void testB64toL256(byte[] input, long[] output) {
         vectorCast(B2L, BSPEC64, LSPEC256, input, output);
     }
@@ -165,7 +166,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testB64toL512(byte[] input, long[] output) {
         vectorCast(B2L, BSPEC64, LSPEC512, input, output);
     }
@@ -176,7 +177,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2F, IRNode.VECTOR_SIZE_2, "1"})
     public static void testB64toF64(byte[] input, float[] output) {
         vectorCast(B2F, BSPEC64, FSPEC64, input, output);
     }
@@ -187,7 +188,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2F, IRNode.VECTOR_SIZE_4, "1"})
     public static void testB64toF128(byte[] input, float[] output) {
         vectorCast(B2F, BSPEC64, FSPEC128, input, output);
     }
@@ -198,7 +199,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2F, IRNode.VECTOR_SIZE_8, "1"})
     public static void testB64toF256(byte[] input, float[] output) {
         vectorCast(B2F, BSPEC64, FSPEC256, input, output);
     }
@@ -209,7 +210,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2F, IRNode.VECTOR_SIZE_16, "1"})
     public static void testB128toF512(byte[] input, float[] output) {
         vectorCast(B2F, BSPEC128, FSPEC512, input, output);
     }
@@ -220,7 +221,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testB64toD64(byte[] input, double[] output) {
         vectorCast(B2D, BSPEC64, DSPEC64, input, output);
     }
@@ -231,7 +232,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testB64toD128(byte[] input, double[] output) {
         vectorCast(B2D, BSPEC64, DSPEC128, input, output);
     }
@@ -242,7 +243,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2D, IRNode.VECTOR_SIZE_4, "1"})
     public static void testB64toD256(byte[] input, double[] output) {
         vectorCast(B2D, BSPEC64, DSPEC256, input, output);
     }
@@ -253,7 +254,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {B2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_B2D, IRNode.VECTOR_SIZE_8, "1"})
     public static void testB64toD512(byte[] input, double[] output) {
         vectorCast(B2D, BSPEC64, DSPEC512, input, output);
     }
@@ -264,7 +265,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2B, IRNode.VECTOR_SIZE_4, "1"})
     public static void testS64toB64(short[] input, byte[] output) {
         vectorCast(S2B, SSPEC64, BSPEC64, input, output);
     }
@@ -275,7 +276,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2B, IRNode.VECTOR_SIZE_8, "1"})
     public static void testS128toB64(short[] input, byte[] output) {
         vectorCast(S2B, SSPEC128, BSPEC64, input, output);
     }
@@ -286,7 +287,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2B, IRNode.VECTOR_SIZE_16, "1"})
     public static void testS256toB128(short[] input, byte[] output) {
         vectorCast(S2B, SSPEC256, BSPEC128, input, output);
     }
@@ -297,7 +298,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2B, IRNode.VECTOR_SIZE_32, "1"})
     public static void testS512toB256(short[] input, byte[] output) {
         vectorCast(S2B, SSPEC512, BSPEC256, input, output);
     }
@@ -308,7 +309,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testS64toI64(short[] input, int[] output) {
         vectorCast(S2I, SSPEC64, ISPEC64, input, output);
     }
@@ -319,7 +320,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2I, IRNode.VECTOR_SIZE_4, "1"})
     public static void testS64toI128(short[] input, int[] output) {
         vectorCast(S2I, SSPEC64, ISPEC128, input, output);
     }
@@ -330,7 +331,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2I, IRNode.VECTOR_SIZE_8, "1"})
     public static void testS128toI256(short[] input, int[] output) {
         vectorCast(S2I, SSPEC128, ISPEC256, input, output);
     }
@@ -341,7 +342,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2I, IRNode.VECTOR_SIZE_16, "1"})
     public static void testS256toI512(short[] input, int[] output) {
         vectorCast(S2I, SSPEC256, ISPEC512, input, output);
     }
@@ -352,7 +353,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testS64toL64(short[] input, long[] output) {
         vectorCast(S2L, SSPEC64, LSPEC64, input, output);
     }
@@ -363,7 +364,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testS64toL128(short[] input, long[] output) {
         vectorCast(S2L, SSPEC64, LSPEC128, input, output);
     }
@@ -374,7 +375,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2L, IRNode.VECTOR_SIZE_4, "1"})
     public static void testS64toL256(short[] input, long[] output) {
         vectorCast(S2L, SSPEC64, LSPEC256, input, output);
     }
@@ -385,7 +386,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testS128toL512(short[] input, long[] output) {
         vectorCast(S2L, SSPEC128, LSPEC512, input, output);
     }
@@ -396,7 +397,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2F, IRNode.VECTOR_SIZE_2, "1"})
     public static void testS64toF64(short[] input, float[] output) {
         vectorCast(S2F, SSPEC64, FSPEC64, input, output);
     }
@@ -407,7 +408,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2F, IRNode.VECTOR_SIZE_4, "1"})
     public static void testS64toF128(short[] input, float[] output) {
         vectorCast(S2F, SSPEC64, FSPEC128, input, output);
     }
@@ -418,7 +419,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2F, IRNode.VECTOR_SIZE_8, "1"})
     public static void testS128toF256(short[] input, float[] output) {
         vectorCast(S2F, SSPEC128, FSPEC256, input, output);
     }
@@ -429,7 +430,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2F, IRNode.VECTOR_SIZE_16, "1"})
     public static void testS256toF512(short[] input, float[] output) {
         vectorCast(S2F, SSPEC256, FSPEC512, input, output);
     }
@@ -440,7 +441,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testS64toD64(short[] input, double[] output) {
         vectorCast(S2D, SSPEC64, DSPEC64, input, output);
     }
@@ -451,7 +452,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testS64toD128(short[] input, double[] output) {
         vectorCast(S2D, SSPEC64, DSPEC128, input, output);
     }
@@ -462,7 +463,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2D, IRNode.VECTOR_SIZE_4, "1"})
     public static void testS64toD256(short[] input, double[] output) {
         vectorCast(S2D, SSPEC64, DSPEC256, input, output);
     }
@@ -473,7 +474,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {S2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_S2D, IRNode.VECTOR_SIZE_8, "1"})
     public static void testS128toD512(short[] input, double[] output) {
         vectorCast(S2D, SSPEC128, DSPEC512, input, output);
     }
@@ -484,7 +485,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2B, IRNode.VECTOR_SIZE_2, "1"})
     public static void testI64toB64(int[] input, byte[] output) {
         vectorCast(I2B, ISPEC64, BSPEC64, input, output);
     }
@@ -495,7 +496,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2B, IRNode.VECTOR_SIZE_4, "1"})
     public static void testI128toB64(int[] input, byte[] output) {
         vectorCast(I2B, ISPEC128, BSPEC64, input, output);
     }
@@ -506,7 +507,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2B, IRNode.VECTOR_SIZE_8, "1"})
     public static void testI256toB64(int[] input, byte[] output) {
         vectorCast(I2B, ISPEC256, BSPEC64, input, output);
     }
@@ -517,7 +518,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2B, IRNode.VECTOR_SIZE_16, "1"})
     public static void testI512toB128(int[] input, byte[] output) {
         vectorCast(I2B, ISPEC512, BSPEC128, input, output);
     }
@@ -528,7 +529,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2S, IRNode.VECTOR_SIZE_2, "1"})
     public static void testI64toS64(int[] input, short[] output) {
         vectorCast(I2S, ISPEC64, SSPEC64, input, output);
     }
@@ -539,7 +540,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2S, IRNode.VECTOR_SIZE_4, "1"})
     public static void testI128toS64(int[] input, short[] output) {
         vectorCast(I2S, ISPEC128, SSPEC64, input, output);
     }
@@ -550,7 +551,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2S, IRNode.VECTOR_SIZE_8, "1"})
     public static void testI256toS128(int[] input, short[] output) {
         vectorCast(I2S, ISPEC256, SSPEC128, input, output);
     }
@@ -561,7 +562,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2S, IRNode.VECTOR_SIZE_16, "1"})
     public static void testI512toS256(int[] input, short[] output) {
         vectorCast(I2S, ISPEC512, SSPEC256, input, output);
     }
@@ -572,7 +573,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testI64toL64(int[] input, long[] output) {
         vectorCast(I2L, ISPEC64, LSPEC64, input, output);
     }
@@ -583,7 +584,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testI64toL128(int[] input, long[] output) {
         vectorCast(I2L, ISPEC64, LSPEC128, input, output);
     }
@@ -594,7 +595,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE_4, "1"})
     public static void testI128toL256(int[] input, long[] output) {
         vectorCast(I2L, ISPEC128, LSPEC256, input, output);
     }
@@ -605,7 +606,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testI256toL512(int[] input, long[] output) {
         vectorCast(I2L, ISPEC256, LSPEC512, input, output);
     }
@@ -616,7 +617,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2F, IRNode.VECTOR_SIZE_2, "1"})
     public static void testI64toF64(int[] input, float[] output) {
         vectorCast(I2F, ISPEC64, FSPEC64, input, output);
     }
@@ -627,7 +628,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2F, IRNode.VECTOR_SIZE_4, "1"})
     public static void testI128toF128(int[] input, float[] output) {
         vectorCast(I2F, ISPEC128, FSPEC128, input, output);
     }
@@ -638,7 +639,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2F, IRNode.VECTOR_SIZE_8, "1"})
     public static void testI256toF256(int[] input, float[] output) {
         vectorCast(I2F, ISPEC256, FSPEC256, input, output);
     }
@@ -649,7 +650,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2F, IRNode.VECTOR_SIZE_16, "1"})
     public static void testI512toF512(int[] input, float[] output) {
         vectorCast(I2F, ISPEC512, FSPEC512, input, output);
     }
@@ -660,7 +661,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testI64toD64(int[] input, double[] output) {
         vectorCast(I2D, ISPEC64, DSPEC64, input, output);
     }
@@ -671,7 +672,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testI64toD128(int[] input, double[] output) {
         vectorCast(I2D, ISPEC64, DSPEC128, input, output);
     }
@@ -682,7 +683,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE_4, "1"})
     public static void testI128toD256(int[] input, double[] output) {
         vectorCast(I2D, ISPEC128, DSPEC256, input, output);
     }
@@ -693,7 +694,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {I2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE_8, "1"})
     public static void testI256toD512(int[] input, double[] output) {
         vectorCast(I2D, ISPEC256, DSPEC512, input, output);
     }
@@ -704,7 +705,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2B, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL64toB64(long[] input, byte[] output) {
         vectorCast(L2B, LSPEC64, BSPEC64, input, output);
     }
@@ -715,7 +716,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2B, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL128toB64(long[] input, byte[] output) {
         vectorCast(L2B, LSPEC128, BSPEC64, input, output);
     }
@@ -726,7 +727,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2B, IRNode.VECTOR_SIZE_4, "1"})
     public static void testL256toB64(long[] input, byte[] output) {
         vectorCast(L2B, LSPEC256, BSPEC64, input, output);
     }
@@ -737,7 +738,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2B, IRNode.VECTOR_SIZE_8, "1"})
     public static void testL512toB64(long[] input, byte[] output) {
         vectorCast(L2B, LSPEC512, BSPEC64, input, output);
     }
@@ -748,7 +749,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2S, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL64toS64(long[] input, short[] output) {
         vectorCast(L2S, LSPEC64, SSPEC64, input, output);
     }
@@ -759,7 +760,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2S, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL128toS64(long[] input, short[] output) {
         vectorCast(L2S, LSPEC128, SSPEC64, input, output);
     }
@@ -770,7 +771,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2S, IRNode.VECTOR_SIZE_4, "1"})
     public static void testL256toS64(long[] input, short[] output) {
         vectorCast(L2S, LSPEC256, SSPEC64, input, output);
     }
@@ -781,7 +782,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2S, IRNode.VECTOR_SIZE_8, "1"})
     public static void testL512toS128(long[] input, short[] output) {
         vectorCast(L2S, LSPEC512, SSPEC128, input, output);
     }
@@ -792,7 +793,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL64toI64(long[] input, int[] output) {
         vectorCast(L2I, LSPEC64, ISPEC64, input, output);
     }
@@ -803,7 +804,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL128toI64(long[] input, int[] output) {
         vectorCast(L2I, LSPEC128, ISPEC64, input, output);
     }
@@ -814,7 +815,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2I, IRNode.VECTOR_SIZE_4, "1"})
     public static void testL256toI128(long[] input, int[] output) {
         vectorCast(L2I, LSPEC256, ISPEC128, input, output);
     }
@@ -825,7 +826,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2I, IRNode.VECTOR_SIZE_8, "1"})
     public static void testL512toI256(long[] input, int[] output) {
         vectorCast(L2I, LSPEC512, ISPEC256, input, output);
     }
@@ -836,7 +837,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2F, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL64toF64(long[] input, float[] output) {
         vectorCast(L2F, LSPEC64, FSPEC64, input, output);
     }
@@ -847,7 +848,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2F, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL128toF64(long[] input, float[] output) {
         vectorCast(L2F, LSPEC128, FSPEC64, input, output);
     }
@@ -858,7 +859,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2F, IRNode.VECTOR_SIZE_4, "1"})
     public static void testL256toF128(long[] input, float[] output) {
         vectorCast(L2F, LSPEC256, FSPEC128, input, output);
     }
@@ -869,7 +870,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2F, IRNode.VECTOR_SIZE_8, "1"})
     public static void testL512toF256(long[] input, float[] output) {
         vectorCast(L2F, LSPEC512, FSPEC256, input, output);
     }
@@ -880,7 +881,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL64toD64(long[] input, double[] output) {
         vectorCast(L2D, LSPEC64, DSPEC64, input, output);
     }
@@ -891,7 +892,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testL128toD128(long[] input, double[] output) {
         vectorCast(L2D, LSPEC128, DSPEC128, input, output);
     }
@@ -902,7 +903,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2D, IRNode.VECTOR_SIZE_4, "1"})
     public static void testL256toD256(long[] input, double[] output) {
         vectorCast(L2D, LSPEC256, DSPEC256, input, output);
     }
@@ -913,7 +914,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {L2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_L2D, IRNode.VECTOR_SIZE_8, "1"})
     public static void testL512toD512(long[] input, double[] output) {
         vectorCast(L2D, LSPEC512, DSPEC512, input, output);
     }
@@ -924,7 +925,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2B, IRNode.VECTOR_SIZE_2, "1"})
     public static void testF64toB64(float[] input, byte[] output) {
         vectorCast(F2B, FSPEC64, BSPEC64, input, output);
     }
@@ -935,7 +936,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2B, IRNode.VECTOR_SIZE_4, "1"})
     public static void testF128toB64(float[] input, byte[] output) {
         vectorCast(F2B, FSPEC128, BSPEC64, input, output);
     }
@@ -946,7 +947,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2B, IRNode.VECTOR_SIZE_8, "1"})
     public static void testF256toB64(float[] input, byte[] output) {
         vectorCast(F2B, FSPEC256, BSPEC64, input, output);
     }
@@ -957,7 +958,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2B, IRNode.VECTOR_SIZE_16, "1"})
     public static void testF512toB128(float[] input, byte[] output) {
         vectorCast(F2B, FSPEC512, BSPEC128, input, output);
     }
@@ -968,7 +969,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE_2, "1"})
     public static void testF64toS64(float[] input, short[] output) {
         vectorCast(F2S, FSPEC64, SSPEC64, input, output);
     }
@@ -979,7 +980,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE_4, "1"})
     public static void testF128toS64(float[] input, short[] output) {
         vectorCast(F2S, FSPEC128, SSPEC64, input, output);
     }
@@ -990,7 +991,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE_8, "1"})
     public static void testF256toS128(float[] input, short[] output) {
         vectorCast(F2S, FSPEC256, SSPEC128, input, output);
     }
@@ -1001,7 +1002,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE_16, "1"})
     public static void testF512toS256(float[] input, short[] output) {
         vectorCast(F2S, FSPEC512, SSPEC256, input, output);
     }
@@ -1012,7 +1013,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testF64toI64(float[] input, int[] output) {
         vectorCast(F2I, FSPEC64, ISPEC64, input, output);
     }
@@ -1023,7 +1024,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2I, IRNode.VECTOR_SIZE_4, "1"})
     public static void testF128toI128(float[] input, int[] output) {
         vectorCast(F2I, FSPEC128, ISPEC128, input, output);
     }
@@ -1034,7 +1035,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2I, IRNode.VECTOR_SIZE_8, "1"})
     public static void testF256toI256(float[] input, int[] output) {
         vectorCast(F2I, FSPEC256, ISPEC256, input, output);
     }
@@ -1045,7 +1046,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2I, IRNode.VECTOR_SIZE_16, "1"})
     public static void testF512toI512(float[] input, int[] output) {
         vectorCast(F2I, FSPEC512, ISPEC512, input, output);
     }
@@ -1056,7 +1057,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testF64toL64(float[] input, long[] output) {
         vectorCast(F2L, FSPEC64, LSPEC64, input, output);
     }
@@ -1067,7 +1068,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testF64toL128(float[] input, long[] output) {
         vectorCast(F2L, FSPEC64, LSPEC128, input, output);
     }
@@ -1078,7 +1079,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE_4, "1"})
     public static void testF128toL256(float[] input, long[] output) {
         vectorCast(F2L, FSPEC128, LSPEC256, input, output);
     }
@@ -1089,7 +1090,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testF256toL512(float[] input, long[] output) {
         vectorCast(F2L, FSPEC256, LSPEC512, input, output);
     }
@@ -1100,7 +1101,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testF64toD64(float[] input, double[] output) {
         vectorCast(F2D, FSPEC64, DSPEC64, input, output);
     }
@@ -1111,7 +1112,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2D, IRNode.VECTOR_SIZE_2, "1"})
     public static void testF64toD128(float[] input, double[] output) {
         vectorCast(F2D, FSPEC64, DSPEC128, input, output);
     }
@@ -1122,7 +1123,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2D, IRNode.VECTOR_SIZE_4, "1"})
     public static void testF128toD256(float[] input, double[] output) {
         vectorCast(F2D, FSPEC128, DSPEC256, input, output);
     }
@@ -1133,7 +1134,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {F2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2D, IRNode.VECTOR_SIZE_8, "1"})
     public static void testF256toD512(float[] input, double[] output) {
         vectorCast(F2D, FSPEC256, DSPEC512, input, output);
     }
@@ -1144,7 +1145,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2B, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD64toB64(double[] input, byte[] output) {
         vectorCast(D2B, DSPEC64, BSPEC64, input, output);
     }
@@ -1155,7 +1156,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2B, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD128toB64(double[] input, byte[] output) {
         vectorCast(D2B, DSPEC128, BSPEC64, input, output);
     }
@@ -1166,7 +1167,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2B, IRNode.VECTOR_SIZE_4, "1"})
     public static void testD256toB64(double[] input, byte[] output) {
         vectorCast(D2B, DSPEC256, BSPEC64, input, output);
     }
@@ -1177,7 +1178,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2B, IRNode.VECTOR_SIZE_8, "1"})
     public static void testD512toB64(double[] input, byte[] output) {
         vectorCast(D2B, DSPEC512, BSPEC64, input, output);
     }
@@ -1188,7 +1189,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD64toS64(double[] input, short[] output) {
         vectorCast(D2S, DSPEC64, SSPEC64, input, output);
     }
@@ -1199,7 +1200,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD128toS64(double[] input, short[] output) {
         vectorCast(D2S, DSPEC128, SSPEC64, input, output);
     }
@@ -1210,7 +1211,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE_4, "1"})
     public static void testD256toS64(double[] input, short[] output) {
         vectorCast(D2S, DSPEC256, SSPEC64, input, output);
     }
@@ -1221,7 +1222,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE_8, "1"})
     public static void testD512toS128(double[] input, short[] output) {
         vectorCast(D2S, DSPEC512, SSPEC128, input, output);
     }
@@ -1232,7 +1233,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD64toI64(double[] input, int[] output) {
         vectorCast(D2I, DSPEC64, ISPEC64, input, output);
     }
@@ -1243,7 +1244,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD128toI64(double[] input, int[] output) {
         vectorCast(D2I, DSPEC128, ISPEC64, input, output);
     }
@@ -1254,7 +1255,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2I, IRNode.VECTOR_SIZE_4, "1"})
     public static void testD256toI128(double[] input, int[] output) {
         vectorCast(D2I, DSPEC256, ISPEC128, input, output);
     }
@@ -1265,7 +1266,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2I, IRNode.VECTOR_SIZE_8, "1"})
     public static void testD512toI256(double[] input, int[] output) {
         vectorCast(D2I, DSPEC512, ISPEC256, input, output);
     }
@@ -1276,7 +1277,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD64toL64(double[] input, long[] output) {
         vectorCast(D2L, DSPEC64, LSPEC64, input, output);
     }
@@ -1287,7 +1288,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD128toL128(double[] input, long[] output) {
         vectorCast(D2L, DSPEC128, LSPEC128, input, output);
     }
@@ -1298,7 +1299,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE_4, "1"})
     public static void testD256toL256(double[] input, long[] output) {
         vectorCast(D2L, DSPEC256, LSPEC256, input, output);
     }
@@ -1309,7 +1310,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testD512toL512(double[] input, long[] output) {
         vectorCast(D2L, DSPEC512, LSPEC512, input, output);
     }
@@ -1320,7 +1321,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testD64toF64(double[] input, float[] output) {
         vectorCast(D2F, DSPEC64, FSPEC64, input, output);
     }
@@ -1331,7 +1332,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2F, IRNode.VECTOR_SIZE_2, "1"})
     public static void testD128toF64(double[] input, float[] output) {
         vectorCast(D2F, DSPEC128, FSPEC64, input, output);
     }
@@ -1342,7 +1343,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2F, IRNode.VECTOR_SIZE_4, "1"})
     public static void testD256toF128(double[] input, float[] output) {
         vectorCast(D2F, DSPEC256, FSPEC128, input, output);
     }
@@ -1353,7 +1354,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {D2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_CAST_D2F, IRNode.VECTOR_SIZE_8, "1"})
     public static void testD512toF256(double[] input, float[] output) {
         vectorCast(D2F, DSPEC512, FSPEC256, input, output);
     }
@@ -1364,7 +1365,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2S, IRNode.VECTOR_SIZE_4, "1"})
     public static void testUB64toS64(byte[] input, short[] output) {
         vectorCast(ZERO_EXTEND_B2S, BSPEC64, SSPEC64, input, output);
     }
@@ -1375,7 +1376,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2S, IRNode.VECTOR_SIZE_8, "1"})
     public static void testUB64toS128(byte[] input, short[] output) {
         vectorCast(ZERO_EXTEND_B2S, BSPEC64, SSPEC128, input, output);
     }
@@ -1386,7 +1387,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2S, IRNode.VECTOR_SIZE_16, "1"})
     public static void testUB128toS256(byte[] input, short[] output) {
         vectorCast(ZERO_EXTEND_B2S, BSPEC128, SSPEC256, input, output);
     }
@@ -1397,7 +1398,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2S, IRNode.VECTOR_SIZE_32, "1"})
     public static void testUB256toS512(byte[] input, short[] output) {
         vectorCast(ZERO_EXTEND_B2S, BSPEC256, SSPEC512, input, output);
     }
@@ -1408,7 +1409,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testUB64toI64(byte[] input, int[] output) {
         vectorCast(ZERO_EXTEND_B2I, BSPEC64, ISPEC64, input, output);
     }
@@ -1419,7 +1420,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2I, IRNode.VECTOR_SIZE_4, "1"})
     public static void testUB64toI128(byte[] input, int[] output) {
         vectorCast(ZERO_EXTEND_B2I, BSPEC64, ISPEC128, input, output);
     }
@@ -1430,7 +1431,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2I, IRNode.VECTOR_SIZE_8, "1"})
     public static void testUB64toI256(byte[] input, int[] output) {
         vectorCast(ZERO_EXTEND_B2I, BSPEC64, ISPEC256, input, output);
     }
@@ -1441,7 +1442,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2I, IRNode.VECTOR_SIZE_16, "1"})
     public static void testUB128toI512(byte[] input, int[] output) {
         vectorCast(ZERO_EXTEND_B2I, BSPEC128, ISPEC512, input, output);
     }
@@ -1452,7 +1453,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testUB64toL64(byte[] input, long[] output) {
         vectorCast(ZERO_EXTEND_B2L, BSPEC64, LSPEC64, input, output);
     }
@@ -1463,7 +1464,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testUB64toL128(byte[] input, long[] output) {
         vectorCast(ZERO_EXTEND_B2L, BSPEC64, LSPEC128, input, output);
     }
@@ -1474,7 +1475,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2L, IRNode.VECTOR_SIZE_4, "1"})
     public static void testUB64toL256(byte[] input, long[] output) {
         vectorCast(ZERO_EXTEND_B2L, BSPEC64, LSPEC256, input, output);
     }
@@ -1485,7 +1486,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UB2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_B2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testUB64toL512(byte[] input, long[] output) {
         vectorCast(ZERO_EXTEND_B2L, BSPEC64, LSPEC512, input, output);
     }
@@ -1496,7 +1497,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {US2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_S2I, IRNode.VECTOR_SIZE_2, "1"})
     public static void testUS64toI64(short[] input, int[] output) {
         vectorCast(ZERO_EXTEND_S2I, SSPEC64, ISPEC64, input, output);
     }
@@ -1507,7 +1508,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {US2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_S2I, IRNode.VECTOR_SIZE_4, "1"})
     public static void testUS64toI128(short[] input, int[] output) {
         vectorCast(ZERO_EXTEND_S2I, SSPEC64, ISPEC128, input, output);
     }
@@ -1518,7 +1519,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {US2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_S2I, IRNode.VECTOR_SIZE_8, "1"})
     public static void testUS128toI256(short[] input, int[] output) {
         vectorCast(ZERO_EXTEND_S2I, SSPEC128, ISPEC256, input, output);
     }
@@ -1529,7 +1530,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {US2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_S2I, IRNode.VECTOR_SIZE_16, "1"})
     public static void testUS256toI512(short[] input, int[] output) {
         vectorCast(ZERO_EXTEND_S2I, SSPEC256, ISPEC512, input, output);
     }
@@ -1540,7 +1541,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {US2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_S2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testUS64toL64(short[] input, long[] output) {
         vectorCast(ZERO_EXTEND_S2L, SSPEC64, LSPEC64, input, output);
     }
@@ -1551,7 +1552,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {US2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_S2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testUS64toL128(short[] input, long[] output) {
         vectorCast(ZERO_EXTEND_S2L, SSPEC64, LSPEC128, input, output);
     }
@@ -1562,7 +1563,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {US2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_S2L, IRNode.VECTOR_SIZE_4, "1"})
     public static void testUS64toL256(short[] input, long[] output) {
         vectorCast(ZERO_EXTEND_S2L, SSPEC64, LSPEC256, input, output);
     }
@@ -1573,7 +1574,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {US2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_S2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testUS128toL512(short[] input, long[] output) {
         vectorCast(ZERO_EXTEND_S2L, SSPEC128, LSPEC512, input, output);
     }
@@ -1584,7 +1585,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UI2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_I2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testUI64toL64(int[] input, long[] output) {
         vectorCast(ZERO_EXTEND_I2L, ISPEC64, LSPEC64, input, output);
     }
@@ -1595,7 +1596,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UI2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_I2L, IRNode.VECTOR_SIZE_2, "1"})
     public static void testUI64toL128(int[] input, long[] output) {
         vectorCast(ZERO_EXTEND_I2L, ISPEC64, LSPEC128, input, output);
     }
@@ -1606,7 +1607,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UI2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_I2L, IRNode.VECTOR_SIZE_4, "1"})
     public static void testUI128toL256(int[] input, long[] output) {
         vectorCast(ZERO_EXTEND_I2L, ISPEC128, LSPEC256, input, output);
     }
@@ -1617,7 +1618,7 @@ public class TestVectorCast {
     }
 
     @Test
-    @IR(counts = {UI2X_NODE, "1"})
+    @IR(counts = {IRNode.VECTOR_UCAST_I2L, IRNode.VECTOR_SIZE_8, "1"})
     public static void testUI256toL512(int[] input, long[] output) {
         vectorCast(ZERO_EXTEND_I2L, ISPEC256, LSPEC512, input, output);
     }

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/VectorReshapeHelper.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/VectorReshapeHelper.java
@@ -71,15 +71,6 @@ public class VectorReshapeHelper {
     public static final VectorSpecies<Float>   FSPEC512 =  FloatVector.SPECIES_512;
     public static final VectorSpecies<Double>  DSPEC512 = DoubleVector.SPECIES_512;
 
-    public static final String B2X_NODE  = IRNode.VECTOR_CAST_B2X;
-    public static final String S2X_NODE  = IRNode.VECTOR_CAST_S2X;
-    public static final String I2X_NODE  = IRNode.VECTOR_CAST_I2X;
-    public static final String L2X_NODE  = IRNode.VECTOR_CAST_L2X;
-    public static final String F2X_NODE  = IRNode.VECTOR_CAST_F2X;
-    public static final String D2X_NODE  = IRNode.VECTOR_CAST_D2X;
-    public static final String UB2X_NODE = IRNode.VECTOR_UCAST_B2X;
-    public static final String US2X_NODE = IRNode.VECTOR_UCAST_S2X;
-    public static final String UI2X_NODE = IRNode.VECTOR_UCAST_I2X;
     public static final String REINTERPRET_NODE = IRNode.VECTOR_REINTERPRET;
 
     public static void runMainHelper(Class<?> testClass, Stream<VectorSpeciesPair> testMethods, String... flags) {

--- a/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
@@ -62,8 +62,8 @@ public class TestAutoVecIntMinMax {
 
     // Test for auto-vectorization of Math.min operation on an array of integers
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
-    @IR(counts = {IRNode.MIN_V, " >0 "})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,  " >0 "})
+    @IR(counts = {IRNode.MIN_VI, " >0 "})
     @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
     private static void testIntMin(int[] a, int[] b) {
         for(int i = 0; i < LENGTH; i++) {
@@ -73,8 +73,8 @@ public class TestAutoVecIntMinMax {
 
     // Test for auto-vectorization of StrictMath.min operation on an array of integers
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
-    @IR(counts = {IRNode.MIN_V, " >0 "})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,  " >0 "})
+    @IR(counts = {IRNode.MIN_VI, " >0 "})
     @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
     private static void testIntStrictMin(int[] a, int[] b) {
         for(int i = 0; i < LENGTH; i++) {
@@ -84,8 +84,8 @@ public class TestAutoVecIntMinMax {
 
     // Test for auto-vectorization of Math.max operation on an array of integers
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
-    @IR(counts = {IRNode.MAX_V, " >0 "})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,  " >0 "})
+    @IR(counts = {IRNode.MAX_VI, " >0 "})
     @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
     private static void testIntMax(int[] a, int[] b) {
         for(int i = 0; i < LENGTH; i++) {
@@ -95,8 +95,8 @@ public class TestAutoVecIntMinMax {
 
     // Test for auto-vectorization of StrictMath.max operation on an array of integers
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR,  " >0 "})
-    @IR(counts = {IRNode.MAX_V, " >0 "})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,  " >0 "})
+    @IR(counts = {IRNode.MAX_VI, " >0 "})
     @IR(counts = {IRNode.STORE_VECTOR, " >0 "})
     private static void testIntStrictMax(int[] a, int[] b) {
         for(int i = 0; i < LENGTH; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloatConversionsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloatConversionsVector.java
@@ -51,7 +51,7 @@ public class TestFloatConversionsVector {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_F2HF, "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE + "min(max_float, max_short)", "> 0"})
     public void test_float_float16(short[] sout, float[] finp) {
         for (int i = 0; i < finp.length; i++) {
             sout[i] = Float.floatToFloat16(finp[i]);
@@ -78,7 +78,7 @@ public class TestFloatConversionsVector {
     }
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_HF2F, "> 0"})
+    @IR(counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE + "min(max_float, max_short)", "> 0"})
     public void test_float16_float(float[] fout, short[] sinp) {
         for (int i = 0; i < sinp.length; i++) {
             fout[i] = Float.float16ToFloat(sinp[i]);

--- a/test/hotspot/jtreg/compiler/vectorization/TestOptionVectorizeIR.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestOptionVectorizeIR.java
@@ -34,8 +34,8 @@ package compiler.vectorization;
 import compiler.lib.ir_framework.*;
 
 public class TestOptionVectorizeIR {
-    static final int RANGE = 512;
-    static final int ITER  = 100;
+    static int RANGE = 1024*2;
+    static int ITER  = 100;
     int[] gold1 = new int[RANGE];
     int[] gold2 = new int[RANGE];
     int[] gold3 = new int[RANGE];
@@ -220,7 +220,7 @@ public class TestOptionVectorizeIR {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.ADD_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test2(int[] data) {
@@ -231,7 +231,7 @@ public class TestOptionVectorizeIR {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.REPLICATE_I, "> 0", IRNode.ADD_VI, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0", IRNode.REPLICATE_I, "> 0", IRNode.ADD_VI, "> 0", IRNode.MUL_VI, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test3(int[] data, int A, int B) {
@@ -273,7 +273,7 @@ public class TestOptionVectorizeIR {
     // ------------------------- Long -----------------------------
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test10(long[] data) {
@@ -283,7 +283,7 @@ public class TestOptionVectorizeIR {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_L, "> 0", IRNode.ADD_VL, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test11(long[] data) {
@@ -347,7 +347,7 @@ public class TestOptionVectorizeIR {
     // ------------------------- Short -----------------------------
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.ADD_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test20(short[] data) {
@@ -357,7 +357,7 @@ public class TestOptionVectorizeIR {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_S, "> 0", IRNode.ADD_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test21(short[] data) {
@@ -420,7 +420,7 @@ public class TestOptionVectorizeIR {
     // ------------------------- Byte -----------------------------
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.ADD_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test30(byte[] data) {
@@ -430,7 +430,7 @@ public class TestOptionVectorizeIR {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_B, "> 0", IRNode.ADD_VB, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test31(byte[] data) {
@@ -493,7 +493,7 @@ public class TestOptionVectorizeIR {
     // ------------------------- Char -----------------------------
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.ADD_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test40(char[] data) {
@@ -503,7 +503,7 @@ public class TestOptionVectorizeIR {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_C, "> 0", IRNode.ADD_VS, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test41(char[] data) {
@@ -565,7 +565,7 @@ public class TestOptionVectorizeIR {
     // ------------------------- Float -----------------------------
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.ADD_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test50(float[] data) {
@@ -575,7 +575,7 @@ public class TestOptionVectorizeIR {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0", IRNode.ADD_VF, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test51(float[] data) {
@@ -637,7 +637,7 @@ public class TestOptionVectorizeIR {
     // ------------------------- Double -----------------------------
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.ADD_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test60(double[] data) {
@@ -647,7 +647,7 @@ public class TestOptionVectorizeIR {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR, "> 0", IRNode.ADD_V, "> 0", IRNode.STORE_VECTOR, "> 0"},
+    @IR(counts = {IRNode.LOAD_VECTOR_D, "> 0", IRNode.ADD_VD, "> 0", IRNode.STORE_VECTOR, "> 0"},
         applyIf = {"AlignVector", "false"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test61(double[] data) {

--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
@@ -73,7 +73,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(counts = {IRNode.REVERSE_V, "> 0"})
+  @IR(counts = {IRNode.REVERSE_VL, "> 0"})
   public void test_reverse_long1(long[] lout, long[] linp) {
       for (int i = 0; i < lout.length; i+=1) {
           lout[i] = Long.reverse(linp[i]);
@@ -89,7 +89,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(failOn = {IRNode.REVERSE_V, IRNode.REVERSE_L})
+  @IR(failOn = {IRNode.REVERSE_VL, IRNode.REVERSE_L})
   public void test_reverse_long2(long[] lout, long[] linp) {
       for (int i = 0; i < lout.length; i+=1) {
           lout[i] = Long.reverse(Long.reverse(linp[i]));
@@ -105,7 +105,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(failOn = {IRNode.REVERSE_V, IRNode.REVERSE_L})
+  @IR(failOn = {IRNode.REVERSE_VL, IRNode.REVERSE_L})
   public void test_reverse_long3(long[] lout, long[] linp) {
       for (int i = 0; i < lout.length; i+=1) {
           lout[i] = Long.reverse(linp[i] ^ linp[i]);
@@ -121,7 +121,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(counts = {IRNode.REVERSE_V, "> 0"})
+  @IR(counts = {IRNode.REVERSE_VI, "> 0"})
   public void test_reverse_int1(int[] iout, int[] iinp) {
       for (int i = 0; i < iout.length; i+=1) {
           iout[i] = Integer.reverse(iinp[i]);
@@ -137,7 +137,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(failOn = {IRNode.REVERSE_V, IRNode.REVERSE_I})
+  @IR(failOn = {IRNode.REVERSE_VI, IRNode.REVERSE_I})
   public void test_reverse_int2(int[] iout, int[] iinp) {
       for (int i = 0; i < iout.length; i+=1) {
           iout[i] = Integer.reverse(Integer.reverse(iinp[i]));
@@ -153,7 +153,7 @@ public class TestReverseBitsVector {
   }
 
   @Test
-  @IR(failOn = {IRNode.REVERSE_V, IRNode.REVERSE_I})
+  @IR(failOn = {IRNode.REVERSE_VI, IRNode.REVERSE_I})
   public void test_reverse_int3(int[] iout, int[] iinp) {
       for (int i = 0; i < iout.length; i+=1) {
           iout[i] = Integer.reverse(iinp[i] ^ iinp[i]);

--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBytes.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBytes.java
@@ -74,7 +74,7 @@ public class TestReverseBytes {
   }
 
   @Test
-  @IR(counts = {IRNode.REVERSE_BYTES_V, "> 0"})
+  @IR(counts = {IRNode.REVERSE_BYTES_VL, "> 0"})
   public void test_reverse_bytes_long(long[] lout, long[] linp) {
       for (int i = 0; i < lout.length; i+=1) {
           lout[i] = Long.reverseBytes(linp[i]);
@@ -90,7 +90,7 @@ public class TestReverseBytes {
   }
 
   @Test
-  @IR(counts = {IRNode.REVERSE_BYTES_V, "> 0"})
+  @IR(counts = {IRNode.REVERSE_BYTES_VI, "> 0"})
   public void test_reverse_bytes_int(int[] iout, int[] iinp) {
       for (int i = 0; i < iout.length; i+=1) {
           iout[i] = Integer.reverseBytes(iinp[i]);
@@ -106,7 +106,7 @@ public class TestReverseBytes {
   }
 
   @Test
-  @IR(counts = {IRNode.REVERSE_BYTES_V, "> 0"})
+  @IR(counts = {IRNode.REVERSE_BYTES_VS, "> 0"})
   public void test_reverse_bytes_short(short[] sout, short[] sinp) {
       for (int i = 0; i < sout.length; i+=1) {
           sout[i] = Short.reverseBytes(sinp[i]);
@@ -122,7 +122,7 @@ public class TestReverseBytes {
   }
 
   @Test
-  @IR(counts = {IRNode.REVERSE_BYTES_V, "> 0"})
+  @IR(counts = {IRNode.REVERSE_BYTES_VS, "> 0"})
   public void test_reverse_bytes_char(char[] cout, char[] cinp) {
       for (int i = 0; i < cout.length; i+=1) {
           cout[i] = Character.reverseBytes(cinp[i]);

--- a/test/hotspot/jtreg/compiler/vectorization/TestSubwordReverseBytes.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSubwordReverseBytes.java
@@ -54,7 +54,7 @@ public class TestSubwordReverseBytes {
     }
 
     @Test
-    @IR(failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(failOn = {IRNode.REVERSE_BYTES_VS})
     public static int[] testShortReverseBytes() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -75,7 +75,7 @@ public class TestSubwordReverseBytes {
     }
 
     @Test
-    @IR(failOn = {IRNode.REVERSE_BYTES_V})
+    @IR(failOn = {IRNode.REVERSE_BYTES_VS})
     public static int[] testCharacterReverseBytes() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -98,7 +98,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] intShiftLargeDistConstant() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -109,7 +109,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] intShiftLargeDistInvariant() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -120,7 +120,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] shortShiftLargeDistConstant() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -131,7 +131,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] shortShiftLargeDistInvariant() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -142,7 +142,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_V, ">0"})
+        counts = {IRNode.LSHIFT_VL, ">0"})
     public long[] longShiftLargeDistConstant() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -153,7 +153,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_V, ">0"})
+        counts = {IRNode.URSHIFT_VL, ">0"})
     public long[] longShiftLargeDistInvariant() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -186,7 +186,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorUnsignedShiftRight() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
@@ -132,7 +132,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     // ---------------- Convert I/L to F/D ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.VECTOR_CAST_I2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_I2F, IRNode.VECTOR_SIZE + "min(max_int, max_float)", ">0"})
     public float[] convertIntToFloat() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -146,7 +146,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
         // The vectorization of some conversions may fail when `+AlignVector`.
         // We can remove the condition after JDK-8303827.
         applyIf = {"AlignVector", "false"},
-        counts = {IRNode.VECTOR_CAST_I2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0"})
     public double[] convertIntToDouble() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -157,7 +157,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx512dq", "true"},
-        counts = {IRNode.VECTOR_CAST_L2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_L2F, IRNode.VECTOR_SIZE + "min(max_long, max_float)", ">0"})
     public float[] convertLongToFloat() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -168,7 +168,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
-        counts = {IRNode.VECTOR_CAST_L2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_L2D, IRNode.VECTOR_SIZE + "min(max_long, max_double)", ">0"})
     public double[] convertLongToDouble() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -180,7 +180,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     // ---------------- Convert Subword-I to F/D ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
-        counts = {IRNode.VECTOR_CAST_S2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_S2F, IRNode.VECTOR_SIZE + "min(max_short, max_float)", ">0"})
     public float[] convertShortToFloat() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -192,7 +192,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
         applyIf = {"MaxVectorSize", ">=32"},
-        counts = {IRNode.VECTOR_CAST_S2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_S2D, IRNode.VECTOR_SIZE + "min(max_short, max_double)", ">0"})
     public double[] convertShortToDouble() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -222,7 +222,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     // ---------------- Convert F/D to I/L ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.VECTOR_CAST_F2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_F2I, IRNode.VECTOR_SIZE + "min(max_float, max_int)", ">0"})
     public int[] convertFloatToInt() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -236,7 +236,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
         // The vectorization of some conversions may fail when `+AlignVector`.
         // We can remove the condition after JDK-8303827.
         applyIf = {"AlignVector", "false"},
-        counts = {IRNode.VECTOR_CAST_F2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE + "min(max_float, max_long)", ">0"})
     public long[] convertFloatToLong() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -247,7 +247,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true"},
-        counts = {IRNode.VECTOR_CAST_D2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_D2I, IRNode.VECTOR_SIZE + "min(max_double, max_int)", ">0"})
     public int[] convertDoubleToInt() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -258,7 +258,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
-        counts = {IRNode.VECTOR_CAST_D2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_D2L, IRNode.VECTOR_SIZE + "min(max_double, max_long)", ">0"})
     public long[] convertDoubleToLong() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -270,7 +270,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     // ---------------- Convert F/D to Subword-I ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
-        counts = {IRNode.VECTOR_CAST_F2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE + "min(max_float, max_short)", ">0"})
     public short[] convertFloatToShort() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -281,7 +281,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
-        counts = {IRNode.VECTOR_CAST_F2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_F2S, IRNode.VECTOR_SIZE + "min(max_float, max_char)", ">0"})
     public char[] convertFloatToChar() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -293,7 +293,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true"},
         applyIf = {"MaxVectorSize", ">=32"},
-        counts = {IRNode.VECTOR_CAST_D2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE + "min(max_double, max_short)", ">0"})
     public short[] convertDoubleToShort() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -305,7 +305,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx", "true"},
         applyIf = {"MaxVectorSize", ">=32"},
-        counts = {IRNode.VECTOR_CAST_D2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_D2S, IRNode.VECTOR_SIZE + "min(max_double, max_char)", ">0"})
     public char[] convertDoubleToChar() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -320,7 +320,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
         // The vectorization of some conversions may fail when `+AlignVector`.
         // We can remove the condition after JDK-8303827.
         applyIf = {"AlignVector", "false"},
-        counts = {IRNode.VECTOR_CAST_F2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_F2D, IRNode.VECTOR_SIZE + "min(max_float, max_double)", ">0"})
     public double[] convertFloatToDouble() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -331,7 +331,7 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.VECTOR_CAST_D2X, ">0"})
+        counts = {IRNode.VECTOR_CAST_D2F, IRNode.VECTOR_SIZE + "min(max_double, max_float)", ">0"})
     public float[] convertDoubleToFloat() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicBooleanOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicBooleanOpTest.java
@@ -44,7 +44,7 @@ import compiler.lib.ir_framework.*;
 
 public class BasicBooleanOpTest extends VectorizationTestRunner {
 
-    private static final int SIZE = 543;
+    private static final int SIZE = 6543;
 
     private boolean[] a;
     private boolean[] b;
@@ -72,9 +72,9 @@ public class BasicBooleanOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.AND_V, ">0"})
+        counts = {IRNode.AND_VB, ">0"})
     @IR(applyIfCPUFeatureAnd = {"avx512f", "false", "sse2", "true"},
-        counts = {IRNode.AND_V, ">0"})
+        counts = {IRNode.AND_VB, ">0"})
     @IR(applyIfCPUFeature = {"avx512f", "true"},
         counts = {IRNode.MACRO_LOGIC_V, ">0"})
     public boolean[] vectorAnd() {
@@ -87,7 +87,7 @@ public class BasicBooleanOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.OR_V, ">0"})
+        counts = {IRNode.OR_VB, ">0"})
     public boolean[] vectorOr() {
         boolean[] res = new boolean[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -98,7 +98,7 @@ public class BasicBooleanOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VB, ">0"})
     public boolean[] vectorXor() {
         boolean[] res = new boolean[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
@@ -34,6 +34,8 @@
  * @run main/othervm -Xbootclasspath/a:.
  *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
+ *                   -XX:CompileCommand=CompileOnly,compiler.vectorization.runner.BasicByteOpTest::*
+ *                   -XX:LoopUnrollLimit=1000
  *                   compiler.vectorization.runner.BasicByteOpTest
  *
  * @requires vm.compiler2.enabled & vm.flagless
@@ -45,7 +47,7 @@ import compiler.lib.ir_framework.*;
 
 public class BasicByteOpTest extends VectorizationTestRunner {
 
-    private static final int SIZE = 543;
+    private static int SIZE = 6543;
 
     private byte[] a;
     private byte[] b;
@@ -65,7 +67,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     // ---------------- Arithmetic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VB, ">0"})
     public byte[] vectorNeg() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -76,7 +78,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true"},
-        counts = {IRNode.ABS_V, ">0"})
+        counts = {IRNode.ABS_VB, ">0"})
     public byte[] vectorAbs() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -87,7 +89,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ADD_V, ">0"})
+        counts = {IRNode.ADD_VB, ">0"})
     public byte[] vectorAdd() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -98,7 +100,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VB, ">0"})
     public byte[] vectorSub() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -109,7 +111,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VB, ">0"})
     public byte[] vectorMul() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -120,7 +122,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.ADD_V, ">0"})
+        counts = {IRNode.MUL_VB, ">0", IRNode.ADD_VB, ">0"})
     public byte[] vectorMulAdd() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -131,7 +133,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.SUB_V, ">0"})
+        counts = {IRNode.MUL_VB, ">0", IRNode.SUB_VB, ">0"})
     public byte[] vectorMulSub() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -143,7 +145,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     // ---------------- Logic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VB, ">0"})
     public byte[] vectorNot() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -154,7 +156,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.AND_V, ">0"})
+        counts = {IRNode.AND_VB, ">0"})
     public byte[] vectorAnd() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -165,7 +167,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.OR_V, ">0"})
+        counts = {IRNode.OR_VB, ">0"})
     public byte[] vectorOr() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -176,7 +178,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VB, ">0"})
     public byte[] vectorXor() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -188,7 +190,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     // ---------------- Shift ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.LSHIFT_V, ">0"})
+        counts = {IRNode.LSHIFT_VB, ">0"})
     public byte[] vectorShiftLeft() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -199,7 +201,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VB, ">0"})
     public byte[] vectorSignedShiftRight() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -210,7 +212,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VB, ">0"})
     public byte[] vectorUnsignedShiftRight() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
@@ -67,7 +67,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     // ---------------- Arithmetic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VS, ">0"})
     public char[] vectorNeg() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -79,7 +79,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(failOn = {IRNode.ABS_V})
+    @IR(failOn = {IRNode.ABS_VI, IRNode.ABS_VB, IRNode.ABS_VL}) // AVS_VC does not exist
     public char[] vectorAbs() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -90,7 +90,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ADD_V, ">0"})
+        counts = {IRNode.ADD_VS, ">0"}) // char add same as for short
     public char[] vectorAdd() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -101,7 +101,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VS, ">0"})
     public char[] vectorSub() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -112,7 +112,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VS, ">0"})
     public char[] vectorMul() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -123,7 +123,8 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.ADD_V, ">0"})
+        counts = {IRNode.MUL_VS, ">0",
+                  IRNode.ADD_VS, ">0"}) // char add same as for short
     public char[] vectorMulAdd() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -134,7 +135,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.SUB_V, ">0"})
+        counts = {IRNode.MUL_VS, ">0", IRNode.SUB_VS, ">0"})
     public char[] vectorMulSub() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -146,7 +147,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     // ---------------- Logic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VS, ">0"})
     public char[] vectorNot() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -157,7 +158,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.AND_V, ">0"})
+        counts = {IRNode.AND_VS, ">0"})
     public char[] vectorAnd() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -168,7 +169,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.OR_V, ">0"})
+        counts = {IRNode.OR_VS, ">0"})
     public char[] vectorOr() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -179,7 +180,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VS, ">0"})
     public char[] vectorXor() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -191,7 +192,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     // ---------------- Shift ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_V, ">0"})
+        counts = {IRNode.LSHIFT_VC, ">0"})
     public char[] vectorShiftLeft() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -202,7 +203,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_V, ">0"})
+        counts = {IRNode.URSHIFT_VC, ">0"})
     public char[] vectorSignedShiftRight() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -213,7 +214,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_V, ">0"})
+        counts = {IRNode.URSHIFT_VC, ">0"})
     public char[] vectorUnsignedShiftRight() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -225,7 +226,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     // ------------- ReverseBytes -------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
-        counts = {IRNode.REVERSE_BYTES_V, ">0"})
+        counts = {IRNode.REVERSE_BYTES_VS, ">0"})
     public char[] reverseBytesWithChar() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
@@ -65,7 +65,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
     // ---------------- Arithmetic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.NEG_V, ">0"})
+        counts = {IRNode.NEG_VD, ">0"})
     public double[] vectorNeg() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -76,7 +76,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ABS_V, ">0"})
+        counts = {IRNode.ABS_VD, ">0"})
     public double[] vectorAbs() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -87,7 +87,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.SQRT_V, ">0"})
+        counts = {IRNode.SQRT_VD, ">0"})
     public double[] vectorSqrt() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -131,7 +131,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ADD_V, ">0"})
+        counts = {IRNode.ADD_VD, ">0"})
     public double[] vectorAdd() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -142,7 +142,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VD, ">0"})
     public double[] vectorSub() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -153,7 +153,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VD, ">0"})
     public double[] vectorMul() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -164,7 +164,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.DIV_V, ">0"})
+        counts = {IRNode.DIV_VD, ">0"})
     public double[] vectorDiv() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -175,7 +175,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.MAX_V, ">0"})
+        counts = {IRNode.MAX_VD, ">0"})
     public double[] vectorMax() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -186,7 +186,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.MIN_V, ">0"})
+        counts = {IRNode.MIN_VD, ">0"})
     public double[] vectorMin() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -197,9 +197,9 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorMulAdd() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -210,9 +210,9 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorMulSub1() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -223,9 +223,9 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorMulSub2() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -236,9 +236,9 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorNegateMulAdd1() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -249,9 +249,9 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorNegateMulAdd2() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -262,9 +262,9 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VD, ">0"})
     public double[] vectorNegateMulSub() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
@@ -65,7 +65,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
     // ---------------- Arithmetic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse", "true"},
-        counts = {IRNode.NEG_V, ">0"})
+        counts = {IRNode.NEG_VF, ">0"})
     public float[] vectorNeg() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -76,7 +76,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse", "true"},
-        counts = {IRNode.ABS_V, ">0"})
+        counts = {IRNode.ABS_VF, ">0"})
     public float[] vectorAbs() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -87,7 +87,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.SQRT_V, ">0"})
+        counts = {IRNode.SQRT_VF, ">0"})
     public float[] vectorSqrt() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -98,7 +98,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ADD_V, ">0"})
+        counts = {IRNode.ADD_VF, ">0"})
     public float[] vectorAdd() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -109,7 +109,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VF, ">0"})
     public float[] vectorSub() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -120,7 +120,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VF, ">0"})
     public float[] vectorMul() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -131,7 +131,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.DIV_V, ">0"})
+        counts = {IRNode.DIV_VF, ">0"})
     public float[] vectorDiv() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -142,7 +142,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.MAX_V, ">0"})
+        counts = {IRNode.MAX_VF, ">0"})
     public float[] vectorMax() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -153,7 +153,7 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.MIN_V, ">0"})
+        counts = {IRNode.MIN_VF, ">0"})
     public float[] vectorMin() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -164,9 +164,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulAdd() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -177,9 +177,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulSub1() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -190,9 +190,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorMulSub2() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -203,9 +203,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulAdd1() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -216,9 +216,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulAdd2() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -229,9 +229,9 @@ public class BasicFloatOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     @IR(applyIfCPUFeatureAnd = {"fma", "true", "avx", "true"},
-        counts = {IRNode.FMA_V, ">0"})
+        counts = {IRNode.FMA_VF, ">0"})
     public float[] vectorNegateMulSub() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -65,7 +65,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     // ---------------- Arithmetic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VI, ">0"})
     public int[] vectorNeg() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -76,7 +76,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true"},
-        counts = {IRNode.ABS_V, ">0"})
+        counts = {IRNode.ABS_VI, ">0"})
     public int[] vectorAbs() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -87,7 +87,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ADD_V, ">0"})
+        counts = {IRNode.ADD_VI, ">0"})
     public int[] vectorAdd() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -98,7 +98,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VI, ">0"})
     public int[] vectorSub() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -109,7 +109,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VI, ">0"})
     public int[] vectorMul() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -120,7 +120,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.ADD_V, ">0"})
+        counts = {IRNode.MUL_VI, ">0", IRNode.ADD_VI, ">0"})
     public int[] vectorMulAdd() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -131,7 +131,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.SUB_V, ">0"})
+        counts = {IRNode.MUL_VI, ">0", IRNode.SUB_VI, ">0"})
     public int[] vectorMulSub() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -154,7 +154,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     // ---------------- Logic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VI, ">0"})
     public int[] vectorNot() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -165,7 +165,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.AND_V, ">0"})
+        counts = {IRNode.AND_VI, ">0"})
     public int[] vectorAnd() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -176,7 +176,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.OR_V, ">0"})
+        counts = {IRNode.OR_VI, ">0"})
     public int[] vectorOr() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -187,7 +187,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VI, ">0"})
     public int[] vectorXor() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -199,7 +199,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     // ---------------- Shift ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_V, ">0"})
+        counts = {IRNode.LSHIFT_VI, ">0"})
     public int[] vectorShiftLeft() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -210,7 +210,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] vectorSignedShiftRight() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -221,7 +221,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_V, ">0"})
+        counts = {IRNode.URSHIFT_VI, ">0"})
     public int[] vectorUnsignedShiftRight() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
@@ -66,7 +66,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     // ---------------- Arithmetic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VL, ">0"})
     public long[] vectorNeg() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -77,7 +77,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512vl", "true"},
-        counts = {IRNode.ABS_V, ">0"})
+        counts = {IRNode.ABS_VL, ">0"})
     public long[] vectorAbs() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -88,7 +88,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ADD_V, ">0"})
+        counts = {IRNode.ADD_VL, ">0"})
     public long[] vectorAdd() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -99,7 +99,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VL, ">0"})
     public long[] vectorSub() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -110,7 +110,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx512dq", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VL, ">0"})
     public long[] vectorMul() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -121,9 +121,9 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
-        counts = {IRNode.ADD_V, ">0"})
+        counts = {IRNode.ADD_VL, ">0"})
     @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VL, ">0"})
     public long[] vectorMulAdd() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -134,7 +134,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.SUB_V, ">0"})
+        counts = {IRNode.MUL_VL, ">0", IRNode.SUB_VL, ">0"})
     public long[] vectorMulSub() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -146,7 +146,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     // ---------------- Logic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VL, ">0"})
     public long[] vectorNot() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -157,7 +157,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.AND_V, ">0"})
+        counts = {IRNode.AND_VL, ">0"})
     public long[] vectorAnd() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -168,7 +168,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.OR_V, ">0"})
+        counts = {IRNode.OR_VL, ">0"})
     public long[] vectorOr() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -179,7 +179,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VL, ">0"})
     public long[] vectorXor() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -191,7 +191,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     // ---------------- Shift ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_V, ">0"})
+        counts = {IRNode.LSHIFT_VL, ">0"})
     public long[] vectorShiftLeft() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -202,7 +202,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VL, ">0"})
     public long[] vectorSignedShiftRight() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -213,7 +213,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_V, ">0"})
+        counts = {IRNode.URSHIFT_VL, ">0"})
     public long[] vectorUnsignedShiftRight() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
@@ -67,7 +67,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     // ---------------- Arithmetic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VS, ">0"})
     public short[] vectorNeg() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -78,7 +78,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true"},
-        counts = {IRNode.ABS_V, ">0"})
+        counts = {IRNode.ABS_VS, ">0"})
     public short[] vectorAbs() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -89,7 +89,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ADD_V, ">0"})
+        counts = {IRNode.ADD_VS, ">0"})
     public short[] vectorAdd() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -100,7 +100,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VS, ">0"})
     public short[] vectorSub() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -111,7 +111,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VS, ">0"})
     public short[] vectorMul() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -122,7 +122,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.ADD_V, ">0"})
+        counts = {IRNode.MUL_VS, ">0", IRNode.ADD_VS, ">0"})
     public short[] vectorMulAdd() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -133,7 +133,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.MUL_V, ">0", IRNode.SUB_V, ">0"})
+        counts = {IRNode.MUL_VS, ">0", IRNode.SUB_VS, ">0"})
     public short[] vectorMulSub() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -145,7 +145,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     // ---------------- Logic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VS, ">0"})
     public short[] vectorNot() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -156,7 +156,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.AND_V, ">0"})
+        counts = {IRNode.AND_VS, ">0"})
     public short[] vectorAnd() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -167,7 +167,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.OR_V, ">0"})
+        counts = {IRNode.OR_VS, ">0"})
     public short[] vectorOr() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -178,7 +178,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.XOR_V, ">0"})
+        counts = {IRNode.XOR_VS, ">0"})
     public short[] vectorXor() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -190,7 +190,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     // ---------------- Shift ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_V, ">0"})
+        counts = {IRNode.LSHIFT_VS, ">0"})
     public short[] vectorShiftLeft() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -201,7 +201,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorSignedShiftRight() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -237,7 +237,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_V, ">0"})
+        counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorUnsignedShiftRight() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -249,7 +249,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     // ------------- ReverseBytes -------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
-        counts = {IRNode.REVERSE_BYTES_V, ">0"})
+        counts = {IRNode.REVERSE_BYTES_VS, ">0"})
     public short[] reverseBytesWithShort() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
@@ -48,7 +48,7 @@ import java.util.Random;
 
 public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
 
-    private static final int SIZE = 543;
+    private static final int SIZE = 6543;
 
     private int[] ints;
     private short[] shorts;
@@ -95,7 +95,7 @@ public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VI, ">0"})
     public int[] indexMinusConstant() {
         int[] res = new int[SIZE];
         for (int i = SIZE / 2; i < SIZE; i++) {
@@ -108,7 +108,7 @@ public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VI, ">0"})
     public int[] indexPlusInvariant() {
         int[] res = new int[SIZE];
         System.arraycopy(ints, 0, res, 0, SIZE);
@@ -122,7 +122,7 @@ public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VI, ">0"})
     public int[] indexMinusInvariant() {
         int[] res = new int[SIZE];
         System.arraycopy(ints, 0, res, 0, SIZE);
@@ -136,7 +136,7 @@ public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_V, ">0"})
+        counts = {IRNode.MUL_VI, ">0"})
     public int[] indexWithInvariantAndConstant() {
         int[] res = new int[SIZE];
         System.arraycopy(ints, 0, res, 0, SIZE);
@@ -150,7 +150,7 @@ public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_V, ">0"})
+        counts = {IRNode.SUB_VI, ">0"})
     public int[] indexWithTwoInvariants() {
         int[] res = new int[SIZE];
         System.arraycopy(ints, 0, res, 0, SIZE);

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
@@ -79,9 +79,8 @@ public class LoopReductionOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse3", "true"},
-        counts = {IRNode.LOAD_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse3", "true"},
-        counts = {IRNode.ADD_REDUCTION_V, ">0"})
+        counts = {IRNode.LOAD_VECTOR_I, ">0",
+                  IRNode.ADD_REDUCTION_V, ">0"})
     public int reductionAddSumOfArray() {
         int res = 0;
         for (int i = 0; i < SIZE; i++) {
@@ -121,9 +120,8 @@ public class LoopReductionOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
-        counts = {IRNode.LOAD_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
-        counts = {IRNode.ADD_REDUCTION_V, ">0"})
+        counts = {IRNode.LOAD_VECTOR_I, ">0",
+                  IRNode.ADD_REDUCTION_V, ">0"})
     public int reductionAddSumOfMultiple() {
         int res = 0;
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/IRExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/IRExample.java
@@ -119,6 +119,109 @@ public class IRExample {
     public void compilePhases() {
         iFld = 42;
     }
+
+    // Rules for vector nodes.
+    @Test
+    // By default, we search for the maximal size possible
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // We can also specify that we want the maximum explicitly
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_MAX, "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // Explicitly take the maximum size for this type (here int)
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "max_for_type", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // Exlicitly take the maximum size for the int type
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "max_int", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // As a last resort, we can match with any size
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // Specify comma separated list of numbers, match for any of them
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // Two or more arguments to min(...): the minimal value is applied
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, max_int, LoopMaxUnroll, 64)", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    static int[] testVectorNode() {
+        int[] a = new int[1024*8];
+        for (int i = 0; i < a.length; i++) {
+            a[i]++;
+        }
+        return a;
+    }
+
+    // Rules for vector nodes.
+    @Test
+    // By default, we search for the maximal size possible
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // In some cases, we can know the exact size, here 16
+    @IR(counts = {IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_16, "> 0"},
+        applyIf = {"MaxVectorSize", "=64"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_8, "> 0"},
+        applyIf = {"MaxVectorSize", "=32"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // In some cases, we can know the exact size, here 4
+    @IR(counts = {IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_4, "> 0"},
+        applyIf = {"MaxVectorSize", "=16"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    static float[] testVectorNodeExactSize1() {
+        float[] a = new float[1024*8];
+        for (int i = 0; i < a.length; i++) {
+            a[i]++;
+        }
+        return a;
+    }
+
+    // Rules for vector nodes. Same as badTestVectorNodeSize but with good rules.
+    @Test
+    // In some cases, we can know the exact size, here 4
+    @IR(counts = {IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_4, "> 0"},
+        applyIf = {"MaxVectorSize", ">=16"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // Hence, we know any other sizes are impossible.
+    // We can also specify that explicitly for failOn
+    @IR(failOn = {IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_2,
+                  IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_8,
+                  IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_16,
+                  IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_32,
+                  IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE_64,
+                  IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE + "2,8,16,32,64"},
+        applyIf = {"MaxVectorSize", ">=16"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    static float[] testVectorNodeExactSize2() {
+        float[] a = new float[1024*8];
+        for (int i = 0; i < a.length/8; i++) {
+            a[i*8 + 0]++; // block of 4, then gap of 4
+            a[i*8 + 1]++;
+            a[i*8 + 2]++;
+            a[i*8 + 3]++;
+        }
+        return a;
+    }
+
+    @Test
+    // Here, we can pack at most 8 given the 8-blocks and 8-gaps.
+    // But we can also never pack more than max_float
+    @IR(counts = {IRNode.LOAD_VECTOR_F, IRNode.VECTOR_SIZE + "min(8, max_float)", "> 0"},
+        applyIf = {"MaxVectorSize", ">=16"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    static float[] testVectorNodeSizeMinClause() {
+        float[] a = new float[1024*8];
+        for (int i = 0; i < a.length/16; i++) {
+            a[i*16 + 0]++; // block of 8, then gap of 8
+            a[i*16 + 1]++;
+            a[i*16 + 2]++;
+            a[i*16 + 3]++;
+            a[i*16 + 4]++;
+            a[i*16 + 5]++;
+            a[i*16 + 6]++;
+            a[i*16 + 7]++;
+        }
+        return a;
+    }
 }
 
 class FailingExamples {
@@ -193,5 +296,30 @@ class FailingExamples {
     @Run(test = "testNotCompiled", mode = RunMode.STANDALONE)
     public void badStandAloneNotCompiled() {
         testNotCompiled();
+    }
+
+    // Failing rules for vector nodes. Same as testVectorNodeExactSize2 but with bad rules.
+    @Test
+    // By default we look for the IRNode.VECTOR_SIZE_MAX, which is more than 4.
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "> 0"},
+        applyIf = {"MaxVectorSize", ">16"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // By default, we look for IRNode.VECTOR_SIZE_ANY. But there are some of size 4.
+    @IR(failOn = {IRNode.LOAD_VECTOR_F},
+        applyIf = {"MaxVectorSize", ">=16"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    // By default, we look for IRNode.VECTOR_SIZE_ANY. But there are at least two of size 4.
+    @IR(counts = {IRNode.LOAD_VECTOR_F, "<2"},
+        applyIf = {"MaxVectorSize", ">=16"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    static float[] badTestVectorNodeSize() {
+        float[] a = new float[1024*8];
+        for (int i = 0; i < a.length/8; i++) {
+            a[i*8 + 0]++; // block of 4, then gap of 4
+            a[i*8 + 1]++;
+            a[i*8 + 2]++;
+            a[i*8 + 3]++;
+        }
+        return a;
     }
 }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -1055,28 +1055,17 @@ class BadIRAnnotationsAfterTestVM {
 
     @Test
     @FailCount(8)
-    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_MAX, "> 0"}, // valid
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, "> 0"}, // valid
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "xxx", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min()", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type)", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,max_int", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,-3", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, xxx)", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, min(max_for_type, max_for_type))", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_MAX, "> 0"}) // valid
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, "> 0"}) // valid
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "xxx", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min()", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type)", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,max_int", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,-3", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, xxx)", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, min(max_for_type, max_for_type))", "> 0"})
     public int[] badVectorNodeSize() {
         int[] a = new int[1024*8];
         for (int i = 0; i < a.length; i++) {

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -999,7 +999,7 @@ class BadIRAnnotationsAfterTestVM {
     public void missingCountString() {}
 
     @Test
-    @FailCount(45)
+    @FailCount(51)
     @IR(counts = {IRNode.STORE, IRNode.STORE})
     @IR(counts = {IRNode.STORE, IRNode.STORE, IRNode.STORE, IRNode.STORE})
     @IR(counts = {IRNode.STORE_OF_CLASS, "Foo", IRNode.STORE})
@@ -1025,6 +1025,12 @@ class BadIRAnnotationsAfterTestVM {
     @IR(counts = {IRNode.STORE, " > 3.0"})
     @IR(counts = {IRNode.STORE, " > a3"})
     @IR(counts = {IRNode.STORE, " > 0x1"})
+    @IR(counts = {IRNode.STORE, "!= 1000"})
+    @IR(counts = {IRNode.STORE, "< 0"})
+    @IR(counts = {IRNode.STORE, "< 1"})
+    @IR(counts = {IRNode.STORE, "<= 0"})
+    @IR(counts = {IRNode.STORE, "> -1"})
+    @IR(counts = {IRNode.STORE, ">= 0"})
     @IR(counts = {IRNode.STORE_OF_CLASS, "Foo", "<"})
     @IR(counts = {IRNode.STORE_OF_CLASS, "Foo", "!"})
     @IR(counts = {IRNode.STORE_OF_CLASS, "Foo", "!3"})
@@ -1046,6 +1052,38 @@ class BadIRAnnotationsAfterTestVM {
     @IR(counts = {IRNode.STORE_OF_CLASS, "Foo", " > a3"})
     @IR(counts = {IRNode.STORE_OF_CLASS, "Foo", " > 0x1"})
     public void wrongCountString() {}
+
+    @Test
+    @FailCount(8)
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_MAX, "> 0"}, // valid
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, "> 0"}, // valid
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "xxx", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min()", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type)", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,max_int", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,-3", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, xxx)", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, min(max_for_type, max_for_type))", "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    public int[] badVectorNodeSize() {
+        int[] a = new int[1024*8];
+        for (int i = 0; i < a.length; i++) {
+            a[i]++;
+        }
+        return a;
+    }
 }
 
 class BadIRNodeForPhase {
@@ -1096,18 +1134,18 @@ class BadIRNodeForPhase {
 
     @Test
     @FailCount(6)
-    @IR(failOn = IRNode.LOAD_VECTOR, phase = CompilePhase.BEFORE_REMOVEUSELESS) // works
+    @IR(failOn = IRNode.LOAD_VECTOR_I, phase = CompilePhase.BEFORE_REMOVEUSELESS) // works
     @IR(failOn = IRNode.STORE_VECTOR, phase = CompilePhase.BEFORE_REMOVEUSELESS) // works
-    @IR(failOn = IRNode.VECTOR_CAST_B2X, phase = CompilePhase.BEFORE_REMOVEUSELESS) // works
-    @IR(failOn = IRNode.LOAD_VECTOR, phase = CompilePhase.BEFORE_MATCHING) // works
+    @IR(failOn = IRNode.VECTOR_CAST_B2I, phase = CompilePhase.BEFORE_REMOVEUSELESS) // works
+    @IR(failOn = IRNode.LOAD_VECTOR_I, phase = CompilePhase.BEFORE_MATCHING) // works
     @IR(failOn = IRNode.STORE_VECTOR, phase = CompilePhase.BEFORE_MATCHING) // works
-    @IR(failOn = IRNode.VECTOR_CAST_B2X, phase = CompilePhase.BEFORE_MATCHING) // works
-    @IR(failOn = IRNode.LOAD_VECTOR, phase = {CompilePhase.MATCHING, CompilePhase.MATCHING})
+    @IR(failOn = IRNode.VECTOR_CAST_B2I, phase = CompilePhase.BEFORE_MATCHING) // works
+    @IR(failOn = IRNode.LOAD_VECTOR_I, phase = {CompilePhase.MATCHING, CompilePhase.MATCHING})
     @IR(failOn = IRNode.STORE_VECTOR, phase = {CompilePhase.MATCHING, CompilePhase.MATCHING})
-    @IR(failOn = IRNode.VECTOR_CAST_B2X, phase = {CompilePhase.MATCHING, CompilePhase.MATCHING})
-    @IR(failOn = IRNode.LOAD_VECTOR, phase = CompilePhase.FINAL_CODE)
+    @IR(failOn = IRNode.VECTOR_CAST_B2I, phase = {CompilePhase.MATCHING, CompilePhase.MATCHING})
+    @IR(failOn = IRNode.LOAD_VECTOR_I, phase = CompilePhase.FINAL_CODE)
     @IR(failOn = IRNode.STORE_VECTOR, phase = CompilePhase.FINAL_CODE)
-    @IR(failOn = IRNode.VECTOR_CAST_B2X, phase = CompilePhase.FINAL_CODE)
+    @IR(failOn = IRNode.VECTOR_CAST_B2I, phase = CompilePhase.FINAL_CODE)
     public void vector() {}
 
     @Test

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -100,12 +100,12 @@ public class TestIRMatching {
                  GoodFailOnRegexConstraint.create(MultipleFailOnBad.class, "fail10()", 1,  2, 3)
         );
 
-        runCheck(BadCountsConstraint.create(BadCount.class, "bad1()", 1, 1, "Load"),
+        runCheck(BadCountsConstraint.create(BadCount.class, "bad1()", 1, 2, "Load"),
                  GoodCountsConstraint.create(BadCount.class, "bad1()", 2),
                  GoodCountsConstraint.create(BadCount.class, "bad2()", 1),
-                 BadCountsConstraint.create(BadCount.class, "bad2()", 2,  1, "Store"),
-                 BadCountsConstraint.create(BadCount.class, "bad3()", 1,  1, "Load"),
-                 BadCountsConstraint.create(BadCount.class, "bad3()", 2,  1, "Store")
+                 BadCountsConstraint.create(BadCount.class, "bad2()", 2,  2, "Store"),
+                 BadCountsConstraint.create(BadCount.class, "bad3()", 1,  2, "Load"),
+                 BadCountsConstraint.create(BadCount.class, "bad3()", 2,  2, "Store")
         );
 
         runCheck(GoodRuleConstraint.create(Calls.class, "calls()", 1),
@@ -629,10 +629,6 @@ class CountComparisons {
                   IRNode.STORE, "<=1",
                   IRNode.STORE, " <= 1",
                   IRNode.STORE, "  <=  1",
-                  IRNode.STORE, "!= 0",
-                  IRNode.STORE, "!=0",
-                  IRNode.STORE, " != 0",
-                  IRNode.STORE, "  !=  0",
                   IRNode.STORE, "> 0",
                   IRNode.STORE, ">0",
                   IRNode.STORE, " > 0",
@@ -823,27 +819,32 @@ class GoodCount {
 
 class BadCount {
     int iFld;
+    int iFld2;
     int result;
+    int result2;
     @Test
-    @IR(counts = {IRNode.LOAD, "!= 1"}) // fail
+    @IR(counts = {IRNode.LOAD, "> 1000"}) // fail
     @IR(counts = {IRNode.STORE, "> 0"})
     public void bad1() {
         result = iFld;
+        result2 = iFld2;
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD, "1"}) // fail
-    @IR(counts = {IRNode.STORE, "< 1"})
+    @IR(counts = {IRNode.LOAD, "2"}) // fail
+    @IR(counts = {IRNode.STORE, "< 2"})
     public void bad2() {
         result = iFld;
+        result2 = iFld2;
     }
 
 
     @Test
     @IR(counts = {IRNode.LOAD, "0"}) // fail
-    @IR(counts = {IRNode.STORE, " <= 0"}) // fail
+    @IR(counts = {IRNode.STORE, " <= 1"}) // fail
     public void bad3() {
         result = iFld;
+        result2 = iFld2;
     }
 }
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestSafepointWhilePrinting.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestSafepointWhilePrinting.java
@@ -75,6 +75,15 @@ public class TestSafepointWhilePrinting {
                 testCompilePhaseBackToBackFirst,1
                 testCompilePhaseBackToBackLast,1
                 ----- END -----
+                ##### IRMatchingVMInfo - used by TestFramework #####
+                <key>:<value>
+                cpuFeatures:empty_cpu_info
+                MaxVectorSize:64
+                MaxVectorSizeIsDefault:1
+                LoopMaxUnroll:64
+                UseAVX:1
+                UseAVXIsDefault:1
+                ----- END VMInfo -----
                 """;
         TestClassParser testClassParser = new TestClassParser(TestSafepointWhilePrinting.class);
         Matchable testClassMatchable = testClassParser.parse(hotspotPidFileName, irEncoding);


### PR DESCRIPTION
I backport this to improve testing of C2 in 22u. It will simplify backporting tests of fixes to C2, as, e.g. " 8313720: C2 SuperWord: wrong result with -XX:+UseVectorCmov -XX:+UseCMoveUnconditionally"

I had to trivially resolve three files:

test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
Resolved the bugid in comment.

patching file test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
patching file test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
These had to be resolved because "8308340: C2: Idealize Fma nodes" is not in 21. Trivial.
That change is huge thus not a candidate for backport.

Further I include "8314513: [IR Framework] Some internal IR Framework tests are failing after JDK-8310308 on PPC and Cascade Lake".  This is a follow-up fix of the tests.

All tests passed locally. 

It's a test-only change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314513](https://bugs.openjdk.org/browse/JDK-8314513) needs maintainer approval
- [x] [JDK-8310308](https://bugs.openjdk.org/browse/JDK-8310308) needs maintainer approval

### Issues
 * [JDK-8310308](https://bugs.openjdk.org/browse/JDK-8310308): IR Framework: check for type and size of vector nodes (**Enhancement** - P4 - Approved)
 * [JDK-8314513](https://bugs.openjdk.org/browse/JDK-8314513): [IR Framework] Some internal IR Framework tests are failing after JDK-8310308 on PPC and Cascade Lake (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/29.diff">https://git.openjdk.org/jdk21u-dev/pull/29.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/29#issuecomment-1855936943)