### PR TITLE
8324514: ClassLoaderData::print_on should print address of class loader

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1009,7 +1009,11 @@ void ClassLoaderData::print_on(outputStream* out) const {
     _holder.print_on(out);
     out->print_cr("");
   }
-  out->print_cr(" - class loader        " INTPTR_FORMAT, p2i(_class_loader.ptr_raw()));
+  if (!_unloading) {
+    out->print_cr(" - class loader        " INTPTR_FORMAT, p2i(_class_loader.peek()));
+  } else {
+    out->print_cr(" - class loader        <unloading, oop is bad>");
+  }
   out->print_cr(" - metaspace           " INTPTR_FORMAT, p2i(_metaspace));
   out->print_cr(" - unloading           %s", _unloading ? "true" : "false");
   out->print_cr(" - class mirror holder %s", _has_class_mirror_holder ? "true" : "false");


### PR DESCRIPTION
Simple diagnostic improvement. Allows better post-mortem diagnostics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324514](https://bugs.openjdk.org/browse/JDK-8324514) needs maintainer approval

### Issue
 * [JDK-8324514](https://bugs.openjdk.org/browse/JDK-8324514): ClassLoaderData::print_on should print address of class loader (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/264/head:pull/264` \
`$ git checkout pull/264`

Update a local copy of the PR: \
`$ git checkout pull/264` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 264`

View PR using the GUI difftool: \
`$ git pr show -t 264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/264.diff">https://git.openjdk.org/jdk21u-dev/pull/264.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/264#issuecomment-1944042180)