### PR TITLE
8310031: Parallel: Implement better work distribution for large object arrays in old gen

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -33,6 +33,7 @@
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/prefetch.inline.hpp"
+#include "utilities/spinYield.hpp"
 #include "utilities/align.hpp"
 
 // Checks an individual oop for missing precise marks. Mark
@@ -123,70 +124,184 @@ static void prefetch_write(void *p) {
   }
 }
 
-// postcondition: ret is a dirty card or end_card
-CardTable::CardValue* PSCardTable::find_first_dirty_card(CardValue* const start_card,
-                                                         CardValue* const end_card) {
-  for (CardValue* i_card = start_card; i_card < end_card; ++i_card) {
-    if (*i_card != PSCardTable::clean_card_val()) {
-      return i_card;
-    }
+void PSCardTable::scan_obj_with_limit(PSPromotionManager* pm,
+                                      oop obj,
+                                      HeapWord* start,
+                                      HeapWord* end) {
+  if (!obj->is_typeArray()) {
+    prefetch_write(start);
+    pm->push_contents_bounded(obj, start, end);
   }
-  return end_card;
 }
 
-// postcondition: ret is a clean card or end_card
-// Note: if a part of an object is on a dirty card, all cards this object
-// resides on are considered dirty.
-CardTable::CardValue* PSCardTable::find_first_clean_card(ObjectStartArray* const start_array,
-                                                         CardValue* const start_card,
-                                                         CardValue* const end_card) {
-  assert(start_card == end_card ||
-         *start_card != PSCardTable::clean_card_val(), "precondition");
-  // Skip the first dirty card.
-  CardValue* i_card = start_card + 1;
-  while (i_card < end_card) {
-    if (*i_card != PSCardTable::clean_card_val()) {
-      i_card++;
+void PSCardTable::pre_scavenge(HeapWord* old_gen_bottom, uint active_workers) {
+  _preprocessing_active_workers = active_workers;
+}
+
+// The "shadow" table is a copy of the card table entries of the current stripe.
+// It is used to separate card reading, clearing and redirtying which reduces
+// complexity significantly.
+class PSStripeShadowCardTable {
+  typedef CardTable::CardValue CardValue;
+
+  const uint _card_shift;
+  const uint _card_size;
+  CardValue _table[PSCardTable::num_cards_in_stripe];
+  const CardValue* _table_base;
+
+public:
+  PSStripeShadowCardTable(PSCardTable* pst, HeapWord* const start, HeapWord* const end) :
+    _card_shift(CardTable::card_shift()),
+    _card_size(CardTable::card_size()),
+    _table_base(_table - (uintptr_t(start) >> _card_shift)) {
+    size_t stripe_byte_size = pointer_delta(end, start) * HeapWordSize;
+    size_t copy_length = align_up(stripe_byte_size, _card_size) >> _card_shift;
+    // The end of the last stripe may not be card aligned as it is equal to old
+    // gen top at scavenge start. We should not clear the card containing old gen
+    // top if not card aligned because there can be promoted objects on that
+    // same card. If it was marked dirty because of the promoted objects and we
+    // cleared it, we would loose a card mark.
+    size_t clear_length = align_down(stripe_byte_size, _card_size) >> _card_shift;
+    CardValue* stripe_start_card = pst->byte_for(start);
+    memcpy(_table, stripe_start_card, copy_length);
+    memset(stripe_start_card, CardTable::clean_card_val(), clear_length);
+  }
+
+  HeapWord* addr_for(const CardValue* const card) {
+    assert(card >= _table && card <=  &_table[PSCardTable::num_cards_in_stripe], "out of bounds");
+    return (HeapWord*) ((card - _table_base) << _card_shift);
+  }
+
+  const CardValue* card_for(HeapWord* addr) {
+    return &_table_base[uintptr_t(addr) >> _card_shift];
+  }
+
+  bool is_dirty(const CardValue* const card) {
+    return !is_clean(card);
+  }
+
+  bool is_clean(const CardValue* const card) {
+    assert(card >= _table && card <  &_table[PSCardTable::num_cards_in_stripe], "out of bounds");
+    return *card == PSCardTable::clean_card_val();
+  }
+
+  const CardValue* find_first_dirty_card(const CardValue* const start,
+                                         const CardValue* const end) {
+    for (const CardValue* i = start; i < end; ++i) {
+      if (is_dirty(i)) {
+        return i;
+      }
+    }
+    return end;
+  }
+
+  const CardValue* find_first_clean_card(const CardValue* const start,
+                                         const CardValue* const end) {
+    for (const CardValue* i = start; i < end; ++i) {
+      if (is_clean(i)) {
+        return i;
+      }
+    }
+    return end;
+  }
+};
+
+template <typename Func>
+void PSCardTable::process_range(Func&& object_start,
+                                PSPromotionManager* pm,
+                                HeapWord* const start,
+                                HeapWord* const end) {
+  assert(start < end, "precondition");
+  assert(is_card_aligned(start), "precondition");
+
+  PSStripeShadowCardTable sct(this, start, end);
+
+  // end might not be card-aligned.
+  const CardValue* end_card = sct.card_for(end - 1) + 1;
+
+  for (HeapWord* i_addr = start; i_addr < end; /* empty */) {
+    const CardValue* dirty_l = sct.find_first_dirty_card(sct.card_for(i_addr), end_card);
+    const CardValue* dirty_r = sct.find_first_clean_card(dirty_l, end_card);
+
+    assert(dirty_l <= dirty_r, "inv");
+
+    if (dirty_l == dirty_r) {
+      assert(dirty_r == end_card, "inv");
+      break;
+    }
+
+    // Located a non-empty dirty chunk [dirty_l, dirty_r).
+    HeapWord* addr_l = sct.addr_for(dirty_l);
+    HeapWord* addr_r = MIN2(sct.addr_for(dirty_r), end);
+
+    // Scan objects overlapping [addr_l, addr_r) limited to [start, end).
+    HeapWord* obj_addr = object_start(addr_l);
+
+    while (true) {
+      assert(obj_addr < addr_r, "inv");
+
+      oop obj = cast_to_oop(obj_addr);
+      const bool is_obj_array = obj->is_objArray();
+      HeapWord* const obj_end_addr = obj_addr + obj->size();
+
+      if (is_obj_array) {
+        // Always scan obj arrays precisely (they are always marked precisely)
+        // to avoid unnecessary work.
+        scan_obj_with_limit(pm, obj, addr_l, addr_r);
+      } else {
+        if (obj_addr < i_addr && i_addr > start) {
+          // Already scanned this object. Has been one that spans multiple dirty chunks.
+          // The second condition makes sure objects reaching in the stripe are scanned once.
+        } else {
+          scan_obj_with_limit(pm, obj, addr_l, end);
+        }
+      }
+
+      if (obj_end_addr >= addr_r) {
+        i_addr = is_obj_array ? addr_r : obj_end_addr;
+        break;
+      }
+
+      // Move to next obj inside this dirty chunk.
+      obj_addr = obj_end_addr;
+    }
+
+    // Finished a dirty chunk.
+    pm->drain_stacks_cond_depth();
+  }
+}
+
+template <typename Func>
+void PSCardTable::preprocess_card_table_parallel(Func&& object_start,
+                                                 HeapWord* old_gen_bottom,
+                                                 HeapWord* old_gen_top,
+                                                 uint stripe_index,
+                                                 uint n_stripes) {
+  const size_t num_cards_in_slice = num_cards_in_stripe * n_stripes;
+  CardValue* cur_card = byte_for(old_gen_bottom) + stripe_index * num_cards_in_stripe;
+  CardValue* const end_card = byte_for(old_gen_top - 1) + 1;
+
+  for (/* empty */; cur_card < end_card; cur_card += num_cards_in_slice) {
+    HeapWord* stripe_addr = addr_for(cur_card);
+    if (is_dirty(cur_card)) {
+      // The first card of this stripe is already dirty, no need to see if the
+      // reaching-in object is a potentially imprecisely marked non-array
+      // object.
       continue;
     }
-    assert(i_card - 1 >= start_card, "inv");
-    assert(*(i_card - 1) != PSCardTable::clean_card_val(), "prev card must be dirty");
-    // Find the final obj on the prev dirty card.
-    HeapWord* obj_addr = start_array->object_start(addr_for(i_card)-1);
-    HeapWord* obj_end_addr = obj_addr + cast_to_oop(obj_addr)->size();
-    CardValue* final_card_by_obj = byte_for(obj_end_addr - 1);
-    assert(final_card_by_obj < end_card, "inv");
-    if (final_card_by_obj <= i_card) {
-      return i_card;
+    HeapWord* first_obj_addr = object_start(stripe_addr);
+    if (first_obj_addr == stripe_addr) {
+      // No object reaching into this stripe.
+      continue;
     }
-    // This final obj extends beyond i_card, check if this new card is dirty.
-    if (*final_card_by_obj == PSCardTable::clean_card_val()) {
-      return final_card_by_obj;
+    oop first_obj = cast_to_oop(first_obj_addr);
+    if (!first_obj->is_array() && is_dirty(byte_for(first_obj_addr))) {
+      // Found a non-array object reaching into the stripe that has
+      // potentially been marked imprecisely. Mark first card of the stripe
+      // dirty so it will be processed later.
+      *cur_card = dirty_card_val();
     }
-    // This new card is dirty, continuing the search...
-    i_card = final_card_by_obj + 1;
   }
-  return end_card;
-}
-
-void PSCardTable::clear_cards(CardValue* const start, CardValue* const end) {
-  for (CardValue* i_card = start; i_card < end; ++i_card) {
-    *i_card = clean_card;
-  }
-}
-
-void PSCardTable::scan_objects_in_range(PSPromotionManager* pm,
-                                        HeapWord* start,
-                                        HeapWord* end) {
-  HeapWord* obj_addr = start;
-  while (obj_addr < end) {
-    oop obj = cast_to_oop(obj_addr);
-    assert(oopDesc::is_oop(obj), "inv");
-    prefetch_write(obj_addr);
-    pm->push_contents(obj);
-    obj_addr += obj->size();
-  }
-  pm->drain_stacks_cond_depth();
 }
 
 // We get passed the space_top value to prevent us from traversing into
@@ -227,103 +342,61 @@ void PSCardTable::scan_objects_in_range(PSPromotionManager* pm,
 // slice_size_in_words to the start of stripe 0 in slice 0 to get to the start
 // of stripe 0 in slice 1.
 
+// Scavenging and accesses to the card table are strictly limited to the stripe.
+// In particular scavenging of an object crossing stripe boundaries is shared
+// among the threads assigned to the stripes it resides on. This reduces
+// complexity and enables shared scanning of large objects.
+// It requires preprocessing of the card table though where imprecise card marks of
+// objects crossing stripe boundaries are propagated to the first card of
+// each stripe covered by the individual object.
+
 void PSCardTable::scavenge_contents_parallel(ObjectStartArray* start_array,
-                                             MutableSpace* sp,
-                                             HeapWord* space_top,
+                                             HeapWord* old_gen_bottom,
+                                             HeapWord* old_gen_top,
                                              PSPromotionManager* pm,
                                              uint stripe_index,
                                              uint n_stripes) {
-  const size_t num_cards_in_stripe = 128;
+  // ObjectStartArray queries can be expensive for large objects. We cache known objects.
+  struct {
+    HeapWord* start_addr;
+    HeapWord* end_addr;
+  } cached_obj {nullptr, old_gen_bottom};
+
+  // Queries must be monotonic because we don't check addr >= cached_obj.start_addr.
+  auto object_start = [&] (HeapWord* addr) {
+    if (addr < cached_obj.end_addr) {
+      assert(cached_obj.start_addr != nullptr, "inv");
+      return cached_obj.start_addr;
+    }
+    HeapWord* result = start_array->object_start(addr);
+
+    cached_obj.start_addr = result;
+    cached_obj.end_addr = result + cast_to_oop(result)->size();
+
+    return result;
+  };
+
+  // Prepare scavenge.
+  preprocess_card_table_parallel(object_start, old_gen_bottom, old_gen_top, stripe_index, n_stripes);
+
+  // Sync with other workers.
+  Atomic::dec(&_preprocessing_active_workers);
+  SpinYield spin_yield;
+  while (Atomic::load_acquire(&_preprocessing_active_workers) > 0) {
+    spin_yield.wait();
+  }
+
+  // Scavenge
+  cached_obj = {nullptr, old_gen_bottom};
   const size_t stripe_size_in_words = num_cards_in_stripe * _card_size_in_words;
   const size_t slice_size_in_words = stripe_size_in_words * n_stripes;
+  HeapWord* cur_addr = old_gen_bottom + stripe_index * stripe_size_in_words;
+  for (/* empty */; cur_addr < old_gen_top; cur_addr += slice_size_in_words) {
+    HeapWord* const stripe_l = cur_addr;
+    HeapWord* const stripe_r = MIN2(cur_addr + stripe_size_in_words,
+                                    old_gen_top);
 
-  HeapWord* cur_stripe_addr = sp->bottom() + stripe_index * stripe_size_in_words;
-
-  for (/* empty */; cur_stripe_addr < space_top; cur_stripe_addr += slice_size_in_words) {
-    // exclusive
-    HeapWord* const cur_stripe_end_addr = MIN2(cur_stripe_addr + stripe_size_in_words,
-                                               space_top);
-
-    // Process a stripe iff it contains any obj-start
-    if (!start_array->object_starts_in_range(cur_stripe_addr, cur_stripe_end_addr)) {
-      continue;
-    }
-
-    // Constraints:
-    // 1. range of cards checked for being dirty or clean: [iter_limit_l, iter_limit_r)
-    // 2. range of cards can be cleared: [clear_limit_l, clear_limit_r)
-    // 3. range of objs (obj-start) can be scanned: [first_obj_addr, cur_stripe_end_addr)
-
-    CardValue* iter_limit_l;
-    CardValue* iter_limit_r;
-    CardValue* clear_limit_l;
-    CardValue* clear_limit_r;
-
-    // Identify left ends and the first obj-start inside this stripe.
-    HeapWord* first_obj_addr = start_array->object_start(cur_stripe_addr);
-    if (first_obj_addr < cur_stripe_addr) {
-      // this obj belongs to previous stripe; can't clear any cards it occupies
-      first_obj_addr += cast_to_oop(first_obj_addr)->size();
-      clear_limit_l = byte_for(first_obj_addr - 1) + 1;
-      iter_limit_l = byte_for(first_obj_addr);
-    } else {
-      assert(first_obj_addr == cur_stripe_addr, "inv");
-      iter_limit_l = clear_limit_l = byte_for(cur_stripe_addr);
-    }
-
-    assert(cur_stripe_addr <= first_obj_addr, "inside this stripe");
-    assert(first_obj_addr <= cur_stripe_end_addr, "can be empty");
-
-    {
-      // Identify right ends.
-      HeapWord* obj_addr = start_array->object_start(cur_stripe_end_addr - 1);
-      HeapWord* obj_end_addr = obj_addr + cast_to_oop(obj_addr)->size();
-      assert(obj_end_addr >= cur_stripe_end_addr, "inv");
-      clear_limit_r = byte_for(obj_end_addr);
-      iter_limit_r = byte_for(obj_end_addr - 1) + 1;
-    }
-
-    assert(iter_limit_l <= clear_limit_l &&
-           clear_limit_r <= iter_limit_r, "clear cards only if we iterate over them");
-
-    // Process dirty chunks, i.e. consecutive dirty cards [dirty_l, dirty_r),
-    // chunk by chunk inside [iter_limit_l, iter_limit_r).
-    CardValue* dirty_l;
-    CardValue* dirty_r;
-
-    for (CardValue* cur_card = iter_limit_l; cur_card < iter_limit_r; cur_card = dirty_r + 1) {
-      dirty_l = find_first_dirty_card(cur_card, iter_limit_r);
-      dirty_r = find_first_clean_card(start_array, dirty_l, iter_limit_r);
-      assert(dirty_l <= dirty_r, "inv");
-
-      // empty
-      if (dirty_l == dirty_r) {
-        assert(dirty_r == iter_limit_r, "no more dirty cards in this stripe");
-        break;
-      }
-
-      assert(*dirty_l != clean_card, "inv");
-      assert(*dirty_r == clean_card || dirty_r >= clear_limit_r,
-             "clean card or belonging to next stripe");
-
-      // Process this non-empty dirty chunk in two steps:
-      {
-        // 1. Clear card in [dirty_l, dirty_r) subject to [clear_limit_l, clear_limit_r) constraint
-        clear_cards(MAX2(dirty_l, clear_limit_l),
-                    MIN2(dirty_r, clear_limit_r));
-      }
-
-      {
-        // 2. Scan objs in [dirty_l, dirty_r) subject to [first_obj_addr, cur_stripe_end_addr) constraint
-        HeapWord* obj_l = MAX2(start_array->object_start(addr_for(dirty_l)),
-                               first_obj_addr);
-
-        HeapWord* obj_r = MIN2(addr_for(dirty_r),
-                               cur_stripe_end_addr);
-
-        scan_objects_in_range(pm, obj_l, obj_r);
-      }
-    }
+    process_range(object_start, pm, stripe_l, stripe_r);
   }
 }
 

--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -177,6 +177,7 @@ class PSPromotionManager {
   TASKQUEUE_STATS_ONLY(inline void record_steal(ScannerTask task);)
 
   void push_contents(oop obj);
+  void push_contents_bounded(oop obj, HeapWord* left, HeapWord* right);
 };
 
 #endif // SHARE_GC_PARALLEL_PSPROMOTIONMANAGER_HPP

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -131,6 +131,11 @@ inline void PSPromotionManager::push_contents(oop obj) {
   }
 }
 
+inline void PSPromotionManager::push_contents_bounded(oop obj, HeapWord* left, HeapWord* right) {
+  PSPushContentsClosure pcc(this);
+  obj->oop_iterate(&pcc, MemRegion(left, right));
+}
+
 template<bool promote_immediately>
 inline oop PSPromotionManager::copy_to_survivor_space(oop o) {
   assert(should_scavenge(&o), "Sanity");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 4bfe2268 from the openjdk/jdk repository.

The commit being backported was authored by Richard Reingruber on 24 Oct 2023 and was reviewed by Thomas Schatzl and Albert Mingkun Yang.

The fix passed our CI testing: most JCK and JTREG (tiers 1-4) tests, also in Xcomp mode, Renaissance benchmark and SAP specific tests with fastdebug and release builds on the standard platforms plus PPC64.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8310031](https://bugs.openjdk.org/browse/JDK-8310031) needs maintainer approval

### Issue
 * [JDK-8310031](https://bugs.openjdk.org/browse/JDK-8310031): Parallel: Implement better work distribution for large object arrays in old gen (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/160.diff">https://git.openjdk.org/jdk21u-dev/pull/160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/160#issuecomment-1893546250)