### PR TITLE
8327501: Common ForkJoinPool prevents class unloading in some cases

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -981,9 +981,12 @@ public class ForkJoinPool extends AbstractExecutorService {
             boolean isCommon = (pool.workerNamePrefix == null);
             @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
-            if (sm == null)
-                return new ForkJoinWorkerThread(null, pool, true, false);
-            else if (isCommon)
+            if (sm == null) {
+                if (isCommon)
+                    return new ForkJoinWorkerThread.InnocuousForkJoinWorkerThread(pool);
+                else
+                    return new ForkJoinWorkerThread(null, pool, true, false);
+            } else if (isCommon)
                 return newCommonWithACC(pool);
             else
                 return newRegularWithACC(pool);

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -981,12 +981,7 @@ public class ForkJoinPool extends AbstractExecutorService {
             boolean isCommon = (pool.workerNamePrefix == null);
             @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
-            if (sm == null) {
-                if (isCommon)
-                    return new ForkJoinWorkerThread.InnocuousForkJoinWorkerThread(pool);
-                else
-                    return new ForkJoinWorkerThread(null, pool, true, false);
-            } else if (isCommon)
+            if (sm != null && isCommon)
                 return newCommonWithACC(pool);
             else
                 return newRegularWithACC(pool);

--- a/test/jdk/java/util/concurrent/tck/ForkJoinPool9Test.java
+++ b/test/jdk/java/util/concurrent/tck/ForkJoinPool9Test.java
@@ -79,6 +79,9 @@ public class ForkJoinPool9Test extends JSR166TestCase {
             assertSame(ForkJoinPool.commonPool(), ForkJoinTask.getPool());
             Thread currentThread = Thread.currentThread();
 
+            ClassLoader preexistingContextClassLoader =
+                    currentThread.getContextClassLoader();
+
             Stream.of(systemClassLoader, null).forEach(cl -> {
                 if (randomBoolean())
                     // should always be permitted, without effect
@@ -95,6 +98,11 @@ public class ForkJoinPool9Test extends JSR166TestCase {
                     () -> System.getProperty("foo"),
                     () -> currentThread.setContextClassLoader(
                         classLoaderDistinctFromSystemClassLoader));
+            else {
+                currentThread.setContextClassLoader(classLoaderDistinctFromSystemClassLoader);
+                assertSame(currentThread.getContextClassLoader(), classLoaderDistinctFromSystemClassLoader);
+                currentThread.setContextClassLoader(preexistingContextClassLoader);
+            }
             // TODO ?
 //          if (haveSecurityManager
 //              && Thread.currentThread().getClass().getSimpleName()


### PR DESCRIPTION
The change is stabilizing in mainline, but it looks simple, so we start testing it for JDK 21 pickup here.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8327501](https://bugs.openjdk.org/browse/JDK-8327501) needs maintainer approval
- [x] [JDK-8328366](https://bugs.openjdk.org/browse/JDK-8328366) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8327501](https://bugs.openjdk.org/browse/JDK-8327501): Common ForkJoinPool prevents class unloading in some cases (**Bug** - P4 - Approved)
 * [JDK-8328366](https://bugs.openjdk.org/browse/JDK-8328366): Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/338/head:pull/338` \
`$ git checkout pull/338`

Update a local copy of the PR: \
`$ git checkout pull/338` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 338`

View PR using the GUI difftool: \
`$ git pr show -t 338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/338.diff">https://git.openjdk.org/jdk21u-dev/pull/338.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/338#issuecomment-1983192898)