### PR TITLE
8327036: [macosx-aarch64] SIGBUS in MarkActivationClosure::do_code_blob reached from Unsafe_CopySwapMemory0

### DIFF
--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -409,6 +409,7 @@ extern "C" {                                                         \
 #define JVM_ENTRY_FROM_LEAF(env, result_type, header)                \
   { {                                                                \
     JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
     VM_ENTRY_BASE_FROM_LEAF(result_type, header, thread)


### PR DESCRIPTION
This changes `JVM_ENTRY_FROM_LEAF` to switch to `WXWrite` before transitioning to the vm.
This is needed on macos/aarch64  because there it is an [invariant of vm coding](https://github.com/openjdk/jdk/blob/0583f7357480c0500daa82f490b2fcc05f2fb65a/src/hotspot/share/runtime/interfaceSupport.inline.hpp#L253-L259) that a thread is in `WXWrite` mode.

Without we can get similar crashes as described in the bug report when writing to the code cache.
Note that in jdk21 we cannot get the very same crash because the nmethod sweeper was removed in jdk20 with [JDK-8290025](https://bugs.openjdk.org/browse/JDK-8290025).

Also `test/jdk/sun/nio/cs/FindDecoderBugs.java` fails with an assertion if the vm option `-XX:+AssertWXAtThreadSync` is set.

Testing:
`test/jdk/sun/nio/cs/FindDecoderBugs.java` with `-XX:+AssertWXAtThreadSync`

The fix passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests (also with ParallelGC).
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327036](https://bugs.openjdk.org/browse/JDK-8327036) needs maintainer approval

### Issue
 * [JDK-8327036](https://bugs.openjdk.org/browse/JDK-8327036): [macosx-aarch64] SIGBUS in MarkActivationClosure::do_code_blob reached from Unsafe_CopySwapMemory0 (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/305/head:pull/305` \
`$ git checkout pull/305`

Update a local copy of the PR: \
`$ git checkout pull/305` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 305`

View PR using the GUI difftool: \
`$ git pr show -t 305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/305.diff">https://git.openjdk.org/jdk21u-dev/pull/305.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/305#issuecomment-1972645072)