### PR TITLE
8323428: Shenandoah: Unused memory in regions compacted during a full GC should be mangled

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -910,6 +910,9 @@ public:
     // Make empty regions that have been allocated into regular
     if (r->is_empty() && live > 0) {
       r->make_regular_bypass();
+      if (ZapUnusedHeapArea) {
+        SpaceMangler::mangle_region(MemRegion(r->top(), r->end()));
+      }
     }
 
     // Reclaim regular regions that became empty


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8323428](https://bugs.openjdk.org/browse/JDK-8323428) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323428](https://bugs.openjdk.org/browse/JDK-8323428): Shenandoah: Unused memory in regions compacted during a full GC should be mangled (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/158.diff">https://git.openjdk.org/jdk21u-dev/pull/158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/158#issuecomment-1885964705)