### PR TITLE
8319548: Unexpected internal name for Filler array klass causes error in VisualVM

### DIFF
--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -335,7 +335,7 @@ void Universe::genesis(TRAPS) {
       // Initialization of the fillerArrayKlass must come before regular
       // int-TypeArrayKlass so that the int-Array mirror points to the
       // int-TypeArrayKlass.
-      _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "Ljdk/internal/vm/FillerArray;", CHECK);
+      _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "[Ljdk/internal/vm/FillerElement;", CHECK);
       for (int i = T_BOOLEAN; i < T_LONG+1; i++) {
         _typeArrayKlassObjs[i] = TypeArrayKlass::create_klass((BasicType)i, CHECK);
       }

--- a/test/hotspot/jtreg/gc/TestFillerObjectInstantiation.java
+++ b/test/hotspot/jtreg/gc/TestFillerObjectInstantiation.java
@@ -45,6 +45,6 @@ public class TestFillerObjectInstantiation {
 
     public static void main(String[] args) throws Exception {
         testInstantiationFails("jdk.internal.vm.FillerObject");
-        testInstantiationFails("jdk.internal.vm.FillerArray");
+        testInstantiationFails("jdk.internal.vm.FillerElement");
     }
 }


### PR DESCRIPTION
Clean backport to improve heap dump reliability w.r.t. filler objects. Only happens after JDK 19.

Additional testing:
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319548](https://bugs.openjdk.org/browse/JDK-8319548) needs maintainer approval

### Issue
 * [JDK-8319548](https://bugs.openjdk.org/browse/JDK-8319548): Unexpected internal name for Filler array klass causes error in VisualVM (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/123.diff">https://git.openjdk.org/jdk21u-dev/pull/123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/123#issuecomment-1876812428)