### PR TITLE
8317358: G1: Make TestMaxNewSize use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,8 @@ package gc.arguments;
  * @bug 7057939
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
- * @requires vm.gc.Serial
+ * @key flag-sensitive
+ * @requires vm.gc.Serial & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null & vm.opt.x.Xms == null & vm.opt.x.Xmx == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -42,7 +43,8 @@ package gc.arguments;
  * @bug 7057939
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
- * @requires vm.gc.Parallel
+ * @key flag-sensitive
+ * @requires vm.gc.Parallel & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null & vm.opt.x.Xms == null & vm.opt.x.Xmx == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -56,7 +58,8 @@ package gc.arguments;
  * @bug 7057939
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
- * @requires vm.gc.G1
+ * @key flag-sensitive
+ * @requires vm.gc.G1 & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null & vm.opt.x.Xms == null & vm.opt.x.Xmx == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -79,46 +82,23 @@ public class TestMaxNewSize {
 
   private static void checkMaxNewSize(String[] flags, int heapsize) throws Exception {
     BigInteger actual = new BigInteger(getMaxNewSize(flags));
-    System.out.println(actual);
-    if (actual.compareTo(new BigInteger((new Long(heapsize)).toString())) == 1) {
+    System.out.println("asserting: " + actual + " <= " + heapsize);
+    if (actual.compareTo(new BigInteger("" + heapsize)) > 0) {
       throw new RuntimeException("MaxNewSize value set to \"" + actual +
         "\", expected otherwise when running with the following flags: " + Arrays.asList(flags).toString());
     }
   }
 
-  private static void checkIncompatibleNewSize(String[] flags) throws Exception {
-    ArrayList<String> finalargs = new ArrayList<String>();
-    finalargs.addAll(Arrays.asList(flags));
-    finalargs.add("-version");
-
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs);
-    OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldContain("Initial young gen size set larger than the maximum young gen size");
-  }
-
-  private static boolean isRunningG1(String[] args) {
-    for (int i = 0; i < args.length; i++) {
-      if (args[i].contains("+UseG1GC")) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private static String getMaxNewSize(String[] flags) throws Exception {
     ArrayList<String> finalargs = new ArrayList<String>();
     finalargs.addAll(Arrays.asList(flags));
-    if (isRunningG1(flags)) {
-      finalargs.add("-XX:G1HeapRegionSize=1M");
-    }
     finalargs.add("-XX:+PrintFlagsFinal");
     finalargs.add("-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs);
+    ProcessBuilder pb = GCArguments.createTestJvm(finalargs);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     String stdout = output.getStdout();
-    //System.out.println(stdout);
     return getFlagValue("MaxNewSize", stdout);
   }
 


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date. This will simplify future test backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317358](https://bugs.openjdk.org/browse/JDK-8317358) needs maintainer approval

### Issue
 * [JDK-8317358](https://bugs.openjdk.org/browse/JDK-8317358): G1: Make TestMaxNewSize use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/85.diff">https://git.openjdk.org/jdk21u-dev/pull/85.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/85#issuecomment-1866313701)