### PR TITLE
8328948: GHA: Restoring sysroot from cache skips the build after JDK-8326960

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -177,7 +177,7 @@ jobs:
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
-        if: steps.create-sysroot.outcome == 'success'
+        if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'
 
       - name: 'Build'
         id: build
@@ -185,4 +185,4 @@ jobs:
         with:
           make-target: 'hotspot ${{ inputs.make-arguments }}'
           platform: linux-${{ matrix.target-cpu }}
-        if: steps.create-sysroot.outcome == 'success'
+        if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'


### PR DESCRIPTION
Fixes a recent GHA regression.

Additional testing:
 - [x] GHA, first run passes cross-builds
 - [x] GHA, second run passes cross-builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328948](https://bugs.openjdk.org/browse/JDK-8328948) needs maintainer approval

### Issue
 * [JDK-8328948](https://bugs.openjdk.org/browse/JDK-8328948): GHA: Restoring sysroot from cache skips the build after JDK-8326960 (**Bug** - P1 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/408/head:pull/408` \
`$ git checkout pull/408`

Update a local copy of the PR: \
`$ git checkout pull/408` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 408`

View PR using the GUI difftool: \
`$ git pr show -t 408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/408.diff">https://git.openjdk.org/jdk21u-dev/pull/408.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/408#issuecomment-2018636767)