### PR TITLE
8326496: [test] checkHsErrFileContent  support printing hserr in error case

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014, 2022 SAP SE. All rights reserved.
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 SAP SE. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ public class SecondaryErrorTest {
     }
     Pattern[] pattern = patternlist.toArray(new Pattern[] {});
 
-    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false, true);
 
     System.out.println("OK.");
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326496](https://bugs.openjdk.org/browse/JDK-8326496) needs maintainer approval

### Issue
 * [JDK-8326496](https://bugs.openjdk.org/browse/JDK-8326496): [test] checkHsErrFileContent  support printing hserr in error case (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/353/head:pull/353` \
`$ git checkout pull/353`

Update a local copy of the PR: \
`$ git checkout pull/353` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 353`

View PR using the GUI difftool: \
`$ git pr show -t 353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/353.diff">https://git.openjdk.org/jdk21u-dev/pull/353.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/353#issuecomment-1991466599)