### PR TITLE
8317631: Refactor ChoiceFormat tests to use JUnit

### DIFF
--- a/test/jdk/java/text/Format/ChoiceFormat/Bug4185732Test.java
+++ b/test/jdk/java/text/Format/ChoiceFormat/Bug4185732Test.java
@@ -22,15 +22,6 @@
  */
 
 /*
- * @test
- * @bug 4185732
- * @library /java/text/testlib
- * @build Bug4185732Test HexDumpReader
- * @run junit Bug4185732Test
- * @summary test that ChoiceFormat invariants are preserved across serialization.
- */
-
-/*
  * This file is available under and governed by the GNU General Public
  * License version 2 only, as published by the Free Software Foundation.
  * However, the following notice accompanied the original version of this
@@ -64,36 +55,50 @@
  * DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
  */
 
-import java.util.*;
-import java.io.*;
+/*
+ * @test
+ * @bug 4185732
+ * @library /java/text/testlib
+ * @build HexDumpReader
+ * @summary Test that ChoiceFormat invariants are preserved across serialization.
+ *          This test depends on Bug4185732.ser.txt and will fail otherwise.
+ * @run junit Bug4185732Test
+ */
+
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.text.ChoiceFormat;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-/**
- *  A Locale can never contain language codes of he, yi or id.
- */
 public class Bug4185732Test {
+
+    /*
+     * The ChoiceFormat class requires that its choiceFormats and choiceLimits
+     * arrays have the same length. This test ensures that the invariant is enforced
+     * during the readObject() call.
+     */
     @Test
-    public void testIt() throws Exception {
+    public void choiceFormatSerializationInvariantsTest() {
         try {
+            // A serialized ChoiceFormat with unequal formats and limits
             final ObjectInputStream in
                 = new ObjectInputStream(HexDumpReader.getStreamFromHexDump("Bug4185732.ser.txt"));
             final ChoiceFormat loc = (ChoiceFormat)in.readObject();
             if (loc.getFormats().length != loc.getLimits().length) {
                 fail("ChoiceFormat did not properly check stream");
             } else {
-                //for some reason, the data file was VALID.  This test
-                //requires a corrupt data file the format and limit
-                //arrays are of different length.
+                // for some reason, the data file was VALID.  This test
+                // requires a corrupt data file the format and limit
+                // arrays are of different length.
                 fail("Test data file was not properly created");
             }
-        } catch (InvalidObjectException e) {
-            //this is what we want to have happen
-        } catch (Exception e) {
-            fail(e.toString());
+        } catch (InvalidObjectException expectedException) {
+            // Expecting an IOE
+        } catch (Exception wrongException) {
+            fail("Expected an InvalidObjectException, instead got: " + wrongException);
         }
     }
 }

--- a/test/jdk/java/text/Format/ChoiceFormat/Bug8001209.java
+++ b/test/jdk/java/text/Format/ChoiceFormat/Bug8001209.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,70 +21,90 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8001209
  * @summary Confirm that the values set by setChoices() are not mutable.
+ * @run junit Bug8001209
  */
-import java.text.*;
+
+import java.text.ChoiceFormat;
+import java.text.ParsePosition;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Bug8001209 {
 
-    public static void main(String[] args) throws Exception {
-        boolean err = false;
+    // Represents the expected output of formatting the ChoiceFormat
+    private static String expectedFormattedOutput;
+    private static ChoiceFormat cFmt;
+    private static ParsePosition status;
+    private static String[] originalSetterArray;
 
-        // Borrow an example in API doc
-        double[] limits = {1,2,3,4,5,6,7};
-        String[] dayOfWeekNames = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
-        ChoiceFormat form = new ChoiceFormat(limits, dayOfWeekNames);
-        ParsePosition status = new ParsePosition(0);
+    // Build the original ChoiceFormat to test if it can be mutated
+    @BeforeAll
+    static void setUpChoiceFormatAndOutput() {
+        double[] limits = {1, 2, 3, 4, 5, 6, 7};
+        originalSetterArray = new String[]{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+        // Constructor calls setChoices
+        cFmt = new ChoiceFormat(limits, originalSetterArray);
+        status = new ParsePosition(0);
 
+        // Build the expected results of formatting with the original ChoiceFormat
         StringBuilder before = new StringBuilder();
         for (double i = 1.0; i <= 7.0; ++i) {
             status.setIndex(0);
-            String s = form.format(i);
+            String s = cFmt.format(i);
             before.append(" ");
             before.append(s);
-            before.append(form.parse(form.format(i),status));
+            before.append(cFmt.parse(cFmt.format(i), status));
         }
-        String original = before.toString();
+        expectedFormattedOutput = before.toString();
+    }
 
-        double[] newLimits = form.getLimits();
-        String[] newFormats = (String[])form.getFormats();
+    /*
+     * Ensure that mutating the arrays returned by getChoices and getLimits does
+     * not affect the internal representation of the ChoiceFormat.
+     */
+    @Test
+    public void immutableArraysFromGetters() {
+        // Modify the array returned by getFormats() -> newFormats
+        String[] newFormats = (String[]) cFmt.getFormats();
         newFormats[6] = "Doyoubi";
         StringBuilder after = new StringBuilder();
         for (double i = 1.0; i <= 7.0; ++i) {
             status.setIndex(0);
-            String s = form.format(i);
+            String s = cFmt.format(i);
             after.append(" ");
             after.append(s);
-            after.append(form.parse(form.format(i),status));
+            after.append(cFmt.parse(cFmt.format(i), status));
         }
-        if (!original.equals(after.toString())) {
-            err = true;
-            System.err.println("  Expected:" + before
-                               + "\n  Got:     " + after);
-        }
+        // Compare the expected results with the new formatted results
+        assertEquals(after.toString(), expectedFormattedOutput,
+                "Mutating array returned from getter changed internals of ChoiceFormat");
+    }
 
-        dayOfWeekNames[6] = "Saturday";
-        after = new StringBuilder();
+    /*
+     * Ensure that mutating the arrays passed to setChoices/constructor does
+     * not affect the internal representation of the ChoiceFormat.
+     */
+    @Test
+    public void immutableArraysFromSetter() {
+        // Modify the array passed to setFormats() -> dayOfWeekNames
+        originalSetterArray[6] = "Saturday";
+        StringBuilder after = new StringBuilder();
         for (double i = 1.0; i <= 7.0; ++i) {
             status.setIndex(0);
-            String s = form.format(i);
+            String s = cFmt.format(i);
             after.append(" ");
             after.append(s);
-            after.append(form.parse(form.format(i),status));
+            after.append(cFmt.parse(cFmt.format(i), status));
         }
-        if (!original.equals(after.toString())) {
-            err = true;
-            System.err.println("  Expected:" + before
-                               + "\n  Got:     " + after);
-        }
-
-        if (err) {
-            throw new RuntimeException("Failed.");
-        } else {
-            System.out.println("Passed.");
-        }
+        // Compare the expected results with the new formatted results
+        assertEquals(after.toString(), expectedFormattedOutput,
+                "Mutating array passed to setter changed internals of ChoiceFormat");
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317631](https://bugs.openjdk.org/browse/JDK-8317631) needs maintainer approval

### Issue
 * [JDK-8317631](https://bugs.openjdk.org/browse/JDK-8317631): Refactor ChoiceFormat tests to use JUnit (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/382/head:pull/382` \
`$ git checkout pull/382`

Update a local copy of the PR: \
`$ git checkout pull/382` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 382`

View PR using the GUI difftool: \
`$ git pr show -t 382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/382.diff">https://git.openjdk.org/jdk21u-dev/pull/382.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/382#issuecomment-2007487968)