### PR TITLE
8319456: jdk/jfr/event/gc/collection/TestGCCauseWith[Serial|Parallel].java : GC cause 'GCLocker Initiated GC' not in the valid causes

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithParallelOld.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithParallelOld.java
@@ -39,7 +39,7 @@ public class TestGCCauseWithParallelOld {
         String testID = "ParallelOld";
         String[] vmFlags = {"-XX:+UseParallelGC"};
         String[] gcNames = {GCHelper.gcParallelScavenge, GCHelper.gcParallelOld};
-        String[] gcCauses = {"Allocation Failure", "Ergonomics", "System.gc()"};
+        String[] gcCauses = {"Allocation Failure", "Ergonomics", "System.gc()", "GCLocker Initiated GC"};
         GCGarbageCollectionUtil.test(testID, vmFlags, gcNames, gcCauses);
     }
 }

--- a/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithSerial.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithSerial.java
@@ -39,7 +39,7 @@ public class TestGCCauseWithSerial {
         String testID = "Serial";
         String[] vmFlags = {"-XX:+UseSerialGC"};
         String[] gcNames = {GCHelper.gcDefNew, GCHelper.gcSerialOld};
-        String[] gcCauses = {"Allocation Failure", "System.gc()"};
+        String[] gcCauses = {"Allocation Failure", "System.gc()", "GCLocker Initiated GC"};
         GCGarbageCollectionUtil.test(testID, vmFlags, gcNames, gcCauses);
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319456](https://bugs.openjdk.org/browse/JDK-8319456) needs maintainer approval

### Issue
 * [JDK-8319456](https://bugs.openjdk.org/browse/JDK-8319456): jdk/jfr/event/gc/collection/TestGCCauseWith[Serial|Parallel].java : GC cause 'GCLocker Initiated GC' not in the valid causes (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/88.diff">https://git.openjdk.org/jdk21u-dev/pull/88.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/88#issuecomment-1866627321)