### PR TITLE
Backport 8d29329138d44800ee4c0c02dacc01a06097de66

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -739,8 +739,6 @@ sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java              8313798 generic-
 
 # jdk_other
 
-javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-all
-
 jdk/incubator/vector/ShortMaxVectorTests.java                   8306592 generic-i586
 jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-x64
 


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.