### PR TITLE
8314838: 3 compiler tests ignore vm flags

### DIFF
--- a/test/hotspot/jtreg/compiler/ciReplay/TestInvalidReplayFile.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInvalidReplayFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class TestInvalidReplayFile {
         w.flush();
         w.close();
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-Xmx100M",
                 "-XX:+ReplayCompiles", "-XX:ReplayDataFile=./bogus-replay-file.txt");

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -82,7 +82,7 @@ public class TestRangeCheckHoistingScaledIV {
     }
 
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "--enable-preview", "--add-modules", "jdk.incubator.vector",
                 "-Xbatch", "-XX:+TraceLoopPredicate", Launcher.class.getName());
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -23,15 +23,21 @@
  */
 
 /**
- * @test SharedStubToInterpTest
- * @summary Checks that stubs to the interpreter can be shared for static or final method.
+ * @test id=C1
  * @bug 8280481
+ * @summary Checks that stubs to the interpreter can be shared for static or final method.
  * @library /test/lib
- *
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="i386" | os.arch=="x86" | os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires vm.opt.TieredStopAtLevel == null & vm.opt.TieredCompilation == null
+ * @requires vm.simpleArch == "x86" | vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @requires vm.debug
+ * @run driver compiler.sharedstubs.SharedStubToInterpTest -XX:TieredStopAtLevel=1
  *
- * @run driver compiler.sharedstubs.SharedStubToInterpTest
+ * @test id=C2
+ * @requires vm.opt.TieredStopAtLevel == null & vm.opt.TieredCompilation == null
+ * @requires vm.simpleArch == "x86" | vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
+ * @requires vm.debug
+ * @run driver compiler.sharedstubs.SharedStubToInterpTest -XX:-TieredCompilation
+ *
  */
 
 package compiler.sharedstubs;
@@ -45,10 +51,9 @@ import jdk.test.lib.process.ProcessTools;
 public class SharedStubToInterpTest {
     private final static int ITERATIONS_TO_HEAT_LOOP = 20_000;
 
-    private static void runTest(String compiler, String test) throws Exception {
+    private static void runTest(String test) throws Exception {
         String testClassName = SharedStubToInterpTest.class.getName() + "$" + test;
         ArrayList<String> command = new ArrayList<String>();
-        command.add(compiler);
         command.add("-XX:+UnlockDiagnosticVMOptions");
         command.add("-Xbatch");
         command.add("-XX:+PrintRelocations");
@@ -61,7 +66,7 @@ public class SharedStubToInterpTest {
         command.add("-XX:CompileCommand=dontinline," + testClassName + "::" + "log02");
         command.add(testClassName);
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(command);
+        ProcessBuilder pb = ProcessTools.createTestJvm(command);
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 
@@ -73,14 +78,9 @@ public class SharedStubToInterpTest {
     }
 
     public static void main(String[] args) throws Exception {
-        List<String> compilers = java.util.Arrays.asList("-XX:-TieredCompilation" /* C2 */,
-            "-XX:TieredStopAtLevel=1" /* C1 */);
-        List<String> tests = java.util.Arrays.asList("StaticMethodTest",
-            "FinalClassTest", "FinalMethodTest");
-        for (String compiler : compilers) {
-            for (String test : tests) {
-                runTest(compiler, test);
-            }
+        String[] methods = new String[] { "StaticMethodTest", "FinalClassTest", "FinalMethodTest"};
+        for (String methodName : methods) {
+            runTest(methodName);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -23,23 +23,22 @@
  */
 
 /**
- * @test SharedTrampolineTest
+ * @test SharedTrampolineTest id=C2
  * @summary Checks that trampolines can be shared for static method.
  * @bug 8280152
  * @library /test/lib
  *
+ * @requires vm.opt.TieredCompilation == null
  * @requires os.arch=="aarch64" | os.arch=="riscv64"
  * @requires vm.debug
  *
- * @run driver compiler.sharedstubs.SharedTrampolineTest
+ * @run driver compiler.sharedstubs.SharedTrampolineTest -XX:-TieredCompilation
  */
 
 package compiler.sharedstubs;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.regex.Pattern;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
@@ -47,10 +46,9 @@ import jdk.test.lib.process.ProcessTools;
 public class SharedTrampolineTest {
     private final static int ITERATIONS_TO_HEAT_LOOP = 20_000;
 
-    private static void runTest(String compiler, String test) throws Exception {
+    private static void runTest(String test) throws Exception {
         String testClassName = SharedTrampolineTest.class.getName() + "$" + test;
         ArrayList<String> command = new ArrayList<String>();
-        command.add(compiler);
         command.add("-XX:+UnlockDiagnosticVMOptions");
         command.add("-Xbatch");
         command.add("-XX:+PrintRelocations");
@@ -60,7 +58,7 @@ public class SharedTrampolineTest {
         command.add(testClassName);
         command.add("a");
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(command);
+        ProcessBuilder pb = ProcessTools.createTestJvm(command);
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 
@@ -72,12 +70,9 @@ public class SharedTrampolineTest {
     }
 
     public static void main(String[] args) throws Exception {
-        List<String> compilers = List.of("-XX:-TieredCompilation" /* C2 */);
-        List<String> tests = List.of("StaticMethodTest");
-        for (String compiler : compilers) {
-            for (String test : tests) {
-                runTest(compiler, test);
-            }
+        String[] tests = new String[] {"StaticMethodTest"};
+        for (String test : tests) {
+            runTest(test);
         }
     }
 


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314838](https://bugs.openjdk.org/browse/JDK-8314838) needs maintainer approval

### Issue
 * [JDK-8314838](https://bugs.openjdk.org/browse/JDK-8314838): 3 compiler tests ignore vm flags (**Sub-task** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/38.diff">https://git.openjdk.org/jdk21u-dev/pull/38.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/38#issuecomment-1857590561)