### PR TITLE
8324598: use mem_unit when working with sysinfo memory and swap related information

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -411,7 +411,7 @@ pid_t os::Linux::gettid() {
 julong os::Linux::host_swap() {
   struct sysinfo si;
   sysinfo(&si);
-  return (julong)si.totalswap;
+  return (julong)(si.totalswap * si.mem_unit);
 }
 
 // Most versions of linux have a bug where the number of processors are

--- a/src/java.base/linux/native/libjava/CgroupMetrics.c
+++ b/src/java.base/linux/native/libjava/CgroupMetrics.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat, Inc.
+ * Copyright (c) 2020, 2024, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,5 +54,5 @@ Java_jdk_internal_platform_CgroupMetrics_getTotalSwapSize0
     if (retval < 0) {
          return 0; // syinfo failed, treat as no swap
     }
-    return (jlong)si.totalswap;
+    return (jlong)(si.totalswap * si.mem_unit);
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8324598](https://bugs.openjdk.org/browse/JDK-8324598) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324598](https://bugs.openjdk.org/browse/JDK-8324598): use mem_unit when working with sysinfo memory and swap related information (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/240/head:pull/240` \
`$ git checkout pull/240`

Update a local copy of the PR: \
`$ git checkout pull/240` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 240`

View PR using the GUI difftool: \
`$ git pr show -t 240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/240.diff">https://git.openjdk.org/jdk21u-dev/pull/240.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/240#issuecomment-1931986225)