### PR TITLE
8325096: Test java/security/cert/CertPathBuilder/akiExt/AKISerialNumber.java is failing

### DIFF
--- a/test/jdk/java/security/cert/CertPathBuilder/akiExt/AKISerialNumber.java
+++ b/test/jdk/java/security/cert/CertPathBuilder/akiExt/AKISerialNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,6 +118,8 @@ public class AKISerialNumber {
         PKIXBuilderParameters params = new PKIXBuilderParameters
             (Collections.singleton(anchor), sel);
         params.setRevocationEnabled(false);
+        // Set date to 2024-01-01 to satisfy cert constraints
+        params.setDate(new java.util.Date(1704067200000l));
 
         ArrayList<X509Certificate> certs = new ArrayList<>();
         certs.add(intCert);


### PR DESCRIPTION
Clean backport to fix the test.

Additional testing:
 - [x] Affected test fails without the patch, passes with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8325096](https://bugs.openjdk.org/browse/JDK-8325096) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325096](https://bugs.openjdk.org/browse/JDK-8325096): Test java/security/cert/CertPathBuilder/akiExt/AKISerialNumber.java is failing (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/236/head:pull/236` \
`$ git checkout pull/236`

Update a local copy of the PR: \
`$ git checkout pull/236` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 236`

View PR using the GUI difftool: \
`$ git pr show -t 236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/236.diff">https://git.openjdk.org/jdk21u-dev/pull/236.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/236#issuecomment-1929193822)