### PR TITLE
8319633: runtime/posixSig/TestPosixSig.java intermittent timeouts on UNIX

### DIFF
--- a/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
+++ b/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
@@ -44,8 +44,17 @@ public class TestPosixSig {
         if (args.length == 0) {
 
             // Create a new java process for the TestPsig Java/JNI test.
+            // We run the VM in interpreted mode, because the JIT might mark
+            // a Java method as not-entrant, which means turning the first instruction
+            // into an illegal one. Calling such a method after establishing
+            // the new SIGILL signal handler with TestPosixSig.changeSigActionFor(4)
+            // below, but before the JNI checker noted and reacted on this signal handler
+            // modification, the JVM may crash or hang in an endless loop, where the
+            // illegal instruction will be continously executed, raising SIGILL, and
+            // the signal handler will return to the illegal instruction again...
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-XX:+CheckJNICalls",
+                "-Xint",
                 "-Djava.library.path=" + libpath + ":.",
                 "TestPosixSig", "dummy");
 


### PR DESCRIPTION
Every 1-2 weeks we run into timeouts when running jtreg test runtime/posixSig/TestPosixSig.java on UNIX.
The thread stack shows that we are in line 54 of TestPosixSig.java (callstack see below).

The reason is the following: The test registers a new dummy signal handler for SIGILL, without delegating the task to the previous handler in the chain. In case the VM then calls a Java method marked as not-entrant at least on PPC64 a SIGILL is raised. Because this is not handled by the registered handler the SIGILL will happen again and again in an endless recursion.
One solution would be to run the test in interpreted mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319633](https://bugs.openjdk.org/browse/JDK-8319633) needs maintainer approval

### Issue
 * [JDK-8319633](https://bugs.openjdk.org/browse/JDK-8319633): runtime/posixSig/TestPosixSig.java intermittent timeouts on UNIX (**Bug** - P4 - Approved) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/30.diff">https://git.openjdk.org/jdk21u-dev/pull/30.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/30#issuecomment-1856120391)