### PR TITLE
8320921: GHA: Parallelize hotspot_compiler test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,9 @@ jobs:
           - 'jdk/tier1 part 3'
           - 'langtools/tier1'
           - 'hs/tier1 common'
-          - 'hs/tier1 compiler'
+          - 'hs/tier1 compiler part 1'
+          - 'hs/tier1 compiler part 2'
+          - 'hs/tier1 compiler part 3'
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
@@ -83,8 +85,16 @@ jobs:
             test-suite: 'test/hotspot/jtreg/:tier1_common'
             debug-suffix: -debug
 
-          - test-name: 'hs/tier1 compiler'
-            test-suite: 'test/hotspot/jtreg/:tier1_compiler'
+          - test-name: 'hs/tier1 compiler part 1'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_1'
+            debug-suffix: -debug
+
+          - test-name: 'hs/tier1 compiler part 2'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_2 test/hotspot/jtreg/:tier1_compiler_not_xcomp'
+            debug-suffix: -debug
+
+          - test-name: 'hs/tier1 compiler part 3'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_3'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 gc'


### PR DESCRIPTION
Clean backport to make GHA testing faster.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320921](https://bugs.openjdk.org/browse/JDK-8320921) needs maintainer approval

### Issue
 * [JDK-8320921](https://bugs.openjdk.org/browse/JDK-8320921): GHA: Parallelize hotspot_compiler test jobs (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/121.diff">https://git.openjdk.org/jdk21u-dev/pull/121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/121#issuecomment-1876782300)