### PR TITLE
8325074: ZGC fails assert(index == 0 || is_power_of_2(index)) failed: Incorrect load shift: 11

### DIFF
--- a/src/hotspot/share/gc/z/zBarrierSet.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.cpp
@@ -152,11 +152,12 @@ void ZBarrierSet::on_slowpath_allocation_exit(JavaThread* thread, oop new_obj) {
   deoptimize_allocation(thread);
 }
 
-void ZBarrierSet::clone_obj_array(objArrayOop src_obj, objArrayOop dst_obj, size_t size) {
+void ZBarrierSet::clone_obj_array(objArrayOop src_obj, objArrayOop dst_obj) {
   volatile zpointer* src = (volatile zpointer*)src_obj->base();
   volatile zpointer* dst = (volatile zpointer*)dst_obj->base();
+  const int length = src_obj->length();
 
-  for (const zpointer* const end = cast_from_oop<const zpointer*>(src_obj) + size; src < end; src++, dst++) {
+  for (const volatile zpointer* const end = src + length; src < end; src++, dst++) {
     zaddress elem = ZBarrier::load_barrier_on_oop_field(src);
     // We avoid healing here because the store below colors the pointer store good,
     // hence avoiding the cost of a CAS.

--- a/src/hotspot/share/gc/z/zBarrierSet.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.hpp
@@ -39,7 +39,7 @@ public:
   static ZBarrierSetAssembler* assembler();
   static bool barrier_needed(DecoratorSet decorators, BasicType type);
 
-  static void clone_obj_array(objArrayOop src, objArrayOop dst, size_t size);
+  static void clone_obj_array(objArrayOop src, objArrayOop dst);
 
   virtual void on_thread_create(Thread* thread);
   virtual void on_thread_destroy(Thread* thread);

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -439,7 +439,7 @@ inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::clone_in_heap(o
     // for cloning arrays transform the clone to an optimized allocation
     // and arraycopy sequence, so the performance of this runtime call
     // does not matter for object arrays.
-    clone_obj_array(objArrayOop(src), objArrayOop(dst), size);
+    clone_obj_array(objArrayOop(src), objArrayOop(dst));
     return;
   }
 


### PR DESCRIPTION
Clean backport to fix a regression introduced by [JDK-8321619](https://bugs.openjdk.org/browse/JDK-8321619) in 21.0.3.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseZGC -XX:+ZGenerational` (some known failures)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325074](https://bugs.openjdk.org/browse/JDK-8325074) needs maintainer approval

### Issue
 * [JDK-8325074](https://bugs.openjdk.org/browse/JDK-8325074): ZGC fails assert(index == 0 || is_power_of_2(index)) failed: Incorrect load shift: 11 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/268/head:pull/268` \
`$ git checkout pull/268`

Update a local copy of the PR: \
`$ git checkout pull/268` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 268`

View PR using the GUI difftool: \
`$ git pr show -t 268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/268.diff">https://git.openjdk.org/jdk21u-dev/pull/268.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/268#issuecomment-1951989396)