### PR TITLE
8316961: Fallback implementations for 64-bit Atomic::{add,xchg} on 32-bit platforms

### DIFF
--- a/src/hotspot/os_cpu/bsd_x86/atomic_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/atomic_bsd_x86.hpp
@@ -153,6 +153,14 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
   return cmpxchg_using_helper<int64_t>(_Atomic_cmpxchg_long, dest, compare_value, exchange_value);
 }
 
+// No direct support for 8-byte xchg; emulate using cmpxchg.
+template<>
+struct Atomic::PlatformXchg<8> : Atomic::XchgUsingCmpxchg<8> {};
+
+// No direct support for 8-byte add; emulate using cmpxchg.
+template<>
+struct Atomic::PlatformAdd<8> : Atomic::AddUsingCmpxchg<8> {};
+
 template<>
 template<typename T>
 inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {

--- a/src/hotspot/os_cpu/linux_arm/atomic_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/atomic_linux_arm.hpp
@@ -128,6 +128,13 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
   return xchg_using_helper<int32_t>(ARMAtomicFuncs::_xchg_func, dest, exchange_value);
 }
 
+// No direct support for 8-byte xchg; emulate using cmpxchg.
+template<>
+struct Atomic::PlatformXchg<8> : Atomic::XchgUsingCmpxchg<8> {};
+
+// No direct support for 8-byte add; emulate using cmpxchg.
+template<>
+struct Atomic::PlatformAdd<8> : Atomic::AddUsingCmpxchg<8> {};
 
 // The memory_order parameter is ignored - we always provide the strongest/most-conservative ordering
 

--- a/src/hotspot/os_cpu/linux_x86/atomic_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/atomic_linux_x86.hpp
@@ -153,6 +153,14 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
   return cmpxchg_using_helper<int64_t>(_Atomic_cmpxchg_long, dest, compare_value, exchange_value);
 }
 
+// No direct support for 8-byte xchg; emulate using cmpxchg.
+template<>
+struct Atomic::PlatformXchg<8> : Atomic::XchgUsingCmpxchg<8> {};
+
+// No direct support for 8-byte add; emulate using cmpxchg.
+template<>
+struct Atomic::PlatformAdd<8> : Atomic::AddUsingCmpxchg<8> {};
+
 template<>
 template<typename T>
 inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {

--- a/test/hotspot/gtest/runtime/test_atomic.cpp
+++ b/test/hotspot/gtest/runtime/test_atomic.cpp
@@ -59,14 +59,14 @@ TEST_VM(AtomicAddTest, int32) {
   Support().test_fetch_add();
 }
 
-// 64bit Atomic::add is only supported on 64bit platforms.
-#ifdef _LP64
 TEST_VM(AtomicAddTest, int64) {
+  // Check if 64-bit atomics are available on the machine.
+  if (!VM_Version::supports_cx8()) return;
+
   using Support = AtomicAddTestSupport<int64_t>;
   Support().test_add();
   Support().test_fetch_add();
 }
-#endif // _LP64
 
 TEST_VM(AtomicAddTest, ptr) {
   uint _test_values[10] = {};
@@ -108,13 +108,13 @@ TEST_VM(AtomicXchgTest, int32) {
   Support().test();
 }
 
-// 64bit Atomic::xchg is only supported on 64bit platforms.
-#ifdef _LP64
 TEST_VM(AtomicXchgTest, int64) {
+  // Check if 64-bit atomics are available on the machine.
+  if (!VM_Version::supports_cx8()) return;
+
   using Support = AtomicXchgTestSupport<int64_t>;
   Support().test();
 }
-#endif // _LP64
 
 template<typename T>
 struct AtomicCmpxchgTestSupport {
@@ -142,6 +142,9 @@ TEST_VM(AtomicCmpxchgTest, int32) {
 }
 
 TEST_VM(AtomicCmpxchgTest, int64) {
+  // Check if 64-bit atomics are available on the machine.
+  if (!VM_Version::supports_cx8()) return;
+
   using Support = AtomicCmpxchgTestSupport<int64_t>;
   Support().test();
 }
@@ -345,12 +348,16 @@ TEST_VM(AtomicBitopsTest, uint32) {
   AtomicBitopsTestSupport<uint32_t>()();
 }
 
-#ifdef _LP64
 TEST_VM(AtomicBitopsTest, int64) {
+  // Check if 64-bit atomics are available on the machine.
+  if (!VM_Version::supports_cx8()) return;
+
   AtomicBitopsTestSupport<int64_t>()();
 }
 
 TEST_VM(AtomicBitopsTest, uint64) {
+  // Check if 64-bit atomics are available on the machine.
+  if (!VM_Version::supports_cx8()) return;
+
   AtomicBitopsTestSupport<uint64_t>()();
 }
-#endif // _LP64


### PR DESCRIPTION
Clean backport to complete Atomics support and make future backports safe.

Additional testing:
 - [x] Linux x86_32 Server, jcstress run
 - [x] Large matrix of Zero builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8316961](https://bugs.openjdk.org/browse/JDK-8316961) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316961](https://bugs.openjdk.org/browse/JDK-8316961): Fallback implementations for 64-bit Atomic::{add,xchg} on 32-bit platforms (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/233/head:pull/233` \
`$ git checkout pull/233`

Update a local copy of the PR: \
`$ git checkout pull/233` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 233`

View PR using the GUI difftool: \
`$ git pr show -t 233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/233.diff">https://git.openjdk.org/jdk21u-dev/pull/233.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/233#issuecomment-1930167536)