### PR TITLE
8309757: com/sun/jdi/ReferrersTest.java fails with virtual test thread factory

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -29,7 +29,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
-com/sun/jdi/ReferrersTest.java 8285422 generic-all
 com/sun/jdi/SetLocalWhileThreadInNative.java 8285422 generic-all
 com/sun/jdi/cds/CDSBreakpointTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSDeleteAllBkptsTest.java 8307778 generic-all

--- a/test/jdk/com/sun/jdi/ReferrersTest.java
+++ b/test/jdk/com/sun/jdi/ReferrersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -452,6 +452,9 @@ public class ReferrersTest extends TestScaffold {
                 return;
             }
             if (name.equals("java.lang.ref.SoftReference")) {
+                return;
+            }
+            if (name.equals("java.lang.reflect.Method")) {
                 return;
             }
             // oh oh, should really check for a subclass of ClassLoader :-)


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

Resolved ProblemList, will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309757](https://bugs.openjdk.org/browse/JDK-8309757) needs maintainer approval

### Issue
 * [JDK-8309757](https://bugs.openjdk.org/browse/JDK-8309757): com/sun/jdi/ReferrersTest.java fails with virtual test thread factory (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/367/head:pull/367` \
`$ git checkout pull/367`

Update a local copy of the PR: \
`$ git checkout pull/367` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 367`

View PR using the GUI difftool: \
`$ git pr show -t 367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/367.diff">https://git.openjdk.org/jdk21u-dev/pull/367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/367#issuecomment-2003281196)