### PR TITLE
8311279: TestStressIGVNAndCCP.java failed with different IGVN traces for the same seed

### DIFF
--- a/test/hotspot/jtreg/compiler/debug/TestStressIGVNAndCCP.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressIGVNAndCCP.java
@@ -44,7 +44,7 @@ public class TestStressIGVNAndCCP {
                              int stressSeed) throws Exception {
         String className = TestStressIGVNAndCCP.class.getName();
         String[] procArgs = {
-            "-Xcomp", "-XX:-TieredCompilation", "-XX:-Inline",
+            "-Xcomp", "-XX:-TieredCompilation", "-XX:-Inline", "-XX:+CICountNative",
             "-XX:CompileOnly=" + className + "::sum", "-XX:+" + traceOption,
             "-XX:+" + stressOption, "-XX:StressSeed=" + stressSeed,
             className, "10"};


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311279](https://bugs.openjdk.org/browse/JDK-8311279) needs maintainer approval

### Issue
 * [JDK-8311279](https://bugs.openjdk.org/browse/JDK-8311279): TestStressIGVNAndCCP.java failed with different IGVN traces for the same seed (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/113.diff">https://git.openjdk.org/jdk21u-dev/pull/113.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/113#issuecomment-1874993953)