### PR TITLE
8322279: Generational ZGC: Use ZFragmentationLimit and ZYoungCompactionLimit as percentage instead of multiples

### DIFF
--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -101,9 +101,9 @@ uint ZHeuristics::nconcurrent_workers() {
 }
 
 size_t ZHeuristics::significant_heap_overhead() {
-  return MaxHeapSize * ZFragmentationLimit;
+  return MaxHeapSize * (ZFragmentationLimit / 100);
 }
 
 size_t ZHeuristics::significant_young_overhead() {
-  return MaxHeapSize * ZYoungCompactionLimit;
+  return MaxHeapSize * (ZYoungCompactionLimit / 100);
 }


### PR DESCRIPTION
This commit fixed incorrect use of production options of generational ZGC. Since JDK21 is the only LST version with generational ZGC， we need to fix the potential bugs.
Additional testing on fastdebug against test/hotspot/jtreg/gc/z

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322279](https://bugs.openjdk.org/browse/JDK-8322279) needs maintainer approval

### Issue
 * [JDK-8322279](https://bugs.openjdk.org/browse/JDK-8322279): Generational ZGC: Use ZFragmentationLimit and ZYoungCompactionLimit as percentage instead of multiples (**Bug** - P2 - Approved)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/173.diff">https://git.openjdk.org/jdk21u-dev/pull/173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/173#issuecomment-1893027930)