### PR TITLE
8328165: improve assert(idx < _maxlrg) failed: oob

### DIFF
--- a/src/hotspot/share/opto/chaitin.hpp
+++ b/src/hotspot/share/opto/chaitin.hpp
@@ -292,7 +292,7 @@ public:
 #endif
 
   //--------------- Live Range Accessors
-  LRG &lrgs(uint idx) const { assert(idx < _maxlrg, "oob"); return _lrgs[idx]; }
+  LRG &lrgs(uint idx) const { assert(idx < _maxlrg, "oob: index %u not smaller than %u", idx, _maxlrg); return _lrgs[idx]; }
 
   // Compute and set effective degree.  Might be folded into SquareUp().
   void Compute_Effective_Degree();


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328165](https://bugs.openjdk.org/browse/JDK-8328165) needs maintainer approval

### Issue
 * [JDK-8328165](https://bugs.openjdk.org/browse/JDK-8328165): improve assert(idx &lt; _maxlrg) failed: oob (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/392/head:pull/392` \
`$ git checkout pull/392`

Update a local copy of the PR: \
`$ git checkout pull/392` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 392`

View PR using the GUI difftool: \
`$ git pr show -t 392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/392.diff">https://git.openjdk.org/jdk21u-dev/pull/392.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/392#issuecomment-2012757549)