### PR TITLE
8319647: Few java/lang/System/LoggerFinder/modules tests ignore vm flags

### DIFF
--- a/test/jdk/java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  *               patched system module, or Xbootclasspath
  *          This test does not require existence of java.logging module,
  *          but require jdk.compiler module
+ * @requires vm.flagless
  * @library /test/lib
  * @build Base jdk.test.lib.compiler.CompilerUtils
  * @run main/othervm JDKLoggerForImageTest

--- a/test/jdk/java/lang/System/LoggerFinder/modules/JDKLoggerForJDKTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/JDKLoggerForJDKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  *            2. clients are in named/unnamed module,
  *               patched system module, or Xbootclasspath
  *          This test DOES require existence of java.logging module
+ * @requires vm.flagless
  * @library /test/lib
  * @build Base jdk.test.lib.compiler.CompilerUtils
  * @run main/othervm JDKLoggerForJDKTest

--- a/test/jdk/java/lang/System/LoggerFinder/modules/LoggerInImageTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/LoggerInImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  *               patched system module, or Xbootclasspath
  *          This test does not require existence of java.logging module,
  *          but require jdk.compiler module
+ * @requires vm.flagless
  * @library /test/lib
  * @build Base jdk.test.lib.compiler.CompilerUtils
  * @run main/othervm LoggerInImageTest

--- a/test/jdk/java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.File;
  *               patched system module, or Xbootclasspath
  *          This test does not require existence of java.logging module,
  *          but require jdk.compiler module
+ * @requires vm.flagless
  * @library /test/lib
  * @build Base jdk.test.lib.compiler.CompilerUtils
  * @run main/othervm NamedLoggerForImageTest

--- a/test/jdk/java/lang/System/LoggerFinder/modules/NamedLoggerForJDKTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/NamedLoggerForJDKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.File;
  *               patched system module, or Xbootclasspath
  *          This test does not require existence of java.logging module,
  *          but require jdk.compiler module
+ * @requires vm.flagless
  * @library /test/lib
  * @build Base jdk.test.lib.compiler.CompilerUtils
  * @run main/othervm NamedLoggerForJDKTest

--- a/test/jdk/java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.File;
  *               patched system module, or Xbootclasspath
  *          This test does not require existence of java.logging module,
  *          but require jdk.compiler module
+ * @requires vm.flagless
  * @library /test/lib
  * @build Base jdk.test.lib.compiler.CompilerUtils
  * @run main/othervm UnnamedLoggerForImageTest

--- a/test/jdk/java/lang/System/LoggerFinder/modules/UnnamedLoggerForJDKTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/modules/UnnamedLoggerForJDKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.File;
  *               patched system module, or Xbootclasspath
  *          This test does not require existence of java.logging module,
  *          but require jdk.compiler module
+ * @requires vm.flagless
  * @library /test/lib
  * @build Base jdk.test.lib.compiler.CompilerUtils
  * @run main/othervm UnnamedLoggerForJDKTest


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319647](https://bugs.openjdk.org/browse/JDK-8319647) needs maintainer approval

### Issue
 * [JDK-8319647](https://bugs.openjdk.org/browse/JDK-8319647): Few java/lang/System/LoggerFinder/modules tests ignore vm flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/397/head:pull/397` \
`$ git checkout pull/397`

Update a local copy of the PR: \
`$ git checkout pull/397` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 397`

View PR using the GUI difftool: \
`$ git pr show -t 397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/397.diff">https://git.openjdk.org/jdk21u-dev/pull/397.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/397#issuecomment-2016581514)