### PR TITLE
8315891: java/foreign/TestLinker.java failed with "error occurred while instantiating class TestLinker: null"

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
@@ -36,14 +36,20 @@ final class LibFallback {
 
     static final boolean SUPPORTED = tryLoadLibrary();
 
+    @SuppressWarnings("removal")
     private static boolean tryLoadLibrary() {
-        try {
-            System.loadLibrary("fallbackLinker");
-        } catch (UnsatisfiedLinkError ule) {
-            return false;
-        }
-        init();
-        return true;
+        return java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedAction<>() {
+                    public Boolean run() {
+                        try {
+                            System.loadLibrary("fallbackLinker");
+                            init();
+                            return true;
+                        } catch (UnsatisfiedLinkError ule) {
+                            return false;
+                        }
+                    }
+                });
     }
 
     static int defaultABI() { return NativeConstants.DEFAULT_ABI; }


### PR DESCRIPTION
Clean backport to allow fallback linker to work under SecurityManager. Makes [JDK-8318737](https://bugs.openjdk.org/browse/JDK-8318737) backport clean.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `java/foreign` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315891](https://bugs.openjdk.org/browse/JDK-8315891) needs maintainer approval

### Issue
 * [JDK-8315891](https://bugs.openjdk.org/browse/JDK-8315891): java/foreign/TestLinker.java failed with "error occurred while instantiating class TestLinker: null" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/260.diff">https://git.openjdk.org/jdk21u-dev/pull/260.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/260#issuecomment-1941423003)