### PR TITLE
8309109: AArch64: [TESTBUG] compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java fails on Neoverse N2 and V1

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java
@@ -28,6 +28,10 @@
  * @summary Verify UseSHA3Intrinsics option processing on supported CPU.
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires os.arch == "aarch64" & os.family == "mac"
+ * @comment sha3 is only implemented on AArch64 for now.
+ *          UseSHA3Intrinsics is only auto-enabled on Apple silicon, because it
+ *          may introduce performance regression on others. See JDK-8297092.
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [afdaa2a3](https://github.com/openjdk/jdk/commit/afdaa2a3305461538f3a36de2b0b540fe2da9b37) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Hao Sun on 28 Jun 2023 and was reviewed by Andrew Haley and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309109](https://bugs.openjdk.org/browse/JDK-8309109) needs maintainer approval

### Issue
 * [JDK-8309109](https://bugs.openjdk.org/browse/JDK-8309109): AArch64: [TESTBUG] compiler/intrinsics/sha/cli/TestUseSHA3IntrinsicsOptionOnSupportedCPU.java fails on Neoverse N2 and V1 (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/244/head:pull/244` \
`$ git checkout pull/244`

Update a local copy of the PR: \
`$ git checkout pull/244` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 244`

View PR using the GUI difftool: \
`$ git pr show -t 244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/244.diff">https://git.openjdk.org/jdk21u-dev/pull/244.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/244#issuecomment-1932815155)