### PR TITLE
8314828: Mark 3 jcmd command-line options test as vm.flagless

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @test
  * @summary Test of diagnostic command help (tests all DCMD executors)
  * @library /test/lib
- *          /vmTestbase
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
  * @test
  * @summary Test of diagnostic command help (tests all DCMD executors)
  * @library /test/lib
+ *          /vmTestbase
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @test
  * @summary Test of invalid diagnostic command (tests all DCMD executors)
  * @library /test/lib
- *          /vmTestbase
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
  * @test
  * @summary Test of invalid diagnostic command (tests all DCMD executors)
  * @library /test/lib
+ *          /vmTestbase
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
@@ -27,7 +27,6 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.dcmd.MainClassJcmdExecutor;
 import jdk.test.lib.dcmd.FileJcmdExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
-import nsk.share.jdi.ArgumentHandler;
 
 import org.testng.annotations.Test;
 
@@ -44,7 +43,7 @@ import org.testng.annotations.Test;
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @library /test/lib
- *          /vmTestbase
+ * @requires vm.flagless
  * @run testng/othervm -XX:+UsePerfData VMVersionTest
  */
 public class VMVersionTest {

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
@@ -43,6 +43,7 @@ import org.testng.annotations.Test;
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @library /test/lib
+ *          /vmTestbase
  * @requires vm.flagless
  * @run testng/othervm -XX:+UsePerfData VMVersionTest
  */


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

As 8312828 breaks the tests, I include follow-up 8316228.
Both are clean backports. Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316228](https://bugs.openjdk.org/browse/JDK-8316228) needs maintainer approval
- [x] [JDK-8314828](https://bugs.openjdk.org/browse/JDK-8314828) needs maintainer approval

### Issues
 * [JDK-8314828](https://bugs.openjdk.org/browse/JDK-8314828): Mark 3 jcmd command-line options test as vm.flagless (**Sub-task** - P4 - Approved)
 * [JDK-8316228](https://bugs.openjdk.org/browse/JDK-8316228): jcmd tests are broken by 8314828 (**Bug** - P1 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/322/head:pull/322` \
`$ git checkout pull/322`

Update a local copy of the PR: \
`$ git checkout pull/322` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 322`

View PR using the GUI difftool: \
`$ git pr show -t 322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/322.diff">https://git.openjdk.org/jdk21u-dev/pull/322.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/322#issuecomment-1977024207)