### PR TITLE
8317188: G1: Make  TestG1ConcRefinementThreads use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ package gc.arguments;
 /*
  * @test TestG1ConcRefinementThreads
  * @bug 8047976
- * @requires vm.gc.G1
+ * @requires vm.gc.G1 & vm.opt.G1ConcRefinementThreads == null
  * @summary Tests argument processing for G1ConcRefinementThreads
  * @library /test/lib
  * @library /
@@ -69,7 +69,7 @@ public class TestG1ConcRefinementThreads {
     }
     Collections.addAll(vmOpts, "-XX:+UseG1GC", "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts);
+    ProcessBuilder pb = GCArguments.createTestJvm(vmOpts);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     output.shouldHaveExitValue(0);


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317188](https://bugs.openjdk.org/browse/JDK-8317188) needs maintainer approval

### Issue
 * [JDK-8317188](https://bugs.openjdk.org/browse/JDK-8317188): G1: Make  TestG1ConcRefinementThreads use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/47.diff">https://git.openjdk.org/jdk21u-dev/pull/47.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/47#issuecomment-1859229204)