### PR TITLE
8328066: WhiteBoxResizeTest failure on linux-x86: Could not reserve enough space for 2097152KB object heap

### DIFF
--- a/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
+++ b/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,8 @@ import static org.testng.Assert.assertThrows;
  * @bug 8186958 8210280 8281631 8285386 8284780
  * @modules java.base/java.util:open
  * @summary White box tests for HashMap-related internals around table sizing
+ * @comment skip running this test on 32 bit VM
+ * @requires vm.bits == "64"
  * @run testng/othervm -Xmx2g WhiteBoxResizeTest
  */
 public class WhiteBoxResizeTest {


### PR DESCRIPTION
I backport this to stabilize the GHA tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8328066](https://bugs.openjdk.org/browse/JDK-8328066) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328066](https://bugs.openjdk.org/browse/JDK-8328066): WhiteBoxResizeTest failure on linux-x86: Could not reserve enough space for 2097152KB object heap (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/381/head:pull/381` \
`$ git checkout pull/381`

Update a local copy of the PR: \
`$ git checkout pull/381` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 381`

View PR using the GUI difftool: \
`$ git pr show -t 381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/381.diff">https://git.openjdk.org/jdk21u-dev/pull/381.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/381#issuecomment-2006670840)