### PR TITLE
8323170: j2dbench is using outdated  javac source/target to be able to build by itself

### DIFF
--- a/src/demo/share/java2d/J2DBench/Makefile
+++ b/src/demo/share/java2d/J2DBench/Makefile
@@ -29,6 +29,23 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+
+ifndef SOURCE
+export SOURCE := 7
+endif
+ifndef TARGET
+export TARGET := 7
+endif
+ifndef JAVAC
+export JAVAC := javac
+endif
+ifndef JAVA
+export JAVA := java
+endif
+ifndef JAR
+export JAR := jar
+endif
+
 SOURCEPATH=src
 CLASSES=build
 DIST=dist
@@ -80,18 +97,18 @@ SCM_DIRs = .hg .svn CVS RCS SCCS Codemgr_wsdata deleted_files
 all: mkdirs J2DBench.jar J2DAnalyzer.jar
 
 run: mkdirs J2DBench.jar
-	java -jar $(DIST)/J2DBench.jar
+	$(JAVA) -jar $(DIST)/J2DBench.jar
 
 analyze: mkdirs J2DAnalyzer.jar
-	java -jar $(DIST)/J2DAnalyzer.jar
+	$(JAVA) -jar $(DIST)/J2DAnalyzer.jar
 
 J2DBench.jar: \
 	$(J2DBENCH_CLASSES) $(J2DBENCH_RESOURCES) \
 	$(CLASSES)/j2dbench.manifest
-	jar cvmf $(CLASSES)/j2dbench.manifest $(DIST)/J2DBench.jar -C $(CLASSES) j2dbench
+	$(JAR) cvmf $(CLASSES)/j2dbench.manifest $(DIST)/J2DBench.jar -C $(CLASSES) j2dbench
 
 J2DAnalyzer.jar: $(J2DANALYZER_CLASSES) $(CLASSES)/j2danalyzer.manifest
-	jar cvmf $(CLASSES)/j2danalyzer.manifest \
+	$(JAR) cvmf $(CLASSES)/j2danalyzer.manifest \
 		$(DIST)/J2DAnalyzer.jar -C $(CLASSES) j2dbench/report
 
 $(CLASSES)/j2dbench/tests/iio/images: $(RESOURCES)/images
@@ -120,7 +137,7 @@ $(CLASSES):
 mkdirs: $(DIST) $(CLASSES)
 
 $(CLASSES)/j2dbench/%.class: $(SOURCEPATH)/j2dbench/%.java
-	javac -g:none -source 1.7 -target 1.7 -d $(CLASSES) -sourcepath $(SOURCEPATH) $<
+	$(JAVAC) -g:none -source $(SOURCE) -target $(TARGET) -d $(CLASSES) -sourcepath $(SOURCEPATH) $<
 
 clean:
 	rm -rf $(CLASSES)

--- a/src/demo/share/java2d/J2DBench/README
+++ b/src/demo/share/java2d/J2DBench/README
@@ -23,6 +23,9 @@ The benchmark requires at least jdk1.4 to compile and run. Note that
 source/target is set to 1.7 in the makefile and build.xml, because of
 support in jdk 14 compiler. To check compatibility with jdk1.4 you can
 use "-source 1.4 -target 1.4" options and jdk1.7.
+Yo can use TARGET/SOURCE of makefile and -Dtarget/surce to set them up for your convinience.
+Similarly you can set JAVA/JAVAC/JAR and -Djava/javac to select diffferent java/javac then is on yoru PATH
+Unluckily in ant, you can not set jar, but ant should honor JAVA_HOME
 
 -----------------------------------------------------------------------
 How To Compile

--- a/src/demo/share/java2d/J2DBench/build.xml
+++ b/src/demo/share/java2d/J2DBench/build.xml
@@ -39,6 +39,27 @@
   <property name="dist"  location="dist"/>
   <property name="resources"  location="resources"/>
 
+  <condition property="source" value="7">
+     <not>
+        <isset property="source"/>
+     </not>
+  </condition>
+  <condition property="target" value="7">
+     <not>
+        <isset property="target"/>
+     </not>
+  </condition>
+  <condition property="java" value="java">
+     <not>
+        <isset property="java"/>
+     </not>
+  </condition>
+  <condition property="javac" value="javac">
+     <not>
+        <isset property="javac"/>
+     </not>
+  </condition>
+
   <target name="init">
     <!-- Create the time stamp -->
     <tstamp/>
@@ -49,13 +70,14 @@
   <target name="compile" depends="init"
         description="compile the source " >
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac debug="off" source="1.7" target="1.7" srcdir="${src}" destdir="${build}"/>
+    <javac debug="off" source="${source}" target="${target}" srcdir="${src}" destdir="${build}" fork="true" executable="${javac}"/>
   </target>
 
   <target name="run" depends="dist"
     description="run J2DBench" >
     <java jar="${dist}/J2DBench.jar"
        fork="true"
+       jvm="${java}"
     >
     </java>
   </target>
@@ -64,6 +86,7 @@
     description="run J2DAnalyzer" >
     <java jar="${dist}/J2DAnalyzer.jar"
        fork="true"
+       jvm="${java}"
     >
     </java>
   </target>


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323170](https://bugs.openjdk.org/browse/JDK-8323170) needs maintainer approval

### Issue
 * [JDK-8323170](https://bugs.openjdk.org/browse/JDK-8323170): j2dbench is using outdated  javac source/target to be able to build by itself (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/278.diff">https://git.openjdk.org/jdk21u-dev/pull/278.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/278#issuecomment-1956510533)