### PR TITLE
8319213: Compatibility.java reads both stdout and stderr of JdkUtils

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1026,7 +1026,7 @@ public class Compatibility {
         cmd[3] = JdkUtils.class.getName();
         cmd[4] = method;
         System.arraycopy(args, 0, cmd, 5, args.length);
-        return ProcessTools.executeCommand(cmd).getOutput();
+        return ProcessTools.executeCommand(cmd).getStdout();
     }
 
     // Executes the specified JDK tools, such as keytool and jarsigner, and


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319213](https://bugs.openjdk.org/browse/JDK-8319213) needs maintainer approval

### Issue
 * [JDK-8319213](https://bugs.openjdk.org/browse/JDK-8319213): Compatibility.java reads both stdout and stderr of JdkUtils (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/199.diff">https://git.openjdk.org/jdk21u-dev/pull/199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/199#issuecomment-1900492743)