### PR TITLE
8266242: java/awt/GraphicsDevice/CheckDisplayModes.java failing on macOS 11 ARM

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
 #define DEFAULT_DEVICE_HEIGHT 768
 #define DEFAULT_DEVICE_DPI 72
 
+static NSInteger architecture = -1;
 /*
  * Convert the mode string to the more convenient bits per pixel value
  */
@@ -58,7 +59,17 @@ static int getBPPFromModeString(CFStringRef mode)
     return 0;
 }
 
-static BOOL isValidDisplayMode(CGDisplayModeRef mode){
+static BOOL isValidDisplayMode(CGDisplayModeRef mode) {
+    // Workaround for apple bug FB13261205, since it only affects arm based macs
+    // and arm support started with macOS 11 ignore the workaround for previous versions
+    if (@available(macOS 11, *)) {
+        if (architecture == -1) {
+            architecture = [[NSRunningApplication currentApplication] executableArchitecture];
+        }
+        if (architecture == NSBundleExecutableArchitectureARM64) {
+            return (CGDisplayModeGetPixelWidth(mode) >= 800);
+        }
+    }
     return (1 < CGDisplayModeGetWidth(mode) && 1 < CGDisplayModeGetHeight(mode));
 }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -459,7 +459,6 @@ java/awt/KeyboardFocusmanager/TypeAhead/MenuItemActivatedTest/MenuItemActivatedT
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
 java/awt/dnd/BadSerializationTest/BadSerializationTest.java 8277817 linux-x64,windows-x64
-java/awt/GraphicsDevice/CheckDisplayModes.java 8266242 macosx-aarch64
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
 java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java 8305061 macosx-x64


### PR DESCRIPTION
Backport of [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242)

Testing
- :green_heart: Local: Test passed
  - `CheckDisplayModes.java`: Test results: passed: 1

```
MacBook Pro
16-inch, 2021
Chip Apple M1 Max
Memory: 32 GB
MacOS: 14.3.1 (23D60)
```

- :yellow_heart: Pipeline: All `GHA Sanity Checks` passed except `linux-cross-compile / build (riscv64)`
  - :x: It failed with message `Error: Unable to find an artifact with the name: bundles-linux-x64`
  - :white_check_mark: This error is on Linux riscv64 - which not caused by current test case, because current PR is for `macOS 11 ARM`
- :green_heart: Testing Machine: SAP nightlies passed on `2024-03-01,02,05`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242): java/awt/GraphicsDevice/CheckDisplayModes.java failing on macOS 11 ARM (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/297/head:pull/297` \
`$ git checkout pull/297`

Update a local copy of the PR: \
`$ git checkout pull/297` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 297`

View PR using the GUI difftool: \
`$ git pr show -t 297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/297.diff">https://git.openjdk.org/jdk21u-dev/pull/297.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/297#issuecomment-1967620636)