### PR TITLE
8317042: G1: Make TestG1ConcMarkStepDurationMillis use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcMarkStepDurationMillis.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcMarkStepDurationMillis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ package gc.arguments;
 
 /*
  * @test TestG1ConcMarkStepDurationMillis
- * @requires vm.gc.G1
+ * @requires vm.gc.G1 & vm.opt.G1ConcMarkStepDurationMillis == null
  * @summary Tests argument processing for double type flag, G1ConcMarkStepDurationMillis
  * @library /test/lib
  * @library /
@@ -78,7 +78,7 @@ public class TestG1ConcMarkStepDurationMillis {
 
     Collections.addAll(vmOpts, "-XX:+UseG1GC", "-XX:G1ConcMarkStepDurationMillis="+expectedValue, "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts);
+    ProcessBuilder pb = GCArguments.createTestJvm(vmOpts);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     output.shouldHaveExitValue(expectedResult == PASS ? 0 : 1);


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317042](https://bugs.openjdk.org/browse/JDK-8317042) needs maintainer approval

### Issue
 * [JDK-8317042](https://bugs.openjdk.org/browse/JDK-8317042): G1: Make TestG1ConcMarkStepDurationMillis use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/45.diff">https://git.openjdk.org/jdk21u-dev/pull/45.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/45#issuecomment-1858169691)