### PR TITLE
8318455: Fix the compiler/sharedstubs/SharedTrampolineTest.java and SharedStubToInterpTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -51,9 +51,10 @@ import jdk.test.lib.process.ProcessTools;
 public class SharedStubToInterpTest {
     private final static int ITERATIONS_TO_HEAT_LOOP = 20_000;
 
-    private static void runTest(String test) throws Exception {
+    private static void runTest(String compiler, String test) throws Exception {
         String testClassName = SharedStubToInterpTest.class.getName() + "$" + test;
         ArrayList<String> command = new ArrayList<String>();
+        command.add(compiler);
         command.add("-XX:+UnlockDiagnosticVMOptions");
         command.add("-Xbatch");
         command.add("-XX:+PrintRelocations");
@@ -80,7 +81,7 @@ public class SharedStubToInterpTest {
     public static void main(String[] args) throws Exception {
         String[] methods = new String[] { "StaticMethodTest", "FinalClassTest", "FinalMethodTest"};
         for (String methodName : methods) {
-            runTest(methodName);
+            runTest(args[0], methodName);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -28,6 +28,7 @@
  * @bug 8280152
  * @library /test/lib
  *
+ * @requires vm.compiler2.enabled
  * @requires vm.opt.TieredCompilation == null
  * @requires os.arch=="aarch64" | os.arch=="riscv64"
  * @requires vm.debug
@@ -46,9 +47,10 @@ import jdk.test.lib.process.ProcessTools;
 public class SharedTrampolineTest {
     private final static int ITERATIONS_TO_HEAT_LOOP = 20_000;
 
-    private static void runTest(String test) throws Exception {
+    private static void runTest(String compiler, String test) throws Exception {
         String testClassName = SharedTrampolineTest.class.getName() + "$" + test;
         ArrayList<String> command = new ArrayList<String>();
+        command.add(compiler);
         command.add("-XX:+UnlockDiagnosticVMOptions");
         command.add("-Xbatch");
         command.add("-XX:+PrintRelocations");
@@ -72,7 +74,7 @@ public class SharedTrampolineTest {
     public static void main(String[] args) throws Exception {
         String[] tests = new String[] {"StaticMethodTest"};
         for (String test : tests) {
-            runTest(test);
+            runTest(args[0], test);
         }
     }
 


### PR DESCRIPTION
Fixes the test when running with C1. Does not apply cleanly, because the relevant problemlist change is not applicable to jdk21u. We backported [JDK-8314838](https://bugs.openjdk.org/browse/JDK-8314838) to 21.0.3, which exposes us to this bug.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, C1, affected test fails without the patch, skipped with it
 - [x] MacOS AArch64 server fastdebug, C2, affected test passes with the patch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318455](https://bugs.openjdk.org/browse/JDK-8318455) needs maintainer approval

### Issue
 * [JDK-8318455](https://bugs.openjdk.org/browse/JDK-8318455): Fix the compiler/sharedstubs/SharedTrampolineTest.java and SharedStubToInterpTest.java (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/339/head:pull/339` \
`$ git checkout pull/339`

Update a local copy of the PR: \
`$ git checkout pull/339` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 339`

View PR using the GUI difftool: \
`$ git pr show -t 339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/339.diff">https://git.openjdk.org/jdk21u-dev/pull/339.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/339#issuecomment-1983378522)