### PR TITLE
8321582: yield <primitive-type>.class not parsed correctly.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2854,6 +2854,7 @@ public class JavacParser implements Parser {
                     case INTLITERAL: case LONGLITERAL: case FLOATLITERAL: case DOUBLELITERAL:
                     case NULL: case IDENTIFIER: case TRUE: case FALSE:
                     case NEW: case SWITCH: case THIS: case SUPER:
+                    case BYTE, CHAR, SHORT, INT, LONG, FLOAT, DOUBLE, VOID, BOOLEAN:
                         isYieldStatement = true;
                         break;
                     case PLUSPLUS: case SUBSUB:

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitch.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitch.java
@@ -1,12 +1,12 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8206986 8222169 8224031 8240964 8267119 8268670
+ * @bug 8206986 8222169 8224031 8240964 8267119 8268670 8321582
  * @summary Check expression switch works.
- * @compile/fail/ref=ExpressionSwitch-old.out --release 9 -XDrawDiagnostics ExpressionSwitch.java
  * @compile ExpressionSwitch.java
  * @run main ExpressionSwitch
  */
 
+// * @compile/fail/ref=ExpressionSwitch-old.out --release 9 -XDrawDiagnostics ExpressionSwitch.java
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -35,6 +35,16 @@ public class ExpressionSwitch {
         localClass(T.A);
         assertEquals(castSwitchExpressions(T.A), "A");
         testTypeInference(true, 0);
+        assertEquals(yieldPrimitiveDotClass("byte"), byte.class);
+        assertEquals(yieldPrimitiveDotClass("char"), char.class);
+        assertEquals(yieldPrimitiveDotClass("short"), short.class);
+        assertEquals(yieldPrimitiveDotClass("int"), int.class);
+        assertEquals(yieldPrimitiveDotClass("long"), long.class);
+        assertEquals(yieldPrimitiveDotClass("float"), float.class);
+        assertEquals(yieldPrimitiveDotClass("double"), double.class);
+        assertEquals(yieldPrimitiveDotClass("void"), void.class);
+        assertEquals(yieldPrimitiveDotClass("boolean"), boolean.class);
+        assertEquals(yieldPrimitiveDotClass("other"), null);
     }
 
     private String print(T t) {
@@ -137,6 +147,21 @@ public class ExpressionSwitch {
         return switch (s) {
             case "a": yield !b; // intentionally repeated !b, test the case clause
             default: yield !b; // intentionally repeated !b, test the default clause
+        };
+    }
+
+    private Class<?> yieldPrimitiveDotClass(String s) {
+        return switch (s) {
+            case "byte":    yield byte.class;
+            case "char":    yield char.class;
+            case "short":   yield short.class;
+            case "int":     yield int.class;
+            case "long":    yield long.class;
+            case "float":   yield float.class;
+            case "double":  yield double.class;
+            case "void":    yield void.class;
+            case "boolean": yield boolean.class;
+            default: yield null;
         };
     }
 


### PR DESCRIPTION
Fixes the javac bug, extends the space of compilable Java programs.

Additional testing:
 - [x] New regression test fails without the fix, passes with it
 - [x] `langtools_all` pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321582](https://bugs.openjdk.org/browse/JDK-8321582) needs maintainer approval

### Issue
 * [JDK-8321582](https://bugs.openjdk.org/browse/JDK-8321582): yield &lt;primitive-type&gt;.class not parsed correctly. (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/128.diff">https://git.openjdk.org/jdk21u-dev/pull/128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/128#issuecomment-1877045979)