### PR TITLE
8325150: (tz) Update Timezone Data to 2024a

### DIFF
--- a/src/java.base/share/data/tzdata/VERSION
+++ b/src/java.base/share/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2023d
+tzdata2024a

--- a/src/java.base/share/data/tzdata/africa
+++ b/src/java.base/share/data/tzdata/africa
@@ -53,6 +53,10 @@
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
 # https://www.jstor.org/stable/1774359
 #
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
+#
 # European-style abbreviations are commonly used along the Mediterranean.
 # For sub-Saharan Africa abbreviations were less standardized.
 # Previous editions of this database used WAT, CAT, SAT, and EAT
@@ -136,7 +140,7 @@ Zone Atlantic/Cape_Verde -1:34:04 -	LMT	1912 Jan 01  2:00u # Praia
 
 # Chad
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Ndjamena	1:00:12 -	LMT	1912        # N'Djamena
+Zone	Africa/Ndjamena	1:00:12 -	LMT	1912 Jan  1 # N'Djamena
 			1:00	-	WAT	1979 Oct 14
 			1:00	1:00	WAST	1980 Mar  8
 			1:00	-	WAT
@@ -162,7 +166,7 @@ Zone	Africa/Ndjamena	1:00:12 -	LMT	1912        # N'Djamena
 #	Inaccessible, Nightingale: uninhabited
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Abidjan	-0:16:08 -	LMT	1912
+Zone	Africa/Abidjan	-0:16:08 -	LMT	1912 Jan  1
 			 0:00	-	GMT
 
 ###############################################################################

--- a/src/java.base/share/data/tzdata/asia
+++ b/src/java.base/share/data/tzdata/asia
@@ -2480,18 +2480,33 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # effective December 21st, 2018....
 # http://adilet.zan.kz/rus/docs/P1800000817 (russian language).
 
+# From Zhanbolat Raimbekov (2024-01-19):
+# Kazakhstan (all parts) switching to UTC+5 on March 1, 2024
+# https://www.gov.kz/memleket/entities/mti/press/news/details/688998?lang=ru
+# [in Russian]
+# (2024-01-20): https://primeminister.kz/ru/decisions/19012024-20
+#
+# From Alexander Krivenyshev (2024-01-19):
+# According to a different news and the official web site for the Ministry of
+# Trade and Integration of the Republic of Kazakhstan:
+# https://en.inform.kz/news/kazakhstan-to-switch-to-single-hour-zone-mar-1-54ad0b/
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 #
 # Almaty (formerly Alma-Ata), representing most locations in Kazakhstan
-# This includes KZ-AKM, KZ-ALA, KZ-ALM, KZ-AST, KZ-BAY, KZ-VOS, KZ-ZHA,
-# KZ-KAR, KZ-SEV, KZ-PAV, and KZ-YUZ.
+# This includes Abai/Abay (ISO 3166-2 code KZ-10), Aqmola/Akmola (KZ-11),
+# Almaty (KZ-19), Almaty city (KZ-75), Astana city (KZ-71),
+# East Kazkhstan (KZ-63), Jambyl/Zhambyl (KZ-31), Jetisu/Zhetysu (KZ-33),
+# Karaganda (KZ-35), North Kazakhstan (KZ-59), Pavlodar (KZ-55),
+# Shyumkent city (KZ-79), Turkistan (KZ-61), and Ulytau (KZ-62).
 Zone	Asia/Almaty	5:07:48 -	LMT	1924 May  2 # or Alma-Ata
 			5:00	-	+05	1930 Jun 21
 			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
 			5:00 RussiaAsia	+05/+06	1992 Jan 19  2:00s
 			6:00 RussiaAsia	+06/+07	2004 Oct 31  2:00s
-			6:00	-	+06
-# Qyzylorda (aka Kyzylorda, Kizilorda, Kzyl-Orda, etc.) (KZ-KZY)
+			6:00	-	+06	2024 Mar  1  0:00
+			5:00	-	+05
+# Qyzylorda (aka Kyzylorda, Kizilorda, Kzyl-Orda, etc.) (KZ-43)
 Zone	Asia/Qyzylorda	4:21:52 -	LMT	1924 May  2
 			4:00	-	+04	1930 Jun 21
 			5:00	-	+05	1981 Apr  1
@@ -2504,8 +2519,7 @@ Zone	Asia/Qyzylorda	4:21:52 -	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
 			6:00	-	+06	2018 Dec 21  0:00
 			5:00	-	+05
