### PR TITLE
8316132: CDSProtectionDomain::get_shared_protection_domain should check for exception

### DIFF
--- a/src/hotspot/share/cds/cdsProtectionDomain.cpp
+++ b/src/hotspot/share/cds/cdsProtectionDomain.cpp
@@ -241,7 +241,7 @@ Handle CDSProtectionDomain::get_shared_protection_domain(Handle class_loader,
                                                             TRAPS) {
   Handle protection_domain;
   if (shared_protection_domain(shared_path_index) == nullptr) {
-    Handle pd = get_protection_domain_from_classloader(class_loader, url, THREAD);
+    Handle pd = get_protection_domain_from_classloader(class_loader, url, CHECK_NH);
     atomic_set_shared_protection_domain(shared_path_index, pd());
   }
 


### PR DESCRIPTION
Clean backport to propagate CDS exceptions better.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `tier{1,2,3}`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316132](https://bugs.openjdk.org/browse/JDK-8316132) needs maintainer approval

### Issue
 * [JDK-8316132](https://bugs.openjdk.org/browse/JDK-8316132): CDSProtectionDomain::get_shared_protection_domain should check for exception (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/144.diff">https://git.openjdk.org/jdk21u-dev/pull/144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/144#issuecomment-1881613014)