### PR TITLE
8321409: Console read line with zero out should zero out underlying buffer in JLine (redux)

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -112,7 +112,7 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
             } catch (EndOfFileException eofe) {
                 return null;
             } finally {
-                jline.getBuffer().zeroOut();
+                jline.zeroOut();
             }
         }
 

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/LineReader.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/LineReader.java
@@ -750,4 +750,9 @@ public interface LineReader {
     void setAutosuggestion(SuggestionType type);
 
     SuggestionType getAutosuggestion();
+
+    // JDK specific modification
+    default void zeroOut() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/LineReaderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/LineReaderImpl.java
@@ -6250,4 +6250,10 @@ public class LineReaderImpl implements LineReader, Flushable
         }
     }
 
+    // JDK specific modification
+    @Override
+    public void zeroOut() {
+        buf.zeroOut();
+        parsedLine = null;
+    }
 }


### PR DESCRIPTION
A change we should have in 21, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321409](https://bugs.openjdk.org/browse/JDK-8321409) needs maintainer approval

### Issue
 * [JDK-8321409](https://bugs.openjdk.org/browse/JDK-8321409): Console read line with zero out should zero out underlying buffer in JLine (redux) (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/69.diff">https://git.openjdk.org/jdk21u-dev/pull/69.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/69#issuecomment-1862542622)