### PR TITLE
8314610: hotspot can't compile with the latest of gtest because of <iomanip>

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
+++ b/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 #include "utilities/vmassert_uninstall.hpp"
+#include <iomanip>
 #include <string.h>
 #include <sstream>
 #include "utilities/vmassert_reinstall.hpp"


### PR DESCRIPTION
```
/home/azul/azul/jdk21u-git/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp: In member function 'virtual void gc_memset_with_concurrent_readers_Test::TestBody()':
/home/azul/azul/jdk21u-git/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp:82:34: error: 'setw' is not a member of 'std'
   82 |                          << std::setw(2) << line_byte(lp, 0) << " "
      |                                  ^~~~
/home/azul/azul/jdk21u-git/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp:34:1: note: 'std::setw' is defined in header '<iomanip>'; did you forget to '#include <iomanip>'?
   33 | #include "unittest.hpp"
  +++ |+#include <iomanip>
   34 | 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8314610](https://bugs.openjdk.org/browse/JDK-8314610) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314610](https://bugs.openjdk.org/browse/JDK-8314610): hotspot can't compile with the latest of gtest because of &lt;iomanip&gt; (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/107.diff">https://git.openjdk.org/jdk21u-dev/pull/107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/107#issuecomment-1873369085)