### PR TITLE
8321164: javac with annotation processor throws AssertionError: Filling jrt:/... during JarFileObject[/...]

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -2398,20 +2398,26 @@ public class Types {
     }
     // where
         private TypeMapping<Boolean> erasure = new StructuralTypeMapping<Boolean>() {
+            @SuppressWarnings("fallthrough")
             private Type combineMetadata(final Type s,
                                          final Type t) {
                 if (t.getMetadata().nonEmpty()) {
-                    switch (s.getKind()) {
-                        case OTHER:
-                        case UNION:
-                        case INTERSECTION:
-                        case PACKAGE:
-                        case EXECUTABLE:
-                        case NONE:
-                        case VOID:
-                        case ERROR:
+                    switch (s.getTag()) {
+                        case CLASS:
+                            if (s instanceof UnionClassType ||
+                                s instanceof IntersectionClassType) {
+                                return s;
+                            }
+                            //fall-through
+                        case BYTE, CHAR, SHORT, LONG, FLOAT, INT, DOUBLE, BOOLEAN,
+                             ARRAY, MODULE, TYPEVAR, WILDCARD, BOT:
+                            return s.dropMetadata(Annotations.class);
+                        case VOID, METHOD, PACKAGE, FORALL, DEFERRED,
+                             NONE, ERROR, UNKNOWN, UNDETVAR, UNINITIALIZED_THIS,
+                             UNINITIALIZED_OBJECT:
                             return s;
-                        default: return s.dropMetadata(Annotations.class);
+                        default:
+                            throw new AssertionError(s.getTag().name());
                     }
                 } else {
                     return s;

--- a/test/langtools/tools/javac/annotations/ReadingMethodWithTypeAnno.java
+++ b/test/langtools/tools/javac/annotations/ReadingMethodWithTypeAnno.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8321164
+ * @summary Indirectly verify that types.erasure does not complete, called from
+ *          ClassReader.isSameBinaryType, which must not complete.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.JavacTask toolbox.TestRunner toolbox.ToolBox
+ * @run main ReadingMethodWithTypeAnno
+ */
+
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import toolbox.JavacTask;
+import toolbox.Task.Expect;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class ReadingMethodWithTypeAnno extends TestRunner {
+    public static void main(String... args) throws Exception {
+        ReadingMethodWithTypeAnno r = new ReadingMethodWithTypeAnno();
+        r.runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    public ReadingMethodWithTypeAnno() throws IOException {
+        super(System.err);
+    }
+
+    @Test
+    public void test_DeclNone_UseNone(Path base) throws IOException {
+        Path libSrc = base.resolve("lib-src");
+        Path libClasses = Files.createDirectories(base.resolve("lib-classes"));
+
+        tb.writeJavaFiles(libSrc,
+                          """
+                          public class Lib {
+                              public void test(java.lang.@Ann String s) {
+                                  new Object() {};
+                              }
+                          }
+                          """,
+                          """
+                          import java.lang.annotation.ElementType;
+                          import java.lang.annotation.Target;
+                          @Target(ElementType.TYPE_USE)
+                          public @interface Ann {}
+                          """);
+
+        new JavacTask(tb)
+                .outdir(libClasses)
+                .files(tb.findJavaFiles(libSrc))
+                .run(Expect.SUCCESS)
+                .writeAll()
+                .getOutput(OutputKind.DIRECT);
+
+        Path src = base.resolve("src");
+        Path classes = Files.createDirectories(base.resolve("classes"));
+
+        tb.writeJavaFiles(src,
+                          """
+                          public class Test {
+                          }
+                          """);
+
+        new JavacTask(tb)
+                .outdir(classes)
+                .classpath(libClasses)
+                .files(tb.findJavaFiles(src))
+                .callback(task -> {
+                    task.addTaskListener(new TaskListener() {
+                        @Override
+                        public void finished(TaskEvent e) {
+                            if (e.getKind() == TaskEvent.Kind.ENTER) {
+                                task.getElements().getTypeElement("Lib");
+                                task.getElements().getTypeElement("Lib$1");
+                            }
+                        }
+                    });
+                })
+                .run(Expect.SUCCESS)
+                .writeAll()
+                .getOutput(OutputKind.DIRECT);
+    }
+
+}
+


### PR DESCRIPTION
Clean backport to fix a corner case in javac.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, new regression test fails without the patch, passes with it
 - [x] macos-aarch64-server-fastdebug, `langtools_all` pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8321164](https://bugs.openjdk.org/browse/JDK-8321164) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321164](https://bugs.openjdk.org/browse/JDK-8321164): javac with annotation processor throws AssertionError: Filling jrt:/... during JarFileObject[/...] (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/146.diff">https://git.openjdk.org/jdk21u-dev/pull/146.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/146#issuecomment-1882771505)