### PR TITLE
8319876: Reduce memory consumption of VM_ThreadDump::doit

### DIFF
--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -228,7 +228,6 @@ VM_ThreadDump::VM_ThreadDump(ThreadDumpResult* result,
   _result = result;
   _num_threads = 0; // 0 indicates all threads
   _threads = nullptr;
-  _result = result;
   _max_depth = max_depth;
   _with_locked_monitors = with_locked_monitors;
   _with_locked_synchronizers = with_locked_synchronizers;
@@ -243,7 +242,6 @@ VM_ThreadDump::VM_ThreadDump(ThreadDumpResult* result,
   _result = result;
   _num_threads = num_threads;
   _threads = threads;
-  _result = result;
   _max_depth = max_depth;
   _with_locked_monitors = with_locked_monitors;
   _with_locked_synchronizers = with_locked_synchronizers;

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -695,7 +695,7 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHasht
                         RegisterMap::UpdateMap::include,
                         RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
-
+    ResourceMark rm;
     // If full, we want to print both vthread and carrier frames
     vframe* start_vf = !full && _thread->is_vthread_mounted()
       ? _thread->carrier_last_java_vframe(&reg_map)


### PR DESCRIPTION
Hi, all

Could I have a review of this backport.

This pull request contains a backport of commit [8ec6b8de3bb3d7aeebdcb45d761b18cce3bab75e](https://github.com/openjdk/jdk/commit/8ec6b8de3bb3d7aeebdcb45d761b18cce3bab75e) from the [openjdk/jdk](https://github.com/openjdk/jdk) repository.
This backport can significantly reduce the `RSS` during the execution of `ThreadMXBean.dumpAllThreads(boolean, boolean)`.

On `jdk21u-dev`, if creates 4096 threads, and the stack depth of each thread is 256.
On the version that does not contain this backport, during the execution of `ThreadMXBean.dumpAllThreads(true, true)`, the `RSS` reaches about 5GiB.
On the version that contains this backport, the max `RSS` is about 300MiB.

There is a difference between `jdk21u-dev` and `openjdk/jdk`. 
On `openjdk/jdk`, `ThreadStackTrace::dump_stack_at_safepoint` will only be executed in `VMThread`.
But on `jdk21u-dev`, `ThreadStackTrace::dump_stack_at_safepoint` will be executed in `VMThread` or `RuntimeWorker`, so when creating `ResourceMark`, can not directedly specify `VMThread` like what `openjdk/jdk` does, but needs to read current thread.

Testing: 
I ran `tier1`, `tier2`, `tier3`, `tier4` on my host machine with the `jdk21u-dev` including this backport.
`tier1`, `tier2`, and `tier3` all passed.
Because my host does not have a `display device`, I added `export JTREG_KEYWORDS="!headful"` before running `tier4`.
Finally, some tests in `tier4` that depend on the printing device failed, and the rest were successful.

The [GHA](https://github.com/yanglong1010/jdk21u-dev/actions/runs/8093195914/job/22116320956) failed in [linux-cross-compile, build(riscv64), Create sysroot].
I've also seen others fail at this step as well (e.g. [link](https://github.com/openjdk-bots/jdk21u-dev/actions/runs/8077954001/job/22081472372)), it looks like there's an issue with the GHA's process.

I would appreciate it if anyone could review this.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319876](https://bugs.openjdk.org/browse/JDK-8319876) needs maintainer approval

### Issue
 * [JDK-8319876](https://bugs.openjdk.org/browse/JDK-8319876): Reduce memory consumption of VM_ThreadDump::doit (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/307/head:pull/307` \
`$ git checkout pull/307`

Update a local copy of the PR: \
`$ git checkout pull/307` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 307`

View PR using the GUI difftool: \
`$ git pr show -t 307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/307.diff">https://git.openjdk.org/jdk21u-dev/pull/307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/307#issuecomment-1972726362)