### PR TITLE
8320113: [macos14] : ShapeNotSetSometimes.java fails intermittently on macOS 14

### DIFF
--- a/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
+++ b/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,45 +21,50 @@
  * questions.
  */
 
-/*
-  @test
-  @key headful
-  @bug 6988428
-  @summary Tests whether shape is always set
-  @author anthony.petrov@oracle.com: area=awt.toplevel
-  @run main ShapeNotSetSometimes
-*/
 
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.ImageIO;
 
+/*
+ * @test
+ * @key headful
+ * @bug 6988428
+ * @summary Tests whether shape is always set
+ * @run main ShapeNotSetSometimes
+ */
 
 public class ShapeNotSetSometimes {
 
     private Frame backgroundFrame;
     private Frame window;
-    private static final Color BACKGROUND_COLOR = Color.GREEN;
-    private static final Color SHAPE_COLOR = Color.WHITE;
+
     private Point[] pointsOutsideToCheck;
     private Point[] shadedPointsToCheck;
     private Point innerPoint;
-
     private final Rectangle bounds = new Rectangle(220, 400, 300, 300);
 
     private static Robot robot;
+    private static final Color BACKGROUND_COLOR = Color.GREEN;
+    private static final Color SHAPE_COLOR = Color.WHITE;
 
     public ShapeNotSetSometimes() throws Exception {
         EventQueue.invokeAndWait(this::initializeGUI);
         robot.waitForIdle();
+        robot.delay(1000);
     }
 
     private void initializeGUI() {
@@ -124,7 +129,7 @@ public class ShapeNotSetSometimes {
     public static void main(String[] args) throws Exception {
         robot = new Robot();
 
-        for(int i = 0; i < 50; i++) {
+        for (int i = 1; i <= 50; i++) {
             System.out.println("Attempt " + i);
             new ShapeNotSetSometimes().doTest();
         }
@@ -136,7 +141,6 @@ public class ShapeNotSetSometimes {
 
         EventQueue.invokeAndWait(window::toFront);
         robot.waitForIdle();
-
         robot.delay(500);
 
         try {
@@ -173,8 +177,8 @@ public class ShapeNotSetSometimes {
         );
 
         if (mustBeExpectedColor != expectedColor.equals(actualColor)) {
+            captureScreen();
             System.out.printf("window.getX() = %3d, window.getY() = %3d\n", window.getX(), window.getY());
-
             System.err.printf(
                     "Checking for transparency failed: point: %3d, %3d\n\tactual    %s\n\texpected %s%s\n",
                     screenX,
@@ -183,6 +187,20 @@ public class ShapeNotSetSometimes {
                     mustBeExpectedColor ? "" : "not ",
                     expectedColor);
             throw new RuntimeException("Test failed. The shape has not been applied.");
+        }
+    }
+
+    private static void captureScreen() {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        Rectangle screenBounds = new Rectangle(0, 0, screenSize.width, screenSize.height);
+        try {
+            ImageIO.write(
+                    robot.createScreenCapture(screenBounds),
+                    "png",
+                    new File("Screenshot.png")
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8320113](https://bugs.openjdk.org/browse/JDK-8320113) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320113](https://bugs.openjdk.org/browse/JDK-8320113): [macos14] : ShapeNotSetSometimes.java fails intermittently on macOS 14 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/346/head:pull/346` \
`$ git checkout pull/346`

Update a local copy of the PR: \
`$ git checkout pull/346` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 346`

View PR using the GUI difftool: \
`$ git pr show -t 346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/346.diff">https://git.openjdk.org/jdk21u-dev/pull/346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/346#issuecomment-1987708303)