### PR TITLE
8322255: Generational ZGC: ZPageSizeMedium should be set before MaxTenuringThreshold

### DIFF
--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -143,6 +143,9 @@ void ZArguments::initialize() {
     FLAG_SET_DEFAULT(ZFragmentationLimit, 5.0);
   }
 
+  // Set medium page size here because MaxTenuringThreshold may use it.
+  ZHeuristics::set_medium_page_size();
+
   if (!FLAG_IS_DEFAULT(ZTenuringThreshold) && ZTenuringThreshold != -1) {
     FLAG_SET_ERGO_IF_DEFAULT(MaxTenuringThreshold, ZTenuringThreshold);
     if (MaxTenuringThreshold == 0) {

--- a/src/hotspot/share/gc/z/zInitialize.cpp
+++ b/src/hotspot/share/gc/z/zInitialize.cpp
@@ -28,7 +28,6 @@
 #include "gc/z/zDriver.hpp"
 #include "gc/z/zGCIdPrinter.hpp"
 #include "gc/z/zGlobals.hpp"
-#include "gc/z/zHeuristics.hpp"
 #include "gc/z/zInitialize.hpp"
 #include "gc/z/zJNICritical.hpp"
 #include "gc/z/zLargePages.hpp"
@@ -54,7 +53,6 @@ ZInitialize::ZInitialize(ZBarrierSet* barrier_set) {
   ZThreadLocalAllocBuffer::initialize();
   ZTracer::initialize();
   ZLargePages::initialize();
-  ZHeuristics::set_medium_page_size();
   ZBarrierSet::set_barrier_set(barrier_set);
   ZJNICritical::initialize();
   ZDriver::initialize();


### PR DESCRIPTION
Clean backport for fixing generational ZGC. The commit fixes the incorrect calculation of MaxTenuringThreshold and the risk is quite low.

Additional testing:
 - [x] Linux aarch64 server fastdebug, `hotspot_gc` with `-XX:+UseZGC +XX+ZGenerational`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322255](https://bugs.openjdk.org/browse/JDK-8322255) needs maintainer approval

### Issue
 * [JDK-8322255](https://bugs.openjdk.org/browse/JDK-8322255): Generational ZGC: ZPageSizeMedium should be set before MaxTenuringThreshold (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/210/head:pull/210` \
`$ git checkout pull/210`

Update a local copy of the PR: \
`$ git checkout pull/210` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 210`

View PR using the GUI difftool: \
`$ git pr show -t 210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/210.diff">https://git.openjdk.org/jdk21u-dev/pull/210.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/210#issuecomment-1905716459)