### PR TITLE
8320888: Shenandoah: Enable ShenandoahVerifyOptoBarriers in debug builds

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -355,7 +355,7 @@
   product(bool, ShenandoahStackWatermarkBarrier, true, DIAGNOSTIC,          \
           "Turn on/off stack watermark barriers in Shenandoah")             \
                                                                             \
-  develop(bool, ShenandoahVerifyOptoBarriers, false,                        \
+  develop(bool, ShenandoahVerifyOptoBarriers, trueInDebug,                  \
           "Verify no missing barriers in C2.")                              \
                                                                             \
   product(bool, ShenandoahLoopOptsAfterExpansion, true, DIAGNOSTIC,         \

--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -97,7 +97,6 @@
  *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:-CreateCoredumpOnCrash
  *                   -XX:+ShenandoahVerify
- *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+ShenandoahVerifyOptoBarriers
  *                   -XX:CompileCommand=dontinline,*::mergeImpl*
  *                   compiler.gcbarriers.UnsafeIntrinsicsTest
  */

--- a/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
@@ -41,29 +41,9 @@
  */
 
 /*
- * @test id=default-debug
- * @summary Tests that we pass at least one jcstress-like test with all verification turned on
- * @requires vm.gc.Shenandoah
- * @requires vm.debug
- * @modules java.base/jdk.internal.misc
- *          java.management
- *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
- *      -XX:+ShenandoahVerify -XX:+ShenandoahVerifyOptoBarriers
- *      TestVerifyJCStress
- *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
- *      -XX:+ShenandoahVerify -XX:+ShenandoahVerifyOptoBarriers
- *      TestVerifyJCStress
- */
-
-/*
  * @test id=default
  * @summary Tests that we pass at least one jcstress-like test with all verification turned on
  * @requires vm.gc.Shenandoah
- * @requires !vm.debug
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
@@ -75,20 +55,6 @@
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
  *      -XX:+ShenandoahVerify
- *      TestVerifyJCStress
- */
-
-/*
- * @test id=iu-debug
- * @summary Tests that we pass at least one jcstress-like test with all verification turned on
- * @requires vm.gc.Shenandoah
- * @requires vm.debug
- * @modules java.base/jdk.internal.misc
- *          java.management
- *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
- *      -XX:+ShenandoahVerify -XX:+ShenandoahVerifyOptoBarriers
  *      TestVerifyJCStress
  */
 
@@ -96,7 +62,6 @@
  * @test id=iu
  * @summary Tests that we pass at least one jcstress-like test with all verification turned on
  * @requires vm.gc.Shenandoah
- * @requires !vm.debug
  * @modules java.base/jdk.internal.misc
  *          java.management
  *

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestSelectiveBarrierFlags.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestSelectiveBarrierFlags.java
@@ -35,9 +35,8 @@
  * @summary Test selective barrier enabling works, by aggressively compiling HelloWorld with combinations
  *          of barrier flags
  * @requires vm.gc.Shenandoah
- * @requires vm.debug
  * @library /test/lib
- * @run driver TestSelectiveBarrierFlags -Xbatch -XX:CompileThreshold=100 -XX:-TieredCompilation -XX:+ShenandoahVerifyOptoBarriers
+ * @run driver TestSelectiveBarrierFlags -Xbatch -XX:CompileThreshold=100 -XX:-TieredCompilation
  */
 
 import java.util.*;


### PR DESCRIPTION
Clean backport to improve Shenandoah maintainability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320888](https://bugs.openjdk.org/browse/JDK-8320888) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320888](https://bugs.openjdk.org/browse/JDK-8320888): Shenandoah: Enable ShenandoahVerifyOptoBarriers in debug builds (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/148.diff">https://git.openjdk.org/jdk21u-dev/pull/148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/148#issuecomment-1882929664)