### PR TITLE
8318983: Fix comment typo in PKCS12Passwd.java

### DIFF
--- a/test/jdk/sun/security/tools/keytool/PKCS12Passwd.java
+++ b/test/jdk/sun/security/tools/keytool/PKCS12Passwd.java
@@ -108,7 +108,7 @@ public class PKCS12Passwd {
 
         check("p12", "newpass", "newpass");
 
-        // Conversely, a JKS keystore can be laoded as a PKCS12, and it follows
+        // Conversely, a JKS keystore can be loaded as a PKCS12, and it follows
         // PKCS12 rules that both passwords are changed at the same time and
         // some commands are rejected.
 


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318983](https://bugs.openjdk.org/browse/JDK-8318983) needs maintainer approval

### Issue
 * [JDK-8318983](https://bugs.openjdk.org/browse/JDK-8318983): Fix comment typo in PKCS12Passwd.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/93.diff">https://git.openjdk.org/jdk21u-dev/pull/93.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/93#issuecomment-1867386758)