### PR TITLE
8324123: aarch64: fix prfm literal encoding in assembler

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -187,6 +187,26 @@ void Address::lea(MacroAssembler *as, Register r) const {
     zrf(Rd, 0);
   }
 
+// This encoding is similar (but not quite identical) to the encoding used
+// by literal ld/st. see JDK-8324123.
+// PRFM does not support writeback or pre/post index.
+void Assembler::prfm(const Address &adr, prfop pfop) {
+  Address::mode mode = adr.getMode();
+  // PRFM does not support pre/post index
+  guarantee((mode != Address::pre) && (mode != Address::post), "prfm does not support pre/post indexing");
+  if (mode == Address::literal) {
+    starti;
+    f(0b11, 31, 30), f(0b011, 29, 27), f(0b000, 26, 24);
+    f(pfop, 4, 0);
+    int64_t offset = (adr.target() - pc()) >> 2;
+    sf(offset, 23, 5);
+  } else {
+    assert((mode == Address::base_plus_offset)
+            || (mode == Address::base_plus_offset_reg), "must be base_plus_offset/base_plus_offset_reg");
+    ld_st2(as_Register(pfop), adr, 0b11, 0b10);
+  }
+}
+
 // An "all-purpose" add/subtract immediate, per ARM documentation:
 // A "programmer-friendly" assembler may accept a negative immediate
 // between -(2^24 -1) and -1 inclusive, causing it to convert a

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -795,6 +795,8 @@ public:
 
   void adrp(Register Rd, const Address &dest, uint64_t &offset) = delete;
 
+  void prfm(const Address &adr, prfop pfop = PLDL1KEEP);
+
 #undef INSN
 
   void add_sub_immediate(Instruction_aarch64 &current_insn, Register Rd, Register Rn,
@@ -1569,17 +1571,6 @@ public:
   INSN(ldrsh,  0b01, 0b10);
   INSN(ldrshw, 0b01, 0b11);
   INSN(ldrsw,  0b10, 0b10);
-
-#undef INSN
-
-#define INSN(NAME, size, op)                                    \
-  void NAME(const Address &adr, prfop pfop = PLDL1KEEP) {       \
-    ld_st2(as_Register(pfop), adr, size, op);                   \
-  }
-
-  INSN(prfm, 0b11, 0b10); // FIXME: PRFM should not be used with
-                          // writeback modes, but the assembler
-                          // doesn't enfore that.
 
 #undef INSN
 


### PR DESCRIPTION
Clean backport of fix of aarch64 PRFM (literal) encoding. 

Additional testing:
 - [x] Linux aarch64 server fastdebug, tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8324123](https://bugs.openjdk.org/browse/JDK-8324123) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324123](https://bugs.openjdk.org/browse/JDK-8324123): aarch64: fix prfm literal encoding in assembler (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/299/head:pull/299` \
`$ git checkout pull/299`

Update a local copy of the PR: \
`$ git checkout pull/299` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 299`

View PR using the GUI difftool: \
`$ git pr show -t 299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/299.diff">https://git.openjdk.org/jdk21u-dev/pull/299.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/299#issuecomment-1968656284)