### PR TITLE
8326824: Test: remove redundant test in compiler/vectorapi/reshape/utils/TestCastMethods.java

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
@@ -62,7 +62,6 @@ public class TestCastMethods {
             makePair(FSPEC128, ISPEC128),
             makePair(FSPEC64, DSPEC128),
             makePair(FSPEC128, DSPEC256),
-            makePair(FSPEC128, ISPEC128),
             makePair(FSPEC128, SSPEC64),
             makePair(DSPEC128, FSPEC64),
             makePair(DSPEC256, FSPEC128),


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326824](https://bugs.openjdk.org/browse/JDK-8326824) needs maintainer approval

### Issue
 * [JDK-8326824](https://bugs.openjdk.org/browse/JDK-8326824): Test: remove redundant test in compiler/vectorapi/reshape/utils/TestCastMethods.java (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/401/head:pull/401` \
`$ git checkout pull/401`

Update a local copy of the PR: \
`$ git checkout pull/401` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 401`

View PR using the GUI difftool: \
`$ git pr show -t 401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/401.diff">https://git.openjdk.org/jdk21u-dev/pull/401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/401#issuecomment-2016591061)