### PR TITLE
Restrict symbol version map to global symbols

### DIFF
--- a/make/hotspot/lib/JvmMapfile.gmk
+++ b/make/hotspot/lib/JvmMapfile.gmk
@@ -53,7 +53,7 @@ endif
 # platform dependent.
 
 ifeq ($(call isTargetOs, linux), true)
-  DUMP_SYMBOLS_CMD := $(NM) $(NMFLAGS) --defined-only *$(OBJ_SUFFIX)
+  DUMP_SYMBOLS_CMD := $(NM) $(NMFLAGS) --defined-only --extern-only *$(OBJ_SUFFIX)
   ifneq ($(FILTER_SYMBOLS_PATTERN), )
     FILTER_SYMBOLS_PATTERN := $(FILTER_SYMBOLS_PATTERN)|
   endif


### PR DESCRIPTION
ld.lld-17 fails to link when symbols such as

    ld.lld: error: version script assignment of 'SUNWprivate_1.1' to
    symbol '_ZTVZ21WB_HandshakeWalkStackE16TraceSelfClosure' failed:
    symbol not defined

    ld.lld: error: version script assignment of 'SUNWprivate_1.1' to
    symbol '_ZTVZ24WB_HandshakeReadMonitorsE19ReadMonitorsClosure'
    failed: symbol not defined

    ld.lld: error: version script assignment of 'SUNWprivate_1.1' to
    symbol '_ZTVZ26WB_AsyncHandshakeWalkStackE16TraceSelfClosure'
    failed: symbol not defined

are listed in the version map. nm indicates these symbols are defined as local symbols. Remove them from the version map to resolve the issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/166.diff">https://git.openjdk.org/jdk21u-dev/pull/166.diff</a>

</details>
