### PR TITLE
8323664: java/awt/font/JNICheck/FreeTypeScalerJNICheck.java still fails with JNI warning on some Windows configurations

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Debug.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Debug.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,20 +153,19 @@ AwtDebugSupport::~AwtDebugSupport() {
 static jboolean isHeadless() {
     jmethodID headlessFn;
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
-    jclass graphicsEnvClass = env->FindClass(
-        "java/awt/GraphicsEnvironment");
+    // be on the safe side and avoid JNI warnings by calling ExceptionCheck
+    // an accumulated exception is not cleared
+    env->ExceptionCheck();
+    jclass graphicsEnvClass = env->FindClass("java/awt/GraphicsEnvironment");
 
     if (graphicsEnvClass != NULL) {
-        headlessFn = env->GetStaticMethodID(
-            graphicsEnvClass, "isHeadless", "()Z");
+        headlessFn = env->GetStaticMethodID(graphicsEnvClass, "isHeadless", "()Z");
         if (headlessFn != NULL) {
-            return env->CallStaticBooleanMethod(graphicsEnvClass,
-                                                headlessFn);
+            return env->CallStaticBooleanMethod(graphicsEnvClass, headlessFn);
         }
     }
     return true;
 }
-
 
 void AwtDebugSupport::AssertCallback(const char * expr, const char * file, int line) {
     static const int ASSERT_MSG_SIZE = 1024;
@@ -177,9 +176,9 @@ void AwtDebugSupport::AssertCallback(const char * expr, const char * file, int l
             "Do you want to break into the debugger?";
 
     static char assertMsg[ASSERT_MSG_SIZE+1];
-    DWORD   lastError = GetLastError();
-    LPSTR       msgBuffer = NULL;
-    int     ret = IDNO;
+    DWORD lastError = GetLastError();
+    LPSTR msgBuffer = NULL;
+    int ret = IDNO;
     static jboolean headless = isHeadless();
 
     DWORD fret= FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |

--- a/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
+++ b/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,7 +45,10 @@ public class FreeTypeScalerJNICheck {
         } else {
             ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Xcheck:jni", FreeTypeScalerJNICheck.class.getName(), "runtest");
             OutputAnalyzer oa = ProcessTools.executeProcess(pb);
-            oa.shouldContain("Done").shouldNotContain("WARNING").shouldHaveExitValue(0);
+            oa.shouldContain("Done")
+                .shouldNotContain("WARNING")
+                .shouldNotContain("AWT Assertion")
+                .shouldHaveExitValue(0);
         }
     }
 
@@ -54,8 +57,7 @@ public class FreeTypeScalerJNICheck {
         BufferedImage bi = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
         Graphics2D g2d = bi.createGraphics();
 
-        for (String ff : families)
-        {
+        for (String ff : families) {
             Font font = new Font(ff, Font.PLAIN, 12);
             Rectangle2D bounds = font.getStringBounds("test", g2d.getFontRenderContext());
             g2d.setFont(font);
@@ -66,4 +68,3 @@ public class FreeTypeScalerJNICheck {
         System.out.println("Done");
     }
 }
-


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8323664](https://bugs.openjdk.org/browse/JDK-8323664), commit [99c9ae12](https://github.com/openjdk/jdk/commit/99c9ae127c0a3b8c4fc6ede87079ff7c693a2905) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 15 Feb 2024 and was reviewed by Phil Race, Matthias Baesken and Alexey Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323664](https://bugs.openjdk.org/browse/JDK-8323664) needs maintainer approval

### Issue
 * [JDK-8323664](https://bugs.openjdk.org/browse/JDK-8323664): java/awt/font/JNICheck/FreeTypeScalerJNICheck.java still fails with JNI warning on some Windows configurations (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/285/head:pull/285` \
`$ git checkout pull/285`

Update a local copy of the PR: \
`$ git checkout pull/285` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 285`

View PR using the GUI difftool: \
`$ git pr show -t 285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/285.diff">https://git.openjdk.org/jdk21u-dev/pull/285.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/285#issuecomment-1961027357)