### PR TITLE
8321131: Console read line with zero out should zero out underlying buffer in JLine

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -67,6 +67,9 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
      * public Console class.
      */
     private static class JdkConsoleImpl implements JdkConsole {
+        private final Terminal terminal;
+        private volatile LineReader jline;
+
         @Override
         public PrintWriter writer() {
             return terminal.writer();
@@ -108,6 +111,8 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
                 return jline.readLine(fmt.formatted(args), '\0').toCharArray();
             } catch (EndOfFileException eofe) {
                 return null;
+            } finally {
+                jline.getBuffer().zeroOut();
             }
         }
 
@@ -125,9 +130,6 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
         public Charset charset() {
             return terminal.encoding();
         }
-
-        private final LineReader jline;
-        private final Terminal terminal;
 
         public JdkConsoleImpl(Terminal terminal) {
             this.terminal = terminal;

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/Buffer.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/Buffer.java
@@ -84,4 +84,8 @@ public interface Buffer {
 
     void copyFrom(Buffer buffer);
 
+    // JDK specific modification
+    default void zeroOut() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/BufferImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/BufferImpl.java
@@ -8,6 +8,7 @@
  */
 package jdk.internal.org.jline.reader.impl;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import jdk.internal.org.jline.reader.Buffer;
@@ -368,5 +369,11 @@ public class BufferImpl implements Buffer
             g0 += l;
             g1 += l;
         }
+    }
+
+    // JDK specific modification
+    @Override
+    public void zeroOut() {
+        Arrays.fill(buffer, 0);
     }
 }


### PR DESCRIPTION
A fix we should have in 21.
I had to resolve one place due to context, it will probably be recognized as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321131](https://bugs.openjdk.org/browse/JDK-8321131) needs maintainer approval

### Issue
 * [JDK-8321131](https://bugs.openjdk.org/browse/JDK-8321131): Console read line with zero out should zero out underlying buffer in JLine (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/33.diff">https://git.openjdk.org/jdk21u-dev/pull/33.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/33#issuecomment-1856596190)