### PR TITLE
8323021: Shenandoah: Encountered reference count always attributed to first worker thread

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -362,7 +362,7 @@ bool ShenandoahReferenceProcessor::discover_reference(oop reference, ReferenceTy
 
   log_trace(gc, ref)("Encountered Reference: " PTR_FORMAT " (%s)", p2i(reference), reference_type_name(type));
   uint worker_id = WorkerThread::worker_id();
-  _ref_proc_thread_locals->inc_encountered(type);
+  _ref_proc_thread_locals[worker_id].inc_encountered(type);
 
   if (UseCompressedOops) {
     return discover<narrowOop>(reference, type, worker_id);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323021](https://bugs.openjdk.org/browse/JDK-8323021) needs maintainer approval

### Issue
 * [JDK-8323021](https://bugs.openjdk.org/browse/JDK-8323021): Shenandoah: Encountered reference count always attributed to first worker thread (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/134.diff">https://git.openjdk.org/jdk21u-dev/pull/134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/134#issuecomment-1879157140)