### PR TITLE
8318737: Fallback linker passes bad JNI handle

### DIFF
--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -199,13 +199,9 @@ jobjectRefType JNIHandles::handle_type(JavaThread* thread, jobject handle) {
     default:
       ShouldNotReachHere();
     }
-  } else {
+  } else if (is_local_handle(thread, handle) || is_frame_handle(thread, handle)) {
     // Not in global storage.  Might be a local handle.
-    if (is_local_handle(thread, handle) || is_frame_handle(thread, handle)) {
-      result = JNILocalRefType;
-    } else {
-      ShouldNotReachHere();
-    }
+    result = JNILocalRefType;
   }
   return result;
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
@@ -43,11 +43,14 @@ final class LibFallback {
                     public Boolean run() {
                         try {
                             System.loadLibrary("fallbackLinker");
-                            init();
-                            return true;
                         } catch (UnsatisfiedLinkError ule) {
                             return false;
                         }
+                        if (!init()) {
+                            // library failed to initialize. Do not silently mark as unsupported
+                            throw new ExceptionInInitializerError("Fallback library failed to initialize");
+                        }
+                        return true;
                     }
                 });
     }
@@ -195,7 +198,7 @@ final class LibFallback {
         }
     }
 
-    private static native void init();
+    private static native boolean init();
 
     private static native long sizeofCif();
 

--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -40,12 +40,29 @@ static jclass LibFallback_class;
 static jmethodID LibFallback_doUpcall_ID;
 static const char* LibFallback_doUpcall_sig = "(JJLjava/lang/invoke/MethodHandle;)V";
 
-JNIEXPORT void JNICALL
+#define CHECK_NULL(expr) \
+  if (expr == NULL) { \
+    return JNI_FALSE; \
+  }
+
+JNIEXPORT jboolean JNICALL
 Java_jdk_internal_foreign_abi_fallback_LibFallback_init(JNIEnv* env, jclass cls) {
-  (*env)->GetJavaVM(env, &VM);
-  LibFallback_class = (*env)->FindClass(env, "jdk/internal/foreign/abi/fallback/LibFallback");
+  jint result = (*env)->GetJavaVM(env, &VM);
+  if (result != 0) {
+    return JNI_FALSE;
+  }
+
+  jclass LibFallback_class_local = (*env)->FindClass(env, "jdk/internal/foreign/abi/fallback/LibFallback");
+  CHECK_NULL(LibFallback_class_local)
+
+  LibFallback_class = (*env)->NewGlobalRef(env, LibFallback_class_local);
+  CHECK_NULL(LibFallback_class)
+
   LibFallback_doUpcall_ID = (*env)->GetStaticMethodID(env,
     LibFallback_class, "doUpcall", LibFallback_doUpcall_sig);
+  CHECK_NULL(LibFallback_doUpcall_ID)
+
+  return JNI_TRUE;
 }
 
 JNIEXPORT jlong JNICALL

--- a/test/jdk/java/foreign/TestDowncallScope.java
+++ b/test/jdk/java/foreign/TestDowncallScope.java
@@ -28,7 +28,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
- * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ * @run testng/othervm -Xcheck:jni -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestDowncallScope
  *

--- a/test/jdk/java/foreign/TestDowncallStack.java
+++ b/test/jdk/java/foreign/TestDowncallStack.java
@@ -28,7 +28,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
- * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ * @run testng/othervm -Xcheck:jni -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestDowncallStack
  */

--- a/test/jdk/java/foreign/TestUpcallScope.java
+++ b/test/jdk/java/foreign/TestUpcallScope.java
@@ -28,7 +28,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
- * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ * @run testng/othervm -Xcheck:jni -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestUpcallScope
  */

--- a/test/jdk/java/foreign/TestUpcallStack.java
+++ b/test/jdk/java/foreign/TestUpcallStack.java
@@ -28,7 +28,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
- * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ * @run testng/othervm -Xcheck:jni -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestUpcallStack
  */


### PR DESCRIPTION
Clean backport to fix Panama's fallback linker.

Additional testing:
 - [x] Linux x86 server fastdebug, `java/foreign`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318737](https://bugs.openjdk.org/browse/JDK-8318737) needs maintainer approval

### Issue
 * [JDK-8318737](https://bugs.openjdk.org/browse/JDK-8318737): Fallback linker passes bad JNI handle (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/267/head:pull/267` \
`$ git checkout pull/267`

Update a local copy of the PR: \
`$ git checkout pull/267` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 267`

View PR using the GUI difftool: \
`$ git pr show -t 267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/267.diff">https://git.openjdk.org/jdk21u-dev/pull/267.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/267#issuecomment-1951877553)