-#
-# Qostanay (aka Kostanay, Kustanay) (KZ-KUS)
+# Qostanay (aka Kostanay, Kustanay) (KZ-39)
 # The 1991/2 rules are unclear partly because of the 1997 Turgai
 # reorganization.
 Zone	Asia/Qostanay	4:14:28 -	LMT	1924 May  2
@@ -2516,9 +2530,9 @@ Zone	Asia/Qostanay	4:14:28 -	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
 			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
 			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
-			6:00	-	+06
-
-# Aqtöbe (aka Aktobe, formerly Aktyubinsk) (KZ-AKT)
+			6:00	-	+06	2024 Mar  1  0:00
+			5:00	-	+05
+# Aqtöbe (aka Aktobe, formerly Aktyubinsk) (KZ-15)
 Zone	Asia/Aqtobe	3:48:40	-	LMT	1924 May  2
 			4:00	-	+04	1930 Jun 21
 			5:00	-	+05	1981 Apr  1
@@ -2528,7 +2542,7 @@ Zone	Asia/Aqtobe	3:48:40	-	LMT	1924 May  2
 			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
 			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
 			5:00	-	+05
-# Mangghystaū (KZ-MAN)
+# Mangghystaū (KZ-47)
 # Aqtau was not founded until 1963, but it represents an inhabited region,
 # so include timestamps before 1963.
 Zone	Asia/Aqtau	3:21:04	-	LMT	1924 May  2
@@ -2540,7 +2554,7 @@ Zone	Asia/Aqtau	3:21:04	-	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	1994 Sep 25  2:00s
 			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
 			5:00	-	+05
-# Atyraū (KZ-ATY) is like Mangghystaū except it switched from
+# Atyraū (KZ-23) is like Mangghystaū except it switched from
 # +04/+05 to +05/+06 in spring 1999, not fall 1994.
 Zone	Asia/Atyrau	3:27:44	-	LMT	1924 May  2
 			3:00	-	+03	1930 Jun 21
@@ -2551,7 +2565,7 @@ Zone	Asia/Atyrau	3:27:44	-	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	1999 Mar 28  2:00s
 			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
 			5:00	-	+05
-# West Kazakhstan (KZ-ZAP)
+# West Kazakhstan (KZ-27)
 # From Paul Eggert (2016-03-18):
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 Zone	Asia/Oral	3:25:24	-	LMT	1924 May  2 # or Ural'sk
@@ -3453,19 +3467,26 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # ... winter time will begin in Palestine from Saturday 10-28-2023,
 # 02:00 AM by 60 minutes back.
 #
-# From Paul Eggert (2023-03-22):
+# From Heba Hamad (2024-01-25):
+# the summer time for the years 2024,2025 will begin in Palestine
+# from Saturday at 02:00 AM by 60 minutes forward as shown below:
+# year date
+# 2024 2024-04-20
+# 2025 2025-04-12
+#
+# From Paul Eggert (2024-01-25):
 # For now, guess that spring and fall transitions will normally
 # continue to use 2022's rules, that during DST Palestine will switch
 # to standard time at 02:00 the last Saturday before Ramadan and back
-# to DST at 02:00 the first Saturday after Ramadan, and that
+# to DST at 02:00 the second Saturday after Ramadan, and that
 # if the normal spring-forward or fall-back transition occurs during
 # Ramadan the former is delayed and the latter advanced.
 # To implement this, I predicted Ramadan-oriented transition dates for
-# 2023 through 2086 by running the following program under GNU Emacs 28.2,
+# 2026 through 2086 by running the following program under GNU Emacs 29.2,
 # with the results integrated by hand into the table below.
 # Predictions after 2086 are approximated without Ramadan.
 #
-# (let ((islamic-year 1444))
+# (let ((islamic-year 1447))
 #   (require 'cal-islam)
 #   (while (< islamic-year 1510)
 #     (let ((a (calendar-islamic-to-absolute (list 9 1 islamic-year)))
@@ -3474,6 +3495,7 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 #       (while (/= saturday (mod (setq a (1- a)) 7)))
 #       (while (/= saturday (mod b 7))
 #         (setq b (1+ b)))
+#       (setq b (+ 7 b))
 #       (setq a (calendar-gregorian-from-absolute a))
 #       (setq b (calendar-gregorian-from-absolute b))
 #       (insert
@@ -3524,84 +3546,84 @@ Rule Palestine	2021	only	-	Oct	29	1:00	0	-
 Rule Palestine	2022	only	-	Mar	27	0:00	1:00	S
 Rule Palestine	2022	2035	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2023	only	-	Apr	29	2:00	1:00	S
