### PR TITLE
8169475: WheelModifier.java fails by timeout

### DIFF
--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -21,13 +21,6 @@
  * questions.
  */
 
-/*
-   @test
-   @key headful
-   @bug 8041470
-   @summary JButtons stay pressed after they have lost focus if you use the mouse wheel
- */
-
 import java.awt.AWTEvent;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -35,22 +28,32 @@ import java.awt.Point;
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.event.AWTEventListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
+/*
+ * @test
+ * @key headful
+ * @bug 8041470
+ * @summary JButtons stay pressed after they have lost focus if you use the mouse wheel
+ */
 public class WheelModifier {
 
     JFrame f;
     JButton fb;
 
-    CountDownLatch pressSema = new CountDownLatch(1);
-    CountDownLatch exitSema = new CountDownLatch(1);
-    CountDownLatch releaseSema = new CountDownLatch(1);
+    final CountDownLatch focusSema = new CountDownLatch(1);
+    final CountDownLatch pressSema = new CountDownLatch(1);
+    final CountDownLatch exitSema = new CountDownLatch(1);
+    final CountDownLatch releaseSema = new CountDownLatch(1);
     volatile CountDownLatch wheelSema;
 
     private volatile Point sLoc;
@@ -59,6 +62,14 @@ public class WheelModifier {
     void createGui() {
         f = new JFrame("frame");
         fb = new JButton("frame_button");
+
+        fb.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusGained(FocusEvent focusEvent) {
+                focusSema.countDown();
+            }
+        });
+
         fb.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseReleased(MouseEvent e) {
@@ -69,7 +80,6 @@ public class WheelModifier {
             @Override
             public void mouseEntered(MouseEvent e) {
                 System.out.println("WheelModifier.mouseEntered: " + e);
-
             }
 
             @Override
@@ -106,9 +116,13 @@ public class WheelModifier {
     }
 
     void run() throws Exception {
+        System.out.println("# Started");
+        if (!focusSema.await(2, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Didn't receive focus in time");
+        }
+
         Robot r = new Robot();
         r.waitForIdle();
-        System.out.println("# Started");
 
         SwingUtilities.invokeAndWait(() -> {
             sLoc = fb.getLocationOnScreen();
@@ -117,33 +131,51 @@ public class WheelModifier {
 
         r.mouseMove(sLoc.x + bSize.width / 2, sLoc.y + bSize.height / 2);
         r.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
-        pressSema.await();
+        if (!pressSema.await(2, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Mouse is not pressed");
+        }
         System.out.println("# Pressed");
 
         r.mouseMove(sLoc.x + bSize.width / 2, sLoc.y + bSize.height * 2);
-        exitSema.await();
+        if (!exitSema.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Mouse did not exit");
+        }
         System.out.println("# Exited");
 
         wheelSema = new CountDownLatch(1);
         r.mouseWheel(1);
-        wheelSema.await();
+        if (!wheelSema.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Mouse is not wheeled 1");
+        }
         System.out.println("# Wheeled 1");
 
         wheelSema = new CountDownLatch(1);
         r.mouseWheel(-1);
-        wheelSema.await();
+        if (!wheelSema.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Mouse is not wheeled 2");
+        }
         System.out.println("# Wheeled 2");
 
         r.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
-        releaseSema.await();
+        if (!releaseSema.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Mouse is not released");
+        }
         System.out.println("# Released!");
     }
 
     public static void main(String[] args) throws Exception {
         WheelModifier test = new WheelModifier();
 
-        SwingUtilities.invokeAndWait(() -> test.createGui());
-        test.run();
+        try {
+            SwingUtilities.invokeAndWait(test::createGui);
+            test.run();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (test.f != null) {
+                    test.f.dispose();
+                }
+            });
+        }
 
         System.out.println("Done.");
     }


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8169475](https://bugs.openjdk.org/browse/JDK-8169475) needs maintainer approval

### Issue
 * [JDK-8169475](https://bugs.openjdk.org/browse/JDK-8169475): WheelModifier.java fails by timeout (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/190/head:pull/190` \
`$ git checkout pull/190`

Update a local copy of the PR: \
`$ git checkout pull/190` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 190`

View PR using the GUI difftool: \
`$ git pr show -t 190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/190.diff">https://git.openjdk.org/jdk21u-dev/pull/190.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/190#issuecomment-1897660407)