### PR TITLE
8316594: C2 SuperWord: wrong result with hand unrolled loops

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2705,15 +2705,12 @@ bool SuperWord::output() {
         // Set the memory dependency of the LoadVector as early as possible.
         // Walk up the memory chain, and ignore any StoreVector that provably
         // does not have any memory dependency.
-        SWPointer p1(n->as_Mem(), this, nullptr, false);
         while (mem->is_StoreVector()) {
-          SWPointer p2(mem->as_Mem(), this, nullptr, false);
-          if (p1.not_equal(p2)) {
-            // Either Less or Greater -> provably no overlap between the two memory regions.
-            mem = mem->in(MemNode::Memory);
-          } else {
-            // No proof that there is no overlap. Stop here.
+          SWPointer p_store(mem->as_Mem(), this, nullptr, false);
+          if (p_store.overlap_possible_with_any_in(p)) {
             break;
+          } else {
+            mem = mem->in(MemNode::Memory);
           }
         }
         Node* adr = first->in(MemNode::Address);

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -722,6 +722,20 @@ class SWPointer : public ArenaObj {
     }
   }
 
+  bool overlap_possible_with_any_in(Node_List* p) {
+    for (uint k = 0; k < p->size(); k++) {
+      MemNode* mem = p->at(k)->as_Mem();
+      SWPointer p_mem(mem, _slp, nullptr, false);
+      // Only if we know that we have Less or Greater can we
+      // be sure that there can never be an overlap between
+      // the two memory regions.
+      if (!not_equal(p_mem)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool not_equal(SWPointer& q)    { return not_equal(cmp(q)); }
   bool equal(SWPointer& q)        { return equal(cmp(q)); }
   bool comparable(SWPointer& q)   { return comparable(cmp(q)); }


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

I had to resove SWPointer / VPointer because 8312332: C2: Refactor SWPointer out from SuperWord is not in 21.

We had previous backports that needed to be resolved because of this refactoring missing. I assume this will hit us in future repeatedly.

Thus I had a look at backporting 8312332, but that depends on three other cleanup changes:
8305636: Expand and clean up predicate classes and move them into separate files
8311691: C2: Remove legacy code related to PostLoopMultiversioning
8308606: C2 SuperWord: remove alignment checks when not required

All four of them can be backported clean, but 8305363 has four follow-up bugs.

So maybe we need to go the path and accept the unclean backports right from the beginning of 21u :(

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8316594](https://bugs.openjdk.org/browse/JDK-8316594) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316594](https://bugs.openjdk.org/browse/JDK-8316594): C2 SuperWord: wrong result with hand unrolled loops (**Bug** - P3 - Approved)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/110.diff">https://git.openjdk.org/jdk21u-dev/pull/110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/110#issuecomment-1874318221)