### PR TITLE
8323154: C2: assert(cmp != nullptr && cmp->Opcode() == Op_Cmp(bt)) failed: no exit test

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -155,7 +155,7 @@ static bool ok_to_convert(Node* inc, Node* var) {
 static bool is_cloop_condition(BoolNode* bol) {
   for (DUIterator_Fast imax, i = bol->fast_outs(imax); i < imax; i++) {
     Node* out = bol->fast_out(i);
-    if (out->is_CountedLoopEnd()) {
+    if (out->is_BaseCountedLoopEnd()) {
       return true;
     }
   }

--- a/test/hotspot/jtreg/compiler/c2/TestMinValueStrideLongCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMinValueStrideLongCountedLoop.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2;
+
+/*
+ * @test
+ * @bug 8323154
+ * @summary Long counted loop exit check should not be transformed into an unsigned check
+ *
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.c2.TestMinValueStrideLongCountedLoop::test
+ *                   compiler.c2.TestMinValueStrideLongCountedLoop
+ */
+
+public class TestMinValueStrideLongCountedLoop {
+    static long limit = 0;
+    static long res = 0;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        for (long i = 0; i >= limit + (Long.MIN_VALUE + 1); i += Long.MIN_VALUE) {
+            res += 42;
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to fix another C2 corner case; introduced by https://bugs.openjdk.org/browse/JDK-8316719, which is in 21.0.2.

Additional testing:
 - [x] New test fails without the fix, passes with it
 - [x] Linux x86_64 fastdebug `tier{1,2,3,4}`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8323154](https://bugs.openjdk.org/browse/JDK-8323154) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323154](https://bugs.openjdk.org/browse/JDK-8323154): C2: assert(cmp != nullptr &amp;&amp; cmp-&gt;Opcode() == Op_Cmp(bt)) failed: no exit test (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/201/head:pull/201` \
`$ git checkout pull/201`

Update a local copy of the PR: \
`$ git checkout pull/201` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 201`

View PR using the GUI difftool: \
`$ git pr show -t 201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/201.diff">https://git.openjdk.org/jdk21u-dev/pull/201.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/201#issuecomment-1903530143)