### PR TITLE
8316462: sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java ignores VM flags

### DIFF
--- a/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
+++ b/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -308,10 +308,9 @@ public final class MonitorVmStartTerminate {
 
         private void executeJava() throws Throwable {
             String className = JavaProcess.class.getName();
-            String classPath = System.getProperty("test.classes");
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-Dtest.timeout.factor=" + System.getProperty("test.timeout.factor", "1.0"),
-                "-cp", classPath, className, mainArgsIdentifier);
+                className, mainArgsIdentifier);
             OutputAnalyzer ob = ProcessTools.executeProcess(pb);
             System.out.println("Java Process " + getMainArgsIdentifier() + " stderr:"
                     + ob.getStderr());


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316462](https://bugs.openjdk.org/browse/JDK-8316462) needs maintainer approval

### Issue
 * [JDK-8316462](https://bugs.openjdk.org/browse/JDK-8316462): sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java ignores VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/66.diff">https://git.openjdk.org/jdk21u-dev/pull/66.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/66#issuecomment-1860723966)