### PR TITLE
8325024: java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java incorrect comment information

### DIFF
--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
@@ -188,7 +188,7 @@ public class OCSPTimeout {
         rootOcsp.setDisableContentLength(true);
         rootOcsp.start();
 
-        // Wait 5 seconds for server ready
+        // Wait 60 seconds for server ready
         boolean readyStatus = rootOcsp.awaitServerReady(60, TimeUnit.SECONDS);
         if (!readyStatus) {
             throw new RuntimeException("Server not ready");


### PR DESCRIPTION
The testcase implement and the commnet is unmatch. Just modify the comment. The risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8325024](https://bugs.openjdk.org/browse/JDK-8325024) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325024](https://bugs.openjdk.org/browse/JDK-8325024): java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java incorrect comment information (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/289/head:pull/289` \
`$ git checkout pull/289`

Update a local copy of the PR: \
`$ git checkout pull/289` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 289`

View PR using the GUI difftool: \
`$ git pr show -t 289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/289.diff">https://git.openjdk.org/jdk21u-dev/pull/289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/289#issuecomment-1962422489)