### PR TITLE
8323276: StressDirListings.java fails on AIX

### DIFF
--- a/test/jdk/com/sun/net/httpserver/simpleserver/StressDirListings.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/StressDirListings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @summary Test to stress directory listings
  * @library /test/lib
- * @run testng/othervm/timeout=180 StressDirListings
+ * @run testng/othervm/timeout=180 -Dsun.net.httpserver.nodelay=true StressDirListings
  */
 
 import java.io.IOException;


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323276](https://bugs.openjdk.org/browse/JDK-8323276) needs maintainer approval

### Issue
 * [JDK-8323276](https://bugs.openjdk.org/browse/JDK-8323276): StressDirListings.java fails on AIX (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/325/head:pull/325` \
`$ git checkout pull/325`

Update a local copy of the PR: \
`$ git checkout pull/325` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 325`

View PR using the GUI difftool: \
`$ git pr show -t 325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/325.diff">https://git.openjdk.org/jdk21u-dev/pull/325.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/325#issuecomment-1976949455)