### PR TITLE
8325470: [AIX] use fclose after fopen in read_psinfo

### DIFF
--- a/src/hotspot/os/aix/os_perf_aix.cpp
+++ b/src/hotspot/os/aix/os_perf_aix.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, IBM Corp.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +87,7 @@ static bool read_psinfo(const u_longlong_t& pid, psinfo_t& psinfo) {
   }
 
   len = fread(&psinfo, 1, sizeof(psinfo_t), fp);
+  fclose(fp);
   return len == sizeof(psinfo_t);
 }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325470](https://bugs.openjdk.org/browse/JDK-8325470) needs maintainer approval

### Issue
 * [JDK-8325470](https://bugs.openjdk.org/browse/JDK-8325470): [AIX] use fclose after fopen in read_psinfo (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/286/head:pull/286` \
`$ git checkout pull/286`

Update a local copy of the PR: \
`$ git checkout pull/286` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 286`

View PR using the GUI difftool: \
`$ git pr show -t 286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/286.diff">https://git.openjdk.org/jdk21u-dev/pull/286.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/286#issuecomment-1961338027)