### PR TITLE
8322040: Missing array bounds check in ClassReader.parameter

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2791,7 +2791,7 @@ public class ClassReader {
                 && parameterAccessFlags[mpIndex] != 0) {
             flags |= parameterAccessFlags[mpIndex];
         }
-        if (parameterNameIndicesMp != null
+        if (parameterNameIndicesMp != null && mpIndex < parameterNameIndicesMp.length
                 // if name_index is 0, then we might still get a name from the LocalVariableTable
                 && parameterNameIndicesMp[mpIndex] != 0) {
             argName = optPoolEntry(parameterNameIndicesMp[mpIndex], poolReader::getName, names.empty);

--- a/test/langtools/tools/javac/classreader/BadMethodParameter.java
+++ b/test/langtools/tools/javac/classreader/BadMethodParameter.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8322040
+ * @summary Missing array bounds check in ClassReader.parameter
+ * @library /tools/lib /tools/javac/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ *      java.base/jdk.internal.classfile
+ *      java.base/jdk.internal.classfile.attribute
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main BadMethodParameter
+ */
+
+import jdk.internal.classfile.ClassModel;
+import jdk.internal.classfile.ClassTransform;
+import jdk.internal.classfile.Classfile;
+import jdk.internal.classfile.MethodTransform;
+import jdk.internal.classfile.attribute.MethodParametersAttribute;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+public class BadMethodParameter extends TestRunner {
+
+    protected ToolBox tb;
+
+    BadMethodParameter() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String... args) throws Exception {
+        new BadMethodParameter().runTests();
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[] {Paths.get(m.getName())});
+    }
+
+    @Test
+    public void testAnnoOnConstructors(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path t = src.resolve("T.java");
+        Path classes = base.resolve("classes");
+
+        Files.createDirectories(classes);
+
+        tb.writeJavaFiles(
+                src,
+                """
+                class T {
+                  public static void f(int x, int y) {
+                  }
+                }
+                """);
+
+        new JavacTask(tb).options("-parameters").files(t).outdir(classes).run();
+
+        transform(classes.resolve("T.class"));
+
+        Path classDir = getClassDir();
+        new JavacTask(tb)
+                .classpath(classes, classDir)
+                .options("-verbose", "-parameters", "-processor", P.class.getName())
+                .classes(P.class.getName())
+                .outdir(classes)
+                .run(Task.Expect.SUCCESS);
+    }
+
+    public Path getClassDir() {
+        String classes = ToolBox.testClasses;
+        if (classes == null) {
+            return Paths.get("build");
+        } else {
+            return Paths.get(classes);
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    public static final class P extends AbstractProcessor {
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            if (processingEnv.getElementUtils().getTypeElement("T") == null) {
+                throw new AssertionError("could not load T");
+            }
+            return false;
+        }
+    }
+
+    private static void transform(Path path) throws IOException {
+        byte[] bytes = Files.readAllBytes(path);
+        ClassModel classModel = Classfile.parse(bytes);
+        MethodTransform methodTransform =
+                (mb, me) -> {
+                    if (me instanceof MethodParametersAttribute mp) {
+                        // create a MethodParameters attribute with the wrong number of entries
+                        mb.with(
+                                MethodParametersAttribute.of(
+                                        mp.parameters().subList(0, mp.parameters().size() - 1)));
+                    } else {
+                        mb.with(me);
+                    }
+                };
+
+        ClassTransform classTransform = ClassTransform.transformingMethods(methodTransform);
+        bytes = classModel.transform(classTransform);
+        Files.write(path, bytes);
+    }
+}


### PR DESCRIPTION
Hi,

This is a backport of [JDK-8322040: Missing array bounds check in ClassReader.parameter](https://bugs.openjdk.org/browse/JDK-8322040).

The fix applied cleanly. The test required updating due to changes in the Class-File API. The modified test fails without the patch, and passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8322040](https://bugs.openjdk.org/browse/JDK-8322040) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322040](https://bugs.openjdk.org/browse/JDK-8322040): Missing array bounds check in ClassReader.parameter (**Bug** - P3 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/74.diff">https://git.openjdk.org/jdk21u-dev/pull/74.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/74#issuecomment-1863133978)