### PR TITLE
8319571: Update jni/nullCaller/NullCallerTest.java to accept flags or mark as flagless

### DIFF
--- a/test/jdk/jni/nullCaller/NullCallerTest.java
+++ b/test/jdk/jni/nullCaller/NullCallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,17 +37,15 @@
 
 // Test disabled on AIX since we cannot invoke the JVM on the primordial thread.
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Properties;
 
 import jdk.test.lib.Platform;
-import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.compiler.CompilerUtils;
+import jdk.test.lib.process.ProcessTools;
 
 public class NullCallerTest {
 
@@ -87,28 +85,10 @@ public class NullCallerTest {
         // build the module used for the test
         compileTestModule();
 
-        var launcher = Path.of(System.getProperty("test.nativepath"), "NullCallerTest");
-        var pb = new ProcessBuilder(launcher.toString());
-        var env = pb.environment();
-
-        var libDir = Platform.libDir().toString();
-        var vmDir = Platform.jvmLibDir().toString();
-
-        // set up shared library path
-        var sharedLibraryPathEnvName = Platform.sharedLibraryPathVariableName();
-        env.compute(sharedLibraryPathEnvName,
-                (k, v) -> (v == null) ? libDir : v + File.pathSeparator + libDir);
-        env.compute(sharedLibraryPathEnvName,
-                (k, v) -> (v == null) ? vmDir : v + File.pathSeparator + vmDir);
-
-        // launch the actual test
-        System.out.println("Launching: " + launcher + " shared library path: " +
-                env.get(sharedLibraryPathEnvName));
-        new OutputAnalyzer(pb.start())
-                .outputTo(System.out)
-                .errorTo(System.err)
-                .shouldHaveExitValue(0);
-
+        ProcessBuilder pb = ProcessTools.createNativeTestProcessBuilder("NullCallerTest");
+        System.out.println("Launching: " + pb.command() + " shared library path: " +
+                               pb.environment().get(Platform.sharedLibraryPathVariableName()));
+        ProcessTools.executeProcess(pb).shouldHaveExitValue(0);
     }
 
 }


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319571](https://bugs.openjdk.org/browse/JDK-8319571) needs maintainer approval

### Issue
 * [JDK-8319571](https://bugs.openjdk.org/browse/JDK-8319571): Update jni/nullCaller/NullCallerTest.java to accept flags or mark as flagless (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/399/head:pull/399` \
`$ git checkout pull/399`

Update a local copy of the PR: \
`$ git checkout pull/399` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 399`

View PR using the GUI difftool: \
`$ git pr show -t 399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/399.diff">https://git.openjdk.org/jdk21u-dev/pull/399.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/399#issuecomment-2016582722)