### PR TITLE
8318809: java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java shows intermittent failures on linux ppc64le and aarch64

### DIFF
--- a/test/jdk/java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java
+++ b/test/jdk/java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java
@@ -281,36 +281,6 @@ public class WhiteBox {
         assertInvariants(q);
     }
 
-    /**
-     * Actions that append an element, and are expected to
-     * leave at most one slack node at tail.
-     */
-    @DataProvider
-    public Object[][] addActions() {
-        return List.<Consumer<ConcurrentLinkedQueue>>of(
-            q -> q.add(1),
-            q -> q.offer(1))
-            .stream().map(x -> new Object[]{ x }).toArray(Object[][]::new);
-    }
-
-    @Test(dataProvider = "addActions")
-    public void addActionsOneNodeSlack(
-        Consumer<ConcurrentLinkedQueue> addAction) {
-        ConcurrentLinkedQueue q = new ConcurrentLinkedQueue();
-        int n = 1 + rnd.nextInt(5);
-        for (int i = 0; i < n; i++) {
-            boolean slack = next(tail(q)) != null;
-            addAction.accept(q);
-            if (slack)
-                assertNull(next(tail(q)));
-            else {
-                assertNotNull(next(tail(q)));
-                assertNull(next(next(tail(q))));
-            }
-            assertInvariants(q);
-        }
-    }
-
     byte[] serialBytes(Object o) {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
Clean backport to stabilize tests and better parity. Removes test cases, guaranteed to be safe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318809](https://bugs.openjdk.org/browse/JDK-8318809) needs maintainer approval

### Issue
 * [JDK-8318809](https://bugs.openjdk.org/browse/JDK-8318809): java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java shows intermittent failures on linux ppc64le and aarch64 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/175.diff">https://git.openjdk.org/jdk21u-dev/pull/175.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/175#issuecomment-1893309625)