### PR TITLE
8309697: [TESTBUG] Remove "@requires vm.flagless" from jtreg vectorization tests

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayCopyTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayCopyTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.ArrayCopyTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
@@ -36,7 +36,7 @@
  *                   compiler.vectorization.runner.ArrayIndexFillTest
  *
  * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayInvariantFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayInvariantFillTest.java
@@ -35,9 +35,14 @@
  *                   -XX:+WhiteBoxAPI
  *                   -XX:-OptimizeFill
  *                   compiler.vectorization.runner.ArrayInvariantFillTest
+ * @run main/othervm -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI
+ *                   -XX:+OptimizeFill
+ *                   compiler.vectorization.runner.ArrayInvariantFillTest
  *
  * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;
@@ -66,7 +71,11 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
     // ---------------- Simple Fill ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_B, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "true"},
+        counts = {IRNode.REPLICATE_B, "0"})
     public byte[] fillByteArray() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -77,7 +86,11 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_S, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "true"},
+        counts = {IRNode.REPLICATE_S, "0"})
     public short[] fillShortArray() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -88,7 +101,11 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_S, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "true"},
+        counts = {IRNode.REPLICATE_S, "0"})
     public char[] fillCharArray() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -99,7 +116,11 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_I, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "true"},
+        counts = {IRNode.REPLICATE_I, "0"})
     public int[] fillIntArray() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -121,7 +142,11 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_F, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "true"},
+        counts = {IRNode.REPLICATE_F, "0"})
     public float[] fillFloatArray() {
         float[] res = new float[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -177,7 +202,11 @@ public class ArrayInvariantFillTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "false"},
         counts = {IRNode.REPLICATE_I, ">0"})
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        applyIf = {"OptimizeFill", "true"},
+        counts = {IRNode.REPLICATE_I, "0"})
     public int[] fillIntArrayWithDouble() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -36,7 +36,7 @@
  *                   compiler.vectorization.runner.ArrayShiftOpTest
  *
  * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.ArrayTypeConvertTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayUnsafeOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayUnsafeOpTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.ArrayUnsafeOpTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicBooleanOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicBooleanOpTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicBooleanOpTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
@@ -38,7 +38,7 @@
  *                   -XX:LoopUnrollLimit=1000
  *                   compiler.vectorization.runner.BasicByteOpTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicCharOpTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
@@ -36,7 +36,7 @@
  *                   compiler.vectorization.runner.BasicDoubleOpTest
  *
  * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicFloatOpTest.java
@@ -36,7 +36,7 @@
  *                   compiler.vectorization.runner.BasicFloatOpTest
  *
  * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -36,7 +36,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicIntOpTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
@@ -37,7 +37,7 @@
  *                   compiler.vectorization.runner.BasicLongOpTest
  *
  * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicShortOpTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopArrayIndexComputeTest.java
@@ -37,7 +37,7 @@
  *                   compiler.vectorization.runner.LoopArrayIndexComputeTest
  *
  * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;
