### PR TITLE
8264899: C1: -XX:AbortVMOnException does not work if all methods in the call stack are compiled with C1 and there are no exception handlers

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -478,6 +478,15 @@ void Runtime1::generate_unwind_exception(StubAssembler *sasm) {
   const Register exception_pc = r3;
   const Register handler_addr = r1;
 
+  if (AbortVMOnException) {
+    __ mov(rscratch1, exception_oop);
+    __ enter();
+    save_live_registers(sasm);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, check_abort_on_vm_exception), rscratch1);
+    restore_live_registers(sasm);
+    __ leave();
+  }
+
   // verify that only r0, is valid at this time
   __ invalidate_registers(false, true, true, true, true, true);
 

--- a/src/hotspot/cpu/arm/c1_Runtime1_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_Runtime1_arm.cpp
@@ -350,6 +350,13 @@ OopMapSet* Runtime1::generate_handle_exception(StubID id, StubAssembler* sasm) {
 
 
 void Runtime1::generate_unwind_exception(StubAssembler* sasm) {
+
+  if (AbortVMOnException) {
+    save_live_registers(sasm);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, check_abort_on_vm_exception), Rexception_obj);
+    restore_live_registers(sasm);
+  }
+
   // FP no longer used to find the frame start
   // on entry, remove_frame() has already been called (restoring FP and LR)
 

--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -552,6 +552,12 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
                        Rexception_save = R31, Rcaller_sp = R30;
         __ set_info("unwind_exception", dont_gc_arguments);
 
+        if (AbortVMOnException) {
+          save_live_registers(sasm);
+          __ call_VM_leaf(CAST_FROM_FN_PTR(address, check_abort_on_vm_exception), Rexception);
+          restore_live_registers(sasm, noreg, noreg);
+        }
+
         __ ld(Rcaller_sp, 0, R1_SP);
         __ push_frame_reg_args(0, R0); // dummy frame for C call
         __ mr(Rexception_save, Rexception); // save over C call

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -498,6 +498,14 @@ void Runtime1::generate_unwind_exception(StubAssembler *sasm) {
   // other registers used in this stub
   const Register handler_addr = x11;
 
+  if (AbortVMOnException) {
+    __ enter();
+    save_live_registers(sasm);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, check_abort_on_vm_exception), x10);
+    restore_live_registers(sasm);
+    __ leave();
+  }
+
   // verify that only x10, is valid at this time
   __ invalidate_registers(false, true, true, true, true, true);
 

--- a/src/hotspot/cpu/s390/c1_Runtime1_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_Runtime1_s390.cpp
@@ -233,6 +233,12 @@ void Runtime1::generate_unwind_exception(StubAssembler *sasm) {
   // Other registers used in this stub.
   const Register handler_addr = Z_R4;
 
+  if (AbortVMOnException) {
+    save_live_registers(sasm);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, check_abort_on_vm_exception), Z_EXC_OOP);
+    restore_live_registers(sasm);
+  }
+
   // Verify that only exception_oop, is valid at this time.
   __ invalidate_registers(Z_EXC_OOP, Z_EXC_PC);
 

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -798,6 +798,14 @@ void Runtime1::generate_unwind_exception(StubAssembler *sasm) {
   const Register handler_addr = rbx;
   const Register thread = NOT_LP64(rdi) LP64_ONLY(r15_thread);
 
+  if (AbortVMOnException) {
+    __ enter();
+    save_live_registers(sasm, 2);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, check_abort_on_vm_exception), rax);
+    restore_live_registers(sasm);
+    __ leave();
+  }
+
   // verify that only rax, is valid at this time
   __ invalidate_registers(false, true, true, true, true, true);
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1504,6 +1504,19 @@ JRT_ENTRY(void, Runtime1::predicate_failed_trap(JavaThread* current))
 
 JRT_END
 
+// Check exception if AbortVMOnException flag set
+JRT_LEAF(void, Runtime1::check_abort_on_vm_exception(oopDesc* ex))
+  ResourceMark rm;
+  const char* message = nullptr;
+  if (ex->is_a(vmClasses::Throwable_klass())) {
+    oop msg = java_lang_Throwable::message(ex);
+    if (msg != nullptr) {
+      message = java_lang_String::as_utf8_string(msg);
+    }
+  }
+  Exceptions::debug_check_abort(ex->klass()->external_name(), message);
+JRT_END
+
 #ifndef PRODUCT
 void Runtime1::print_statistics() {
   tty->print_cr("C1 Runtime statistics:");

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,6 +190,8 @@ class Runtime1: public AllStatic {
   static int  is_instance_of(oopDesc* mirror, oopDesc* obj);
 
   static void predicate_failed_trap(JavaThread* current);
+
+  static void check_abort_on_vm_exception(oopDesc* ex);
 
   static void print_statistics()                 PRODUCT_RETURN;
 };

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test TestAbortVmOnException
+ * @summary Test -XX:AbortVMOnException=MyAbortException with C1 compilation
+ * @library /test/lib
+ * @run driver TestAbortVmOnException
+ * @bug 8264899
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.IOException;
+
+
+public class TestAbortVmOnException {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            if (args[0].equals("throwExceptionWithMessage")) {
+                throw new MyAbortException("MyExceptionMessage");
+            } else {
+                throw new MyAbortException();
+            }
+        }
+        // Run process throwing MyException
+        Process myExceptionThrowingProcess = runProcess( "MyAbortException", false, null);
+        parseOutput(myExceptionThrowingProcess, "fatal error: Saw MyAbortException, aborting");
+        // Run process throwing MyException with message
+        Process myExceptionThrowingWithMessageProcess = runProcess( "MyAbortException", true, null);
+        parseOutput(myExceptionThrowingWithMessageProcess, "fatal error: Saw MyAbortException: MyExceptionMessage, aborting");
+        // Run process throwing MyException with message and check message
+        Process myExceptionThrowingWithMessageCheckProcess = runProcess( "MyAbortException", true, "MyExceptionMessage");
+        parseOutput(myExceptionThrowingWithMessageCheckProcess, "fatal error: Saw MyAbortException: MyExceptionMessage, aborting");
+        System.out.println("PASSED");
+    }
+
+    private static Process runProcess(String exceptionName, boolean withMessage, String exceptionMessage) throws IOException {
+        if (exceptionMessage == null) {
+            return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
+                "-XX:AbortVMOnException=" + exceptionName, "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", TestAbortVmOnException.class.getName(),
+                withMessage ? "throwExceptionWithMessage" : "throwException").start();
+        } else {
+            return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
+                "-XX:AbortVMOnException=" + exceptionName, "-XX:AbortVMOnExceptionMessage=" + exceptionMessage,
+                "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", TestAbortVmOnException.class.getName(),
+                withMessage ? "throwExceptionWithMessage" : "throwException").start();
+        }
+    }
+
+    private static void parseOutput(Process process, String expectedString) throws IOException {
+        OutputAnalyzer output = new OutputAnalyzer(process);
+        output.stdoutShouldNotBeEmpty();
+        output.shouldContain(expectedString);
+    }
+
+}
+
+class MyAbortException extends RuntimeException {
+    public MyAbortException() {
+        super();
+    }
+
+    public MyAbortException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
A useful fix for AbortVMOnException)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8264899](https://bugs.openjdk.org/browse/JDK-8264899) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264899](https://bugs.openjdk.org/browse/JDK-8264899): C1: -XX:AbortVMOnException does not work if all methods in the call stack are compiled with C1 and there are no exception handlers (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/95.diff">https://git.openjdk.org/jdk21u-dev/pull/95.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/95#issuecomment-1868329391)