### PR TITLE
8322282: Incorrect LoaderConstraintTable::add_entry after JDK-8298468

### DIFF
--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -348,7 +348,7 @@ bool LoaderConstraintTable::add_entry(Symbol* class_name,
   } else if (pp1 == nullptr) {
     pp2->extend_loader_constraint(class_name, loader1, klass);
   } else if (pp2 == nullptr) {
-    pp1->extend_loader_constraint(class_name, loader1, klass);
+    pp1->extend_loader_constraint(class_name, loader2, klass);
   } else {
     merge_loader_constraints(class_name, pp1, pp2, klass);
   }


### PR DESCRIPTION
Clean backport to fix a JDK 21 regression. The fix is trivial.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `tier{1,2,3}`
 - [x] Linux AArch64 server fastdebug, `tier{1,2,3}`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8322282](https://bugs.openjdk.org/browse/JDK-8322282) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322282](https://bugs.openjdk.org/browse/JDK-8322282): Incorrect LoaderConstraintTable::add_entry after JDK-8298468 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/205.diff">https://git.openjdk.org/jdk21u-dev/pull/205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/205#issuecomment-1904615827)