### PR TITLE
8185862: AWT Assertion Failure in ::GetDIBits(hBMDC, hBM, 0, 1, 0, gpBitmapInfo, 0) 'awt_Win32GraphicsDevice.cpp', at line 185

### DIFF
--- a/src/java.desktop/share/classes/java/awt/GraphicsEnvironment.java
+++ b/src/java.desktop/share/classes/java/awt/GraphicsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
  * questions.
  */
 
-
 package java.awt;
 
 import java.awt.image.BufferedImage;
@@ -36,7 +35,6 @@ import sun.font.FontManager;
 import sun.font.FontManagerFactory;
 import sun.java2d.HeadlessGraphicsEnvironment;
 import sun.java2d.SunGraphicsEnvironment;
-import sun.security.action.GetPropertyAction;
 
 /**
  *

--- a/src/java.desktop/windows/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/windows/classes/sun/awt/PlatformGraphicsInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,20 +28,41 @@ package sun.awt;
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 
+import sun.awt.windows.WToolkit;
+
 public class PlatformGraphicsInfo {
+
+    private static final boolean hasDisplays;
+
+    static {
+        loadAWTLibrary();
+        hasDisplays = hasDisplays0();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadAWTLibrary() {
+        java.security.AccessController.doPrivileged(
+            new java.security.PrivilegedAction<Void>() {
+                public Void run() {
+                    System.loadLibrary("awt");
+                    return null;
+                }
+            });
+    }
+
+    private static native boolean hasDisplays0();
 
     public static GraphicsEnvironment createGE() {
         return new Win32GraphicsEnvironment();
     }
 
     public static Toolkit createToolkit() {
-        return new sun.awt.windows.WToolkit();
+        return new WToolkit();
     }
 
     public static boolean getDefaultHeadlessProperty() {
-        // On Windows, we assume we can always create headful apps.
-        // Here is where we can add code that would actually check.
-        return false;
+        // If we don't find usable displays, we run headless.
+        return !hasDisplays;
     }
 
     /*
@@ -54,5 +75,4 @@ public class PlatformGraphicsInfo {
             "\nThe application does not have desktop access,\n" +
             "but this program performed an operation which requires it.";
     }
-
 }

--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsEnvironment.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,8 @@ public final class Win32GraphicsEnvironment extends SunGraphicsEnvironment {
         WToolkit.loadLibraries();
         // setup flags before initializing native layer
         WindowsFlags.initFlags();
-        initDisplayWrapper();
+
+        initDisplay();
 
         // Install correct surface manager factory.
         SurfaceManagerFactory.setInstance(new WindowsSurfaceManagerFactory());
@@ -82,19 +83,11 @@ public final class Win32GraphicsEnvironment extends SunGraphicsEnvironment {
     }
 
     /**
-     * Initializes native components of the graphics environment.  This
+     * Initializes native components of the graphics environment. This
      * includes everything from the native GraphicsDevice elements to
      * the DirectX rendering layer.
      */
     private static native void initDisplay();
-
-    private static boolean displayInitialized;      // = false;
-    public static void initDisplayWrapper() {
-        if (!displayInitialized) {
-            displayInitialized = true;
-            initDisplay();
-        }
-    }
 
     public Win32GraphicsEnvironment() {
     }

--- a/src/java.desktop/windows/native/libawt/windows/Devices.h
+++ b/src/java.desktop/windows/native/libawt/windows/Devices.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,5 +73,7 @@ static CriticalSection          arrayLock;
 // Some helper functions (from awt_MMStub.h/cpp)
 
 BOOL WINAPI MonitorBounds (HMONITOR, RECT*);
+
+int WINAPI CountMonitors (void);
 
 #endif // _DEVICES_H_

--- a/src/java.desktop/windows/native/libawt/windows/awt_PlatformGraphicsInfo.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PlatformGraphicsInfo.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <sun_awt_PlatformGraphicsInfo.h>
+#include "Devices.h"
+
+/*
+ * Class:     sun_awt_PlatformGraphicsInfo
+ * Method:    hasDisplays0
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_sun_awt_PlatformGraphicsInfo_hasDisplays0(JNIEnv *env, jclass thisClass) {
+    return CountMonitors() > 0 ? JNI_TRUE : JNI_FALSE;
+}

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,7 +180,9 @@ void AwtWin32GraphicsDevice::Initialize()
     }
     gpBitmapInfo->bmiHeader.biBitCount = 0;
     HDC hBMDC = this->GetDC();
+    VERIFY(hBMDC != NULL);
     HBITMAP hBM = ::CreateCompatibleBitmap(hBMDC, 1, 1);
+    VERIFY(hBM != NULL);
     VERIFY(::GetDIBits(hBMDC, hBM, 0, 1, NULL, gpBitmapInfo, DIB_RGB_COLORS));
 
     if (colorData->bitsperpixel > 8) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,8 @@
 BOOL DWMIsCompositionEnabled();
 
 void initScreens(JNIEnv *env) {
-
     if (!Devices::UpdateInstance(env)) {
         JNU_ThrowInternalError(env, "Could not update the devices array.");
-        return;
     }
 }
 

--- a/test/jdk/javax/swing/reliability/HangDuringStaticInitialization.java
+++ b/test/jdk/javax/swing/reliability/HangDuringStaticInitialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 /**
  * @test
  * @bug 8189604 8208702
- * @requires !vm.debug | os.family != "windows"
  * @run main/othervm -Djava.awt.headless=false HangDuringStaticInitialization
  * @run main/othervm -Djava.awt.headless=true HangDuringStaticInitialization
  */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8185862](https://bugs.openjdk.org/browse/JDK-8185862) from commit [dcca5daa](https://github.com/openjdk/jdk22u/commit/dcca5daaf7f51c6579369c6ba3430a3d7962dbf2) from the [openjdk/jdk22u](https://git.openjdk.org/jdk22u) repository.

I had to resolve a copyright in src\java.desktop\windows\native\libawt\windows\awt_Win32GraphicsDevice.cpp, will mark as clean.

Thanks
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8185862](https://bugs.openjdk.org/browse/JDK-8185862) needs maintainer approval

### Issue
 * [JDK-8185862](https://bugs.openjdk.org/browse/JDK-8185862): AWT Assertion Failure in ::GetDIBits(hBMDC, hBM, 0, 1, 0, gpBitmapInfo, 0) 'awt_Win32GraphicsDevice.cpp', at line 185 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/407/head:pull/407` \
`$ git checkout pull/407`

Update a local copy of the PR: \
`$ git checkout pull/407` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 407`

View PR using the GUI difftool: \
`$ git pr show -t 407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/407.diff">https://git.openjdk.org/jdk21u-dev/pull/407.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/407#issuecomment-2018386126)