### PR TITLE
8315042: NPE in PKCS7.parseOldSignedData

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -152,6 +152,10 @@ public class PKCS7 {
         ObjectIdentifier contentType = block.contentType;
         DerValue content = block.getContent();
 
+        if (content == null) {
+            throw new ParsingException("content is null");
+        }
+
         if (contentType.equals(ContentInfo.SIGNED_DATA_OID)) {
             parseSignedData(content);
         } else if (contentType.equals(ContentInfo.OLD_SIGNED_DATA_OID)) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8c0d026d](https://github.com/openjdk/jdk/commit/8c0d026d0f508e0c896fd28d725915c52d1b689d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Mark Powers on 4 Oct 2023 and was reviewed by Valerie Peng and Weijun Wang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315042](https://bugs.openjdk.org/browse/JDK-8315042) needs maintainer approval

### Issue
 * [JDK-8315042](https://bugs.openjdk.org/browse/JDK-8315042): NPE in PKCS7.parseOldSignedData (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/111.diff">https://git.openjdk.org/jdk21u-dev/pull/111.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/111#issuecomment-1876184131)