### PR TITLE
8318410: jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh fails on Japanese Windows

### DIFF
--- a/test/jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh
+++ b/test/jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,18 @@ echo "Creating manifest file..."
 # java Setup <workdir> <premain-class>
 # - outputs boot class path to boot.dir
 
-"$JAVA" ${TESTVMOPTS} -classpath "${TESTCLASSES}" Setup "${TESTCLASSES}" Agent
+OS=`uname -s`
+case ${OS} in
+    CYGWIN*)
+        CYGWIN="CYGWIN"
+        ;;
+    *)
+        CYGWIN=""
+        ;;
+esac
+
+"$JAVA" ${TESTVMOPTS} -classpath "${TESTCLASSES}" Setup "${TESTCLASSES}" Agent "${CYGWIN}"
+
 BOOTDIR=`cat ${TESTCLASSES}/boot.dir`
 
 echo "Created ${BOOTDIR}"

--- a/test/jdk/java/lang/instrument/BootClassPath/Setup.java
+++ b/test/jdk/java/lang/instrument/BootClassPath/Setup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,10 @@ public class Setup {
         }
         String workDir = args[0];
         String premainClass = args[1];
+        boolean isCygwin = false;
+        if (args.length == 3 && args[2].equals("CYGWIN")) {
+            isCygwin = true;
+        }
 
         String manifestFile = workDir + fileSeparator + "MANIFEST.MF";
         String bootClassPath = "boot" + suffix();
@@ -94,7 +98,12 @@ public class Setup {
          */
         f = new File(workDir + fileSeparator + "boot.dir");
         try (FileOutputStream out = new FileOutputStream(f)) {
-            out.write(bootDir.getBytes(filePathEncoding));
+            if (osName.startsWith("Windows") && isCygwin) {
+                out.write(bootDir.getBytes("UTF-8"));
+            }
+            else {
+                out.write(bootDir.getBytes(filePathEncoding));
+            }
         }
     }
 
@@ -131,39 +140,39 @@ public class Setup {
         // Use null if encoding isn't used.
         String[][] names = {
             { "UTF-8",          unicode,        ""              },
-            { "windows-1256",   null,           ""              },
+            { "Cp1256",         null,           ""              },
             { "iso-8859-6",     arabic,         null            },
             { "GBK",            s_chinese,      s_chinese       },
             { "GB18030",        s_chinese,      s_chinese       },
             { "GB2312",         s_chinese,      null            },
-            { "x-windows-950",  null,           t_chinese       },
-            { "x-MS950-HKSCS",  null,           t_chinese       },
-            { "x-euc-tw",       t_chinese,      null            },
+            { "MS950",          null,           t_chinese       },
+            { "MS950_HKSCS_XP", null,           t_chinese       },
+            { "EUC-TW",         t_chinese,      null            },
             { "Big5",           t_chinese,      null            },
             { "Big5-HKSCS",     t_chinese,      null            },
             { "windows-1251",   null,           ""              },
             { "iso-8859-5",     russian,        null            },
             { "koi8-r",         russian,        null            },
-            { "windows-1253",   null,           ""              },
+            { "Cp1253",         null,           ""              },
             { "iso-8859-7",     greek,          null            },
-            { "windows-1255",   null,           ""              },
-            { "iso8859-8",      hebrew,         null            },
-            { "windows-31j",    null,           japanese        },
+            { "Cp1255",         null,           ""              },
+            { "iso-8859-8",     hebrew,         null            },
+            { "MS932",          null,           japanese        },
             { "x-eucJP-Open",   japanese,       null            },
-            { "x-EUC-JP-LINUX", japanese,       null            },
+            { "EUC-JP-LINUX",   japanese,       null            },
             { "x-pck",          japanese,       null            },
-            { "x-windows-949",  null,           korean          },
+            { "MS949",          null,           korean          },
             { "euc-kr",         korean,         null            },
-            { "windows-1257",   null,           ""              },
+            { "Cp1257",         null,           ""              },
             { "iso-8859-13",    lithuanian,     null            },
-            { "windows-1250",   null,           ""              },
+            { "Cp1250",         null,           ""              },
             { "iso-8859-2",     czech,          null            },
-            { "windows-1254",   null,           ""              },
+            { "Cp1254",         null,           ""              },
             { "iso-8859-9",     turkish,        null            },
-            { "windows-1252",   null,           ""              },
+            { "Cp1252",         null,           ""              },
             { "iso-8859-1",     spanish,        null            },
             { "iso-8859-15",    spanish,        null            },
-            { "x-windows-874",  null,           thai            },
+            { "MS874",          null,           thai            },
             { "tis-620",        thai,           null            },
         };
 


### PR DESCRIPTION
I would like to backport JDK-8318410 to 21u-dev because the test dose not work as intended.
The fix applies cleanly to 21u-dev.
I tested BootClassPathTest on Windows(English,Japanese) and Linux(locales used in the test with LANG/LC_ALL/LC_CTYPE).

Could someone please review it?

Thanks,
Kimura Yukihiro

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318410](https://bugs.openjdk.org/browse/JDK-8318410) needs maintainer approval

### Issue
 * [JDK-8318410](https://bugs.openjdk.org/browse/JDK-8318410): jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh fails on Japanese Windows (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/36.diff">https://git.openjdk.org/jdk21u-dev/pull/36.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/36#issuecomment-1857442141)