### PR TITLE
8322772: Clean up code after JDK-8322417

### DIFF
--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -120,7 +120,7 @@ public final class JdkConsoleImpl implements JdkConsole {
                             ioe.addSuppressed(x);
                     }
                     if (ioe != null) {
-                        java.util.Arrays.fill(passwd, ' ');
+                        Arrays.fill(passwd, ' ');
                         try {
                             if (reader instanceof LineReader lr) {
                                 lr.zeroOut();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8322772](https://bugs.openjdk.org/browse/JDK-8322772), commit [32d80e2c](https://github.com/openjdk/jdk/commit/32d80e2caf6063b58128bd5f3dc87b276f3bd0cb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 29 Dec 2023 and was reviewed by Martin Doerr, Goetz Lindenmaier, Matthias Baesken and Vyom Tewari.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322772](https://bugs.openjdk.org/browse/JDK-8322772) needs maintainer approval

### Issue
 * [JDK-8322772](https://bugs.openjdk.org/browse/JDK-8322772): Clean up code after JDK-8322417 (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/104.diff">https://git.openjdk.org/jdk21u-dev/pull/104.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/104#issuecomment-1872366382)