### PR TITLE
8323667: Library debug files contain non-reproducible full gcc include paths

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -117,6 +117,11 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
       FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${DEBUG_PREFIX_CFLAGS}],
         IF_FALSE: [
             DEBUG_PREFIX_CFLAGS=
+        ],
+        IF_TRUE: [
+            # Add debug prefix map gcc system include paths, as they cause
+            # non-deterministic debug paths depending on gcc path location.
+            DEBUG_PREFIX_MAP_GCC_INCLUDE_PATHS
         ]
       )
     fi
@@ -156,6 +161,55 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
 
   AC_SUBST(CFLAGS_DEBUG_SYMBOLS)
   AC_SUBST(ASFLAGS_DEBUG_SYMBOLS)
+])
+
+# gcc will embed the full system include paths in the debug info
+# resulting in non-deterministic debug symbol files and thus
+# non-reproducible native libraries if gcc includes are located
+# in different paths.
+# Add -fdebug-prefix-map'ings for root and gcc include paths,
+# pointing to a common set of folders so that the binaries are deterministic:
+#  root include : /usr/include
+#  gcc include  : /usr/local/gcc_include
+#  g++ include  : /usr/local/gxx_include
+AC_DEFUN([DEBUG_PREFIX_MAP_GCC_INCLUDE_PATHS],
+[
+    # Determine gcc system include paths.
+    # Assume default roots to start with:
+    GCC_ROOT_INCLUDE="/usr/include"
+
+    # Determine is sysroot or devkit specified?
+    if test "x$SYSROOT" != "x"; then
+      GCC_ROOT_INCLUDE="${SYSROOT%/}/usr/include"
+    fi
+
+    # Add root include mapping => /usr/include
+    GCC_INCLUDE_DEBUG_MAP_FLAGS="-fdebug-prefix-map=${GCC_ROOT_INCLUDE}/=/usr/include/"
+
+    # Add gcc system include mapping => /usr/local/gcc_include
+    #   Find location of stddef.h using build C compiler
+    GCC_SYSTEM_INCLUDE=`$ECHO "#include <stddef.h>" | \
+                        $CC $CFLAGS -v -E - 2>&1 | \
+                        $GREP stddef | $TAIL -1 | $TR -s " " | $CUT -d'"' -f2`
+    if test "x$GCC_SYSTEM_INCLUDE" != "x"; then
+      GCC_SYSTEM_INCLUDE=`$DIRNAME $GCC_SYSTEM_INCLUDE`
+      GCC_INCLUDE_DEBUG_MAP_FLAGS="$GCC_INCLUDE_DEBUG_MAP_FLAGS \
+          -fdebug-prefix-map=${GCC_SYSTEM_INCLUDE}/=/usr/local/gcc_include/"
+    fi
+
+    # Add g++ system include mapping => /usr/local/gxx_include
+    #   Find location of cstddef using build C++ compiler
+    GXX_SYSTEM_INCLUDE=`$ECHO "#include <cstddef>" | \
+                        $CXX $CXXFLAGS -v -E -x c++ - 2>&1 | \
+                        $GREP cstddef | $TAIL -1 | $TR -s " " | $CUT -d'"' -f2`
+    if test "x$GXX_SYSTEM_INCLUDE" != "x"; then
+      GXX_SYSTEM_INCLUDE=`$DIRNAME $GXX_SYSTEM_INCLUDE`
+      GCC_INCLUDE_DEBUG_MAP_FLAGS="$GCC_INCLUDE_DEBUG_MAP_FLAGS \
+          -fdebug-prefix-map=${GXX_SYSTEM_INCLUDE}/=/usr/local/gxx_include/"
+    fi
+
+    # Add to debug prefix cflags
+    DEBUG_PREFIX_CFLAGS="$DEBUG_PREFIX_CFLAGS $GCC_INCLUDE_DEBUG_MAP_FLAGS"
 ])
 
 AC_DEFUN([FLAGS_SETUP_WARNINGS],


### PR DESCRIPTION
Native library debug files contain the full gcc system include paths, which then results in the native library being non-reproducible (via the CRC bytes), if built with differing gcc include path location.
This is a backport of the jdk fix to -fdebug-prefix-map these gcc paths when absolute paths are not allowed for a release build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323667](https://bugs.openjdk.org/browse/JDK-8323667) needs maintainer approval

### Issue
 * [JDK-8323667](https://bugs.openjdk.org/browse/JDK-8323667): Library debug files contain non-reproducible full gcc include paths (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/251/head:pull/251` \
`$ git checkout pull/251`

Update a local copy of the PR: \
`$ git checkout pull/251` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 251`

View PR using the GUI difftool: \
`$ git pr show -t 251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/251.diff">https://git.openjdk.org/jdk21u-dev/pull/251.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/251#issuecomment-1936054298)