### PR TITLE
8322957: Generational ZGC: Relocation selection must join the STS

### DIFF
--- a/src/hotspot/share/gc/shared/workerThread.hpp
+++ b/src/hotspot/share/gc/shared/workerThread.hpp
@@ -93,8 +93,8 @@ private:
 
   WorkerThread* create_worker(uint name_suffix);
 
-  void set_indirectly_suspendible_threads();
-  void clear_indirectly_suspendible_threads();
+  void set_indirect_states();
+  void clear_indirect_states();
 
 protected:
   virtual void on_create_worker(WorkerThread* worker) {}
@@ -111,6 +111,8 @@ public:
   uint set_active_workers(uint num_workers);
 
   void threads_do(ThreadClosure* tc) const;
+  template <typename Function>
+  void threads_do_f(Function function) const;
 
   const char* name() const { return _name; }
 

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -285,6 +285,10 @@ void ZGeneration::desynchronize_relocation() {
   _relocate.desynchronize();
 }
 
+bool ZGeneration::is_relocate_queue_active() const {
+  return _relocate.is_queue_active();
+}
+
 void ZGeneration::reset_statistics() {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
   _freed = 0;
@@ -1492,7 +1496,7 @@ void ZGenerationOld::remap_young_roots() {
   uint remap_nworkers = clamp(ZGeneration::young()->workers()->active_workers() + prev_nworkers, 1u, ZOldGCThreads);
   _workers.set_active_workers(remap_nworkers);
 
-  // TODO: The STS joiner is only needed to satisfy z_assert_is_barrier_safe that doesn't
+  // TODO: The STS joiner is only needed to satisfy ZBarrier::assert_is_state_barrier_safe that doesn't
   // understand the driver locker. Consider making the assert aware of the driver locker.
   SuspendibleThreadSetJoiner sts_joiner;
 

--- a/src/hotspot/share/gc/z/zGeneration.hpp
+++ b/src/hotspot/share/gc/z/zGeneration.hpp
@@ -166,6 +166,7 @@ public:
   // Relocation
   void synchronize_relocation();
   void desynchronize_relocation();
+  bool is_relocate_queue_active() const;
   zaddress relocate_or_remap_object(zaddress_unsafe addr);
   zaddress remap_object(zaddress_unsafe addr);
 

--- a/src/hotspot/share/gc/z/zIterator.inline.hpp
+++ b/src/hotspot/share/gc/z/zIterator.inline.hpp
@@ -26,11 +26,21 @@
 
 #include "gc/z/zIterator.hpp"
 
+#include "gc/z/zVerify.hpp"
 #include "memory/iterator.inline.hpp"
 #include "oops/objArrayOop.hpp"
 #include "oops/oop.inline.hpp"
 
 inline bool ZIterator::is_invisible_object(oop obj) {
+  // This is a good place to make sure that we can't concurrently iterate over
+  // objects while VMThread operations think they have exclusive access to the
+  // object graph.
+  //
+  // One example that have caused problems is the JFR Leak Profiler, which
+  // sets the mark word to a value that makes the object arrays look like
+  // invisible objects.
+  z_verify_safepoints_are_blocked();
+
   return obj->mark_acquire().is_marked();
 }
 

--- a/src/hotspot/share/gc/z/zRelocate.hpp
+++ b/src/hotspot/share/gc/z/zRelocate.hpp
@@ -41,6 +41,7 @@ private:
   uint                 _nworkers;
   uint                 _nsynchronized;
   bool                 _synchronize;
+  volatile bool        _is_active;
   volatile int         _needs_attention;
 
   bool needs_attention() const;
@@ -52,6 +53,10 @@ private:
 
 public:
   ZRelocateQueue();
+
+  void activate(uint nworkers);
+  void deactivate();
+  bool is_active() const;
 
   void join(uint nworkers);
   void resize_workers(uint nworkers);
@@ -99,6 +104,8 @@ public:
   void desynchronize();
 
   ZRelocateQueue* queue();
+
+  bool is_queue_active() const;
 };
 
 #endif // SHARE_GC_Z_ZRELOCATE_HPP

--- a/src/hotspot/share/gc/z/zUncoloredRoot.inline.hpp
+++ b/src/hotspot/share/gc/z/zUncoloredRoot.inline.hpp
@@ -29,11 +29,12 @@
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zBarrier.inline.hpp"
 #include "gc/z/zHeap.inline.hpp"
+#include "gc/z/zBarrier.hpp"
 #include "oops/oop.hpp"
 
 template <typename ObjectFunctionT>
 inline void ZUncoloredRoot::barrier(ObjectFunctionT function, zaddress_unsafe* p, uintptr_t color) {
-  z_assert_is_barrier_safe();
+  z_verify_safepoints_are_blocked();
 
   const zaddress_unsafe addr = Atomic::load(p);
   assert_is_valid(addr);

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -43,15 +43,66 @@
 #include "runtime/frame.inline.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/handles.hpp"
-#include "runtime/javaThread.hpp"
+#include "runtime/javaThread.inline.hpp"
+#include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/stackFrameStream.inline.hpp"
 #include "runtime/stackWatermark.inline.hpp"
 #include "runtime/stackWatermarkSet.inline.hpp"
+#include "runtime/thread.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/preserveException.hpp"
 #include "utilities/resourceHash.hpp"
+
+#ifdef ASSERT
+
+// Used to verify that safepoints operations can't be scheduled concurrently
+// with callers to this function. Typically used to verify that object oops
+// and headers are safe to access.
+void z_verify_safepoints_are_blocked() {
+  Thread* current = Thread::current();
+
+  if (current->is_ConcurrentGC_thread()) {
+    assert(current->is_suspendible_thread(), // Thread prevents safepoints
+        "Safepoints are not blocked by current thread");
+
+  } else if (current->is_Worker_thread()) {
+    assert(// Check if ...
+        // the thread prevents safepoints
+        current->is_suspendible_thread() ||
+        // the coordinator thread is the safepointing VMThread
+        current->is_indirectly_safepoint_thread() ||
+        // the coordinator thread prevents safepoints
+        current->is_indirectly_suspendible_thread() ||
+        // the RelocateQueue prevents safepoints
+        //
+        // RelocateQueue acts as a pseudo STS leaver/joiner and blocks
+        // safepoints. There's currently no infrastructure  to check if the
+        // current thread is active or not, so check the global states instead.
+        ZGeneration::young()->is_relocate_queue_active() ||
+        ZGeneration::old()->is_relocate_queue_active(),
+        "Safepoints are not blocked by current thread");
+
+  } else if (current->is_Java_thread()) {
+    JavaThreadState state = JavaThread::cast(current)->thread_state();
+    assert(state == _thread_in_Java || state == _thread_in_vm || state == _thread_new,
+        "Safepoints are not blocked by current thread from state: %d", state);
+
+  } else if (current->is_JfrSampler_thread()) {
+    // The JFR sampler thread blocks out safepoints with this lock.
+    assert_lock_strong(Threads_lock);
+
+  } else if (current->is_VM_thread()) {
+    // The VM Thread doesn't schedule new safepoints while executing
+    // other safepoint or handshake operations.
+
+  } else {
+    fatal("Unexpected thread type");
+  }
+}
+
+#endif
 
 #define BAD_OOP_ARG(o, p)   "Bad oop " PTR_FORMAT " found at " PTR_FORMAT, untype(o), p2i(p)
 

--- a/src/hotspot/share/gc/z/zVerify.hpp
+++ b/src/hotspot/share/gc/z/zVerify.hpp
@@ -30,6 +30,8 @@ class frame;
 class ZForwarding;
 class ZPageAllocator;
 
+NOT_DEBUG(inline) void z_verify_safepoints_are_blocked() NOT_DEBUG_RETURN;
+
 class ZVerify : public AllStatic {
 private:
   static void roots_strong(bool verify_after_old_mark);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -73,6 +73,7 @@ Thread::Thread() {
   set_lgrp_id(-1);
   DEBUG_ONLY(clear_suspendible_thread();)
   DEBUG_ONLY(clear_indirectly_suspendible_thread();)
+  DEBUG_ONLY(clear_indirectly_safepoint_thread();)
 
   // allocated data structures
   set_osthread(nullptr);

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -206,6 +206,7 @@ class Thread: public ThreadShadow {
  private:
   DEBUG_ONLY(bool _suspendible_thread;)
   DEBUG_ONLY(bool _indirectly_suspendible_thread;)
+  DEBUG_ONLY(bool _indirectly_safepoint_thread;)
 
  public:
   // Determines if a heap allocation failure will be retried
@@ -224,6 +225,10 @@ class Thread: public ThreadShadow {
   void set_indirectly_suspendible_thread()   { _indirectly_suspendible_thread = true; }
   void clear_indirectly_suspendible_thread() { _indirectly_suspendible_thread = false; }
   bool is_indirectly_suspendible_thread()    { return _indirectly_suspendible_thread; }
+
+  void set_indirectly_safepoint_thread()   { _indirectly_safepoint_thread = true; }
+  void clear_indirectly_safepoint_thread() { _indirectly_safepoint_thread = false; }
+  bool is_indirectly_safepoint_thread()    { return _indirectly_safepoint_thread; }
 #endif
 
  private:


### PR DESCRIPTION
Clean backport to fix Generational ZGC. 

FYI @fisk, @stefank, I am picking this up to 21u. Tell me if this is a bad idea :)

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc` with `-XX:+UseZGC -XX:+ZGenerational`
 - [x] Linux x86_64 server fastdebug, `tier{1,2,3,4}`
 - [x] Linux x86_64 server fastdebug, `tier{1,2,3,4}` with `-XX:+UseZGC -XX:+ZGenerational` (some failures, look pre-existing; e.g. `serviceability/sa` and friends)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322957](https://bugs.openjdk.org/browse/JDK-8322957) needs maintainer approval

### Issue
 * [JDK-8322957](https://bugs.openjdk.org/browse/JDK-8322957): Generational ZGC: Relocation selection must join the STS (**Bug** - P2 - Approved)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/189.diff">https://git.openjdk.org/jdk21u-dev/pull/189.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/189#issuecomment-1896330257)