### PR TITLE
Backport 1281e18f1447848d7eb5e3bde508ac002b4c390d

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -293,8 +293,10 @@ public class CtwRunner {
                 String.format("-XX:ReplayDataFile=replay_%s_%%p.log", phase),
                 // MethodHandle MUST NOT be compiled
                 "-XX:CompileCommand=exclude,java/lang/invoke/MethodHandle.*",
-                // Stress* are c2-specific stress flags, so IgnoreUnrecognizedVMOptions is needed
                 "-XX:+IgnoreUnrecognizedVMOptions",
+                // Do not pay extra zapping cost for explicit GC invocations
+                "-XX:-ZapUnusedHeapArea",
+                // Stress* are c2-specific stress flags, so IgnoreUnrecognizedVMOptions is needed
                 "-XX:+StressLCM",
                 "-XX:+StressGCM",
                 "-XX:+StressIGVN",


### PR DESCRIPTION
Clean backport to improve CTW testing times.

Additional testing:
 - [x] Ad-hoc CTW time measurements for `java.base` demonstrate the same improvements as in mainline
 - [x] Linux x86_64 server fastdebug, large CTW runs pass with this patch applied
 - [x] MacOS AArch64 server fastdebug, `applications/ctw/modules` passes