### PR TITLE
8320309: AIX: pthreads created by foreign test library don't work as expected

### DIFF
--- a/test/lib/native/testlib_threads.h
+++ b/test/lib/native/testlib_threads.h
@@ -81,10 +81,15 @@ void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
     }
 #else
     pthread_t thread;
-    int result = pthread_create(&thread, NULL, procedure, &helper);
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    size_t stack_size = 0x100000;
+    pthread_attr_setstacksize(&attr, stack_size);
+    int result = pthread_create(&thread, &attr, procedure, &helper);
     if (result != 0) {
         fatal("failed to create thread", result);
     }
+    pthread_attr_destroy(&attr);
     result = pthread_join(thread, NULL);
     if (result != 0) {
         fatal("failed to join thread", result);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8320309](https://bugs.openjdk.org/browse/JDK-8320309), commit [8b47a149](https://github.com/openjdk/jdk/commit/8b47a14958913c70291d46afdde4e527f9bdc91a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Varada M on 22 Nov 2023 and was reviewed by Martin Doerr, Matthias Baesken and Thomas Stuefe.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320309](https://bugs.openjdk.org/browse/JDK-8320309) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320309](https://bugs.openjdk.org/browse/JDK-8320309): AIX: pthreads created by foreign test library don't work as expected (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/159.diff">https://git.openjdk.org/jdk21u-dev/pull/159.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/159#issuecomment-1888542953)