### PR TITLE
8327799: JFR view: the "Park Until" field of jdk.ThreadPark is invalid if the parking method is not absolute

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
@@ -272,6 +272,9 @@ public final class ValueFormatter {
     }
 
     public static String formatTimestamp(Instant instant) {
+        if (Instant.MIN.equals(instant)) {
+            return "N/A";
+        }
         return LocalTime.ofInstant(instant, ZoneId.systemDefault()).format(DATE_FORMAT);
     }
 }


### PR DESCRIPTION
Hi, all

Could I have a review of this backport ? I would be very grateful.

This pull request contains a backport of commit [6f8b0a33fa15f1dfc8b0c116375df0f90d9d8759](https://github.com/openjdk/jdk/commit/6f8b0a33fa15f1dfc8b0c116375df0f90d9d8759) from the [openjdk/jdk](https://github.com/openjdk/jdk) repository.

This backport is clean.

```java
UNSAFE.park(true, System.currentTimeMillis() + 1000);
UNSAFE.park(false, 2000L * 1000 * 1000);
```

``` bash
jfr view jdk.ThreadPark test.jfr
                                                    Java Thread Park

Start Time Duration Event Thread Stack Trace             Class Parked On Park Timeout Park Until Address of Object Pa...
---------- -------- ------------ ----------------------- --------------- ------------ ---------- -----------------------
20:11:10     1.00 s main         jdk.internal.misc.Un... N/A                      N/A 20:11:11   0x00000000
20:11:11     1.00 s main         jdk.internal.misc.Un... N/A                   1.00 s 08:05:43   0x00000000

```

If the parking method is not absolute (the second line of the Java code above), the real value of `until` field in JFR's `jdk.ThreadPark` event is `Long.MIN_VALUE`, which will be convert back to `java.time.Instant.MIN`, but `jfr view` displays this value as '08:05:43' of my timezone (the `Park Until` column above).  This is somewhat misleading, better to show `N/A`.

Testing: 
test/jdk/jdk/jfr/tool/TestView.java
test/jdk/jdk/jfr/jcmd/TestJcmdView.java

All passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327799](https://bugs.openjdk.org/browse/JDK-8327799) needs maintainer approval

### Issue
 * [JDK-8327799](https://bugs.openjdk.org/browse/JDK-8327799): JFR view: the "Park Until" field of jdk.ThreadPark is invalid if the parking method is not absolute (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/366/head:pull/366` \
`$ git checkout pull/366`

Update a local copy of the PR: \
`$ git checkout pull/366` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 366`

View PR using the GUI difftool: \
`$ git pr show -t 366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/366.diff">https://git.openjdk.org/jdk21u-dev/pull/366.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/366#issuecomment-1998834281)