-Rule Palestine	2024	only	-	Apr	13	2:00	1:00	S
-Rule Palestine	2025	only	-	Apr	 5	2:00	1:00	S
+Rule Palestine	2024	only	-	Apr	20	2:00	1:00	S
+Rule Palestine	2025	only	-	Apr	12	2:00	1:00	S
 Rule Palestine	2026	2054	-	Mar	Sat<=30	2:00	1:00	S
 Rule Palestine	2036	only	-	Oct	18	2:00	0	-
 Rule Palestine	2037	only	-	Oct	10	2:00	0	-
 Rule Palestine	2038	only	-	Sep	25	2:00	0	-
 Rule Palestine	2039	only	-	Sep	17	2:00	0	-
-Rule Palestine	2039	only	-	Oct	22	2:00	1:00	S
-Rule Palestine	2039	2067	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2040	only	-	Sep	 1	2:00	0	-
-Rule Palestine	2040	only	-	Oct	13	2:00	1:00	S
+Rule Palestine	2040	only	-	Oct	20	2:00	1:00	S
+Rule Palestine	2040	2067	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2041	only	-	Aug	24	2:00	0	-
-Rule Palestine	2041	only	-	Sep	28	2:00	1:00	S
+Rule Palestine	2041	only	-	Oct	 5	2:00	1:00	S
 Rule Palestine	2042	only	-	Aug	16	2:00	0	-
-Rule Palestine	2042	only	-	Sep	20	2:00	1:00	S
+Rule Palestine	2042	only	-	Sep	27	2:00	1:00	S
 Rule Palestine	2043	only	-	Aug	 1	2:00	0	-
-Rule Palestine	2043	only	-	Sep	12	2:00	1:00	S
+Rule Palestine	2043	only	-	Sep	19	2:00	1:00	S
 Rule Palestine	2044	only	-	Jul	23	2:00	0	-
-Rule Palestine	2044	only	-	Aug	27	2:00	1:00	S
+Rule Palestine	2044	only	-	Sep	 3	2:00	1:00	S
 Rule Palestine	2045	only	-	Jul	15	2:00	0	-
-Rule Palestine	2045	only	-	Aug	19	2:00	1:00	S
+Rule Palestine	2045	only	-	Aug	26	2:00	1:00	S
 Rule Palestine	2046	only	-	Jun	30	2:00	0	-
-Rule Palestine	2046	only	-	Aug	11	2:00	1:00	S
+Rule Palestine	2046	only	-	Aug	18	2:00	1:00	S
 Rule Palestine	2047	only	-	Jun	22	2:00	0	-
-Rule Palestine	2047	only	-	Jul	27	2:00	1:00	S
+Rule Palestine	2047	only	-	Aug	 3	2:00	1:00	S
 Rule Palestine	2048	only	-	Jun	 6	2:00	0	-
-Rule Palestine	2048	only	-	Jul	18	2:00	1:00	S
+Rule Palestine	2048	only	-	Jul	25	2:00	1:00	S
 Rule Palestine	2049	only	-	May	29	2:00	0	-
-Rule Palestine	2049	only	-	Jul	 3	2:00	1:00	S
+Rule Palestine	2049	only	-	Jul	10	2:00	1:00	S
 Rule Palestine	2050	only	-	May	21	2:00	0	-
-Rule Palestine	2050	only	-	Jun	25	2:00	1:00	S
+Rule Palestine	2050	only	-	Jul	 2	2:00	1:00	S
 Rule Palestine	2051	only	-	May	 6	2:00	0	-
-Rule Palestine	2051	only	-	Jun	17	2:00	1:00	S
+Rule Palestine	2051	only	-	Jun	24	2:00	1:00	S
 Rule Palestine	2052	only	-	Apr	27	2:00	0	-
-Rule Palestine	2052	only	-	Jun	 1	2:00	1:00	S
+Rule Palestine	2052	only	-	Jun	 8	2:00	1:00	S
 Rule Palestine	2053	only	-	Apr	12	2:00	0	-
-Rule Palestine	2053	only	-	May	24	2:00	1:00	S
+Rule Palestine	2053	only	-	May	31	2:00	1:00	S
 Rule Palestine	2054	only	-	Apr	 4	2:00	0	-
