### PR TITLE
8319651: Several network tests ignore vm flags when start java process

### DIFF
--- a/test/jdk/java/net/InetAddress/ptr/Lookup.java
+++ b/test/jdk/java/net/InetAddress/ptr/Lookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,18 +41,15 @@
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class Lookup {
     private static final String HOST = "icann.org";
     private static final String SKIP = "SKIP";
-    private static final String CLASS_PATH = System.getProperty(
-            "test.class.path");
 
     public static void main(String args[]) throws IOException {
         String addr = null;
@@ -135,20 +132,16 @@ public class Lookup {
     }
 
     static String lookupWithIPv4Prefer() throws IOException {
-        String java = JDKToolFinder.getTestJDKTool("java");
         String testClz = Lookup.class.getName();
-        List<String> cmd = List.of(java, "-Djava.net.preferIPv4Stack=true",
-                "-cp", CLASS_PATH, testClz);
-        System.out.println("Executing: " + cmd);
-        return new OutputAnalyzer(new ProcessBuilder(cmd).start()).getOutput();
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-Djava.net.preferIPv4Stack=true", testClz);
+        return new OutputAnalyzer(pb.start()).getOutput();
     }
 
     static String reverseWithIPv4Prefer(String addr) throws IOException {
-        String java = JDKToolFinder.getTestJDKTool("java");
         String testClz = Lookup.class.getName();
-        List<String> cmd = List.of(java, "-Djava.net.preferIPv4Stack=true",
-                                   "-cp", CLASS_PATH, testClz, "reverse", addr);
-        System.out.println("Executing: " + cmd);
-        return new OutputAnalyzer(new ProcessBuilder(cmd).start()).getOutput();
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-Djava.net.preferIPv4Stack=true", testClz, "reverse", addr);
+        return new OutputAnalyzer(pb.start()).getOutput();
     }
 }

--- a/test/jdk/java/net/ServerSocket/AcceptCauseFileDescriptorLeak.java
+++ b/test/jdk/java/net/ServerSocket/AcceptCauseFileDescriptorLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,8 @@
  *          can cause fd leak.
  *          This test may fail intermittently if foreign processes will
  *          try to establish connection to the test server socket.
- * @requires (os.family != "windows")
+ * @requires os.family != "windows"
+ * @requires vm.flagless
  * @library /test/lib
  * @build jdk.test.lib.Utils
  *        jdk.test.lib.Asserts

--- a/test/jdk/java/net/ServerSocket/AcceptInheritHandle.java
+++ b/test/jdk/java/net/ServerSocket/AcceptInheritHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,12 @@ import java.net.*;
 import java.nio.channels.ServerSocketChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import jdk.test.lib.net.IPSupport;
+import jdk.test.lib.process.ProcessTools;
 
 public class AcceptInheritHandle {
 
@@ -95,16 +97,12 @@ public class AcceptInheritHandle {
         System.out.println("\nStarting test for " + ssp.name());
 
         List<String> commands = new ArrayList<>();
-        commands.add(JAVA);
-        for (String arg : jvmArgs)
-            commands.add(arg);
-        commands.add("-cp");
-        commands.add(CLASSPATH);
+        Collections.addAll(commands, jvmArgs);
         commands.add("AcceptInheritHandle");
         commands.add(ssp.name());
 
         System.out.println("Executing: "+ commands);
-        ProcessBuilder pb = new ProcessBuilder(commands);
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(commands);
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
         Process serverProcess = pb.start();
         DataInputStream dis = new DataInputStream(serverProcess.getInputStream());

--- a/test/jdk/java/net/URLClassLoader/getresourceasstream/TestDriver.java
+++ b/test/jdk/java/net/URLClassLoader/getresourceasstream/TestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@
  * @run main/othervm TestDriver
  */
 
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 
 import java.io.IOException;
@@ -53,33 +52,33 @@ public class TestDriver {
             throws Throwable {
 
         Path userDir = Paths.get(System.getProperty("user.dir"));
-        String java = JDKToolFinder.getTestJDKTool("java");
         String basename = userDir.getFileName().toString();
         setup(userDir);
         ProcessBuilder[] tests = new ProcessBuilder[]{
-                new ProcessBuilder(
-                        java, TEST_NAME, "./" + ARCHIVE_NAME
+                ProcessTools.createTestJavaProcessBuilder(
+                        TEST_NAME,
+                        "./" + ARCHIVE_NAME
                 ),
-                new ProcessBuilder(
-                        java, "-cp", ".",
+                ProcessTools.createTestJavaProcessBuilder(
+                        "-cp", ".",
                         "-Djava.security.policy=file:./policy",
                         "-Djava.security.manager",
                         TEST_NAME, "./" + ARCHIVE_NAME
                 ),
-                new ProcessBuilder(
-                        java, "-cp", ".",
+                ProcessTools.createTestJavaProcessBuilder(
+                        "-cp", ".",
                         "-Djava.security.policy=file:./policy",
                         "-Djava.security.manager",
                         TEST_NAME, "./" + ARCHIVE_NAME
                 ),
-                new ProcessBuilder(
-                        java, "-cp", "..",
+                ProcessTools.createTestJavaProcessBuilder(
+                        "-cp", "..",
                         "-Djava.security.policy=file:../policy",
                         "-Djava.security.manager",
                         TEST_NAME, "../" + ARCHIVE_NAME
                 ).directory(userDir.resolve("tmp").toFile()),
-                new ProcessBuilder(
-                        java, "-cp", basename,
+                ProcessTools.createTestJavaProcessBuilder(
+                        "-cp", basename,
                         "-Djava.security.policy=file:" + basename + "/policy",
                         "-Djava.security.manager",
                         TEST_NAME, basename + "/" + ARCHIVE_NAME

--- a/test/jdk/java/net/URLClassLoader/sealing/CheckSealedTest.java
+++ b/test/jdk/java/net/URLClassLoader/sealing/CheckSealedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,8 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static jdk.test.lib.process.ProcessTools.createTestJavaProcessBuilder;
+import static jdk.test.lib.process.ProcessTools.executeCommand;
 
 public class CheckSealedTest {
     private static final String ARCHIVE_NAME = "b.jar";
@@ -55,31 +57,30 @@ public class CheckSealedTest {
 
         String baseDir = System.getProperty("user.dir") + File.separator;
         String javac = JDKToolFinder.getTestJDKTool("javac");
-        String java = JDKToolFinder.getTestJDKTool("java");
 
         setup(baseDir);
         String srcDir = System.getProperty("test.src");
         String cp = srcDir + File.separator + "a" + File.pathSeparator
                 + srcDir + File.separator + "b.jar" + File.pathSeparator
                 + ".";
+
+        // Compile
+        ProcessTools.executeCommand(javac, "-cp", cp, "-d", ".",
+                srcDir + File.separator + TEST_NAME + ".java");
+
         List<String[]> allCMDs = List.of(
-                // Compile command
-                new String[]{
-                        javac, "-cp", cp, "-d", ".",
-                        srcDir + File.separator + TEST_NAME + ".java"
-                },
                 // Run test the first time
                 new String[]{
-                        java, "-cp", cp, TEST_NAME, "1"
+                        "-cp", cp, TEST_NAME, "1"
                 },
                 // Run test the second time
                 new String[]{
-                        java, "-cp", cp, TEST_NAME, "2"
+                        "-cp", cp, TEST_NAME, "2"
                 }
         );
 
         for (String[] cmd : allCMDs) {
-            ProcessTools.executeCommand(cmd)
+            executeCommand(createTestJavaProcessBuilder(cmd))
                         .outputTo(System.out)
                         .errorTo(System.out)
                         .shouldHaveExitValue(0);

--- a/test/jdk/java/net/URLConnection/6212146/TestDriver.java
+++ b/test/jdk/java/net/URLConnection/6212146/TestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary URLConnection.connect() fails on JAR Entry it creates
  * file handler leak
  * @library /test/lib
+ * @requires vm.flagless
  * @build jdk.test.lib.Utils
  *        jdk.test.lib.Asserts
  *        jdk.test.lib.JDKToolFinder

--- a/test/jdk/java/net/URLConnection/ContentHandlers/ContentHandlersTest.java
+++ b/test/jdk/java/net/URLConnection/ContentHandlers/ContentHandlersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -56,6 +58,7 @@ import static java.util.Collections.singletonMap;
 /*
  * @test
  * @bug 8064925
+ * @library /test/lib
  * @summary Basic test for ContentHandler. Ensures discovery paths for content
  *          handlers follow a particular order.
  */
@@ -268,14 +271,10 @@ public class ContentHandlersTest {
                                Collection<Path> classpath,
                                String classname, String... args) {
 
-        String java = getJDKTool("java");
-
-        List<String> commands = new ArrayList<>();
-        commands.add(java);
-        commands.addAll(properties.entrySet()
+        List<String> commands = properties.entrySet()
                 .stream()
                 .map(e -> "-D" + e.getKey() + "=" + e.getValue())
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
 
         String cp = classpath.stream()
                 .map(Path::toString)
@@ -285,7 +284,7 @@ public class ContentHandlersTest {
         commands.add(classname);
         commands.addAll(Arrays.asList(args));
 
-        return run(new ProcessBuilder(commands));
+        return run(ProcessTools.createTestJavaProcessBuilder(commands));
     }
 
     private static Result run(ProcessBuilder b) {

--- a/test/jdk/java/net/httpclient/security/Driver.java
+++ b/test/jdk/java/net/httpclient/security/Driver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * Driver for tests
@@ -126,12 +127,10 @@ public class Driver {
         String testClassPath = System.getProperty("test.class.path", "?");
         String testClasses = System.getProperty("test.classes", "?");
         String sep = System.getProperty("file.separator", "?");
-        String javaCmd = testJdk + sep + "bin" + sep + "java";
         int retval = 10; // 10 is special exit code denoting a bind error
                          // in which case, we retry
         while (retval == 10) {
             List<String> cmd = new ArrayList<>();
-            cmd.add(javaCmd);
             cmd.add("-ea");
             cmd.add("-esa");
             cmd.add("-Dtest.jdk=" + testJdk);
@@ -150,7 +149,7 @@ public class Driver {
             cmd.add("Security");
             cmd.add(testnum);
 
-            ProcessBuilder processBuilder = new ProcessBuilder(cmd)
+            ProcessBuilder processBuilder = ProcessTools.createTestJavaProcessBuilder(cmd)
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .redirectErrorStream(true);
 

--- a/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
+++ b/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,8 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
+
+import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.FileUtils;
 import jdk.test.lib.JDKToolFinder;
 import static java.lang.String.format;
@@ -234,12 +236,8 @@ public class Basic {
 
     static Result java(List<String> sysProps, Collection<Path> classpath,
                        String classname, String arg) {
-        String java = getJDKTool("java");
 
-        List<String> commands = new ArrayList<>();
-        commands.add(java);
-        for (String prop : sysProps)
-            commands.add(prop);
+        List<String> commands = new ArrayList<>(sysProps);
 
         String cp = classpath.stream()
                 .map(Path::toString)
@@ -249,7 +247,7 @@ public class Basic {
         commands.add(classname);
         commands.add(arg);
 
-        return run(new ProcessBuilder(commands));
+        return run(ProcessTools.createTestJavaProcessBuilder(commands));
     }
 
     static Result run(ProcessBuilder pb) {

--- a/test/jdk/javax/net/ssl/DTLS/DTLSWontNegotiateV10.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSWontNegotiateV10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,13 @@
  * questions.
  */
 
+import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.security.SecurityUtils;
 
 import javax.net.ssl.*;
 import java.io.IOException;
 import java.net.*;
 import java.nio.ByteBuffer;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -87,14 +87,13 @@ public class DTLSWontNegotiateV10 {
         Process clientProcess = null;
         try (DTLSServer server = new DTLSServer(protocol)) {
             List<String> command = List.of(
-                    Path.of(System.getProperty("java.home"), "bin", "java").toString(),
                     "DTLSWontNegotiateV10",
                     // if server is "DTLS" then the client should be v1.0 and vice versa
                     protocol.equals(DTLS) ? DTLSV_1_0 : DTLS,
                     Integer.toString(server.getListeningPortNumber())
             );
 
-            ProcessBuilder builder = new ProcessBuilder(command);
+            ProcessBuilder builder = ProcessTools.createTestJavaProcessBuilder(command);
             clientProcess = builder.inheritIO().start();
             server.run();
             System.out.println("Success: DTLSv1.0 connection was not established.");

--- a/test/jdk/javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +21,19 @@
  * questions.
  */
 
+import jdk.test.lib.process.ProcessTools;
+
 import javax.net.ssl.*;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.security.Security;
 import java.util.List;
 
 /*
  * @test id=Server
  * @bug 8301379
+ * @library /test/lib
  * @summary Verify that Java will not negotiate disabled cipher suites when the
  * other side of the connection requests them.
  *
@@ -42,6 +44,7 @@ import java.util.List;
 /*
  * @test id=Client
  * @bug 8301379
+ * @library /test/lib
  * @summary Verify that Java will not negotiate disabled cipher suites when the
  * other side of the connection requests them.
  *
@@ -61,13 +64,12 @@ public class TLSWontNegotiateDisabledCipherAlgos {
         if (args[0].equals("server")) {
             try (TLSServer server = new TLSServer(useDisabledAlgo)) {
                 List<String> command = List.of(
-                        Path.of(System.getProperty("java.home"), "bin", "java").toString(),
                         "TLSWontNegotiateDisabledCipherAlgos",
                         "client",
                         Boolean.toString(!useDisabledAlgo),
                         Integer.toString(server.getListeningPort())
                 );
-                ProcessBuilder builder = new ProcessBuilder(command);
+                ProcessBuilder builder = ProcessTools.createTestJavaProcessBuilder(command);
                 Process p = builder.inheritIO().start();
                 server.run();
                 p.destroy();

--- a/test/jdk/sun/net/www/protocol/jar/GetContentTypeTest.java
+++ b/test/jdk/sun/net/www/protocol/jar/GetContentTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,10 @@
  *        GetContentType GetContentTypeTest
  * @run main/othervm GetContentTypeTest
  * @summary Test JarURLConnection.getContentType would
- *          would return default "content/unknown"
+ *          return default "content/unknown"
  */
 
-import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
@@ -49,9 +49,9 @@ public class GetContentTypeTest {
         Path resJar = Paths.get(System.getProperty("test.src"),
                 "resource.jar");
         Path classes = Paths.get(System.getProperty("test.classes"));
-        ProcessTools.executeCommand(
-                JDKToolFinder.getTestJDKTool("java"),
-                "-cp", resJar + File.pathSeparator + classes, "GetContentType")
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-cp", resJar + File.pathSeparator + classes, "GetContentType");
+        new OutputAnalyzer(pb.start())
                 .outputTo(System.out)
                 .errorTo(System.out)
                 .shouldHaveExitValue(0);

--- a/test/jdk/sun/net/www/protocol/jar/jarbug/TestDriver.java
+++ b/test/jdk/sun/net/www/protocol/jar/jarbug/TestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import java.nio.file.Paths;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.compiler.CompilerUtils;
+import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
 
@@ -81,14 +82,14 @@ public class TestDriver {
         CompilerUtils.compile(srcDir.resolve("src").resolve("test"), targetDir);
 
         // Run tests
-        String java = JDKToolFinder.getTestJDKTool("java");
         String cp = targetDir.toString() + File.pathSeparator + jarFile;
         String[] tests = new String[]{"TestBug4361044", "TestBug4523159"};
         for (String test : tests) {
-            ProcessTools.executeCommand(java, "-cp", cp, test)
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .shouldHaveExitValue(0);
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-cp", cp, test);
+            new OutputAnalyzer(pb.start())
+                    .outputTo(System.out)
+                    .errorTo(System.out)
+                    .shouldHaveExitValue(0);
         }
     }
 }

--- a/test/jdk/sun/net/www/protocol/jrt/OtherResourcesTest.java
+++ b/test/jdk/sun/net/www/protocol/jrt/OtherResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,8 @@
  * questions.
  */
 
-import jdk.test.lib.JDKToolFinder;
-import static jdk.test.lib.process.ProcessTools.executeCommand;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
@@ -39,12 +39,13 @@ import static jdk.test.lib.process.ProcessTools.executeCommand;
 public class OtherResourcesTest {
     public static void main(String[] args) throws Throwable {
         String classes = System.getProperty("test.classes");
-        executeCommand(JDKToolFinder.getTestJDKTool("java"),
-                       "--limit-modules", "java.base",
-                       "-cp", classes, "OtherResources")
-                      .outputTo(System.out)
-                      .errorTo(System.out)
-                      .shouldHaveExitValue(0);
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "--limit-modules", "java.base",
+                "-cp", classes, "OtherResources");
+        new OutputAnalyzer(pb.start())
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .shouldHaveExitValue(0);
     }
 }
 


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8319651](https://bugs.openjdk.org/browse/JDK-8319651) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319651](https://bugs.openjdk.org/browse/JDK-8319651): Several network tests ignore vm flags when start java process (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/400/head:pull/400` \
`$ git checkout pull/400`

Update a local copy of the PR: \
`$ git checkout pull/400` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 400`

View PR using the GUI difftool: \
`$ git pr show -t 400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/400.diff">https://git.openjdk.org/jdk21u-dev/pull/400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/400#issuecomment-2016589184)