### PR TITLE
8307408: Some jdk/sun/tools/jhsdb tests don't pass test JVM args to the debuggee JVM

### DIFF
--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -28,3 +28,6 @@
 #############################################################################
 
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8309218 generic-all
+
+sun/tools/jhsdb/JShellHeapDumpTest.java            8276539 generic-all
+sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8276539 generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,6 +742,7 @@ sun/tools/jstat/jstatLineCounts3.sh                             8248691,8268211 
 sun/tools/jstat/jstatLineCounts4.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
 
 sun/tools/jhsdb/JStackStressTest.java                           8276210 linux-aarch64
+sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java              8313798 generic-aarch64
 
 ############################################################################
 

--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,7 +150,14 @@ public class JShellHeapDumpTest {
         System.out.println("Starting Jshell");
         long startTime = System.currentTimeMillis();
         try {
-            ProcessBuilder pb = new ProcessBuilder(JDKToolFinder.getTestJDKTool("jshell"));
+            JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jshell");
+            if (doSleep) {
+                launcher.addVMArgs(Utils.getTestJavaOpts());
+            } else {
+                // Don't allow use of SerialGC. See JDK-8313655.
+                launcher.addVMArgs(Utils.getFilteredTestJavaOpts("-XX:\\+UseSerialGC"));
+            }
+            ProcessBuilder pb = new ProcessBuilder(launcher.getCommand());
             jShellProcess = ProcessTools.startProcess("JShell", pb,
                                                       s -> {  // warm-up predicate
                                                           return s.contains("Welcome to JShell");

--- a/test/jdk/sun/tools/jhsdb/JStackStressTest.java
+++ b/test/jdk/sun/tools/jhsdb/JStackStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,9 @@ public class JStackStressTest {
         System.out.println("Starting Jshell");
         long startTime = System.currentTimeMillis();
         try {
-            ProcessBuilder pb = new ProcessBuilder(JDKToolFinder.getTestJDKTool("jshell"));
+            JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jshell");
+            launcher.addVMArgs(Utils.getTestJavaOpts());
+            ProcessBuilder pb = new ProcessBuilder(launcher.getCommand());
             jShellProcess = ProcessTools.startProcess("JShell", pb);
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8307408](https://bugs.openjdk.org/browse/JDK-8307408) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307408](https://bugs.openjdk.org/browse/JDK-8307408): Some jdk/sun/tools/jhsdb tests don't pass test JVM args to the debuggee JVM (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/73.diff">https://git.openjdk.org/jdk21u-dev/pull/73.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/73#issuecomment-1863108248)