### PR TITLE
8325194: GHA: Add macOS M1 testing

### DIFF
--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -56,8 +56,14 @@ runs:
 
     - name: 'Build JTReg'
       run: |
+        # If runner architecture is x64 set JAVA_HOME_17_X64 otherwise set to JAVA_HOME_17_arm64
+        if [[ '${{ runner.arch }}' == 'X64' ]]; then
+          JDK="$JAVA_HOME_17_X64"
+        else
+          JDK="$JAVA_HOME_17_arm64"
+        fi
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$(realpath bootjdk/jdk)"
+        bash make/build.sh --jdk "$JDK"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ runs:
     - name: 'Build JTReg'
       run: |
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
+        bash make/build.sh --jdk "$(realpath bootjdk/jdk)"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,9 @@ on:
       platform:
         required: true
         type: string
+      runs-on:
+        required: true
+        type: string
       extra-conf-options:
         required: false
         type: string
@@ -55,7 +58,7 @@ on:
 jobs:
   build-macos:
     name: build
-    runs-on: macos-11
+    runs-on: ${{ inputs.runs-on }}
 
     strategy:
       fail-fast: false
@@ -74,7 +77,7 @@ jobs:
         id: bootjdk
         uses: ./.github/actions/get-bootjdk
         with:
-          platform: macos-x64
+          platform: ${{ inputs.platform }}
 
       - name: 'Get JTReg'
         id: jtreg
@@ -87,7 +90,7 @@ jobs:
       - name: 'Install toolchain and dependencies'
         run: |
           # Run Homebrew installation and xcode-select
-          brew install make
+          brew install autoconf make
           sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-toolset-version }}.app/Contents/Developer
           # This will make GNU make available as 'make' and not only as 'gmake'
           echo '/usr/local/opt/make/libexec/gnubin' >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -227,6 +227,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
+      runs-on: 'macos-11'
       xcode-toolset-version: '12.5.1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -238,8 +239,8 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      xcode-toolset-version: '12.5.1'
-      extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
+      runs-on: 'macos-14'
+      xcode-toolset-version: '14.3.1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-aarch64 == 'true'
@@ -319,6 +320,16 @@ jobs:
       platform: macos-x64
       bootjdk-platform: macos-x64
       runs-on: macos-11
+
+  test-macos-aarch64:
+    name: macos-aarch64
+    needs:
+      - build-macos-aarch64
+    uses: ./.github/workflows/test.yml
+    with:
+      platform: macos-aarch64
+      bootjdk-platform: macos-aarch64
+      runs-on: macos-14
 
   test-windows-x64:
     name: windows-x64

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,10 @@ LINUX_X64_BOOT_JDK_SHA256=bb863b2d542976d1ae4b7b81af3e78b1e4247a64644350b552d298
 MACOS_X64_BOOT_JDK_EXT=tar.gz
 MACOS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk20/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/openjdk-20_macos-x64_bin.tar.gz
 MACOS_X64_BOOT_JDK_SHA256=47cf960d9bb89dbe987535a389f7e26c42de7c984ef5108612d77c81aa8cc6a4
+
+MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
+MACOS_AARCH64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk20/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/openjdk-20_macos-aarch64_bin.tar.gz
+MACOS_AARCH64_BOOT_JDK_SHA256=d020f5c512c043cfb7119a591bc7e599a5bfd76d866d939f5562891d9db7c9b3
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
 WINDOWS_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk20/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/openjdk-20_windows-x64_bin.zip


### PR DESCRIPTION
Now that macOS M1 executors are [available in GitHub actions](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/) it makes sense to move the build to run on M1 (rather than cross-compiled) and also enable testing on the platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8325194](https://bugs.openjdk.org/browse/JDK-8325194) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8325444](https://bugs.openjdk.org/browse/JDK-8325444) needs maintainer approval

### Issues
 * [JDK-8325194](https://bugs.openjdk.org/browse/JDK-8325194): GHA: Add macOS M1 testing (**Enhancement** - P4 - Approved)
 * [JDK-8325444](https://bugs.openjdk.org/browse/JDK-8325444): GHA: JDK-8325194 causes a regression (**Bug** - P3 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/238.diff">https://git.openjdk.org/jdk21u-dev/pull/238.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/238#issuecomment-1930083194)