### PR TITLE
8314830: runtime/ErrorHandling/ tests ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jdk.test.lib.process.ProcessTools;
  * @bug 8194652
  * @summary Printing native stack shows an "error occurred during error reporting".
  * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
  * @requires vm.debug
  * @requires vm.flavor != "zero"
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ClassPathEnvVar.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ClassPathEnvVar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8271003
  * @summary CLASSPATH env variable setting should not be truncated in a hs err log.
+ * @requires vm.flagless
  * @requires vm.debug
  * @library /test/lib
  * @run driver ClassPathEnvVar

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileOverwriteTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileOverwriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, SAP. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -30,6 +30,7 @@
  *           in the error file name)
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
  * @requires (vm.debug == true)
  * @run driver ErrorFileOverwriteTest
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileRedirectTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ErrorFileRedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, SAP. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,6 +29,7 @@
  * @summary Test ErrorFileToStderr and ErrorFileToStdout
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
  * @requires (vm.debug == true)
  * @run driver ErrorFileRedirectTest
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8272586
+ * @requires vm.flagless
  * @requires vm.compiler2.enabled
  * @summary Test that abstract machine code is dumped for the top frames in a hs-err log
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /*
  * @test
+ * @requires vm.flagless
  * @requires (vm.debug == true)
  * @bug 8167108
  * @summary Nested ThreadsListHandle info should be in error handling output.

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ProblematicFrameTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ProblematicFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @requires vm.flagless
  * @run driver ProblematicFrameTest
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ReattemptErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ReattemptErrorTest.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Check secondary error handling
  * @library /test/lib
+ * @requires vm.flagless
  * @requires vm.debug
  * @requires os.family != "windows"
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ResourceMarkTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ResourceMarkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @bug 8284274
  * @summary Test that reporting doesn't crash because missing ResourceMarks
  * @library /test/lib
+ * @requires vm.flagless
  * @requires vm.debug
  * @requires os.family != "windows"
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, 2022 SAP SE. All rights reserved.
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary SafeFetch32 and SafeFetchN do not work in error handling
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @requires vm.debug
  * @requires vm.flavor != "zero"
  * @author Thomas Stuefe (SAP)

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014, 2022 SAP SE. All rights reserved.
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @test
  * @summary Check secondary error handling
  * @library /test/lib
+ * @requires vm.flagless
  * @requires vm.debug
  * @requires os.family != "windows"
  * @modules java.base/jdk.internal.misc
@@ -38,6 +39,7 @@
  * @test
  * @summary Check secondary error handling
  * @library /test/lib
+ * @requires vm.flagless
  * @requires vm.debug
  * @requires os.family != "windows"
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -28,6 +28,7 @@
  * @bug 8191101
  * @summary Show Registers on assert/guarantee
  * @library /test/lib
+ * @requires vm.flagless
  * @requires (vm.debug == true) & (os.family == "linux")
  * @author Thomas Stuefe (SAP)
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
@@ -26,6 +26,7 @@
  * @summary Test using -XX:+CrashOnOutOfMemoryError
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestCrashOnOutOfMemoryError
  * @bug 8138745
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestExitOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestExitOnOutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @summary Test using -XX:ExitOnOutOfMemoryError
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestExitOnOutOfMemoryError
  * @bug 8138745
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestGZippedHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestGZippedHeapDumpOnOutOfMemoryError.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +33,7 @@
  * @test
  * @summary Test verifies that -XX:HeapDumpGzipLevel=1 works
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver/timeout=240 TestGZippedHeapDumpOnOutOfMemoryError run 1
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test TestHeapDumpOnOutOfMemoryError
  * @summary Test verifies that -XX:HeapDumpOnOutOfMemoryError dumps heap when OutOfMemory is thrown in heap
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestHeapDumpOnOutOfMemoryError run heap
  */
 
@@ -32,6 +33,7 @@
  * @test TestHeapDumpOnOutOfMemoryError
  * @summary Test verifies that -XX:HeapDumpOnOutOfMemoryError dumps heap when OutOfMemory is thrown in metaspace.
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver/timeout=240 TestHeapDumpOnOutOfMemoryError run metaspace
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpPath.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestHeapDumpPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test TestHeapDumpPath
  * @summary Test verifies that -XX:HeapDumpPath= supports directory as a parameter.
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestHeapDumpPath
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestOnError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestOnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Test using -XX:OnError=<cmd>
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @requires vm.debug
  * @run driver TestOnError
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestOnOutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @summary Test using single and multiple -XX:OnOutOfMemoryError=<cmd>
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver TestOnOutOfMemoryError
  * @bug 8078470 8177522
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,6 +27,7 @@
  * @test segv
  * @summary Test that for a given crash situation we see the correct siginfo in the hs-err file
  * @library /test/lib
+ * @requires vm.flagless
  * @requires vm.debug
  * @requires os.family != "windows"
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary ThreadsListHandle info should be in error handling output.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver ThreadsListHandleInErrorHandlingTest
  */
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017, 2022 SAP SE. All rights reserved.
  * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary Hanging Error Reporting steps may lead to torn error logs
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @requires (vm.debug == true) & (os.family != "windows")
  * @run driver TimeoutInErrorHandlingTest
  * @author Thomas Stuefe (SAP)
@@ -53,6 +54,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary Error handling step timeouts should never be blocked by OnError etc.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @requires vm.flagless
  * @requires (vm.debug == true) & (os.family != "windows")
  * @run driver TimeoutInErrorHandlingTest with-on-error
  */

--- a/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/VeryEarlyAssertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2022 SAP. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,6 +29,7 @@
  * @summary No hs-err file if fatal error is raised during dynamic initialization.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
  * @requires (vm.debug == true)
  * @requires os.family == "linux"
  * @run driver VeryEarlyAssertTest
@@ -49,8 +50,7 @@ public class VeryEarlyAssertTest {
   public static void main(String[] args) throws Exception {
 
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-version");
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-version");
     Map<String, String> env = pb.environment();
     env.put("HOTSPOT_FATAL_ERROR_DURING_DYNAMIC_INITIALIZATION", "1");
 


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.


runtime/ErrorHandling/TestAbortVmOnException.java was added by "8264899: C1: -XX:AbortVMOnException does not work if all methods in the call stack are compiled with C1 and there are no exception handlers", skiped

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314830](https://bugs.openjdk.org/browse/JDK-8314830) needs maintainer approval

### Issue
 * [JDK-8314830](https://bugs.openjdk.org/browse/JDK-8314830): runtime/ErrorHandling/ tests ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/76.diff">https://git.openjdk.org/jdk21u-dev/pull/76.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/76#issuecomment-1863183909)