### PR TITLE
8327382: [21u] GHA: Enable fallback linker for x86_32

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,8 +146,8 @@ jobs:
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
-      apt-extra-packages: 'libfreetype-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc6-i386 libgcc-s1:i386 libstdc++6:i386'
-      extra-conf-options: '--with-target-bits=32'
+      apt-extra-packages: 'libfreetype-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc6-i386 libgcc-s1:i386 libstdc++6:i386 libffi-dev:i386'
+      extra-conf-options: '--with-target-bits=32 --enable-fallback-linker --enable-libffi-bundling'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x86 == 'true'


### PR DESCRIPTION
FFM API carries the fallback linker, based on libffi. [JDK-8312522](https://bugs.openjdk.org/browse/JDK-8312522) amended GHA to run x86_32 with it, by requesting `--enable-fallback-linker`: https://github.com/openjdk/jdk/commit/32ac72c3d35138f5253e4defc948304ac3ea1b53#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R149-R150

I think we should do the same for 21u. This improves current situation in two ways: a) we gain fallback linker testability via x86_32 tests; b) tests that rely on FFM work on x86_32.

Additional testing:
 - [ ] GHA passes on x86_32

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8327382](https://bugs.openjdk.org/browse/JDK-8327382) needs maintainer approval

### Issue
 * [JDK-8327382](https://bugs.openjdk.org/browse/JDK-8327382): [21u] GHA: Enable fallback linker for x86_32 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/330/head:pull/330` \
`$ git checkout pull/330`

Update a local copy of the PR: \
`$ git checkout pull/330` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 330`

View PR using the GUI difftool: \
`$ git pr show -t 330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/330.diff">https://git.openjdk.org/jdk21u-dev/pull/330.diff</a>

</details>
