### PR TITLE
8325743: test/jdk/java/nio/channels/unixdomain/SocketOptions.java enhance user name output in error case

### DIFF
--- a/test/jdk/java/nio/channels/unixdomain/SocketOptions.java
+++ b/test/jdk/java/nio/channels/unixdomain/SocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,8 @@ public class SocketOptions {
                 // Check returned user name
 
                 if (!s1.equals(s2)) {
-                    throw new RuntimeException("wrong username");
+                    throw new RuntimeException("wrong username, actual " + s1 +
+                                               " but expected value from property user.name is " + s2);
                 }
 
                 // Try setting the option: Read only


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8325743](https://bugs.openjdk.org/browse/JDK-8325743) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325743](https://bugs.openjdk.org/browse/JDK-8325743): test/jdk/java/nio/channels/unixdomain/SocketOptions.java enhance user name output in error case (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/350/head:pull/350` \
`$ git checkout pull/350`

Update a local copy of the PR: \
`$ git checkout pull/350` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 350`

View PR using the GUI difftool: \
`$ git pr show -t 350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/350.diff">https://git.openjdk.org/jdk21u-dev/pull/350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/350#issuecomment-1991092076)