### PR TITLE
8311581: Remove obsolete code and comments in TestLVT.java

### DIFF
--- a/test/hotspot/jtreg/runtime/LocalVariableTable/TestLVT.java
+++ b/test/hotspot/jtreg/runtime/LocalVariableTable/TestLVT.java
@@ -41,21 +41,16 @@ public class TestLVT {
     public static void main(String[] args) throws Exception {
         test();  // Test good LVT in this test
 
-        String jarFile = System.getProperty("test.src") + "/testcase.jar";
-
-        // java -cp $testSrc/testcase.jar DuplicateLVT
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("DuplicateLVT");
         new OutputAnalyzer(pb.start())
             .shouldContain("Duplicated LocalVariableTable attribute entry for 'by' in class file DuplicateLVT")
             .shouldHaveExitValue(1);
 
-        // java -cp $testclasses/testcase.jar DuplicateLVTT
         pb = ProcessTools.createJavaProcessBuilder("DuplicateLVTT");
         new OutputAnalyzer(pb.start())
             .shouldContain("Duplicated LocalVariableTypeTable attribute entry for 'list' in class file DuplicateLVTT")
             .shouldHaveExitValue(1);
 
-        // java -cp $testclasses/testcase.jar NotFoundLVTT
         pb = ProcessTools.createJavaProcessBuilder("NotFoundLVTT");
         new OutputAnalyzer(pb.start())
             .shouldContain("LVTT entry for 'list' in class file NotFoundLVTT does not match any LVT entry")


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311581](https://bugs.openjdk.org/browse/JDK-8311581) needs maintainer approval

### Issue
 * [JDK-8311581](https://bugs.openjdk.org/browse/JDK-8311581): Remove obsolete code and comments in TestLVT.java (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/54.diff">https://git.openjdk.org/jdk21u-dev/pull/54.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/54#issuecomment-1859240303)