### PR TITLE
8314333: Update com/sun/jdi/ProcessAttachTest.java to use ProcessTools.createTestJvm(..)

### DIFF
--- a/test/jdk/com/sun/jdi/ProcessAttachTest.java
+++ b/test/jdk/com/sun/jdi/ProcessAttachTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,6 @@ class ProcessAttachTestTarg {
 
 public class ProcessAttachTest {
 
-    public static final String TESTCLASSES = System.getProperty("test.classes");
-
     public static void main(String[] args) throws Exception {
 
         System.out.println("Test 1: Debuggee start with suspend=n");
@@ -71,9 +69,8 @@ public class ProcessAttachTest {
     }
 
     private static void runTest(String jdwpArg) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 jdwpArg,
-                "-classpath", TESTCLASSES,
                 "ProcessAttachTestTarg");
         Process p = null;
         try {


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314333](https://bugs.openjdk.org/browse/JDK-8314333) needs maintainer approval

### Issue
 * [JDK-8314333](https://bugs.openjdk.org/browse/JDK-8314333): Update com/sun/jdi/ProcessAttachTest.java to use ProcessTools.createTestJvm(..) (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/64.diff">https://git.openjdk.org/jdk21u-dev/pull/64.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/64#issuecomment-1860700314)