### PR TITLE
8323519: Add applications/ctw/modules to Hotspot tiered testing

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -253,6 +253,7 @@ tier2_compiler = \
   -:hotspot_slow_compiler
 
 tier3_compiler = \
+  applications/ctw/modules \
   compiler/c2/ \
   compiler/ciReplay/ \
   compiler/compilercontrol/ \


### PR DESCRIPTION
Clean backport to improve testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323519](https://bugs.openjdk.org/browse/JDK-8323519) needs maintainer approval

### Issue
 * [JDK-8323519](https://bugs.openjdk.org/browse/JDK-8323519): Add applications/ctw/modules to Hotspot tiered testing (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/304/head:pull/304` \
`$ git checkout pull/304`

Update a local copy of the PR: \
`$ git checkout pull/304` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 304`

View PR using the GUI difftool: \
`$ git pr show -t 304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/304.diff">https://git.openjdk.org/jdk21u-dev/pull/304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/304#issuecomment-1971189025)