### PR TITLE
8314629: Generational ZGC: Clearing All SoftReferences log line lacks GCId

### DIFF
--- a/src/hotspot/share/gc/z/zReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/z/zReferenceProcessor.cpp
@@ -113,6 +113,7 @@ static void list_append(zaddress& head, zaddress& tail, zaddress reference) {
 ZReferenceProcessor::ZReferenceProcessor(ZWorkers* workers)
   : _workers(workers),
     _soft_reference_policy(nullptr),
+    _clear_all_soft_refs(false),
     _encountered_count(),
     _discovered_count(),
     _enqueued_count(),
@@ -124,8 +125,9 @@ void ZReferenceProcessor::set_soft_reference_policy(bool clear) {
   static AlwaysClearPolicy always_clear_policy;
   static LRUMaxHeapPolicy lru_max_heap_policy;
 
+  _clear_all_soft_refs = clear;
+
   if (clear) {
-    log_info(gc, ref)("Clearing All SoftReferences");
     _soft_reference_policy = &always_clear_policy;
   } else {
     _soft_reference_policy = &lru_max_heap_policy;
@@ -437,6 +439,10 @@ public:
 
 void ZReferenceProcessor::process_references() {
   ZStatTimerOld timer(ZSubPhaseConcurrentReferencesProcess);
+
+  if (_clear_all_soft_refs) {
+    log_info(gc, ref)("Clearing All SoftReferences");
+  }
 
   // Process discovered lists
   ZReferenceProcessorTask task(this);

--- a/src/hotspot/share/gc/z/zReferenceProcessor.hpp
+++ b/src/hotspot/share/gc/z/zReferenceProcessor.hpp
@@ -41,6 +41,7 @@ private:
 
   ZWorkers* const      _workers;
   ReferencePolicy*     _soft_reference_policy;
+  bool                 _clear_all_soft_refs;
   ZPerWorker<Counters> _encountered_count;
   ZPerWorker<Counters> _discovered_count;
   ZPerWorker<Counters> _enqueued_count;


### PR DESCRIPTION
Clean backport of enhancement of generational ZGC to fix the GC ID of SoftReferences clearing.

Additional testing:
 - [x] Linux aarch64 server fastdebug, `hotspot_gc` with `-XX:+UseZGC +XX+ZGenerational`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314629](https://bugs.openjdk.org/browse/JDK-8314629) needs maintainer approval

### Issue
 * [JDK-8314629](https://bugs.openjdk.org/browse/JDK-8314629): Generational ZGC: Clearing All SoftReferences log line lacks GCId (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/271.diff">https://git.openjdk.org/jdk21u-dev/pull/271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/271#issuecomment-1953407295)