### PR TITLE
8315241: (fs) Move toRealPath tests in java/nio/file/Path/Misc.java to separate JUnit 5 test

### DIFF
--- a/test/jdk/java/nio/file/Path/Misc.java
+++ b/test/jdk/java/nio/file/Path/Misc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333 7029979 8295753
+ * @bug 4313887 6838333 7029979
  * @summary Unit test for miscellenous java.nio.file.Path methods
  * @library .. /test/lib
  * @build jdk.test.lib.Platform
@@ -32,28 +32,17 @@
 import java.io.*;
 import java.nio.file.*;
 
-import static java.nio.file.LinkOption.*;
-
 import jdk.test.lib.Platform;
 
 public class Misc {
-    static boolean supportsLinks;
-
     public static void main(String[] args) throws IOException {
         Path dir = TestUtil.createTemporaryDirectory();
         try {
-            supportsLinks = TestUtil.supportsLinks(dir);
-
             // equals and hashCode methods
             testEqualsAndHashCode();
 
             // toFile method
             testToFile(dir);
-
-            // toRealPath method
-            testToRealPath(dir);
-
-
         } finally {
             TestUtil.removeAll(dir);
         }
@@ -90,136 +79,6 @@ public class Misc {
         File d = dir.toFile();
         assertTrue(d.toString().equals(dir.toString()));
         assertTrue(d.toPath().equals(dir));
-    }
-
-    /**
-     * Exercise toRealPath method
-     */
-    static void testToRealPath(Path dir) throws IOException {
-        final Path file = Files.createFile(dir.resolve("foo"));
-        final Path link = dir.resolve("link");
-
-        /**
-         * Test: toRealPath() will access same file as toRealPath(NOFOLLOW_LINKS)
-         */
-        assertTrue(Files.isSameFile(file.toRealPath(), file.toRealPath(NOFOLLOW_LINKS)));
-
-        /**
-         * Test: toRealPath should fail if file does not exist
-         */
-        Path doesNotExist = dir.resolve("DoesNotExist");
-        try {
-            doesNotExist.toRealPath();
-            throw new RuntimeException("IOException expected");
-        } catch (IOException expected) {
-        }
-        try {
-            doesNotExist.toRealPath(NOFOLLOW_LINKS);
-            throw new RuntimeException("IOException expected");
-        } catch (IOException expected) {
-        }
-
-        /**
-         * Test: toRealPath() should resolve links
-         */
-        if (supportsLinks) {
-            Path resolvedFile = file;
-            if (Platform.isWindows()) {
-                // Path::toRealPath does not work with environments using the
-                // legacy subst mechanism. This is a workaround to keep the
-                // test working if 'dir' points to a location on a subst drive.
-                // See JDK-8213216.
-                //
-                Path tempLink = dir.resolve("tempLink");
-                Files.createSymbolicLink(tempLink, dir.toAbsolutePath());
-                Path resolvedDir = tempLink.toRealPath();
-                Files.delete(tempLink);
-                resolvedFile = resolvedDir.resolve(file.getFileName());
-            }
-
-            Files.createSymbolicLink(link, resolvedFile.toAbsolutePath());
-            assertTrue(link.toRealPath().equals(resolvedFile.toRealPath()));
-            Files.delete(link);
-        }
-
-        /**
-         * Test: toRealPath(NOFOLLOW_LINKS) should not resolve links
-         */
-        if (supportsLinks) {
-            Files.createSymbolicLink(link, file.toAbsolutePath());
-            assertTrue(link.toRealPath(NOFOLLOW_LINKS).getFileName().equals(link.getFileName()));
-            Files.delete(link);
-        }
-
-        /**
-         * Test: toRealPath(NOFOLLOW_LINKS) with broken link
-         */
-        if (supportsLinks) {
-            Path broken = Files.createSymbolicLink(link, doesNotExist);
-            assertTrue(link.toRealPath(NOFOLLOW_LINKS).getFileName().equals(link.getFileName()));
-            Files.delete(link);
-        }
-
-        /**
-         * Test: toRealPath should eliminate "."
-         */
-        assertTrue(dir.resolve(".").toRealPath().equals(dir.toRealPath()));
-        assertTrue(dir.resolve(".").toRealPath(NOFOLLOW_LINKS).equals(dir.toRealPath(NOFOLLOW_LINKS)));
-
-        /**
-         * Test: toRealPath should eliminate ".." when it doesn't follow a
-         *       symbolic link
-         */
-        Path subdir = Files.createDirectory(dir.resolve("subdir"));
-        assertTrue(subdir.resolve("..").toRealPath().equals(dir.toRealPath()));
-        assertTrue(subdir.resolve("..").toRealPath(NOFOLLOW_LINKS).equals(dir.toRealPath(NOFOLLOW_LINKS)));
-
-        /**
-         * Test: toRealPath yields accurate case of path elements when
-         *       not following links
-         */
-        if (Platform.isOSX()) {
-            // theTarget = dir/subdir/theTarget
-            Path theTarget = Path.of(subdir.toString(), "theTarget");
-            Files.createFile(theTarget);
-
-            // dir/theLink -> dir/subdir
-            Path theLink = Path.of(dir.toString(), "theLink");
-            Files.createSymbolicLink(theLink, subdir);
-
-            // thePath = dir/thelink/thetarget (all lower case)
-            Path thePath = Path.of(dir.toString(), "thelink", "thetarget");
-            Path noFollow = thePath.toRealPath(NOFOLLOW_LINKS);
-            int nc = noFollow.getNameCount();
-
-            // Real path should retain case as dir/theLink/theTarget
-            assertTrue(noFollow.getName(nc - 2).equals(Path.of("theLink")));
-            assertTrue(noFollow.getName(nc - 1).equals(Path.of("theTarget")));
-            assertTrue(noFollow.toString().equals(
-                Path.of(dir.toString(), "theLink", "theTarget").toString()));
-
-            // Test where a link is preceded by ".." in the path
-            Path superBeforeLink =
-                Path.of(subdir.toString(), "..", "thelink", "thetarget");
-            noFollow = superBeforeLink.toRealPath(NOFOLLOW_LINKS);
-            nc = noFollow.getNameCount();
-            assertTrue(noFollow.getName(nc - 2).equals(Path.of("theLink")));
-            assertTrue(noFollow.getName(nc - 1).equals(Path.of("theTarget")));
-
-            // Test where a link is followed by ".." in the path
-            Path linkBeforeSuper =
-                Path.of(dir.toString(), "thelink", "..", "subdir", "thetarget");
-            noFollow = linkBeforeSuper.toRealPath(NOFOLLOW_LINKS);
-            nc = noFollow.getNameCount();
-            assertTrue(noFollow.getName(nc - 4).equals(Path.of("theLink")));
-            assertTrue(noFollow.getName(nc - 1).equals(Path.of("theTarget")));
-
-            Files.delete(theTarget);
-        }
-
-        // clean-up
-        Files.delete(subdir);
-        Files.delete(file);
     }
 
     static void assertTrue(boolean okay) {

--- a/test/jdk/java/nio/file/Path/ToRealPath.java
+++ b/test/jdk/java/nio/file/Path/ToRealPath.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8295753
+ * @summary Verify correct operation of Path.toRealPath
+ * @library .. /test/lib
+ * @build ToRealPath jdk.test.lib.Platform
+ * @run junit ToRealPath
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jdk.test.lib.Platform;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static java.nio.file.LinkOption.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ToRealPath {
+    static final boolean SUPPORTS_LINKS;
+    static final Path DIR;
+    static final Path SUBDIR;
+    static final Path FILE;
+    static final Path LINK;
+
+    static {
+        try {
+            DIR = TestUtil.createTemporaryDirectory();
+            SUBDIR = Files.createDirectory(DIR.resolve("subdir"));
+            FILE = Files.createFile(DIR.resolve("foo"));
+            LINK = DIR.resolve("link");
+            SUPPORTS_LINKS = TestUtil.supportsLinks(DIR);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    };
+
+    public boolean supportsLinks() {
+        return SUPPORTS_LINKS;
+    }
+
+    @Test
+    public void locateSameFile() throws IOException {
+        assertTrue(Files.isSameFile(FILE.toRealPath(),
+                                    FILE.toRealPath(NOFOLLOW_LINKS)));
+    }
+
+    @Test
+    public void failNotExist() {
+        Path doesNotExist = DIR.resolve("DoesNotExist");
+        assertThrows(IOException.class, () -> doesNotExist.toRealPath());
+    }
+
+    @Test
+    public void failNotExistNoFollow() {
+        Path doesNotExist = DIR.resolve("DoesNotExist");
+        assertThrows(IOException.class,
+                     () -> doesNotExist.toRealPath(NOFOLLOW_LINKS));
+    }
+
+    @EnabledIf("supportsLinks")
+    @Test
+    public void shouldResolveLinks() throws IOException {
+        Path resolvedFile = FILE;
+        if (Platform.isWindows()) {
+            // Path::toRealPath does not work with environments using the
+            // legacy subst mechanism. This is a workaround to keep the
+            // test working if 'dir' points to a location on a subst drive.
+            // See JDK-8213216.
+            //
+            Path tempLink = DIR.resolve("tempLink");
+            Files.createSymbolicLink(tempLink, DIR.toAbsolutePath());
+            Path resolvedDir = tempLink.toRealPath();
+            Files.delete(tempLink);
+            resolvedFile = resolvedDir.resolve(FILE.getFileName());
+        }
+
+        Files.createSymbolicLink(LINK, resolvedFile.toAbsolutePath());
+        assertTrue(LINK.toRealPath().equals(resolvedFile.toRealPath()));
+        Files.delete(LINK);
+    }
+
+    @Test
+    @EnabledIf("supportsLinks")
+    public void shouldNotResolveLinks() throws IOException {
+        Files.createSymbolicLink(LINK, FILE.toAbsolutePath());
+        assertEquals(LINK.toRealPath(NOFOLLOW_LINKS).getFileName(),
+                     LINK.getFileName());
+        Files.delete(LINK);
+    }
+
+    @Test
+    public void eliminateDot() throws IOException {
+        assertEquals(DIR.resolve(".").toRealPath(),
+                     DIR.toRealPath());
+    }
+
+    @Test
+    public void eliminateDotNoFollow() throws IOException {
+        assertEquals(DIR.resolve(".").toRealPath(NOFOLLOW_LINKS),
+                     DIR.toRealPath(NOFOLLOW_LINKS));
+    }
+
+    @Test
+    public void eliminateDots() throws IOException {
+        assertEquals(SUBDIR.resolve("..").toRealPath(),
+                     DIR.toRealPath());
+    }
+
+    @Test
+    public void eliminateDotsNoFollow() throws IOException {
+        assertEquals(SUBDIR.resolve("..").toRealPath(NOFOLLOW_LINKS),
+                     DIR.toRealPath(NOFOLLOW_LINKS));
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    public final void macOSTests() throws IOException {
+        // theTarget = dir/subdir/theTarget
+        Path theTarget = Path.of(SUBDIR.toString(), "theTarget");
+        Files.createFile(theTarget);
+
+        // dir/theLink -> dir/subdir
+        Path theLink = Path.of(DIR.toString(), "theLink");
+        Files.createSymbolicLink(theLink, SUBDIR);
+
+        // thePath = dir/thelink/thetarget (all lower case)
+        Path thePath = Path.of(DIR.toString(), "thelink", "thetarget");
+        Path noFollow = thePath.toRealPath(NOFOLLOW_LINKS);
+        int nc = noFollow.getNameCount();
+
+        // Real path should retain case as dir/theLink/theTarget
+        assertEquals(noFollow.getName(nc - 2), Path.of("theLink"));
+        assertEquals(noFollow.getName(nc - 1), Path.of("theTarget"));
+        assertEquals(noFollow.toString(),
+                     Path.of(DIR.toString(), "theLink", "theTarget").toString());
+
+        // Test where a link is preceded by ".." in the path
+        Path superBeforeLink =
+            Path.of(SUBDIR.toString(), "..", "thelink", "thetarget");
+        noFollow = superBeforeLink.toRealPath(NOFOLLOW_LINKS);
+        nc = noFollow.getNameCount();
+        assertEquals(noFollow.getName(nc - 2), Path.of("theLink"));
+        assertEquals(noFollow.getName(nc - 1), Path.of("theTarget"));
+
+        // Test where a link is followed by ".." in the path
+        Path linkBeforeSuper =
+            Path.of(DIR.toString(), "thelink", "..", "subdir", "thetarget");
+        noFollow = linkBeforeSuper.toRealPath(NOFOLLOW_LINKS);
+        nc = noFollow.getNameCount();
+        assertEquals(noFollow.getName(nc - 4), Path.of("theLink"));
+        assertEquals(noFollow.getName(nc - 1), Path.of("theTarget"));
+
+        Files.delete(theTarget);
+    }
+
+    @AfterAll
+    public static void cleanup() throws IOException {
+        Files.delete(SUBDIR);
+        Files.delete(FILE);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315241](https://bugs.openjdk.org/browse/JDK-8315241) needs maintainer approval

### Issue
 * [JDK-8315241](https://bugs.openjdk.org/browse/JDK-8315241): (fs) Move toRealPath tests in java/nio/file/Path/Misc.java to separate JUnit 5 test (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/184/head:pull/184` \
`$ git checkout pull/184`

Update a local copy of the PR: \
`$ git checkout pull/184` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 184`

View PR using the GUI difftool: \
`$ git pr show -t 184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/184.diff">https://git.openjdk.org/jdk21u-dev/pull/184.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/184#issuecomment-1895837625)