### PR TITLE
8320570: NegativeArraySizeException decoding >1G UTF8 bytes with non-ascii characters

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -584,7 +584,7 @@ public final class String
                 this.value = dst;
                 this.coder = UTF16;
             } else { // !COMPACT_STRINGS
-                byte[] dst = new byte[length << 1];
+                byte[] dst = StringUTF16.newBytesFor(length);
                 int dp = decodeUTF8_UTF16(bytes, offset, offset + length, dst, 0, true);
                 if (dp != length) {
                     dst = Arrays.copyOf(dst, dp << 1);
@@ -605,7 +605,7 @@ public final class String
                 this.value = Arrays.copyOfRange(bytes, offset, offset + length);
                 this.coder = LATIN1;
             } else {
-                byte[] dst = new byte[length << 1];
+                byte[] dst = StringUTF16.newBytesFor(length);
                 int dp = 0;
                 while (dp < length) {
                     int b = bytes[offset++];
@@ -750,15 +750,15 @@ public final class String
                 return new String(dst, LATIN1);
             }
             if (dp == 0) {
-                dst = new byte[length << 1];
+                dst = StringUTF16.newBytesFor(length);
             } else {
-                byte[] buf = new byte[length << 1];
+                byte[] buf = StringUTF16.newBytesFor(length);
                 StringLatin1.inflate(dst, 0, buf, 0, dp);
                 dst = buf;
             }
             dp = decodeUTF8_UTF16(bytes, offset, sl, dst, dp, false);
         } else { // !COMPACT_STRINGS
-            dst = new byte[length << 1];
+            dst = StringUTF16.newBytesFor(length);
             dp = decodeUTF8_UTF16(bytes, offset, offset + length, dst, 0, false);
         }
         if (dp != length) {
@@ -1304,7 +1304,7 @@ public final class String
         }
 
         int dp = 0;
-        byte[] dst = new byte[val.length << 1];
+        byte[] dst = StringUTF16.newBytesFor(val.length);
         for (byte c : val) {
             if (c < 0) {
                 dst[dp++] = (byte) (0xc0 | ((c & 0xff) >> 6));

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -574,7 +574,7 @@ public final class String
                     this.coder = LATIN1;
                     return;
                 }
-                byte[] buf = new byte[length << 1];
+                byte[] buf = StringUTF16.newBytesFor(length);
                 StringLatin1.inflate(dst, 0, buf, 0, dp);
                 dst = buf;
                 dp = decodeUTF8_UTF16(bytes, offset, sl, dst, dp, true);

--- a/test/jdk/java/lang/String/CompactString/NegativeSize.java
+++ b/test/jdk/java/lang/String/CompactString/NegativeSize.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/*
+ * @test
+ * @bug 8077559
+ * @summary Tests Compact String for negative size.
+ * @requires vm.bits == 64 & os.maxMemory >= 4G
+ * @run main/othervm -XX:+CompactStrings -Xmx4g NegativeSize
+ * @run main/othervm -XX:-CompactStrings -Xmx4g NegativeSize
+ */
+
+// In Java8: java.lang.OutOfMemoryError: Java heap space
+// In Java9+: was java.lang.NegativeArraySizeException: -1894967266
+public class NegativeSize {
+
+    static byte[] generateData() {
+        int asciisize = 1_200_000_000;
+        byte[] nonAscii = "非アスキー".getBytes();
+        int nonAsciiSize = nonAscii.length;
+        // 1 GB
+        byte[] arr = new byte[asciisize + nonAsciiSize];
+        for (int i=0; i<asciisize; ++i) {
+            arr[i] = (byte)('0' + (i % 40));
+        }
+        for(int i=0; i<nonAsciiSize; ++i) {
+            arr[i + asciisize] = nonAscii[i];
+        }
+        return arr;
+    }
+
+
+    public static void main(String[] args) throws IOException {
+
+        try {
+            byte[] largeBytes = generateData();
+            String inStr = new String(largeBytes, StandardCharsets.UTF_8);
+            System.out.println(inStr.length());
+            System.out.println(inStr.substring(1_200_000_000));
+        } catch (OutOfMemoryError ex) {
+            if (ex.getMessage().startsWith("UTF16 String size is")) {
+                System.out.println("Succeeded with OutOfMemoryError");
+            } else {
+                throw new RuntimeException("Failed: Not the OutOfMemoryError expected", ex);
+            }
+        } catch (NegativeArraySizeException ex) {
+            throw new RuntimeException("Failed: Expected OutOfMemoryError", ex);
+        }
+    }
+}
+
+


### PR DESCRIPTION
Backport of [JDK-8320570](https://bugs.openjdk.org/browse/JDK-8320570)
- `NegativeSize.java` - Clean backport
- `String.java` - only 1 line change is unclean, the rest are clean. Details as bellow.
- This PR contains 2 commits
  - The commit 1: is a clean backport part
  - The commit 2: is a manual fix of the following 1 line:
    - In the `jdk master` branch, the variable name is `utf16`
	- Well in `jdk21u-dev`, the varialbe name is `buf`
	- So we manully applied the following line

```diff
@@ -592,7 +592,7 @@
                     this.coder = LATIN1;
                     return;
                 }
-                byte[] utf16 = new byte[length << 1];
+                byte[] utf16 = StringUTF16.newBytesFor(length);
                 StringLatin1.inflate(latin1, 0, utf16, 0, dp);
                 dp = decodeUTF8_UTF16(latin1, sp, length, utf16, dp, true);
                 if (dp != length) {

```

- So this PR can be considered as `semantics clean`


Testing
- Local: Passed on MacOS M1 laptop
  - `test/jdk/java/lang/String/CompactString/NegativeSize.java` - Test results: passed: 1
- Pipeline: 
- Testing Machine:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320570](https://bugs.openjdk.org/browse/JDK-8320570) needs maintainer approval

### Issue
 * [JDK-8320570](https://bugs.openjdk.org/browse/JDK-8320570): NegativeArraySizeException decoding &gt;1G UTF8 bytes with non-ascii characters (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/344/head:pull/344` \
`$ git checkout pull/344`

Update a local copy of the PR: \
`$ git checkout pull/344` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 344`

View PR using the GUI difftool: \
`$ git pr show -t 344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/344.diff">https://git.openjdk.org/jdk21u-dev/pull/344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/344#issuecomment-1986462576)