### PR TITLE
8314832: Few runtime/os tests ignore vm flags

### DIFF
--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -27,6 +27,7 @@
  * @bug 8303215 8312182
  * @summary On THP=always systems, we prevent THPs from forming within thread stacks
  * @library /test/lib
+ * @requires vm.flagless
  * @requires os.family == "linux"
  * @requires vm.debug
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
@@ -40,6 +41,7 @@
  * @bug 8303215 8312182
  * @summary On THP=always systems, we prevent THPs from forming within thread stacks (negative test)
  * @library /test/lib
+ * @requires vm.flagless
  * @requires os.family == "linux"
  * @requires vm.debug
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDetection.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDetection.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Test that the JVM detects the OS hugepage/THP settings correctly.
  * @library /test/lib
+ * @requires vm.flagless
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/os/TestTrimNative.java
+++ b/test/hotspot/jtreg/runtime/os/TestTrimNative.java
@@ -26,6 +26,7 @@
 
 /*
  * @test id=trimNative
+ * @requires vm.flagless
  * @requires (os.family=="linux") & !vm.musl
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -36,6 +37,7 @@
 
 /*
  * @test id=trimNativeStrict
+ * @requires vm.flagless
  * @requires (os.family=="linux") & !vm.musl
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -47,6 +49,7 @@
 /*
  * @test id=trimNativeHighInterval
  * @summary High interval trimming should not even kick in for short program runtimes
+ * @requires vm.flagless
  * @requires (os.family=="linux") & !vm.musl
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -58,6 +61,7 @@
 /*
  * @test id=trimNativeLowInterval
  * @summary Very low (sub-second) interval, nothing should explode
+ * @requires vm.flagless
  * @requires (os.family=="linux") & !vm.musl
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -69,6 +73,7 @@
 /*
  * @test id=trimNativeLowIntervalStrict
  * @summary Very low (sub-second) interval, nothing should explode (stricter test, manual mode)
+ * @requires vm.flagless
  * @requires (os.family=="linux") & !vm.musl
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -80,6 +85,7 @@
 /*
  * @test id=testOffByDefault
  * @summary Test that trimming is disabled by default
+ * @requires vm.flagless
  * @requires (os.family=="linux") & !vm.musl
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -91,6 +97,7 @@
 /*
  * @test id=testOffExplicit
  * @summary Test that trimming can be disabled explicitly
+ * @requires vm.flagless
  * @requires (os.family=="linux") & !vm.musl
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -102,6 +109,7 @@
 /*
  * @test id=testOffOnNonCompliantPlatforms
  * @summary Test that trimming is correctly reported as unavailable if unavailable
+ * @requires vm.flagless
  * @requires (os.family!="linux") | vm.musl
  * @modules java.base/jdk.internal.misc
  * @library /test/lib


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8314832](https://bugs.openjdk.org/browse/JDK-8314832) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314832](https://bugs.openjdk.org/browse/JDK-8314832): Few runtime/os tests ignore vm flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/361/head:pull/361` \
`$ git checkout pull/361`

Update a local copy of the PR: \
`$ git checkout pull/361` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 361`

View PR using the GUI difftool: \
`$ git pr show -t 361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/361.diff">https://git.openjdk.org/jdk21u-dev/pull/361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/361#issuecomment-1994677677)