-Rule Palestine	2054	only	-	May	16	2:00	1:00	S
-Rule Palestine	2055	only	-	May	 1	2:00	1:00	S
-Rule Palestine	2056	only	-	Apr	22	2:00	1:00	S
-Rule Palestine	2057	only	-	Apr	 7	2:00	1:00	S
-Rule Palestine	2058	max	-	Mar	Sat<=30	2:00	1:00	S
+Rule Palestine	2054	only	-	May	23	2:00	1:00	S
+Rule Palestine	2055	only	-	May	 8	2:00	1:00	S
+Rule Palestine	2056	only	-	Apr	29	2:00	1:00	S
+Rule Palestine	2057	only	-	Apr	14	2:00	1:00	S
+Rule Palestine	2058	only	-	Apr	 6	2:00	1:00	S
+Rule Palestine	2059	max	-	Mar	Sat<=30	2:00	1:00	S
 Rule Palestine	2068	only	-	Oct	20	2:00	0	-
 Rule Palestine	2069	only	-	Oct	12	2:00	0	-
 Rule Palestine	2070	only	-	Oct	 4	2:00	0	-
 Rule Palestine	2071	only	-	Sep	19	2:00	0	-
 Rule Palestine	2072	only	-	Sep	10	2:00	0	-
-Rule Palestine	2072	only	-	Oct	15	2:00	1:00	S
+Rule Palestine	2072	only	-	Oct	22	2:00	1:00	S
 Rule Palestine	2072	max	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2073	only	-	Sep	 2	2:00	0	-
-Rule Palestine	2073	only	-	Oct	 7	2:00	1:00	S
+Rule Palestine	2073	only	-	Oct	14	2:00	1:00	S
 Rule Palestine	2074	only	-	Aug	18	2:00	0	-
-Rule Palestine	2074	only	-	Sep	29	2:00	1:00	S
+Rule Palestine	2074	only	-	Oct	 6	2:00	1:00	S
 Rule Palestine	2075	only	-	Aug	10	2:00	0	-
-Rule Palestine	2075	only	-	Sep	14	2:00	1:00	S
+Rule Palestine	2075	only	-	Sep	21	2:00	1:00	S
 Rule Palestine	2076	only	-	Jul	25	2:00	0	-
-Rule Palestine	2076	only	-	Sep	 5	2:00	1:00	S
+Rule Palestine	2076	only	-	Sep	12	2:00	1:00	S
 Rule Palestine	2077	only	-	Jul	17	2:00	0	-
-Rule Palestine	2077	only	-	Aug	28	2:00	1:00	S
+Rule Palestine	2077	only	-	Sep	 4	2:00	1:00	S
 Rule Palestine	2078	only	-	Jul	 9	2:00	0	-
-Rule Palestine	2078	only	-	Aug	13	2:00	1:00	S
+Rule Palestine	2078	only	-	Aug	20	2:00	1:00	S
 Rule Palestine	2079	only	-	Jun	24	2:00	0	-
-Rule Palestine	2079	only	-	Aug	 5	2:00	1:00	S
+Rule Palestine	2079	only	-	Aug	12	2:00	1:00	S
 Rule Palestine	2080	only	-	Jun	15	2:00	0	-
-Rule Palestine	2080	only	-	Jul	20	2:00	1:00	S
+Rule Palestine	2080	only	-	Jul	27	2:00	1:00	S
 Rule Palestine	2081	only	-	Jun	 7	2:00	0	-
-Rule Palestine	2081	only	-	Jul	12	2:00	1:00	S
+Rule Palestine	2081	only	-	Jul	19	2:00	1:00	S
 Rule Palestine	2082	only	-	May	23	2:00	0	-
-Rule Palestine	2082	only	-	Jul	 4	2:00	1:00	S
+Rule Palestine	2082	only	-	Jul	11	2:00	1:00	S
 Rule Palestine	2083	only	-	May	15	2:00	0	-
-Rule Palestine	2083	only	-	Jun	19	2:00	1:00	S
+Rule Palestine	2083	only	-	Jun	26	2:00	1:00	S
 Rule Palestine	2084	only	-	Apr	29	2:00	0	-
-Rule Palestine	2084	only	-	Jun	10	2:00	1:00	S
+Rule Palestine	2084	only	-	Jun	17	2:00	1:00	S
 Rule Palestine	2085	only	-	Apr	21	2:00	0	-
-Rule Palestine	2085	only	-	Jun	 2	2:00	1:00	S
+Rule Palestine	2085	only	-	Jun	 9	2:00	1:00	S
 Rule Palestine	2086	only	-	Apr	13	2:00	0	-
-Rule Palestine	2086	only	-	May	18	2:00	1:00	S
+Rule Palestine	2086	only	-	May	25	2:00	1:00	S
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct
@@ -3629,7 +3651,7 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 
 # Philippines
 
