### PR TITLE
8318490: Increase timeout for JDK tests that are close to the limit when run with libgraal

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsicRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsicRangeChecks.java
@@ -27,7 +27,7 @@
  * @summary Verifies that string intrinsics throw array out of bounds exceptions.
  * @library /compiler/patches /test/lib
  * @build java.base/java.lang.Helper
- * @run main/othervm -Xbatch -XX:CompileThreshold=100 compiler.intrinsics.string.TestStringIntrinsicRangeChecks
+ * @run main/othervm/timeout=300 -Xbatch -XX:CompileThreshold=100 compiler.intrinsics.string.TestStringIntrinsicRangeChecks
  */
 package compiler.intrinsics.string;
 

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX1.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX1.java
@@ -37,7 +37,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @summary Test that vector cast intrinsics work as intended on avx1.
  * @requires vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
- * @run main compiler.vectorapi.reshape.TestVectorCastAVX1
+ * @run main/timeout=300 compiler.vectorapi.reshape.TestVectorCastAVX1
  */
 public class TestVectorCastAVX1 {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX2.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX2.java
@@ -37,7 +37,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @summary Test that vector cast intrinsics work as intended on avx2.
  * @requires vm.cpu.features ~= ".*avx2.*"
  * @library /test/lib /
- * @run main compiler.vectorapi.reshape.TestVectorCastAVX2
+ * @run main/timeout=300 compiler.vectorapi.reshape.TestVectorCastAVX2
  */
 public class TestVectorCastAVX2 {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512.java
@@ -37,7 +37,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @summary Test that vector cast intrinsics work as intended on avx512.
  * @requires vm.cpu.features ~= ".*avx512.*"
  * @library /test/lib /
- * @run main compiler.vectorapi.reshape.TestVectorCastAVX512
+ * @run main/timeout=300 compiler.vectorapi.reshape.TestVectorCastAVX512
  */
 public class TestVectorCastAVX512 {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
@@ -37,7 +37,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @summary Test that vector cast intrinsics work as intended on avx512bw.
  * @requires vm.cpu.features ~= ".*avx512bw.*"
  * @library /test/lib /
- * @run main compiler.vectorapi.reshape.TestVectorCastAVX512BW
+ * @run main/timeout=300 compiler.vectorapi.reshape.TestVectorCastAVX512BW
  */
 public class TestVectorCastAVX512BW {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512DQ.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512DQ.java
@@ -37,7 +37,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @summary Test that vector cast intrinsics work as intended on avx512dq.
  * @requires vm.cpu.features ~= ".*avx512dq.*"
  * @library /test/lib /
- * @run main compiler.vectorapi.reshape.TestVectorCastAVX512DQ
+ * @run main/timeout=300 compiler.vectorapi.reshape.TestVectorCastAVX512DQ
  */
 public class TestVectorCastAVX512DQ {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastNeon.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastNeon.java
@@ -37,7 +37,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @summary Test that vector cast intrinsics work as intended on neon.
  * @requires vm.cpu.features ~= ".*asimd.*"
  * @library /test/lib /
- * @run main compiler.vectorapi.reshape.TestVectorCastNeon
+ * @run main/timeout=300 compiler.vectorapi.reshape.TestVectorCastNeon
  */
 public class TestVectorCastNeon {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastSVE.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastSVE.java
@@ -37,7 +37,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @summary Test that vector cast intrinsics work as intended on sve.
  * @requires vm.cpu.features ~= ".*sve.*"
  * @library /test/lib /
- * @run main compiler.vectorapi.reshape.TestVectorCastSVE
+ * @run main/timeout=300 compiler.vectorapi.reshape.TestVectorCastSVE
  */
 public class TestVectorCastSVE {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/thread/thread007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/thread/thread007.java
@@ -32,7 +32,7 @@
  *     Try to start the given number of threads starting simultaneously
  *     when notifyall() is signaled at the stopLine object.
  *
- * @run main/othervm nsk.stress.thread.thread007 500 2m 5s
+ * @run main/othervm/timeout=300 nsk.stress.thread.thread007 500 2m 5s
  */
 
 package nsk.stress.thread;

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/thread/thread008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/thread/thread008.java
@@ -33,7 +33,7 @@
  *     starting simultaneously when notifyall() is signaled at the
  *     stopLine object.
  *
- * @run main/othervm nsk.stress.thread.thread008 500 2m 5s
+ * @run main/othervm/timeout=300 nsk.stress.thread.thread008 500 2m 5s
  */
 
 package nsk.stress.thread;

--- a/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte128VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Byte128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte256VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Byte256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte512VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Byte512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte64VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Byte64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation ByteMaxVectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation ByteMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Double128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Double128VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Double128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Double256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Double256VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Double256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Double512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Double512VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Double512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Double64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Double64VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Double64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation DoubleMaxVectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation DoubleMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Float128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Float128VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Float128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Float256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Float256VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Float256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Float512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Float512VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Float512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Float64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Float64VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Float64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation FloatMaxVectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation FloatMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Int128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Int128VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Int128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Int256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Int256VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Int256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Int512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Int512VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Int512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Int64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Int64VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Int64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation IntMaxVectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation IntMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Long128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Long128VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Long128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Long256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Long256VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Long256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Long512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Long512VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Long512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Long64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Long64VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Long64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation LongMaxVectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation LongMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Short128VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Short128VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Short256VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Short256VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Short512VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Short512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Short64VectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation Short64VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation ShortMaxVectorTests
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation ShortMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation $vectorteststype$
+ * @run testng/othervm/timeout=300 -ea -esa -Xbatch -XX:-TieredCompilation $vectorteststype$
  */
 
 #warn This file is preprocessed before being compiled


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8318490](https://bugs.openjdk.org/browse/JDK-8318490) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318490](https://bugs.openjdk.org/browse/JDK-8318490): Increase timeout for JDK tests that are close to the limit when run with libgraal (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/142.diff">https://git.openjdk.org/jdk21u-dev/pull/142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/142#issuecomment-1881182162)