### PR TITLE
8316446: 4 sun/management/jdp tests ignore VM flags

### DIFF
--- a/test/jdk/sun/management/jdp/DynamicLauncher.java
+++ b/test/jdk/sun/management/jdp/DynamicLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public abstract class DynamicLauncher {
 
     protected OutputAnalyzer runVM() throws Exception {
         String[] options = this.options();
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(options);
+        ProcessBuilder pb = ProcessTools.createTestJvm(options);
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
         System.out.println(out.getStdout());
         System.err.println(out.getStderr());


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316446](https://bugs.openjdk.org/browse/JDK-8316446) needs maintainer approval

### Issue
 * [JDK-8316446](https://bugs.openjdk.org/browse/JDK-8316446): 4 sun/management/jdp tests ignore VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/72.diff">https://git.openjdk.org/jdk21u-dev/pull/72.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/72#issuecomment-1863098508)