-# From Paul Eggert (2018-11-18):
+# From Paul Eggert (2024-01-21):
 # The Spanish initially used American (west-of-Greenwich) time.
 # It is unknown what time Manila kept when the British occupied it from
 # 1762-10-06 through 1764-04; for now assume it kept American time.
@@ -3637,7 +3659,7 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 # Philippines, issued a proclamation announcing that 1844-12-30 was to
 # be immediately followed by 1845-01-01; see R.H. van Gent's
 # History of the International Date Line
-# https://www.staff.science.uu.nl/~gent0113/idl/idl_philippines.htm
+# https://webspace.science.uu.nl/~gent0113/idl/idl_philippines.htm
 # The rest of the data entries are from Shanks & Pottenger.
 
 # From Jesper Nørgaard Welen (2006-04-26):
@@ -4064,7 +4086,8 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 # The English-language name of Vietnam's most populous city is "Ho Chi Minh
 # City"; use Ho_Chi_Minh below to avoid a name of more than 14 characters.
 
-# From Paul Eggert (2022-07-27) after a 2014 heads-up from Trần Ngọc Quân:
+# From Paul Eggert (2024-01-14) after a 2014 heads-up from Trần Ngọc Quân
+# and a 2024-01-14 heads-up from Đoàn Trần Công Danh:
 # Trần Tiến Bình's authoritative book "Lịch Việt Nam: thế kỷ XX-XXI (1901-2100)"
 # (Nhà xuất bản Văn Hoá - Thông Tin, Hanoi, 2005), pp 49-50,
 # is quoted verbatim in:
@@ -4094,14 +4117,35 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 #
 # Trần cites the following sources; it's unclear which supplied the info above.
 #
-# Hoàng Xuân Hãn: "Lịch và lịch Việt Nam". Tập san Khoa học Xã hội,
-# No. 9, Paris, February 1982.
+#   Hoàng Xuân Hãn: "Lịch và lịch Việt Nam". Tập san Khoa học Xã hội,
+#   No. 9, Paris, February 1982.
 #
-# Lê Thành Lân: "Lịch và niên biểu lịch sử hai mươi thế kỷ (0001-2010)",
-# NXB Thống kê, Hanoi, 2000.
+#   Lê Thành Lân: "Lịch và niên biểu lịch sử hai mươi thế kỷ (0001-2010)",
+#   NXB Thống kê, Hanoi, 2000.
 #
-# Lê Thành Lân: "Lịch hai thế kỷ (1802-2010) và các lịch vĩnh cửu",
-# NXB Thuận Hoá, Huế, 1995.
+#   Lê Thành Lân: "Lịch hai thế kỷ (1802-2010) và các lịch vĩnh cửu",
+#   NXB Thuận Hoá, Huế, 1995.
+#
+# Here is the decision for the September 1945 transition:
+# Võ Nguyên Giáp, Việt Nam Dân Quốc Công Báo, No. 1 (1945-09-29), page 13
+# http://baochi.nlv.gov.vn/baochi/cgi-bin/baochi?a=d&d=JwvzO19450929.2.5&dliv=none
+# It says that on 1945-09-01 at 24:00, Vietnam moved back two hours, to +07.
+# It also mentions a 1945-03-29 decree (by a Japanese Goveror-General)
+# to set the time zone to +09, but does not say whether that decree
+# merely legalized an earlier change to +09.
+#
+# July 1955 transition:
+# Ngô Đình Diệm, Công Báo Việt Nam, No. 92 (1955-07-02), page 1780-1781
+# Ordinance (Dụ) No. 46 (1955-06-25)
+# http://ddsnext.crl.edu/titles/32341#?c=0&m=29&s=0&cv=4&r=0&xywh=-89%2C342%2C1724%2C1216
+# It says that on 1955-07-01 at 01:00, South Vietnam moved back 1 hour (to +07).
+#
+# December 1959 transition:
+# Ngô Đình Diệm, Công Báo Việt Nam Cộng Hòa, 1960 part 1 (1960-01-02), page 62
+# Decree (Sắc lệnh) No. 362-TTP (1959-12-30)
+# http://ddsnext.crl.edu/titles/32341#?c=0&m=138&s=0&cv=793&r=0&xywh=-54%2C1504%2C1705%2C1202
+# It says that on 1959-12-31 at 23:00, South Vietnam moved forward 1 hour (to +08).
+
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 		#STDOFF	7:06:30.13
@@ -4109,9 +4153,9 @@ Zone Asia/Ho_Chi_Minh	7:06:30 -	LMT	1906 Jul  1
 			7:06:30	-	PLMT	1911 May  1 # Phù Liễn MT
 			7:00	-	+07	1942 Dec 31 23:00
 			8:00	-	+08	1945 Mar 14 23:00
