### PR TITLE
8320206: Some intrinsics/stubs missing vzeroupper on x86_64

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_adler.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_adler.cpp
@@ -330,6 +330,7 @@ address StubGenerator::generate_updateBytesAdler32() {
   __ movq(r13, xtmp4);
   __ movq(r12, xtmp3);
 
+  __ vzeroupper();
   __ leave();
   __ ret(0);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_chacha.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_chacha.cpp
@@ -291,6 +291,9 @@ address StubGenerator::generate_chacha20Block_avx() {
   // registers.  That length should be returned through %rax.
   __ mov64(rax, outlen);
 
+  if (outlen == 256) {
+    __ vzeroupper();
+  }
   __ leave();
   __ ret(0);
   return start;
@@ -460,6 +463,7 @@ address StubGenerator::generate_chacha20Block_avx512() {
   // and that length should be returned through %rax.
   __ mov64(rax, 1024);
 
+  __ vzeroupper();
   __ leave();
   __ ret(0);
   return start;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1108,6 +1108,7 @@ bool LibraryCallKit::inline_countPositives() {
   Node* ba_start = array_element_address(ba, offset, T_BYTE);
   Node* result = new CountPositivesNode(control(), memory(TypeAryPtr::BYTES), ba_start, len);
   set_result(_gvn.transform(result));
+  clear_upper_avx();
   return true;
 }
 
@@ -1362,6 +1363,7 @@ bool LibraryCallKit::inline_string_indexOfChar(StrIntrinsicNode::ArgEnc ae) {
   set_control(_gvn.transform(region));
   record_for_igvn(region);
   set_result(_gvn.transform(phi));
+  clear_upper_avx();
 
   return true;
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8320206](https://bugs.openjdk.org/browse/JDK-8320206) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320206](https://bugs.openjdk.org/browse/JDK-8320206): Some intrinsics/stubs missing vzeroupper on x86_64 (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/75.diff">https://git.openjdk.org/jdk21u-dev/pull/75.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/75#issuecomment-1863156585)