### PR TITLE
8322142: JFR: Periodic tasks aren't orphaned between recordings

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
@@ -63,11 +63,7 @@ final class BatchManager {
         }
         for (PeriodicTask task : activeSortedTasks(tasks)) {
             if (task.isSchedulable()) {
-                Batch batch = task.getBatch();
-                // If new task, or period has changed, find new batch
-                if (batch == null) {
-                    batch = findBatch(task.getPeriod());
-                }
+                Batch batch = findBatch(task.getPeriod(), task.getBatch());
                 batch.add(task);
             }
         }
@@ -89,7 +85,7 @@ final class BatchManager {
         return tasks;
     }
 
-    private Batch findBatch(long period) {
+    private Batch findBatch(long period, Batch oldBatch) {
         // All events with a period less than 1000 ms
         // get their own unique batch. The rationale for
         // this is to avoid a scenario where a user (mistakenly) specifies
@@ -102,7 +98,7 @@ final class BatchManager {
                 return batch;
             }
         }
-        Batch batch = new Batch(period);
+        Batch batch = oldBatch != null ? oldBatch : new Batch(period);
         batches.add(batch);
         return batch;
     }


### PR DESCRIPTION
Backport to fix https://bugs.openjdk.org/browse/JDK-8322142 for jdk21. 

First time commiting to openjdk, so please pardon if this is the wrong approach to the PR. I followed instructions in https://wiki.openjdk.org/display/JDKUpdates/How+to+contribute+or+backport+a+fix - not sure if those are still valid for 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322142](https://bugs.openjdk.org/browse/JDK-8322142) needs maintainer approval

### Issue
 * [JDK-8322142](https://bugs.openjdk.org/browse/JDK-8322142): JFR: Periodic tasks aren't orphaned between recordings (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/203.diff">https://git.openjdk.org/jdk21u-dev/pull/203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/203#issuecomment-1906618881)