### PR TITLE
8315611: Open source swing text/html and tree test

### DIFF
--- a/test/jdk/javax/swing/text/html/TableView/bug4813831.java
+++ b/test/jdk/javax/swing/text/html/TableView/bug4813831.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4813831
+ * @summary Verifies contents of table cells in HTML in JEditorPane wraps correctly
+ * @key headful
+ * @run main bug4813831
+*/
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.text.View;
+import javax.swing.text.ParagraphView;
+import javax.swing.text.html.HTMLEditorKit;
+
+import java.awt.Robot;
+import java.awt.Shape;
+
+public class bug4813831 {
+
+    private static boolean passed = false;
+    private boolean finished = false;
+
+    private static JEditorPane jep;
+    private static JFrame f;
+
+    public void init() {
+
+        String text =
+            "<html><body>" +
+            "<table border><tr>" +
+            "<td align=center>XXXXXXXXXXXXXX<BR>X<BR>X</td>" +
+            "</tr></table>" +
+            "</body></html>";
+
+        f = new JFrame();
+        jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(text);
+
+        f.getContentPane().add(jep);
+        f.setSize(20,500);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+
+    public static void main(String args[]) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        bug4813831 test = new bug4813831();
+        try {
+            SwingUtilities.invokeAndWait(() -> test.init());
+            robot.waitForIdle();
+            robot.delay(1000);
+            Shape r = jep.getBounds();
+            View v = jep.getUI().getRootView(jep);
+            do {
+                int n = v.getViewCount();
+                Shape sh = v.getChildAllocation(n - 1, r);
+                if (sh != null) {
+                    r = sh;
+                }
+                v = v.getView(n - 1);
+            } while (!(v instanceof ParagraphView));
+
+            int n = v.getViewCount();
+            // there should be 3 lines or more (if the first long line was wrapped) in a cell
+            passed = n >= 3;
+
+            if (passed) {
+                Shape sh = v.getChildAllocation(n - 2, r);
+                int x1 = sh.getBounds().x;
+                sh = v.getChildAllocation(n - 1, r);
+                int x2 = sh.getBounds().x;
+                System.out.println("x1: " + x1 + " x2: " + x2);
+                // lines should be equally aligned
+                passed = (x1 == x2);
+            }
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/tree/DefaultTreeCellEditor/bug4480602.java
+++ b/test/jdk/javax/swing/tree/DefaultTreeCellEditor/bug4480602.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4480602
+ * @summary Verifies if DefaultTreeCellEditor.inHitRegion() incorrectly
+ *          handles row bounds
+ * @key headful
+ * @run main bug4480602
+*/
+
+import java.awt.ComponentOrientation;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.MouseEvent;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellEditor;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.SwingUtilities;
+
+import java.util.Date;
+
+public class bug4480602 {
+
+    static JTree tree;
+    static JFrame fr;
+    static MyTreeCellEditor editor;
+
+    static Robot robot;
+    boolean passed = false;
+    boolean do_test = false;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("Test");
+
+                String s = "0\u05D01\u05D02\u05D03\u05D04\u05D05";
+                DefaultMutableTreeNode root = new DefaultMutableTreeNode(s);
+                root.add(new DefaultMutableTreeNode(s));
+                root.add(new DefaultMutableTreeNode(s));
+
+                tree = new JTree(root);
+                editor = new MyTreeCellEditor(tree, new DefaultTreeCellRenderer());
+                tree.setCellEditor(editor);
+                tree.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+                tree.setEditable(true);
+                JScrollPane sp = new JScrollPane(tree);
+                fr.getContentPane().add(sp);
+
+                fr.setSize(250,200);
+                fr.setLocationRelativeTo(null);
+                fr.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                Rectangle rect = tree.getRowBounds(1);
+                editor.testTreeCellEditor(rect);
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    static class MyTreeCellEditor extends DefaultTreeCellEditor {
+
+        public MyTreeCellEditor(JTree tree, DefaultTreeCellRenderer renderer) {
+            super(tree, renderer);
+        }
+
+        public void testTreeCellEditor(Rectangle rect) {
+            int x = rect.x + 10;
+            int y = rect.y + rect.height / 2;
+            MouseEvent me = new MouseEvent(tree,
+                                           MouseEvent.MOUSE_PRESSED,
+                                           (new Date()).getTime(),
+                                           MouseEvent.BUTTON1_DOWN_MASK,
+                                           rect.x + 10, rect.y + 10,
+                                           1, true);
+            isCellEditable(me);
+
+            if (tree == null) {
+                throw new RuntimeException("isCellEditable() should set the tree");
+            }
+            if (lastRow != 1) {
+                throw new RuntimeException("isCellEditable() should set the lastRow");
+            }
+            if (offset == 0) {
+                throw new RuntimeException("isCellEditable() should determine offset");
+            }
+
+            if (!inHitRegion(x,y)) {
+                throw new RuntimeException("Hit region should contain point ("+x+", "+y+")");
+            }
+            x = rect.x + rect.width - 10;
+            if (inHitRegion(x,y)) {
+                throw new RuntimeException("Hit region shouldn't contain point ("+x+", "+y+")");
+            }
+        }
+    }
+
+}

--- a/test/jdk/javax/swing/tree/DefaultTreeCellRenderer/bug4180224.java
+++ b/test/jdk/javax/swing/tree/DefaultTreeCellRenderer/bug4180224.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4180224
+ * @summary DefaultTreeCellRenderer.hasFocus protected (not private) now.
+ * @key headful
+ * @run main bug4180224
+*/
+
+import javax.swing.tree.DefaultTreeCellRenderer;
+
+public class bug4180224 {
+
+    static class MyDTCR extends DefaultTreeCellRenderer {
+        void test() {
+            hasFocus = false;
+        }
+    }
+
+    public static void main(String[] argv) {
+        MyDTCR m = new MyDTCR();
+        m.test();
+    }
+}

--- a/test/jdk/javax/swing/tree/FixedHeightLayoutCache/bug4745001.java
+++ b/test/jdk/javax/swing/tree/FixedHeightLayoutCache/bug4745001.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4745001
+ * @summary JTree with setLargeModel(true) not display correctly
+ *          when we expand/collapse nodes
+ * @key headful
+ * @run main bug4745001
+*/
+
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
+import javax.swing.event.TreeExpansionEvent;
+import javax.swing.event.TreeExpansionListener;
+import javax.swing.SwingUtilities;
+
+public class bug4745001 {
+
+    static JTree tree;
+    static JFrame fr;
+    boolean stateChanged;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        bug4745001 test = new bug4745001();
+        try {
+            SwingUtilities.invokeAndWait(() -> test.init());
+            robot.waitForIdle();
+            robot.delay(1000);
+            test.start();
+            robot.delay(1000);
+            test.destroy();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        fr = new JFrame("Test");
+        fr.getContentPane().setLayout(new FlowLayout());
+
+        tree = new JTree();
+        tree.setRowHeight(20);
+        tree.setLargeModel(true);
+        tree.setPreferredSize(new Dimension(100, 400));
+        tree.setRootVisible(false);
+        tree.setShowsRootHandles(true);
+
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode("");
+        DefaultMutableTreeNode a = new DefaultMutableTreeNode("a");
+        DefaultMutableTreeNode b = new DefaultMutableTreeNode("b");
+        DefaultMutableTreeNode c = new DefaultMutableTreeNode("c");
+        root.add(a);
+        root.add(b);
+        root.add(c);
+        b.add(new DefaultMutableTreeNode("b1"));
+        c.add(new DefaultMutableTreeNode("c2"));
+        tree.setModel(new DefaultTreeModel(root));
+
+        fr.getContentPane().add(tree);
+
+        tree.addTreeExpansionListener(new TreeExpansionListener() {
+            public void treeExpanded(TreeExpansionEvent e) {
+                TreePath path = e.getPath();
+                if (path != null) {
+                    DefaultMutableTreeNode node =
+                        (DefaultMutableTreeNode)path.getLastPathComponent();
+                    node.removeAllChildren();
+                    String s = (String)node.getUserObject();
+                    node.add(new DefaultMutableTreeNode(s + "1"));
+                    node.add(new DefaultMutableTreeNode(s + "2"));
+                    node.add(new DefaultMutableTreeNode(s + "3"));
+                    DefaultTreeModel model = (DefaultTreeModel)tree.getModel();
+                    model.nodeStructureChanged(node);
+                    synchronized (bug4745001.this) {
+                        stateChanged = true;
+                        bug4745001.this.notifyAll();
+                    }
+                }
+            }
+
+            public void treeCollapsed(TreeExpansionEvent e) {
+                synchronized (bug4745001.this) {
+                    stateChanged = true;
+                    bug4745001.this.notifyAll();
+                }
+            }
+        });
+
+        fr.pack();
+        fr.setVisible(true);
+    }
+
+    void changeNodeStateForRow(final int row, final boolean expand) throws Exception {
+        try {
+            stateChanged = false;
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    try {
+                        if (expand) {
+                            tree.expandRow(row);
+                        } else {
+                            tree.collapseRow(row);
+                        }
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                    }
+                 }
+            });
+            synchronized (this) {
+                while (!stateChanged) {
+                    bug4745001.this.wait();
+                }
+            }
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
+
+    public void start() throws Exception {
+        // expand node "c"
+        changeNodeStateForRow(2, true);
+        // expand node "b"
+        changeNodeStateForRow(1, true);
+        // collapse node "c"
+        changeNodeStateForRow(1, false);
+    }
+
+    String[] expected = new String[] {"a", "b", "c", "c1", "c2", "c3"};
+
+    public void destroy() {
+        for (int i = 0; i < expected.length; i++) {
+            Object obj = tree.getPathForRow(i).getLastPathComponent();
+            if (!obj.toString().equals(expected[i])) {
+                throw new RuntimeException("Unexpected node at row "+i);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Backport of [JDK-8315611](https://bugs.openjdk.org/browse/JDK-8315611)

Testing
- Local: `Passed`
  - `test/jdk/javax/swing/text/html/TableView/bug4813831.java` - Test results: passed: 1
  - `test/jdk/javax/swing/tree/DefaultTreeCellEditor/` - Test results: passed: 1
  - `test/jdk/javax/swing/tree/DefaultTreeCellRenderer/bug4180224.java` - Test results: passed: 1
  - `test/jdk/javax/swing/tree/FixedHeightLayoutCache/` - Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-29`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315611](https://bugs.openjdk.org/browse/JDK-8315611) needs maintainer approval

### Issue
 * [JDK-8315611](https://bugs.openjdk.org/browse/JDK-8315611): Open source swing text/html and tree test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/223.diff">https://git.openjdk.org/jdk21u-dev/pull/223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/223#issuecomment-1913537503)