### PR TITLE
8314837: 5 compiled/codecache tests ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
@@ -28,9 +28,7 @@
  * @library /test/lib
  * @requires vm.debug
  *
- * @run driver jdk.test.lib.helpers.ClassFileInstaller
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
- *                   compiler.codecache.CheckCodeCacheInfo
+ * @run driver compiler.codecache.CheckCodeCacheInfo
  */
 
 package compiler.codecache;
@@ -68,9 +66,9 @@ public class CheckCodeCacheInfo {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb;
 
-        pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintCodeCache",
-                                                   "-XX:+Verbose",
-                                                   "-version");
+        pb = ProcessTools.createTestJvm("-XX:+PrintCodeCache",
+                                        "-XX:+Verbose",
+                                        "-version");
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
         out.shouldHaveExitValue(0);
         out.stdoutShouldMatch(VERBOSE_REGEXP);

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -33,6 +33,7 @@ import jdk.test.lib.process.ProcessTools;
  * @test
  * @bug 8276036 8277213 8277441
  * @summary test for the value of full_count in the message of insufficient codecache
+ * @requires vm.compMode != "Xint"
  * @library /test/lib
  */
 public class CodeCacheFullCountTest {
@@ -54,7 +55,7 @@ public class CodeCacheFullCountTest {
     }
 
     public static void runTest() throws Throwable {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJvm(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         // Ignore adapter creation failures

--- a/test/hotspot/jtreg/compiler/codecache/cli/TestSegmentedCodeCacheOption.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/TestSegmentedCodeCacheOption.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8015774
  * @summary Verify SegmentedCodeCache option's processing
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
@@ -26,6 +26,7 @@
  * @key randomness
  * @bug 8015774
  * @summary Verify processing of options related to code heaps sizing.
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/compiler/codecache/cli/printcodecache/TestPrintCodeCacheOption.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/printcodecache/TestPrintCodeCacheOption.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8015774
  * @summary Verify that PrintCodeCache option print correct information.
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.compiler


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8314837](https://bugs.openjdk.org/browse/JDK-8314837) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314837](https://bugs.openjdk.org/browse/JDK-8314837): 5 compiled/codecache tests ignore VM flags (**Sub-task** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/39.diff">https://git.openjdk.org/jdk21u-dev/pull/39.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/39#issuecomment-1857610862)