### PR TITLE
8325213: Flags introduced by configure script are not passed to ADLC build

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -51,7 +51,7 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   endif
 
   # Set the C++ standard
-  ADLC_CFLAGS += $(ADLC_LANGSTD_CXXFLAG)
+  ADLC_CFLAGS += $(ADLC_LANGSTD_CXXFLAGS)
 
   # NOTE: The old build didn't set -DASSERT for windows but it doesn't seem to
   # hurt.


### PR DESCRIPTION
Clean backport of the trivial ADLC build fix [JDK-8325213](https://bugs.openjdk.org/browse/JDK-8325213).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325213](https://bugs.openjdk.org/browse/JDK-8325213) needs maintainer approval

### Issue
 * [JDK-8325213](https://bugs.openjdk.org/browse/JDK-8325213): Flags introduced by configure script are not passed to ADLC build (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/288/head:pull/288` \
`$ git checkout pull/288`

Update a local copy of the PR: \
`$ git checkout pull/288` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 288`

View PR using the GUI difftool: \
`$ git pr show -t 288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/288.diff">https://git.openjdk.org/jdk21u-dev/pull/288.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/288#issuecomment-1961496760)