### PR TITLE
Backport a56286f7ad9a8110026f48eb45f1d7a273b2f9fb

### DIFF
--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -41,6 +41,8 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 // and Operational Models for ARMv8"
 #define CPU_MULTI_COPY_ATOMIC
 
+#define DEFAULT_CACHE_LINE_SIZE 64
+
 // According to the ARMv8 ARM, "Concurrent modification and execution
 // of instructions can lead to the resulting instruction performing
 // any behavior that can be achieved by executing any sequence of

--- a/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
+++ b/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
@@ -48,6 +48,8 @@ const bool HaveVFP = true;
 // arm32 is not specified as multi-copy-atomic
 // So we must not #define CPU_MULTI_COPY_ATOMIC
 
+#define DEFAULT_CACHE_LINE_SIZE 64
+
 #define STUBROUTINES_MD_HPP    "stubRoutines_arm.hpp"
 #define INTERP_MASM_MD_HPP     "interp_masm_arm.hpp"
 #define TEMPLATETABLE_MD_HPP   "templateTable_arm.hpp"

--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -30,6 +30,8 @@
 #define SUPPORTS_NATIVE_CX8
 #endif
 
+#define DEFAULT_CACHE_LINE_SIZE 64
+
 #define SUPPORT_MONITOR_COUNT
 
 #ifdef __APPLE__

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -641,7 +641,7 @@ const bool support_IRIW_for_not_multiple_copy_atomic_cpu = PPC64_ONLY(true) NOT_
 
 // The expected size in bytes of a cache line, used to pad data structures.
 #ifndef DEFAULT_CACHE_LINE_SIZE
-  #define DEFAULT_CACHE_LINE_SIZE 64
+#error "Platform should define DEFAULT_CACHE_LINE_SIZE"
 #endif
 
 


### PR DESCRIPTION
Clean backport to improve platform support. Unblocks future backports that rely on default cache line size.