-			9:00	-	+09	1945 Sep  2
+			9:00	-	+09	1945 Sep  1 24:00
 			7:00	-	+07	1947 Apr  1
-			8:00	-	+08	1955 Jul  1
+			8:00	-	+08	1955 Jul  1 01:00
 			7:00	-	+07	1959 Dec 31 23:00
 			8:00	-	+08	1975 Jun 13
 			7:00	-	+07

--- a/src/java.base/share/data/tzdata/australasia
+++ b/src/java.base/share/data/tzdata/australasia
@@ -443,11 +443,11 @@ Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
 
 # French Polynesia
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Gambier	 -8:59:48 -	LMT	1912 Oct # Rikitea
+Zone	Pacific/Gambier	 -8:59:48 -	LMT	1912 Oct  1 # Rikitea
 			 -9:00	-	-09
-Zone	Pacific/Marquesas -9:18:00 -	LMT	1912 Oct
+Zone	Pacific/Marquesas -9:18:00 -	LMT	1912 Oct  1
 			 -9:30	-	-0930
-Zone	Pacific/Tahiti	 -9:58:16 -	LMT	1912 Oct # Papeete
+Zone	Pacific/Tahiti	 -9:58:16 -	LMT	1912 Oct  1 # Papeete
 			-10:00	-	-10
 # Clipperton (near North America) is administered from French Polynesia;
 # it is uninhabited.
@@ -825,7 +825,7 @@ Zone Pacific/Apia	 12:33:04 -	LMT	1892 Jul  5
 # Solomon Is
 # excludes Bougainville, for which see Papua New Guinea
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct # Honiara
+Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct  1 # Honiara
 			11:00	-	+11
 
 # Tokelau
@@ -985,6 +985,10 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # For data circa 1899, a common source is:
 # Milne J. Civil time. Geogr J. 1899 Feb;13(2):173-94.
 # https://www.jstor.org/stable/1774359
+#
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
 #
 # A reliable and entertaining source about time zones is
 # Derek Howse, Greenwich time and longitude, Philip Wilson Publishers (1997).
@@ -2062,7 +2066,7 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # ordaining - by a masterpiece of diplomatic flattery - that
 # the Fourth of July should be celebrated twice in that year."
 # This happened in 1892, according to the Evening News (Sydney) of 1892-07-20.
-# https://www.staff.science.uu.nl/~gent0113/idl/idl.htm
+# https://webspace.science.uu.nl/~gent0113/idl/idl_alaska_samoa.htm
 
 # Although Shanks & Pottenger says they both switched to UT -11:30
 # in 1911, and to -11 in 1950. many earlier sources give -11

--- a/src/java.base/share/data/tzdata/etcetera
+++ b/src/java.base/share/data/tzdata/etcetera
@@ -28,7 +28,7 @@
 
 # These entries are for uses not otherwise covered by the tz database.
 # Their main practical use is for platforms like Android that lack
-# support for POSIX-style TZ strings.  On such platforms these entries
+# support for POSIX.1-2017-style TZ strings.  On such platforms these entries
 # can be useful if the timezone database is wrong or if a ship or
 # aircraft at sea is not in a timezone.
 

--- a/src/java.base/share/data/tzdata/europe
+++ b/src/java.base/share/data/tzdata/europe
@@ -1013,9 +1013,34 @@ Zone	Europe/Sofia	1:33:16 -	LMT	1880
 # Czech Republic (Czechia)
 # Slovakia
 #
-# From Paul Eggert (2018-04-15):
-# The source for Czech data is: Kdy začíná a končí letní čas. 2018-04-15.
+# From Ivan Benovic (2024-01-30):
+# https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1946/54/
+# (This is an official link to the Czechoslovak Summer Time Act of
+# March 8, 1946 that authorizes the Czechoslovak government to set the
+# exact dates of change to summer time and back to Central European Time.
+# The act also implicitly confirms Central European Time as the
+# official time zone of Czechoslovakia and currently remains in force
+# in both the Czech Republic and Slovakia.)
+# https://www.psp.cz/eknih/1945pns/tisky/t0216_00.htm
+# (This is a link to the original legislative proposal dating back to
+# February 22, 1946. The accompanying memorandum to the proposal says
+# that an advisory committee on European railroad transportation that
+# met in Brussels in October 1945 decided that the change of time
+# should be carried out in all participating countries in a strictly
+# coordinated manner....)
+#
+# From Paul Eggert (2024-01-30):
+# The source for Czech data is: Kdy začíná a končí letní čas.
 # https://kalendar.beda.cz/kdy-zacina-a-konci-letni-cas
