### PR TITLE
8316410: GC: Make TestCompressedClassFlags use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jdk.test.lib.Platform;
  * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @requires vm.opt.CompressedClassSpaceSize == null & vm.opt.UseCompressedClassPointers == null
  * @run driver gc.arguments.TestCompressedClassFlags
  */
 public class TestCompressedClassFlags {
@@ -50,7 +51,7 @@ public class TestCompressedClassFlags {
     }
 
     private static OutputAnalyzer runJava(String ... args) throws Exception {
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(args);
+        ProcessBuilder pb = GCArguments.createTestJvm(args);
         return new OutputAnalyzer(pb.start());
     }
 }


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316410](https://bugs.openjdk.org/browse/JDK-8316410) needs maintainer approval

### Issue
 * [JDK-8316410](https://bugs.openjdk.org/browse/JDK-8316410): GC: Make TestCompressedClassFlags use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/43.diff">https://git.openjdk.org/jdk21u-dev/pull/43.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/43#issuecomment-1858156747)