### PR TITLE
8320052: Zero: Use __atomic built-ins for atomic RMW operations

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -331,22 +331,6 @@ extern "C" {
   }
 };
 
-/////////////////////////////////////////////////////////////////////////////
-// Implementations of atomic operations not supported by processors.
-//  -- http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Atomic-Builtins.html
-
-#ifndef _LP64
-extern "C" {
-  long long unsigned int __sync_val_compare_and_swap_8(
-    volatile void *ptr,
-    long long unsigned int oldval,
-    long long unsigned int newval) {
-    ShouldNotCallThis();
-    return 0; // silence compiler warnings
-  }
-};
-#endif // !_LP64
-
 #ifndef PRODUCT
 void os::verify_stack_alignment() {
 }

--- a/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
@@ -71,17 +71,9 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
                                              T exchange_value,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(4 == sizeof(T));
-  // __sync_lock_test_and_set is a bizarrely named atomic exchange
-  // operation.  Note that some platforms only support this with the
-  // limitation that the only valid value to store is the immediate
-  // constant 1.  There is a test for this in JNI_CreateJavaVM().
-  T result = __sync_lock_test_and_set (dest, exchange_value);
-  // All atomic operations are expected to be full memory barriers
-  // (see atomic.hpp). However, __sync_lock_test_and_set is not
-  // a full memory barrier, but an acquire barrier. Hence, this added
-  // barrier. Some platforms (notably ARM) have peculiarities with
-  // their barrier implementations, delegate it to OrderAccess.
-  OrderAccess::fence();
+  FULL_MEM_BARRIER;
+  T result = __atomic_exchange_n(dest, exchange_value, __ATOMIC_RELAXED);
+  FULL_MEM_BARRIER;
   return result;
 }
 
@@ -91,8 +83,9 @@ inline T Atomic::PlatformXchg<8>::operator()(T volatile* dest,
                                              T exchange_value,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(8 == sizeof(T));
-  T result = __sync_lock_test_and_set (dest, exchange_value);
-  OrderAccess::fence();
+  FULL_MEM_BARRIER;
+  T result = __atomic_exchange_n(dest, exchange_value, __ATOMIC_RELAXED);
+  FULL_MEM_BARRIER;
   return result;
 }
 

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -492,22 +492,6 @@ extern "C" {
   }
 };
 
-/////////////////////////////////////////////////////////////////////////////
-// Implementations of atomic operations not supported by processors.
-//  -- http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Atomic-Builtins.html
-
-#ifndef _LP64
-extern "C" {
-  long long unsigned int __sync_val_compare_and_swap_8(
-    volatile void *ptr,
-    long long unsigned int oldval,
-    long long unsigned int newval) {
-    ShouldNotCallThis();
-    return 0; // silence compiler warnings
-  }
-};
-#endif // !_LP64
-
 #ifndef PRODUCT
 void os::verify_stack_alignment() {
 }


### PR DESCRIPTION
Clean backport to improve Atomic support in JDK 21, and prepare for [JDK-8316961](https://bugs.openjdk.org/browse/JDK-8316961) backport.

Additional testing:
 - [x] Large matrix of Zero builds
 - [x] Linux x86_32 Zero fastdebug jcstress run

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320052](https://bugs.openjdk.org/browse/JDK-8320052) needs maintainer approval

### Issue
 * [JDK-8320052](https://bugs.openjdk.org/browse/JDK-8320052): Zero: Use __atomic built-ins for atomic RMW operations (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/227/head:pull/227` \
`$ git checkout pull/227`

Update a local copy of the PR: \
`$ git checkout pull/227` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 227`

View PR using the GUI difftool: \
`$ git pr show -t 227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/227.diff">https://git.openjdk.org/jdk21u-dev/pull/227.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/227#issuecomment-1917521392)