### PR TITLE
8326000: Remove obsolete comments for class sun.security.ssl.SunJSSE

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SunJSSE.java
+++ b/src/java.base/share/classes/sun/security/ssl/SunJSSE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,25 +31,6 @@ import static sun.security.util.SecurityConstants.PROVIDER_VER;
 
 /**
  * The JSSE provider.
- *
- * SunJSSE now supports an experimental FIPS compliant mode when used with an
- * appropriate FIPS certified crypto provider. In FIPS mode, we:
- *  . allow only TLS 1.0 or later
- *  . allow only FIPS approved ciphersuites
- *  . perform all crypto in the FIPS crypto provider
- *
- * It is currently not possible to use both FIPS compliant SunJSSE and
- * standard JSSE at the same time because of the various static data structures
- * we use.
- *
- * However, we do want to allow FIPS mode to be enabled at runtime and without
- * editing the java.security file. That means we need to allow
- * Security.removeProvider("SunJSSE") to work, which creates an instance of
- * this class in non-FIPS mode. That is why we delay the selection of the mode
- * as long as possible. This is until we open an SSL/TLS connection and the
- * data structures need to be initialized or until SunJSSE is initialized in
- * FIPS mode.
- *
  */
 public class SunJSSE extends java.security.Provider {
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8326000](https://bugs.openjdk.org/browse/JDK-8326000), commit [c2d9fa26](https://github.com/openjdk/jdk/commit/c2d9fa26ce903be7c86a47db5ff289cdb9de3a62) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 18 Feb 2024 and was reviewed by Matthias Baesken and Anthony Scarpino.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326000](https://bugs.openjdk.org/browse/JDK-8326000) needs maintainer approval

### Issue
 * [JDK-8326000](https://bugs.openjdk.org/browse/JDK-8326000): Remove obsolete comments for class sun.security.ssl.SunJSSE (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/281.diff">https://git.openjdk.org/jdk21u-dev/pull/281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/281#issuecomment-1959429538)