### PR TITLE
8322920: Some ProcessTools.execute* functions are declared to throw Throwable

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -698,7 +698,7 @@ public final class ProcessTools {
      * @param cmds The command line to execute.
      * @return The output from the process.
      */
-    public static OutputAnalyzer executeProcess(String... cmds) throws Throwable {
+    public static OutputAnalyzer executeProcess(String... cmds) throws Exception {
         return executeProcess(new ProcessBuilder(cmds));
     }
 
@@ -743,8 +743,7 @@ public final class ProcessTools {
      * @param cmds The command line to execute.
      * @return The {@linkplain OutputAnalyzer} instance wrapping the process.
      */
-    public static OutputAnalyzer executeCommand(String... cmds)
-            throws Throwable {
+    public static OutputAnalyzer executeCommand(String... cmds) throws Exception {
         String cmdLine = String.join(" ", cmds);
         System.out.println("Command line: [" + cmdLine + "]");
         OutputAnalyzer analyzer = ProcessTools.executeProcess(cmds);
@@ -761,8 +760,7 @@ public final class ProcessTools {
      * @param pb The ProcessBuilder to execute.
      * @return The {@linkplain OutputAnalyzer} instance wrapping the process.
      */
-    public static OutputAnalyzer executeCommand(ProcessBuilder pb)
-            throws Throwable {
+    public static OutputAnalyzer executeCommand(ProcessBuilder pb) throws Exception {
         String cmdLine = pb.command().stream()
                 .map(x -> (x.contains(" ") || x.contains("$"))
                         ? ("'" + x + "'") : x)


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322920](https://bugs.openjdk.org/browse/JDK-8322920) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322920](https://bugs.openjdk.org/browse/JDK-8322920): Some ProcessTools.execute* functions are declared to throw Throwable (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/374/head:pull/374` \
`$ git checkout pull/374`

Update a local copy of the PR: \
`$ git checkout pull/374` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 374`

View PR using the GUI difftool: \
`$ git pr show -t 374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/374.diff">https://git.openjdk.org/jdk21u-dev/pull/374.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/374#issuecomment-2004059850)