### PR TITLE
8325326: [PPC64] Don't relocate in case of allocation failure

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2798,15 +2798,16 @@ encode %{
     intptr_t val = $src$$constant;
     relocInfo::relocType constant_reloc = $src->constant_reloc();  // src
     address const_toc_addr;
+    RelocationHolder r; // Initializes type to none.
     if (constant_reloc == relocInfo::oop_type) {
       // Create an oop constant and a corresponding relocation.
-      AddressLiteral a = __ allocate_oop_address((jobject)val);
+      AddressLiteral a = __ constant_oop_address((jobject)val);
       const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
-      __ relocate(a.rspec());
+      r = a.rspec();
     } else if (constant_reloc == relocInfo::metadata_type) {
+      // Notify OOP recorder (don't need the relocation)
       AddressLiteral a = __ constant_metadata_address((Metadata *)val);
       const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
-      __ relocate(a.rspec());
     } else {
       // Create a non-oop constant, no relocation needed.
       const_toc_addr = __ long_constant((jlong)$src$$constant);
@@ -2816,6 +2817,7 @@ encode %{
       ciEnv::current()->record_out_of_memory_failure();
       return;
     }
+    __ relocate(r); // If set above.
     // Get the constant's TOC offset.
     toc_offset = __ offset_to_method_toc(const_toc_addr);
 
@@ -2829,15 +2831,16 @@ encode %{
       intptr_t val = $src$$constant;
       relocInfo::relocType constant_reloc = $src->constant_reloc();  // src
       address const_toc_addr;
+      RelocationHolder r; // Initializes type to none.
       if (constant_reloc == relocInfo::oop_type) {
         // Create an oop constant and a corresponding relocation.
-        AddressLiteral a = __ allocate_oop_address((jobject)val);
+        AddressLiteral a = __ constant_oop_address((jobject)val);
         const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
-        __ relocate(a.rspec());
+        r = a.rspec();
       } else if (constant_reloc == relocInfo::metadata_type) {
+        // Notify OOP recorder (don't need the relocation)
         AddressLiteral a = __ constant_metadata_address((Metadata *)val);
         const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
-        __ relocate(a.rspec());
       } else {  // non-oop pointers, e.g. card mark base, heap top
         // Create a non-oop constant, no relocation needed.
         const_toc_addr = __ long_constant((jlong)$src$$constant);
@@ -2847,6 +2850,7 @@ encode %{
         ciEnv::current()->record_out_of_memory_failure();
         return;
       }
+      __ relocate(r); // If set above.
       // Get the constant's TOC offset.
       const int toc_offset = __ offset_to_method_toc(const_toc_addr);
       // Store the toc offset of the constant.


### PR DESCRIPTION
Clean backport of [JDK-8325326](https://bugs.openjdk.org/browse/JDK-8325326).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325326](https://bugs.openjdk.org/browse/JDK-8325326) needs maintainer approval

### Issue
 * [JDK-8325326](https://bugs.openjdk.org/browse/JDK-8325326): [PPC64] Don't relocate in case of allocation failure (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/311/head:pull/311` \
`$ git checkout pull/311`

Update a local copy of the PR: \
`$ git checkout pull/311` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 311`

View PR using the GUI difftool: \
`$ git pr show -t 311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/311.diff">https://git.openjdk.org/jdk21u-dev/pull/311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/311#issuecomment-1973431303)