+# Its main text disagrees with its quoted sources only in 1918,
+# where the main text says spring and autumn transitions
+# occurred at 02:00 and 03:00 respectively (as usual),
+# whereas the 1918 source "Oznámení o zavedení letního času v roce 1918"
+# says transitions were at 01:00 and 02:00 respectively.
+# As the 1918 source appears to be a humorous piece, and it is
+# unlikely that Prague would have disagreed with its neighbors by an hour,
+# go with the main text for now.
+#
 # We know of no English-language name for historical Czech winter time;
 # abbreviate it as "GMT", as it happened to be GMT.
 #

--- a/src/java.base/share/data/tzdata/leapseconds
+++ b/src/java.base/share/data/tzdata/leapseconds
@@ -26,13 +26,10 @@
 # This file is in the public domain.
 
 # This file is generated automatically from the data in the public-domain
-# NIST format leap-seconds.list file, which can be copied from
-# <ftp://ftp.nist.gov/pub/time/leap-seconds.list>
-# or <ftp://ftp.boulder.nist.gov/pub/time/leap-seconds.list>.
-# The NIST file is used instead of its IERS upstream counterpart
+# NIST/IERS format leap-seconds.list file, which can be copied from
 # <https://hpiers.obspm.fr/iers/bul/bulc/ntp/leap-seconds.list>
-# because under US law the NIST file is public domain
-# whereas the IERS file's copyright and license status is unclear.
+# or, in a variant with different comments, from
+# <ftp://ftp.boulder.nist.gov/pub/time/leap-seconds.list>.
 # For more about leap-seconds.list, please see
 # The NTP Timescale and Leap Seconds
 # <https://www.eecis.udel.edu/~mills/leap.html>.
@@ -95,11 +92,11 @@ Leap	2016	Dec	31	23:59:60	+	S
 # Any additional leap seconds will come after this.
 # This Expires line is commented out for now,
 # so that pre-2020a zic implementations do not reject this file.
-#Expires 2024	Jun	28	00:00:00
+#Expires 2024	Dec	28	00:00:00
 
 # POSIX timestamps for the data in this file:
-#updated 1467936000 (2016-07-08 00:00:00 UTC)
-#expires 1719532800 (2024-06-28 00:00:00 UTC)
+#updated 1704708379 (2024-01-08 10:06:19 UTC)
+#expires 1735344000 (2024-12-28 00:00:00 UTC)
 
-#	Updated through IERS Bulletin C66
-#	File expires on:  28 June 2024
+#	Updated through IERS Bulletin C (https://hpiers.obspm.fr/iers/bul/bulc/bulletinc.dat)
+#	File expires on 28 December 2024

--- a/src/java.base/share/data/tzdata/northamerica
+++ b/src/java.base/share/data/tzdata/northamerica
@@ -1291,6 +1291,10 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 #	<http://cs.ucla.edu/~eggert/The-Waste-of-Daylight-19th.pdf>
 #	[PDF] (1914-03)
 #
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
+#
 # See the 'europe' file for Greenland.
 
 # Canada
@@ -1377,7 +1381,7 @@ Zone America/Menominee	-5:50:27 -	LMT	1885 Sep 18 12:00
 # From Paul Eggert (2014-10-18):
 # H. David Matthews and Mary Vincent's map
 # "It's about TIME", _Canadian Geographic_ (September-October 1998)
-# http://www.canadiangeographic.ca/Magazine/SO98/alacarte.asp
+# https://web.archive.org/web/19990827055050/https://canadiangeographic.ca/SO98/geomap.htm
 # contains detailed boundaries for regions observing nonstandard
 # time and daylight saving time arrangements in Canada circa 1998.
 #
@@ -1665,6 +1669,15 @@ Zone America/Moncton	-4:19:08 -	LMT	1883 Dec  9
 #     Some cities in the United States have pushed the deadline back
 #     three weeks and will change over from daylight saving in October.
 
