### PR TITLE
8159927: Add a test to verify JMOD files created in the images do not have debug symbols

### DIFF
--- a/test/jdk/jdk/modules/etc/JmodExcludedFiles.java
+++ b/test/jdk/jdk/modules/etc/JmodExcludedFiles.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8159927
+ * @modules java.base/jdk.internal.util
+ * @run main JmodExcludedFiles
+ * @summary Test that JDK JMOD files do not include native debug symbols
+ */
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import jdk.internal.util.OperatingSystem;
+
+public class JmodExcludedFiles {
+    public static void main(String[] args) throws Exception {
+        String javaHome = System.getProperty("java.home");
+        Path jmods = Path.of(javaHome, "jmods");
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(jmods, "*.jmod")) {
+            for (Path jmodFile : stream) {
+                try (ZipFile zip = new ZipFile(jmodFile.toFile())) {
+                    if (zip.stream().map(ZipEntry::getName)
+                                    .anyMatch(JmodExcludedFiles::isNativeDebugSymbol)) {
+                        throw new RuntimeException(jmodFile + " is expected not to include native debug symbols");
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean isNativeDebugSymbol(String name) {
+        int index = name.indexOf("/");
+        if (index < 0) {
+            throw new RuntimeException("unexpected entry name: " + name);
+        }
+        String section = name.substring(0, index);
+        if (section.equals("lib") || section.equals("bin")) {
+            if (OperatingSystem.isMacOS()) {
+                String n = name.substring(index+1);
+                int i = n.indexOf("/");
+                if (i != -1) {
+                    return n.substring(0, i).endsWith(".dSYM");
+                }
+            }
+            return name.endsWith(".diz")
+                    || name.endsWith(".debuginfo")
+                    || name.endsWith(".map")
+                    || name.endsWith(".pdb");
+        }
+        return false;
+    }
+}

--- a/test/jdk/jdk/modules/etc/JmodExcludedFiles.java
+++ b/test/jdk/jdk/modules/etc/JmodExcludedFiles.java
@@ -32,22 +32,19 @@
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import jdk.internal.util.OperatingSystem;
 
 public class JmodExcludedFiles {
-    private static String javaHome = System.getProperty("java.home");
-
     public static void main(String[] args) throws Exception {
+        String javaHome = System.getProperty("java.home");
         Path jmods = Path.of(javaHome, "jmods");
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(jmods, "*.jmod")) {
             for (Path jmodFile : stream) {
                 try (ZipFile zip = new ZipFile(jmodFile.toFile())) {
-                    JModSymbolFileMatcher jsfm = new JModSymbolFileMatcher(jmodFile.toString());
                     if (zip.stream().map(ZipEntry::getName)
-                                    .anyMatch(jsfm::isNativeDebugSymbol)) {
+                                    .anyMatch(JmodExcludedFiles::isNativeDebugSymbol)) {
                         throw new RuntimeException(jmodFile + " is expected not to include native debug symbols");
                     }
                 }
@@ -55,47 +52,25 @@ public class JmodExcludedFiles {
         }
     }
 
-    static class JModSymbolFileMatcher {
-        private String jmod;
-
-        JModSymbolFileMatcher(String jmod) {
-            this.jmod = jmod;
+    private static boolean isNativeDebugSymbol(String name) {
+        int index = name.indexOf("/");
+        if (index < 0) {
+            throw new RuntimeException("unexpected entry name: " + name);
         }
-
-        boolean isNativeDebugSymbol(String name) {
-            int index = name.indexOf("/");
-            if (index < 0) {
-                throw new RuntimeException("unexpected entry name: " + name);
-            }
-            String section = name.substring(0, index);
-            if (section.equals("lib") || section.equals("bin")) {
-                if (OperatingSystem.isMacOS()) {
-                    String n = name.substring(index + 1);
-                    int i = n.indexOf("/");
-                    if (i != -1) {
-                        if (n.substring(0, i).endsWith(".dSYM")) {
-                            System.err.println("Found symbols in " + jmod + ": " + name);
-                            return true;
-                        }
-                    }
-                }
-                if (OperatingSystem.isWindows() && name.endsWith(".pdb")) {
-                    // on Windows we check if we should have public symbols through --with-external-symbols-in-bundles=public (JDK-8237192)
-                    String strippedpdb = javaHome + "/bin/" + name.substring(index + 1, name.length() - 4) + ".stripped.pdb";
-                    if (!Files.exists(Paths.get(strippedpdb))) {
-                        System.err.println("Found symbols in " + jmod + ": " + name +
-                                ". No stripped pdb file " + strippedpdb + " exists.");
-                        return true;
-                    }
-                }
-                if (name.endsWith(".diz")
-                        || name.endsWith(".debuginfo")
-                        || name.endsWith(".map")) {
-                    System.err.println("Found symbols in " + jmod + ": " + name);
-                    return true;
+        String section = name.substring(0, index);
+        if (section.equals("lib") || section.equals("bin")) {
+            if (OperatingSystem.isMacOS()) {
+                String n = name.substring(index+1);
+                int i = n.indexOf("/");
+                if (i != -1) {
+                    return n.substring(0, i).endsWith(".dSYM");
                 }
             }
-            return false;
+            return name.endsWith(".diz")
+                    || name.endsWith(".debuginfo")
+                    || name.endsWith(".map")
+                    || name.endsWith(".pdb");
         }
+        return false;
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6c0bebcc](https://github.com/openjdk/jdk/commit/6c0bebccb0092d9726eb89a054e023e92edf7ca6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

Testing: 
- [x] Added test case passes. 

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8159927](https://bugs.openjdk.org/browse/JDK-8159927) needs maintainer approval

### Issue
 * [JDK-8159927](https://bugs.openjdk.org/browse/JDK-8159927): Add a test to verify JMOD files created in the images do not have debug symbols (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/378/head:pull/378` \
`$ git checkout pull/378`

Update a local copy of the PR: \
`$ git checkout pull/378` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 378`

View PR using the GUI difftool: \
`$ git pr show -t 378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/378.diff">https://git.openjdk.org/jdk21u-dev/pull/378.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/378#issuecomment-2007537552)