### PR TITLE
8317317: G1: Make TestG1RemSetFlags use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1RemSetFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1RemSetFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ package gc.arguments;
 
 /*
  * @test TestG1RemSetFlags
- * @requires vm.gc.G1
+ * @requires vm.gc.G1 & vm.opt.UnlockExperimentalVMOptions == null & vm.opt.G1RemSetHowlNumBuckets == null & vm.opt.G1RemSetHowlMaxNumBuckets == null
  * @summary Verify that the remembered set flags are updated as expected
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management
@@ -48,7 +48,7 @@ public class TestG1RemSetFlags {
     flagList.add("-XX:+PrintFlagsFinal");
     flagList.add("-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flagList);
+    ProcessBuilder pb = GCArguments.createTestJvm(flagList);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(exitValue);
   }


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317317](https://bugs.openjdk.org/browse/JDK-8317317) needs maintainer approval

### Issue
 * [JDK-8317317](https://bugs.openjdk.org/browse/JDK-8317317): G1: Make TestG1RemSetFlags use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/50.diff">https://git.openjdk.org/jdk21u-dev/pull/50.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/50#issuecomment-1859232129)