### PR TITLE
8325137: com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java can fail in Xcomp with out of expected range

### DIFF
--- a/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
+++ b/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @summary Basic test of ThreadMXBean.getThreadCpuTime(long[]) and
  *          getThreadUserTime(long[]).
  * @author  Paul Hohensee
+ * @requires vm.compMode != "Xcomp"
  */
 
 import java.lang.management.*;


### PR DESCRIPTION
Backport of [JDK-8325137](https://bugs.openjdk.org/browse/JDK-8325137)

Testing
- Local: Test passed
  - `ThreadCpuTimeArray.java` - Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-03-01,02,05`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325137](https://bugs.openjdk.org/browse/JDK-8325137) needs maintainer approval

### Issue
 * [JDK-8325137](https://bugs.openjdk.org/browse/JDK-8325137): com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java can fail in Xcomp with out of expected range (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/303/head:pull/303` \
`$ git checkout pull/303`

Update a local copy of the PR: \
`$ git checkout pull/303` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 303`

View PR using the GUI difftool: \
`$ git pr show -t 303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/303.diff">https://git.openjdk.org/jdk21u-dev/pull/303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/303#issuecomment-1970227017)