### PR TITLE
8320830: [AIX] Dont mix os::dll_load() with direct dlclose() calls

### DIFF
--- a/src/hotspot/os/aix/libodm_aix.cpp
+++ b/src/hotspot/os/aix/libodm_aix.cpp
@@ -35,7 +35,7 @@
 dynamicOdm::dynamicOdm() {
   const char* libodmname = "/usr/lib/libodm.a(shr_64.o)";
   char ebuf[512];
-  void* _libhandle = os::dll_load(libodmname, ebuf, sizeof(ebuf));
+  _libhandle = os::dll_load(libodmname, ebuf, sizeof(ebuf));
 
   if (!_libhandle) {
     trcVerbose("Cannot load %s (error %s)", libodmname, ebuf);
@@ -48,14 +48,14 @@ dynamicOdm::dynamicOdm() {
   _odm_terminate   = (fun_odm_terminate  )dlsym(_libhandle, "odm_terminate"  );
   if (!_odm_initialize || !_odm_set_path || !_odm_mount_class || !_odm_get_obj || !_odm_terminate) {
     trcVerbose("Couldn't find all required odm symbols from %s", libodmname);
-    dlclose(_libhandle);
+    os::dll_unload(_libhandle);
     _libhandle = nullptr;
     return;
   }
 }
 
 dynamicOdm::~dynamicOdm() {
-  if (_libhandle) { dlclose(_libhandle); }
+  if (_libhandle) { os::dll_unload(_libhandle); }
 }
 
 

--- a/src/hotspot/os/aix/libperfstat_aix.cpp
+++ b/src/hotspot/os/aix/libperfstat_aix.cpp
@@ -114,7 +114,7 @@ bool libperfstat::init() {
 void libperfstat::cleanup() {
 
   if (g_libhandle) {
-    dlclose(g_libhandle);
+    os::dll_unload(g_libhandle);
     g_libhandle = nullptr;
   }
 


### PR DESCRIPTION
Backport of [JDK-8320830](https://bugs.openjdk.org/browse/JDK-8320830).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320830](https://bugs.openjdk.org/browse/JDK-8320830) needs maintainer approval

### Issue
 * [JDK-8320830](https://bugs.openjdk.org/browse/JDK-8320830): [AIX] Dont mix os::dll_load() with direct dlclose() calls (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/86.diff">https://git.openjdk.org/jdk21u-dev/pull/86.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/86#issuecomment-1866325788)