### PR TITLE
8311893: Interactive component with ARIA role 'tabpanel' does not have a programmatically associated name

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -404,7 +404,6 @@ public class Table<T> extends Content {
             } else {
                 tablist.add(getCaption(defaultTab));
             }
-            table.put(HtmlAttr.ARIA_LABELLEDBY, defaultTabId.name());
             if (renderTabs) {
                 for (var tab : tabs) {
                     if (occurringTabs.contains(tab)) {
@@ -417,7 +416,8 @@ public class Table<T> extends Content {
             }
             var tabpanel = new HtmlTree(TagName.DIV)
                     .setId(HtmlIds.forTabPanel(id))
-                    .put(HtmlAttr.ROLE, "tabpanel");
+                    .put(HtmlAttr.ROLE, "tabpanel")
+                    .put(HtmlAttr.ARIA_LABELLEDBY, defaultTabId.name());
             table.add(getTableBody());
             tabpanel.add(table);
             main.add(tablist);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
@@ -157,7 +157,7 @@ function show(tableId, selected, columns) {
 }
 
 function updateTabs(tableId, selected) {
-    document.querySelector('div#' + tableId +' .summary-table')
+    document.getElementById(tableId + '.tabpanel')
         .setAttribute('aria-labelledby', selected);
     document.querySelectorAll('button[id^="' + tableId + '"]')
         .forEach(function(tab, index) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
@@ -157,7 +157,7 @@ function show(tableId, selected, columns) {
 }
 
 function updateTabs(tableId, selected) {
-    document.getElementById(tableId + '.tabpanel' )
+    document.getElementById(tableId + '.tabpanel')
         .setAttribute('aria-labelledby', selected);
     document.querySelectorAll('button[id^="' + tableId + '"]')
         .forEach(function(tab, index) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
@@ -157,7 +157,7 @@ function show(tableId, selected, columns) {
 }
 
 function updateTabs(tableId, selected) {
-    document.getElementById(tableId + '.tabpanel')
+    document.getElementById(tableId + '.tabpanel' )
         .setAttribute('aria-labelledby', selected);
     document.querySelectorAll('button[id^="' + tableId + '"]')
         .forEach(function(tab, index) {

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableStyles/TestHtmlTableStyles.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableStyles/TestHtmlTableStyles.java
@@ -65,7 +65,7 @@ public class TestHtmlTableStyles extends JavadocTester {
                     <div class="caption"><span>Constructors</span></div>
                     <div class="summary-table two-column-summary">""",
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">""");
+                    <div class="summary-table three-column-summary">""");
 
         checkOutput("pkg1/package-summary.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -84,24 +84,24 @@ public class TestHtmlTableTags extends JavadocTester {
         //Package summary
         checkOutput("pkg1/package-summary.html", true,
                 """
-                    <div class="summary-table two-column-summary" aria-labelledby="class-summary-tab0">""");
+                    <div class="summary-table two-column-summary">""");
 
         checkOutput("pkg2/package-summary.html", true,
                 """
-                    <div class="summary-table two-column-summary" aria-labelledby="class-summary-tab0">""");
+                    <div class="summary-table two-column-summary">""");
 
         // Class documentation
         checkOutput("pkg1/C1.html", true,
                 """
                     <div class="summary-table three-column-summary">""",
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">""");
+                    <div class="summary-table three-column-summary">""");
 
         checkOutput("pkg2/C2.html", true,
                 """
                     <div class="summary-table three-column-summary">""",
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">""");
+                    <div class="summary-table three-column-summary">""");
 
         checkOutput("pkg2/C2.ModalExclusionType.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
@@ -97,7 +97,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <div class="summary-table two-column-summary" aria-labelledby="class-summary-tab0">""",
+                    <div class="summary-table two-column-summary">""",
                 """
                     <header role="banner" class="flex-header">
                     <nav role="navigation">
@@ -413,7 +413,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <div class="caption"><span>Enum Constants</span></div>
                     """,
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">
+                    <div class="summary-table three-column-summary">
                     """,
                 """
                     <section class="method-summary" id="method-summary">
@@ -454,7 +454,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <div id="method-summary-table">
                     """,
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">
+                    <div class="summary-table three-column-summary">
                     """,
                 """
                     <section class="method-details" id="method-detail">

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1183,8 +1183,8 @@ public class TestModules extends JavadocTester {
                     ck="show('all-modules-table', 'all-modules-table-tab3', 2)" class="table-tab">Ot\
                     her Modules</button>\
                     </div>
-                    <div id="all-modules-table.tabpanel" role="tabpanel">
-                    <div class="summary-table two-column-summary" aria-labelledby="all-modules-table-tab0">""");
+                    <div id="all-modules-table.tabpanel" role="tabpanel" aria-labelledby="all-modules-table-tab0">
+                    <div class="summary-table two-column-summary">""");
         checkOutput("index.html", false,
                 """
                     <div class="overview-summary">
@@ -1264,8 +1264,8 @@ public class TestModules extends JavadocTester {
                     ck="show('all-packages-table', 'all-packages-table-tab2', 2)" class="table-tab">P\
                     ackage Group 1</button>\
                     </div>
-                    <div id="all-packages-table.tabpanel" role="tabpanel">
-                    <div class="summary-table two-column-summary" aria-labelledby="all-packages-table-tab0">""");
+                    <div id="all-packages-table.tabpanel" role="tabpanel" aria-labelledby="all-packages-table-tab0">
+                    <div class="summary-table two-column-summary">""");
     }
 
     void checkGroupOptionPackageOrdering() {
@@ -1413,7 +1413,7 @@ public class TestModules extends JavadocTester {
                     """);
         checkOutput("allclasses-index.html", found,
                 """
-                    <div class="summary-table two-column-summary" aria-labelledby="all-classes-table-tab0">
+                    <div class="summary-table two-column-summary">
                     """);
         checkOutput("allpackages-index.html", found,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
@@ -141,8 +141,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Modules</span></div>
                 </div>
-                <div id="module.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="module-tab0">
+                <div id="module.tabpanel" role="tabpanel" aria-labelledby="module-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Module</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -157,8 +157,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Packages</span></div>
                 </div>
-                <div id="package.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="package-tab0">
+                <div id="package.tabpanel" role="tabpanel" aria-labelledby="package-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Package</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -173,8 +173,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Interfaces</span></div>
                 </div>
-                <div id="interface.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="interface-tab0">
+                <div id="interface.tabpanel" role="tabpanel" aria-labelledby="interface-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Interface</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -189,8 +189,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Classes</span></div>
                 </div>
-                <div id="class.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="class-tab0">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Class</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -205,8 +205,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Enum Classes</span></div>
                 </div>
-                <div id="enum-class.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="enum-class-tab0">
+                <div id="enum-class.tabpanel" role="tabpanel" aria-labelledby="enum-class-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Enum Class</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -221,8 +221,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Exception Classes</span></div>
                 </div>
-                <div id="exception-class.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="exception-class-tab0">
+                <div id="exception-class.tabpanel" role="tabpanel" aria-labelledby="exception-class-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Exception Class</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -243,8 +243,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Record Classes</span></div>
                 </div>
-                <div id="record-class.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="record-class-tab0">
+                <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Record Class</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -259,8 +259,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Annotation Interfaces</span></div>
                 </div>
-                <div id="annotation-interface.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="annotation-interface-tab0">
+                <div id="annotation-interface.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Annotation Interface</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -274,8 +274,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Fields</span></div>
                 </div>
-                <div id="field.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="field-tab0">
+                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Field</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -308,8 +308,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Methods</span></div>
                 </div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Method</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -374,8 +374,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Constructors</span></div>
                 </div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Constructor</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -409,8 +409,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Enum Constants</span></div>
                 </div>
-                <div id="enum-constant.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="enum-constant-tab0">
+                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Enum Constant</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -443,8 +443,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Annotation Interface Elements</span></div>
                 </div>
-                <div id="annotation-interface-member.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="annotation-interface-member-tab0">
+                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Annotation Interface Element</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -471,8 +471,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Terminally Deprecated Elements</span></div>
                 </div>
-                <div id="for-removal.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="for-removal-tab0">
+                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Element</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
@@ -486,8 +486,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Deprecated Methods</span></div>
                 </div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Method</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
@@ -501,8 +501,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Deprecated Constructors</span></div>
                 </div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Constructor</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
@@ -516,8 +516,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Deprecated Enum Constants</span></div>
                 </div>
-                <div id="enum-constant.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="enum-constant-tab0">
+                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Enum Constant</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
@@ -531,8 +531,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Deprecated Annotation Interface Elements</span></div>
                 </div>
-                <div id="annotation-interface-member.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="annotation-interface-member-tab0">
+                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Annotation Interface Element</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
@@ -620,8 +620,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Terminally Deprecated Elements</span></div>
                 </div>
-                <div id="for-removal.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="for-removal-tab0">
+                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Element</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
@@ -635,8 +635,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Deprecated Methods</span></div>
                 </div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Method</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
@@ -650,8 +650,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>Deprecated Constructors</span></div>
                 </div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Constructor</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Deprecated in</div>
                 <div class="table-header col-last">Description</div>
@@ -694,8 +694,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Classes</span></div>
                 </div>
-                <div id="class.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="class-tab0">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Class</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -710,8 +710,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Fields</span></div>
                 </div>
-                <div id="field.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="field-tab0">
+                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Field</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -726,8 +726,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Methods</span></div>
                 </div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Method</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>
@@ -755,8 +755,8 @@ public class TestNewApiList extends JavadocTester {
                 <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                 <div class="caption"><span>New Constructors</span></div>
                 </div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table three-column-release-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table three-column-release-summary">
                 <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Constructor</div>
                 <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Added in</div>
                 <div class="table-header col-last">Description</div>

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
@@ -315,7 +315,7 @@ public class TestOverrideMethods  extends JavadocTester {
         // Only those should be shown in summary; m1, m3, m9 should listed as declared in Base
         checkOutput("pkg6/Sub.html", true,
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">
+                    <div class="summary-table three-column-summary">
                     <div class="table-header col-first">Modifier and Type</div>
                     <div class="table-header col-second">Method</div>
                     <div class="table-header col-last">Description</div>

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -95,8 +95,8 @@ public class TestPreview extends JavadocTester {
                     <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                     <div class="caption"><span>Record Classes</span></div>
                     </div>
-                    <div id="record-class.tabpanel" role="tabpanel">
-                    <div class="summary-table three-column-summary" aria-labelledby="record-class-tab0">
+                    <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab0">
+                    <div class="summary-table three-column-summary">
                     <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Record Class</div>
                     <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Preview Feature</div>
                     <div class="table-header col-last">Description</div>
@@ -110,8 +110,8 @@ public class TestPreview extends JavadocTester {
                     <div class="table-tabs" role="tablist" aria-orientation="horizontal">
                     <div class="caption"><span>Methods</span></div>
                     </div>
-                    <div id="method.tabpanel" role="tabpanel">
-                    <div class="summary-table three-column-summary" aria-labelledby="method-tab0">
+                    <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                    <div class="summary-table three-column-summary">
                     <div class="table-header col-first sort-asc" onclick="sortTable(this, 0, 3)">Method</div>
                     <div class="table-header col-second" onclick="sortTable(this, 1, 3)">Preview Feature</div>
                     <div class="table-header col-last">Description</div>

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -783,8 +783,8 @@ public class TestSearch extends JavadocTester {
                     ck="show('all-classes-table', 'all-classes-table-tab6', 2)" class="table-tab">An\
                     notation Interfaces</button>\
                     </div>
-                    <div id="all-classes-table.tabpanel" role="tabpanel">
-                    <div class="summary-table two-column-summary" aria-labelledby="all-classes-table-tab0">
+                    <div id="all-classes-table.tabpanel" role="tabpanel" aria-labelledby="all-classes-table-tab0">
+                    <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Class</div>
                     <div class="table-header col-last">Description</div>""");
         checkOutput("allpackages-index.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
@@ -355,8 +355,8 @@ public class TestSpecTag extends JavadocTester {
                     <button id="external-specs-tab2" role="tab" aria-selected="false" aria-controls="external-specs.tabpanel" \
                     tabindex="-1" onkeydown="switchTab(event)" onclick="show('external-specs', 'external-specs-tab2', 2)" \
                     class="table-tab">example.net</button></div>
-                    <div id="external-specs.tabpanel" role="tabpanel">
-                    <div class="summary-table two-column-summary" aria-labelledby="external-specs-tab0">
+                    <div id="external-specs.tabpanel" role="tabpanel" aria-labelledby="external-specs-tab0">
+                    <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Specification</div>
                     <div class="table-header col-last">Referenced In</div>""",
                 """


### PR DESCRIPTION
This PR is a backport of https://github.com/openjdk/jdk/pull/16148.
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311893](https://bugs.openjdk.org/browse/JDK-8311893) needs maintainer approval

### Issue
 * [JDK-8311893](https://bugs.openjdk.org/browse/JDK-8311893): Interactive component with ARIA role 'tabpanel' does not have a programmatically associated name (**Enhancement** - P4 - Approved)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/234.diff">https://git.openjdk.org/jdk21u-dev/pull/234.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/234#issuecomment-1926736498)