### PR TITLE
8315600: Open source few more headless Swing misc tests

### DIFF
--- a/test/jdk/javax/swing/tree/FixedHeightLayoutCache/bug4210354.java
+++ b/test/jdk/javax/swing/tree/FixedHeightLayoutCache/bug4210354.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4210354
+ * @summary Tests whether method FixedHeightLayoutCache.getBounds returns bad Rectangle
+ * @run main bug4210354
+ */
+
+import java.awt.Rectangle;
+
+import javax.swing.tree.AbstractLayoutCache;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.FixedHeightLayoutCache;
+import javax.swing.tree.TreePath;
+
+public class bug4210354 {
+    static class DummyNodeDimensions extends AbstractLayoutCache.NodeDimensions {
+        private final Rectangle rectangle;
+
+        public DummyNodeDimensions(Rectangle r) {
+            rectangle = r;
+        }
+        public Rectangle getNodeDimensions(Object value, int row, int depth,
+                                           boolean expanded, Rectangle bounds) {
+            return rectangle;
+        }
+
+        /* create the TreeModel of depth 1 with specified num of children */
+        public DefaultTreeModel getTreeModelILike(int childrenCount) {
+            DefaultMutableTreeNode root = new DefaultMutableTreeNode("root");
+            for (int i = 0; i < childrenCount; i++) {
+                DefaultMutableTreeNode child =
+                        new DefaultMutableTreeNode("root.child" + i);
+                root.insert(child, i);
+            }
+            return new DefaultTreeModel(root);
+        }
+    }
+
+    public void init() {
+        int x = 1, y = 2, dx = 3, dy = 4, h = 3;
+        DummyNodeDimensions dim = new DummyNodeDimensions(new Rectangle(x, y, dx, dy));
+        FixedHeightLayoutCache fhlc = new FixedHeightLayoutCache();
+        fhlc.setModel(dim.getTreeModelILike(3));
+        fhlc.setRootVisible(true);
+        fhlc.setNodeDimensions(dim);
+        fhlc.setRowHeight(h);
+        int row = 0;
+        TreePath path = fhlc.getPathForRow(row);
+        Rectangle r = fhlc.getBounds(path, new Rectangle());
+        Rectangle r2 = new Rectangle(x, row * h, dx, h);
+        if (r.width != r2.width) {
+            throw new RuntimeException("FixedHeightLayoutCache.getBounds returns bad Rectangle");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        bug4210354 b = new bug4210354();
+        b.init();
+    }
+}

--- a/test/jdk/javax/swing/undo/UndoManager/bug4706533.java
+++ b/test/jdk/javax/swing/undo/UndoManager/bug4706533.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4706533
+ * @summary UndoManager.setLimit(0) doesn't correctly trim the UndoManager size
+ * @run main bug4706533
+ */
+
+import javax.swing.undo.AbstractUndoableEdit;
+import javax.swing.undo.CannotUndoException;
+import javax.swing.undo.CannotRedoException;
+import javax.swing.undo.UndoManager;
+
+public class bug4706533 {
+
+    public static void main(String[] args) throws Exception {
+        UndoManager manager = new UndoManager();
+        manager.setLimit(1);
+        AbstractUndoableEdit edit = new MyUndoableEdit();
+        manager.addEdit(edit);
+        manager.setLimit(0);
+        try {
+            manager.undo();
+            throw new RuntimeException("The limit should be zero");
+        } catch (CannotUndoException e) {
+            //Expected to be thrown
+        }
+    }
+
+    static class MyUndoableEdit extends AbstractUndoableEdit {
+        @Override
+        public void undo() throws CannotUndoException {}
+        @Override
+        public void redo() throws CannotRedoException {}
+    }
+}

--- a/test/jdk/javax/swing/undo/bug4992178.java
+++ b/test/jdk/javax/swing/undo/bug4992178.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4992178
+ * @summary REGRESSION: Allow unlimited number of edits in an UndoManager
+ * @run main bug4992178
+ */
+
+import javax.swing.undo.AbstractUndoableEdit;
+import javax.swing.undo.CannotRedoException;
+import javax.swing.undo.CannotUndoException;
+import javax.swing.undo.UndoManager;
+
+public class bug4992178 {
+
+    public static void main(String[] argv) throws Exception {
+        TestUndoManager manager = new TestUndoManager();
+        manager.setLimit(1);
+        AbstractUndoableEdit edit = new MyUndoableEdit();
+        manager.addEdit(edit);
+
+        manager.setLimit(-1);
+
+        manager.discardAllEdits();
+
+        if (manager.getVectorSize() != 0) {
+            throw new RuntimeException(
+                "UndoManager's vector size should be 0 after discarding all changes");
+        }
+    }
+
+    static class TestUndoManager extends UndoManager {
+        public int getVectorSize() {
+            return edits.size();
+        }
+    }
+
+    static class MyUndoableEdit extends AbstractUndoableEdit {
+        @Override
+        public void undo() throws CannotUndoException {}
+        @Override
+        public void redo() throws CannotRedoException {}
+    }
+
+}


### PR DESCRIPTION
Backport of [JDK-8315600](https://bugs.openjdk.org/browse/JDK-8315600)

Testing
- Local: Test passed on MacOS M1 Laptop
  - bug4210354.java - Test results: passed: 1
  - bug4706533.java - Test results: passed: 1
  - bug4992178.java - Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-26`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315600](https://bugs.openjdk.org/browse/JDK-8315600) needs maintainer approval

### Issue
 * [JDK-8315600](https://bugs.openjdk.org/browse/JDK-8315600): Open source few more headless Swing misc tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/209/head:pull/209` \
`$ git checkout pull/209`

Update a local copy of the PR: \
`$ git checkout pull/209` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 209`

View PR using the GUI difftool: \
`$ git pr show -t 209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/209.diff">https://git.openjdk.org/jdk21u-dev/pull/209.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/209#issuecomment-1905618474)