### PR TITLE
8324998: Add test cases for String.regionMatches comparing Turkic dotted/dotless I with uppercase latin I

### DIFF
--- a/test/jdk/java/lang/String/CompactString/RegionMatches.java
+++ b/test/jdk/java/lang/String/CompactString/RegionMatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,9 +96,13 @@ public class RegionMatches extends CompactString {
                 // Turkish I with dot
                 new Object[] { "\u0130", false, 0, "i", 0, 1, false },
                 new Object[] { "\u0130", true,  0, "i", 0, 1, true },
+                new Object[] { "\u0130", false, 0, "I", 0, 1, false },
+                new Object[] { "\u0130", true,  0, "I", 0, 1, true },
                 // i without dot
                 new Object[] { "\u0131", false, 0, "i", 0, 1, false },
                 new Object[] { "\u0131", true,  0, "i", 0, 1, true },
+                new Object[] { "\u0131", false, 0, "I", 0, 1, false },
+                new Object[] { "\u0131", true,  0, "I", 0, 1, true },
                 // Exhaustive list of 1-char latin1 strings that match
                 // case-insensitively:
                 // for (char c1 = 0; c1 < 255; c1++) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c3c1d5bd](https://github.com/openjdk/jdk/commit/c3c1d5bd12f80c6a720e431961e90b09c2d972f9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Eirik Bjørsnøs on 30 Jan 2024 and was reviewed by Naoto Sato and Iris Clark.

Testing: 
- [x] Modified test passes

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324998](https://bugs.openjdk.org/browse/JDK-8324998) needs maintainer approval

### Issue
 * [JDK-8324998](https://bugs.openjdk.org/browse/JDK-8324998): Add test cases for String.regionMatches comparing Turkic dotted/dotless I with uppercase latin I (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/379/head:pull/379` \
`$ git checkout pull/379`

Update a local copy of the PR: \
`$ git checkout pull/379` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 379`

View PR using the GUI difftool: \
`$ git pr show -t 379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/379.diff">https://git.openjdk.org/jdk21u-dev/pull/379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/379#issuecomment-2007568968)