### PR TITLE
8326891: Prefer RPATH over RUNPATH for $ORIGIN rpaths in internal JDK binaries

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -28,7 +28,7 @@
 # Setup flags for C/C++ compiler
 #
 
-###############################################################################
+################################################################################
 #
 # How to compile shared libraries.
 #
@@ -37,7 +37,10 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
     # Default works for linux, might work on other platforms as well.
     SHARED_LIBRARY_FLAGS='-shared'
-    SET_EXECUTABLE_ORIGIN='-Wl,-rpath,\$$ORIGIN[$]1'
+    # --disable-new-dtags forces use of RPATH instead of RUNPATH for rpaths.
+    # This protects internal library dependencies within the JDK from being
+    # overridden using LD_LIBRARY_PATH. See JDK-8326891 for more information.
+    SET_EXECUTABLE_ORIGIN='-Wl,-rpath,\$$ORIGIN[$]1 -Wl,--disable-new-dtags'
     SET_SHARED_LIBRARY_ORIGIN="-Wl,-z,origin $SET_EXECUTABLE_ORIGIN"
     SET_SHARED_LIBRARY_NAME='-Wl,-soname=[$]1'
     SET_SHARED_LIBRARY_MAPFILE='-Wl,-version-script=[$]1'
@@ -63,6 +66,9 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
       # Default works for linux, might work on other platforms as well.
       SHARED_LIBRARY_FLAGS='-shared'
       SET_EXECUTABLE_ORIGIN='-Wl,-rpath,\$$ORIGIN[$]1'
+      if test "x$OPENJDK_TARGET_OS" = xlinux; then
+        SET_EXECUTABLE_ORIGIN="$SET_EXECUTABLE_ORIGIN -Wl,--disable-new-dtags"
+      fi
       SET_SHARED_LIBRARY_NAME='-Wl,-soname=[$]1'
       SET_SHARED_LIBRARY_MAPFILE='-Wl,-version-script=[$]1'
 

--- a/test/jdk/tools/launcher/RunpathTest.java
+++ b/test/jdk/tools/launcher/RunpathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 7190813 8022719
- * @summary Check for extended  RPATHs on *nixes
+ * @summary Check for extended RPATHs on Linux
+ * @requires os.family == "linux"
  * @compile -XDignore.symbol.file RunpathTest.java
  * @run main RunpathTest
  * @author ksrini
@@ -57,25 +58,23 @@ public class RunpathTest extends TestHelper {
         final TestResult tr = doExec(elfreaderCmd, "-d", javacmd);
         if (!tr.matches(expectedRpath)) {
             System.out.println(tr);
-            throw new RuntimeException("FAILED: RPATH/RUNPATH strings " +
+            throw new RuntimeException("FAILED: RPATH strings " +
                     expectedRpath + " not found in " + javaCmd);
         }
-        System.out.println(javacmd + " contains expected RPATHS/RUNPATH");
+        System.out.println(javacmd + " contains expected RPATHS");
     }
 
     void testRpath() {
-        String expectedRpath = ".*R(UN)?PATH.*\\$ORIGIN/../lib.*";
+        String expectedRpath = ".*RPATH.*\\$ORIGIN/../lib.*";
         elfCheck(javaCmd, expectedRpath);
     }
 
     public static void main(String... args) throws Exception {
-        if (isLinux) {
-            RunpathTest rp = new RunpathTest();
-            if (rp.elfreaderCmd == null) {
-                System.err.println("Warning: test passes vacuously");
-                return;
-            }
-            rp.testRpath();
+        RunpathTest rp = new RunpathTest();
+        if (rp.elfreaderCmd == null) {
+            System.err.println("Warning: test passes vacuously");
+            return;
         }
+        rp.testRpath();
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326891](https://bugs.openjdk.org/browse/JDK-8326891) needs maintainer approval

### Issue
 * [JDK-8326891](https://bugs.openjdk.org/browse/JDK-8326891): Prefer RPATH over RUNPATH for $ORIGIN rpaths in internal JDK binaries (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/345/head:pull/345` \
`$ git checkout pull/345`

Update a local copy of the PR: \
`$ git checkout pull/345` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 345`

View PR using the GUI difftool: \
`$ git pr show -t 345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/345.diff">https://git.openjdk.org/jdk21u-dev/pull/345.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/345#issuecomment-1987672130)