### PR TITLE
8320145: Compiler should accept final variable in Record Pattern

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3362,6 +3362,8 @@ public class JavacParser implements Parser {
                 case RPAREN: parenDepth--; break;
                 case ARROW: return parenDepth > 0 ? PatternResult.EXPRESSION
                                                    : pendingResult;
+                case FINAL:
+                    if (parenDepth > 0) return PatternResult.PATTERN;
                 default: return pendingResult;
             }
             lookahead++;

--- a/test/langtools/tools/javac/patterns/T8317300.out
+++ b/test/langtools/tools/javac/patterns/T8317300.out
@@ -1,5 +1,3 @@
 T8317300.java:13:18: compiler.err.mod.not.allowed.here: final
-T8317300.java:20:22: compiler.err.illegal.start.of.expr
-T8317300.java:20:31: compiler.err.expected: token.identifier
-T8317300.java:20:37: compiler.err.expected: ';'
-4 errors
+T8317300.java:20:22: compiler.err.mod.not.allowed.here: final
+2 errors

--- a/test/langtools/tools/javac/patterns/T8320145.java
+++ b/test/langtools/tools/javac/patterns/T8320145.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8320145
+ * @summary Compiler should accept final variable in Record Pattern
+ * @compile T8320145.java
+ */
+public class T8320145 {
+    record ARecord(String aComponent) {}
+    record BRecord(ARecord aComponent) {}
+    record CRecord(ARecord aComponent1, ARecord aComponent2) {}
+
+    public String match(Object o) {
+        return switch(o) {
+            case ARecord(final String s) -> s;
+            case BRecord(ARecord(final String s)) -> s;
+            case CRecord(ARecord(String s), ARecord(final String s2)) -> s;
+            default -> "No match";
+        };
+    }
+}


### PR DESCRIPTION
Clean backport to fix the new language feature in JDK 21. The patch extends the space of compilable programs.

Additional testing:
 - [x] New regression test fails without the fix, passes with it
 - [x] macos-aarch64-server-fastdebug, `langtools_all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320145](https://bugs.openjdk.org/browse/JDK-8320145) needs maintainer approval

### Issue
 * [JDK-8320145](https://bugs.openjdk.org/browse/JDK-8320145): Compiler should accept final variable in Record Pattern (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/125.diff">https://git.openjdk.org/jdk21u-dev/pull/125.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/125#issuecomment-1876879896)