### PR TITLE
8324753: [AIX] adjust os_posix after JDK-8318696

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -757,11 +757,11 @@ void os::dll_unload(void *lib) {
 }
 
 jlong os::lseek(int fd, jlong offset, int whence) {
-  return (jlong) ::lseek(fd, offset, whence);
+  return (jlong) AIX_ONLY(::lseek64) NOT_AIX(::lseek)(fd, offset, whence);
 }
 
 int os::ftruncate(int fd, jlong length) {
-   return ::ftruncate(fd, length);
+   return AIX_ONLY(::ftruncate64) NOT_AIX(::ftruncate)(fd, length);
 }
 
 const char* os::get_current_directory(char *buf, size_t buflen) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324753](https://bugs.openjdk.org/browse/JDK-8324753) needs maintainer approval

### Issue
 * [JDK-8324753](https://bugs.openjdk.org/browse/JDK-8324753): [AIX] adjust os_posix after JDK-8318696 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/242.diff">https://git.openjdk.org/jdk21u-dev/pull/242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/242#issuecomment-1932026569)