### PR TITLE
8322583: RISC-V: Enable fast class initialization checks

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -201,6 +201,9 @@ class VM_Version : public Abstract_VM_Version {
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
   static bool supports_on_spin_wait() { return UseZihintpause; }
+
+  // RISCV64 supports fast class initialization checks
+  static bool supports_fast_class_init_checks() { return true; }
 };
 
 #endif // CPU_RISCV_VM_VERSION_RISCV_HPP


### PR DESCRIPTION
Hi, The same issue also exists in the JDK21U. Since corresponding fixes for the other ports are already there in jdk21u, I would like to backport this to jdk21u too. So I would like to backport this to JDK21U. Tier1-3 tested with release build using qemu systems. This is a risc-v specific change. Backport is clean, risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322583](https://bugs.openjdk.org/browse/JDK-8322583) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322583](https://bugs.openjdk.org/browse/JDK-8322583): RISC-V: Enable fast class initialization checks (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/132.diff">https://git.openjdk.org/jdk21u-dev/pull/132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/132#issuecomment-1878218220)