### PR TITLE
8314835: gtest wrappers should be marked as flagless

### DIFF
--- a/test/hotspot/jtreg/gtest/AsyncLogGtest.java
+++ b/test/hotspot/jtreg/gtest/AsyncLogGtest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +34,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=AsyncLogTest* -Xlog:async
  * @run main/native GTestWrapper --gtest_filter=Log*Test* -Xlog:async
  */

--- a/test/hotspot/jtreg/gtest/NMTGtests.java
+++ b/test/hotspot/jtreg/gtest/NMTGtests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,6 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=NMT*:os* -XX:NativeMemoryTracking=off
  */
 
@@ -40,6 +41,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=NMT*:os* -XX:NativeMemoryTracking=summary
  */
 
@@ -48,5 +50,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=NMT*:os* -XX:NativeMemoryTracking=detail
  */

--- a/test/hotspot/jtreg/gtest/NativeHeapTrimmerGtest.java
+++ b/test/hotspot/jtreg/gtest/NativeHeapTrimmerGtest.java
@@ -28,5 +28,6 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.xml
+ * @requires vm.flagless
  * @run main/native GTestWrapper --gtest_filter=os.trim* -Xlog:trimnative -XX:+UnlockExperimentalVMOptions -XX:TrimNativeHeapInterval=100
  */


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314835](https://bugs.openjdk.org/browse/JDK-8314835) needs maintainer approval

### Issue
 * [JDK-8314835](https://bugs.openjdk.org/browse/JDK-8314835): gtest wrappers should be marked as flagless (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/282/head:pull/282` \
`$ git checkout pull/282`

Update a local copy of the PR: \
`$ git checkout pull/282` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 282`

View PR using the GUI difftool: \
`$ git pr show -t 282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/282.diff">https://git.openjdk.org/jdk21u-dev/pull/282.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/282#issuecomment-1959543099)