### PR TITLE
8323552: AbstractMemorySegmentImpl#mismatch returns -1 when comparing distinct areas of the same instance of MemorySegment

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -688,10 +688,6 @@ public abstract sealed class AbstractMemorySegmentImpl
         long dstBytes = dstToOffset - dstFromOffset;
         srcImpl.checkAccess(srcFromOffset, srcBytes, true);
         dstImpl.checkAccess(dstFromOffset, dstBytes, true);
-        if (dstImpl == srcImpl) {
-            srcImpl.checkValidState();
-            return -1;
-        }
 
         long bytes = Math.min(srcBytes, dstBytes);
         long i = 0;

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -1,6 +1,6 @@
 /*
- *  Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
- *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License version 2 only, as
@@ -24,6 +24,7 @@
 /*
  * @test
  * @enablePreview
+ * @bug 8323552
  * @run testng TestMismatch
  */
 
@@ -45,7 +46,7 @@ import static org.testng.Assert.assertThrows;
 
 public class TestMismatch {
 
-    // stores a increasing sequence of values into the memory of the given segment
+    // stores an increasing sequence of values into the memory of the given segment
     static MemorySegment initializeSegment(MemorySegment segment) {
         for (int i = 0 ; i < segment.byteSize() ; i++) {
             segment.set(ValueLayout.JAVA_BYTE, i, (byte)i);
@@ -277,6 +278,32 @@ public class TestMismatch {
                 }
             }
         }
+    }
+
+    @Test
+    public void testSameSegment() {
+        var segment = MemorySegment.ofArray(new byte[]{
+                1,2,3,4,  1,2,3,4,  1,4});
+
+        long match = MemorySegment.mismatch(
+                segment, 0L, 4L,
+                segment, 4L, 8L);
+        assertEquals(match, -1);
+
+        long noMatch = MemorySegment.mismatch(
+                segment, 0L, 4L,
+                segment, 1L, 5L);
+        assertEquals(noMatch, 0);
+
+        long noMatchEnd = MemorySegment.mismatch(
+                segment, 0L, 2L,
+                segment, 8L, 10L);
+        assertEquals(noMatchEnd, 1);
+
+        long same = MemorySegment.mismatch(
+                segment, 0L, 8L,
+                segment, 0L, 8L);
+        assertEquals(same, -1);
     }
 
     enum SegmentKind {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [93579c29](https://github.com/openjdk/jdk/commit/93579c29e3ba60a8bc16d712e7ffc733f324a223) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Per Minborg on 25 Mar 2024 and was reviewed by Maurizio Cimadamore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8323552](https://bugs.openjdk.org/browse/JDK-8323552) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323552](https://bugs.openjdk.org/browse/JDK-8323552): AbstractMemorySegmentImpl#mismatch returns -1 when comparing distinct areas of the same instance of MemorySegment (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/404/head:pull/404` \
`$ git checkout pull/404`

Update a local copy of the PR: \
`$ git checkout pull/404` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 404`

View PR using the GUI difftool: \
`$ git pr show -t 404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/404.diff">https://git.openjdk.org/jdk21u-dev/pull/404.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/404#issuecomment-2017845399)