### PR TITLE
8310919: runtime/ErrorHandling/TestAbortVmOnException.java times out due to core dumps taking a long time on OSX

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestAbortVmOnException.java
@@ -60,13 +60,14 @@ public class TestAbortVmOnException {
     private static Process runProcess(String exceptionName, boolean withMessage, String exceptionMessage) throws IOException {
         if (exceptionMessage == null) {
             return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
-                "-XX:AbortVMOnException=" + exceptionName, "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", TestAbortVmOnException.class.getName(),
+                "-XX:AbortVMOnException=" + exceptionName, "-Xcomp", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash",
+                "-XX:CompileCommand=compileonly,TestAbortVmOnException::*", TestAbortVmOnException.class.getName(),
                 withMessage ? "throwExceptionWithMessage" : "throwException").start();
         } else {
             return ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions",
                 "-XX:AbortVMOnException=" + exceptionName, "-XX:AbortVMOnExceptionMessage=" + exceptionMessage,
-                "-Xcomp", "-Xbatch", "-XX:TieredStopAtLevel=3", TestAbortVmOnException.class.getName(),
-                withMessage ? "throwExceptionWithMessage" : "throwException").start();
+                "-Xcomp", "-XX:TieredStopAtLevel=3", "-XX:-CreateCoredumpOnCrash", "-XX:CompileCommand=compileonly,TestAbortVmOnException::*",
+                TestAbortVmOnException.class.getName(),withMessage ? "throwExceptionWithMessage" : "throwException").start();
         }
     }
 


### PR DESCRIPTION
I backport this to keep the 21u test suite up-to-date.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8310919](https://bugs.openjdk.org/browse/JDK-8310919) needs maintainer approval

### Issue
 * [JDK-8310919](https://bugs.openjdk.org/browse/JDK-8310919): runtime/ErrorHandling/TestAbortVmOnException.java times out due to core dumps taking a long time on OSX (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/102.diff">https://git.openjdk.org/jdk21u-dev/pull/102.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/102#issuecomment-1871182388)