@@ -277,7 +277,7 @@ public class LoopArrayIndexComputeTest extends VectorizationTestRunner {
         byte[] res = new byte[SIZE];
         System.arraycopy(bytes, 0, res, 0, SIZE);
         for (int i = 0; i < SIZE / 2; i++) {
-            res[i] *= bytes[i + 3];
+            res[i] += bytes[i + 3];
         }
         return res;
     }

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopCombinedOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopCombinedOpTest.java
@@ -36,7 +36,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.LoopCombinedOpTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopControlFlowTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopControlFlowTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.LoopControlFlowTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopLiveOutNodesTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopLiveOutNodesTest.java
@@ -36,7 +36,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.LoopLiveOutNodesTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopRangeStrideTest.java
@@ -36,8 +36,8 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.LoopRangeStrideTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
- * @requires (os.arch=="amd64" | os.arch=="x86_64" | os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
@@ -36,7 +36,7 @@
  *                   compiler.vectorization.runner.LoopReductionOpTest
  *
  * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  *
  */
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/MultipleLoopsTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/MultipleLoopsTest.java
@@ -36,7 +36,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.MultipleLoopsTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/StripMinedLoopTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/StripMinedLoopTest.java
@@ -36,7 +36,7 @@
  *                   -XX:LoopStripMiningIter=10
  *                   compiler.vectorization.runner.StripMinedLoopTest
  *
- * @requires vm.compiler2.enabled & vm.flagless
+ * @requires vm.compiler2.enabled
  */
 
 package compiler.vectorization.runner;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/VectorizationTestRunner.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/VectorizationTestRunner.java
@@ -25,18 +25,11 @@ package compiler.vectorization.runner;
 
 import compiler.lib.ir_framework.*;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
-import java.io.File;
-
-import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 
 import jdk.test.whitebox.WhiteBox;
@@ -51,17 +44,14 @@ public class VectorizationTestRunner {
     private static final int NMETHOD_COMP_LEVEL_IDX = 1;
     private static final int NMETHOD_INSTS_IDX = 2;
 
-    private static final long COMP_THRES_SECONDS = 30;
-
     protected void run() {
+        Class klass = getClass();
+
         // 1) Vectorization correctness test
-        // For each method annotated with @Test in the test method, this test runner
+        // For each method annotated with "@Test" in test classes, this test runner
         // invokes it twice - first time in the interpreter and second time compiled
         // by C2. Then this runner compares the two return values. Hence we require
         // each test method returning a primitive value or an array of primitive type.
-        // And each test method should not throw any exceptions.
-        Class klass = getClass();
-        // Add extra VM options to verify experimental auto-vectorization
         WB.setBooleanVMFlag("UnlockExperimentalVMOptions", true);
         WB.setBooleanVMFlag("PostLoopMultiversioning", true);
         for (Method method : klass.getDeclaredMethods()) {
@@ -80,8 +70,6 @@ public class VectorizationTestRunner {
         // To test vectorizability, invoke the IR test framework to check existence of
         // expected C2 IR node.
         TestFramework irTest = new TestFramework(klass);
-        // Add extra VM options to enable more auto-vectorization chances
-        irTest.addFlags("-XX:-OptimizeFill");
         irTest.start();
     }
 
@@ -117,9 +105,9 @@ public class VectorizationTestRunner {
         Object expected = null;
         Object actual = null;
 
-        // Lock compilation and inovke the method to get reference result from
-        // the interpreter
-        WB.lockCompilation();
+        // Temporarily disable the compiler and invoke the method to get reference
+        // result from the interpreter
+        WB.setBooleanVMFlag("UseCompiler", false);
         try {
             expected = method.invoke(this);
         } catch (Exception e) {
@@ -127,16 +115,13 @@ public class VectorizationTestRunner {
             fail("Exception is thrown in test method invocation (interpreter).");
         }
         assert(WB.getMethodCompilationLevel(method) == COMP_LEVEL_INTP);
-        WB.unlockCompilation();
+        WB.setBooleanVMFlag("UseCompiler", true);
 
         // Compile the method and invoke it again
         long enqueueTime = System.currentTimeMillis();
         WB.enqueueMethodForCompilation(method, COMP_LEVEL_C2);
         while (WB.getMethodCompilationLevel(method) != COMP_LEVEL_C2) {
-            if (System.currentTimeMillis() - enqueueTime > COMP_THRES_SECONDS * 1000) {
-                fail("Method is not compiled after " + COMP_THRES_SECONDS + "s.");
-            }
-            Thread.sleep(50 /*ms*/);
+            Thread.sleep(100 /*ms*/);
         }
         try {
             actual = method.invoke(this);


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

I had to resolve VectorizationTestRunner.java because "8311691: C2: Remove legacy code related to PostLoopMultiversioning" is not in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8309697](https://bugs.openjdk.org/browse/JDK-8309697) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309697](https://bugs.openjdk.org/browse/JDK-8309697): [TESTBUG] Remove "@<!---->requires vm.flagless" from jtreg vectorization tests (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/226.diff">https://git.openjdk.org/jdk21u-dev/pull/226.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/226#issuecomment-1916404580)