+# From Chris Walton (2024-01-09):
+# The [Toronto] changes in 1947, 1948, and 1949 took place at 2:00 a.m. local
+# time instead of midnight....  Toronto Daily Star - ...
+# April 2, 1947 - Page 39 ... April 7, 1948 - Page 13 ...
+# April 2, 1949 - Page 1 ... April 7, 1949 - Page 24 ...
+# November 25, 1949 - Page 52 ... April 21, 1950 - Page 14 ...
+# September 19, 1950 - Page 46 ... September 20, 1950 - Page 3 ...
+# November 24, 1950 - Page 21
+
 # From Arthur David Olson (2010-07-17):
 #
 # "Standard Time and Time Zones in Canada" appeared in
@@ -1726,13 +1739,9 @@ Rule	Toronto	1927	1937	-	Sep	Sun>=25	2:00	0	S
 Rule	Toronto	1928	1937	-	Apr	Sun>=25	2:00	1:00	D
 Rule	Toronto	1938	1940	-	Apr	lastSun	2:00	1:00	D
 Rule	Toronto	1938	1939	-	Sep	lastSun	2:00	0	S
-Rule	Toronto	1945	1946	-	Sep	lastSun	2:00	0	S
-Rule	Toronto	1946	only	-	Apr	lastSun	2:00	1:00	D
-Rule	Toronto	1947	1949	-	Apr	lastSun	0:00	1:00	D
-Rule	Toronto	1947	1948	-	Sep	lastSun	0:00	0	S
-Rule	Toronto	1949	only	-	Nov	lastSun	0:00	0	S
-Rule	Toronto	1950	1973	-	Apr	lastSun	2:00	1:00	D
-Rule	Toronto	1950	only	-	Nov	lastSun	2:00	0	S
+Rule	Toronto	1945	1948	-	Sep	lastSun	2:00	0	S
+Rule	Toronto	1946	1973	-	Apr	lastSun	2:00	1:00	D
+Rule	Toronto	1949	1950	-	Nov	lastSun	2:00	0	S
 Rule	Toronto	1951	1956	-	Sep	lastSun	2:00	0	S
 # Shanks & Pottenger say Toronto ended DST a week early in 1971,
 # namely on 1971-10-24, but Mark Brader wrote (2003-05-31) that this
@@ -3455,7 +3464,7 @@ Zone	America/Jamaica	-5:07:10 -	LMT	1890        # Kingston
 # Martinique
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Martinique	-4:04:20 -      LMT	1890        # Fort-de-France
-			-4:04:20 -	FFMT	1911 May    # Fort-de-France MT
+			-4:04:20 -	FFMT	1911 May  1 # Fort-de-France MT
 			-4:00	-	AST	1980 Apr  6
 			-4:00	1:00	ADT	1980 Sep 28
 			-4:00	-	AST
@@ -3562,7 +3571,7 @@ Zone America/Puerto_Rico -4:24:25 -	LMT	1899 Mar 28 12:00 # San Juan
 # St Pierre and Miquelon
 # There are too many St Pierres elsewhere, so we'll use 'Miquelon'.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
+Zone America/Miquelon	-3:44:40 -	LMT	1911 Jun 15 # St Pierre
 			-4:00	-	AST	1980 May
 			-3:00	-	-03	1987
 			-3:00	Canada	-03/-02

--- a/src/java.base/share/data/tzdata/southamerica
+++ b/src/java.base/share/data/tzdata/southamerica
@@ -1593,8 +1593,11 @@ Zone Atlantic/Stanley	-3:51:24 -	LMT	1890
 			-3:00	-	-03
 
 # French Guiana
+# For the 1911/1912 establishment of standard time in French possessions, see:
+# Société Française de Physique, Recueil de constantes physiques (1913),
+# page 752, 18b.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul
+Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul  1
 			-4:00	-	-04	1967 Oct
 			-3:00	-	-03
 

--- a/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
@@ -1,1 +1,1 @@
-tzdata2023d
+tzdata2024a


### PR DESCRIPTION
Backporting tz2024a, local build and relevant tests passing on linux x64.

`make run-test TEST="jdk/java/util/TimeZone jdk/java/time/test jdk/sun/util/resources jdk/sun/text/resources jdk/sun/util/calendar"`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325150](https://bugs.openjdk.org/browse/JDK-8325150) needs maintainer approval

### Issue
 * [JDK-8325150](https://bugs.openjdk.org/browse/JDK-8325150): (tz) Update Timezone Data to 2024a (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/248/head:pull/248` \
`$ git checkout pull/248`

Update a local copy of the PR: \
`$ git checkout pull/248` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 248`

View PR using the GUI difftool: \
`$ git pr show -t 248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/248.diff">https://git.openjdk.org/jdk21u-dev/pull/248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/248#issuecomment-1934735029)