### PR TITLE
8318157: RISC-V: implement ensureMaterializedForStackWalk intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2352,6 +2352,11 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
+    } else if (_method->intrinsic_id() == vmIntrinsicID::_ensureMaterializedForStackWalk) {
+      // The NOP here is purely to ensure that eliding a call to
+      // JVM_EnsureMaterializedForStackWalk doesn't change the code size.
+      __ nop();
+      __ block_comment("call JVM_EnsureMaterializedForStackWalk (elided)");
     } else {
       int method_index = resolved_method_index(cbuf);
       RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)


### PR DESCRIPTION
Hi! I would like to backport [JDK-8318157](https://bugs.openjdk.org/browse/JDK-8318157) to jdk21u in order to improve performance via the ensureMaterializedForStackWalk C2 intrinsic. It's a clean backport related only to RISC-V.
Tested: tier1 tests passed.

The benchmark shows the following performance improvement on the T-Head RVB-ICE board:
**Before**
```
Benchmark                                             Mode  Cnt    Score    Error  Units
ScopedValues.CreateBindThenGetThenRemove_ScopedValue  avgt   10  801.570 ± 40.067  ns/op
ScopedValues.bindThenGetNoRemove_ThreadLocal          avgt   10   47.918 ±  0.267  ns/op
ScopedValues.bindThenGetThenRemove_ScopedValue        avgt   10  733.398 ± 44.490  ns/op
ScopedValues.bindThenGetThenRemove_ThreadLocal        avgt   10  862.636 ± 12.210  ns/op
ScopedValues.bindViaGet_ScopedValue                   avgt   10  551.035 ± 18.560  ns/op
ScopedValues.bind_ScopedValue                         avgt   10  556.024 ± 21.099  ns/op
ScopedValues.bind_ThreadLocal                         avgt   10  850.550 ± 17.945  ns/op
ScopedValues.counter_ScopedValue                      avgt   10   35.339 ±  0.322  ns/op
ScopedValues.counter_ThreadLocal                      avgt   10   43.619 ±  0.187  ns/op
ScopedValues.setNoRemove_ScopedValue                  avgt   10   40.175 ±  0.259  ns/op
ScopedValues.setNoRemove_ThreadLocal                  avgt   10   43.164 ±  0.343  ns/op
ScopedValues.sixValues_ScopedValue                    avgt   10    2.550 ±  0.015  us/op
ScopedValues.sixValues_ThreadLocal                    avgt   10    8.932 ±  0.019  us/op
ScopedValues.thousandAdds_ScopedValue                 avgt   10    0.161 ±  0.004  us/op
ScopedValues.thousandAdds_ThreadLocal                 avgt   10    9.649 ±  0.019  us/op
ScopedValues.thousandIsBoundQueries                   avgt   10   32.859 ±  0.368  ns/op
ScopedValues.thousandMaybeGets                        avgt   10  153.627 ±  3.627  ns/op
```
**After**
```
Benchmark                                             Mode  Cnt    Score    Error  Units
ScopedValues.CreateBindThenGetThenRemove_ScopedValue  avgt   10  370.934 ±  5.118  ns/op
ScopedValues.bindThenGetNoRemove_ThreadLocal          avgt   10   48.777 ±  3.015  ns/op
ScopedValues.bindThenGetThenRemove_ScopedValue        avgt   10  317.331 ± 19.020  ns/op
ScopedValues.bindThenGetThenRemove_ThreadLocal        avgt   10  880.733 ± 56.253  ns/op
ScopedValues.bindViaGet_ScopedValue                   avgt   10  159.534 ±  6.276  ns/op
ScopedValues.bind_ScopedValue                         avgt   10  160.035 ±  5.857  ns/op
ScopedValues.bind_ThreadLocal                         avgt   10  854.117 ± 13.623  ns/op
ScopedValues.counter_ScopedValue                      avgt   10   35.351 ±  0.344  ns/op
ScopedValues.counter_ThreadLocal                      avgt   10   48.654 ±  0.306  ns/op
ScopedValues.setNoRemove_ScopedValue                  avgt   10   40.246 ±  0.259  ns/op
ScopedValues.setNoRemove_ThreadLocal                  avgt   10   47.947 ±  0.283  ns/op
ScopedValues.sixValues_ScopedValue                    avgt   10    2.121 ±  0.004  us/op
ScopedValues.sixValues_ThreadLocal                    avgt   10    9.894 ±  0.019  us/op
ScopedValues.thousandAdds_ScopedValue                 avgt   10    0.162 ±  0.005  us/op
ScopedValues.thousandAdds_ThreadLocal                 avgt   10   10.900 ±  0.021  us/op
ScopedValues.thousandIsBoundQueries                   avgt   10   31.986 ±  0.407  ns/op
ScopedValues.thousandMaybeGets                        avgt   10  159.027 ±  4.133  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318157](https://bugs.openjdk.org/browse/JDK-8318157) needs maintainer approval

### Issue
 * [JDK-8318157](https://bugs.openjdk.org/browse/JDK-8318157): RISC-V: implement ensureMaterializedForStackWalk intrinsic (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/224.diff">https://git.openjdk.org/jdk21u-dev/pull/224.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/224#issuecomment-1914792283)