### PR TITLE
8328638: Fallback option for POST-only OCSP requests

### DIFF
--- a/src/java.base/share/classes/sun/security/action/GetPropertyAction.java
+++ b/src/java.base/share/classes/sun/security/action/GetPropertyAction.java
@@ -27,6 +27,7 @@ package sun.security.action;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Locale;
 import java.util.Properties;
 import sun.security.util.Debug;
 
@@ -223,4 +224,37 @@ public class GetPropertyAction implements PrivilegedAction<String> {
             return def;
         }
     }
+
+    /**
+     * Convenience method for fetching System property values that are booleans.
+     *
+     * @param prop the name of the System property
+     * @param def a default value
+     * @param dbg a Debug object, if null no debug messages will be sent
+     *
+     * @return a boolean value corresponding to the value in the System property.
+     *      If the property value is neither "true" or "false", the default value
+     *      will be returned.
+     */
+    public static boolean privilegedGetBooleanProp(String prop, boolean def, Debug dbg) {
+        String rawPropVal = privilegedGetProperty(prop, "");
+        if ("".equals(rawPropVal)) {
+            return def;
+        }
+
+        String lower = rawPropVal.toLowerCase(Locale.ROOT);
+        if ("true".equals(lower)) {
+            return true;
+        } else if ("false".equals(lower)) {
+            return false;
+        } else {
+            if (dbg != null) {
+                dbg.println("Warning: Unexpected value for " + prop +
+                            ": " + rawPropVal +
+                            ". Using default value: " + def);
+            }
+            return def;
+        }
+    }
+
 }

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -105,7 +105,7 @@ public final class OCSP {
      * problems.
      */
     private static final boolean USE_GET = initializeBoolean(
-            "com.sun.security.ocsp.useget", "true");
+            "com.sun.security.ocsp.useget", true);
 
     /**
      * Initialize the timeout length by getting the OCSP timeout
@@ -121,9 +121,9 @@ public final class OCSP {
         return timeoutVal;
     }
 
-    private static boolean initializeBoolean(String prop, String def) {
-        String flag = GetPropertyAction.privilegedGetProperty(prop, def);
-        boolean value = Boolean.parseBoolean(flag);
+    private static boolean initializeBoolean(String prop, boolean def) {
+        boolean value =
+                GetPropertyAction.privilegedGetBooleanProp(prop, def, debug);
         if (debug != null) {
             debug.println(prop + " set to " + value);
         }

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,6 +86,28 @@ public final class OCSP {
             "com.sun.security.ocsp.readtimeout", DEFAULT_READ_TIMEOUT);
 
     /**
+     * Boolean value indicating whether OCSP client can use GET for OCSP
+     * requests. There is an ambiguity in RFC recommendations.
+     *
+     * RFC 5019 says a stronger thing, "MUST":
+     *    "When sending requests that are less than or equal to 255 bytes in
+     *     total (after encoding) including the scheme and delimiters (http://),
+     *     server name and base64-encoded OCSPRequest structure, clients MUST
+     *     use the GET method (to enable OCSP response caching)."
+     *
+     * RFC 6960 says a weaker thing, "MAY":
+     *    "HTTP-based OCSP requests can use either the GET or the POST method to
+     *     submit their requests.  To enable HTTP caching, small requests (that
+     *     after encoding are less than 255 bytes) MAY be submitted using GET."
+     *
+     * For performance reasons, we default to stronger behavior. But this
+     * option also allows to fallback to weaker behavior in case of compatibility
+     * problems.
+     */
+    private static final boolean USE_GET = initializeBoolean(
+            "com.sun.security.ocsp.useget", "true");
+
+    /**
      * Initialize the timeout length by getting the OCSP timeout
      * system property. If the property has not been set, or if its
      * value is negative, set the timeout length to the default.
@@ -97,6 +119,15 @@ public final class OCSP {
             debug.println(prop + " set to " + timeoutVal + " milliseconds");
         }
         return timeoutVal;
+    }
+
+    private static boolean initializeBoolean(String prop, String def) {
+        String flag = GetPropertyAction.privilegedGetProperty(prop, def);
+        boolean value = Boolean.parseBoolean(flag);
+        if (debug != null) {
+            debug.println(prop + " set to " + value);
+        }
+        return value;
     }
 
     private OCSP() {}
@@ -186,7 +217,7 @@ public final class OCSP {
             encodedGetReq.append(URLEncoder.encode(
                     Base64.getEncoder().encodeToString(bytes), UTF_8));
 
-            if (encodedGetReq.length() <= 255) {
+            if (USE_GET && encodedGetReq.length() <= 255) {
                 url = new URI(encodedGetReq.toString()).toURL();
                 con = (HttpURLConnection)url.openConnection();
                 con.setConnectTimeout(CONNECT_TIMEOUT);

--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
@@ -32,6 +32,7 @@
  *          java.base/sun.security.x509
  * @run main/othervm GetAndPostTests
  * @run main/othervm -Dcom.sun.security.ocsp.useget=false GetAndPostTests
+ * @run main/othervm -Dcom.sun.security.ocsp.useget=foo GetAndPostTests
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8179503
+ * @bug 8179503 8328638
  * @summary Java should support GET OCSP calls
  * @library /javax/net/ssl/templates /java/security/testlibrary
  * @build SimpleOCSPServer
@@ -31,6 +31,7 @@
  *          java.base/sun.security.provider.certpath
  *          java.base/sun.security.x509
  * @run main/othervm GetAndPostTests
+ * @run main/othervm -Dcom.sun.security.ocsp.useget=false GetAndPostTests
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -704,6 +704,9 @@ public class SimpleOCSPServer {
      * responses.
      */
     private class OcspHandler implements Runnable {
+        private final boolean USE_GET =
+            !System.getProperty("com.sun.security.ocsp.useget", "").equals("false");
+
         private final Socket sock;
         InetSocketAddress peerSockAddr;
 
@@ -876,6 +879,12 @@ public class SimpleOCSPServer {
             // Okay, make sure we got what we needed from the header, then
             // read the remaining OCSP Request bytes
             if (properContentType && length >= 0) {
+                if (USE_GET && length <= 255) {
+                    // Received a small POST request. Check that our client code properly
+                    // handled the relevant flag. We expect small GET requests, unless
+                    // explicitly disabled.
+                    throw new IOException("Should have received small GET, not POST.");
+                }
                 byte[] ocspBytes = new byte[length];
                 inStream.read(ocspBytes);
                 return new LocalOcspRequest(ocspBytes);

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -30,6 +30,9 @@
  * @run main/othervm -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca OCSP
  * @run main/othervm/timeout=180 -Djava.security.debug=certpath,ocsp
+ *  -Dcom.sun.security.ocsp.useget=false
+ *  CAInterop actalisauthenticationrootca OCSP
+ * @run main/othervm/timeout=180 -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca CRL
  */
 
@@ -40,6 +43,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop amazonrootca1 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca1 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop amazonrootca1 CRL
  */
 
@@ -50,6 +54,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop amazonrootca2 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca2 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop amazonrootca2 CRL
  */
 
@@ -60,6 +65,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop amazonrootca3 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca3 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop amazonrootca3 CRL
  */
 
@@ -70,6 +76,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop amazonrootca4 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca4 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop amazonrootca4 CRL
  */
 
@@ -80,6 +87,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop buypassclass2ca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop buypassclass2ca OCSP
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop buypassclass2ca CRL
  */
 
@@ -90,6 +98,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop buypassclass3ca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop buypassclass3ca OCSP
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop buypassclass3ca CRL
  */
 
@@ -100,6 +109,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop comodorsaca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop comodorsaca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop comodorsaca CRL
  */
 
@@ -110,6 +120,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop comodoeccca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop comodoeccca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop comodoeccca CRL
  */
 
@@ -120,6 +131,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop usertrustrsaca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop usertrustrsaca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop usertrustrsaca CRL
  */
 
@@ -130,6 +142,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop usertrusteccca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop usertrusteccca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop usertrusteccca CRL
  */
 
@@ -140,6 +153,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop letsencryptisrgx1 DEFAULT
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop letsencryptisrgx1 DEFAULT
  */
 
 /*
@@ -149,6 +163,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop letsencryptisrgx2 DEFAULT
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop letsencryptisrgx2 DEFAULT
  */
 
 /*
@@ -158,6 +173,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsignrootcar6 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsignrootcar6 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop globalsignrootcar6 CRL
  */
 
@@ -168,6 +184,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop entrustrootcaec1 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop entrustrootcaec1 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop entrustrootcaec1 CRL
  */
 
@@ -178,6 +195,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop entrustrootcag4 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop entrustrootcag4 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop entrustrootcag4 CRL
  */
 
@@ -188,6 +206,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop godaddyrootg2ca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop godaddyrootg2ca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop godaddyrootg2ca CRL
  */
 
@@ -198,6 +217,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop starfieldrootg2ca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop starfieldrootg2ca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop starfieldrootg2ca CRL
  */
 
@@ -208,6 +228,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsigneccrootcar4 DEFAULT
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsigneccrootcar4 DEFAULT
  */
 
 /*
@@ -217,6 +238,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar1 DEFAULT
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootcar1 DEFAULT
  */
 
 /*
@@ -226,6 +248,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar2 DEFAULT
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootcar2 DEFAULT
  */
 
 /*
@@ -235,6 +258,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar3 DEFAULT
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootecccar3 DEFAULT
  */
 
 /*
@@ -243,6 +267,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootecccar4 DEFAULT
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar4 DEFAULT
  */
 
@@ -253,6 +278,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop microsoftecc2017 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftecc2017 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop microsoftecc2017 CRL
  */
 
@@ -263,6 +289,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop microsoftrsa2017 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftrsa2017 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop microsoftrsa2017 CRL
  */
 
@@ -273,6 +300,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca1g3 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca1g3 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop quovadisrootca1g3 CRL
  */
 
@@ -283,6 +311,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca2g3 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca2g3 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop quovadisrootca2g3 CRL
  */
 
@@ -293,6 +322,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca3g3 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca3g3 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop quovadisrootca3g3 CRL
  */
 
@@ -303,6 +333,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop digicerttlseccrootg5 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop digicerttlseccrootg5 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop digicerttlseccrootg5 CRL
  */
 
@@ -313,6 +344,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop digicerttlsrsarootg5 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop digicerttlsrsarootg5 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop digicerttlsrsarootg5 CRL
  */
 
@@ -323,6 +355,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop sslrootrsaca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrootrsaca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop sslrootrsaca CRL
  */
 
@@ -333,6 +366,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop sslrootevrsaca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrootevrsaca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop sslrootevrsaca CRL
  */
 
@@ -343,6 +377,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop sslrooteccca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrooteccca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop sslrooteccca CRL
  */
 
@@ -353,6 +388,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop teliasonerarootcav1 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop teliasonerarootcav1 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop teliasonerarootcav1 CRL
  */
 
@@ -363,6 +399,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop twcaglobalrootca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop twcaglobalrootca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop twcaglobalrootca CRL
  */
 
@@ -373,6 +410,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop certignarootca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certignarootca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop certignarootca CRL
  */
 
@@ -383,6 +421,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustcommercialca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustcommercialca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustcommercialca CRL
  */
 
@@ -393,6 +432,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustnetworkingca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustnetworkingca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustnetworkingca CRL
  */
 
@@ -403,6 +443,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustpremiumca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustpremiumca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustpremiumca CRL
  */
 
@@ -413,6 +454,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustpremiumeccca OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustpremiumeccca OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustpremiumeccca CRL
  */
 
@@ -423,6 +465,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop teliarootcav2 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop teliarootcav2 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop teliarootcav2 CRL
  */
 
@@ -433,6 +476,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop emsignrootcag1 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop emsignrootcag1 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop emsignrootcag1 CRL
  */
 
@@ -443,6 +487,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop emsigneccrootcag3 OCSP
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop emsigneccrootcag3 OCSP
  * @run main/othervm -Djava.security.debug=certpath CAInterop emsigneccrootcag3 CRL
  */
 
@@ -453,6 +498,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop certainlyrootr1 DEFAULT
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certainlyrootr1 DEFAULT
  */
 
 /*
@@ -462,6 +508,7 @@
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop certainlyroote1 DEFAULT
+ * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certainlyroote1 DEFAULT
  */
 
 /**


### PR DESCRIPTION
Improves JDK OCSP compatibility with some real world OCSP responders. Starts to be a problem since JDK 17 introduced GET OCSP requests. The default behavior is not changed.

The backports are almost clean, I just had to add the import for `Locale` in one of the files. It is added in mainline by [JDK-8312443](https://bugs.openjdk.org/browse/JDK-8312443), which I do not want to backport at the moment, as it changes existing security code.

Additional testing:
 - [x] `jdk_security` pass, including new test cases

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8328810](https://bugs.openjdk.org/browse/JDK-8328810) to be approved
- [x] [JDK-8328638](https://bugs.openjdk.org/browse/JDK-8328638) needs maintainer approval
- [x] [JDK-8329213](https://bugs.openjdk.org/browse/JDK-8329213) needs maintainer approval

### Issues
 * [JDK-8328638](https://bugs.openjdk.org/browse/JDK-8328638): Fallback option for POST-only OCSP requests (**Enhancement** - P4 - Approved)
 * [JDK-8329213](https://bugs.openjdk.org/browse/JDK-8329213): Better validation for com.sun.security.ocsp.useget option (**Enhancement** - P4 - Approved)
 * [JDK-8328810](https://bugs.openjdk.org/browse/JDK-8328810): Fallback option for POST-only OCSP requests (**CSR**)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/413/head:pull/413` \
`$ git checkout pull/413`

Update a local copy of the PR: \
`$ git checkout pull/413` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 413`

View PR using the GUI difftool: \
`$ git pr show -t 413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/413.diff">https://git.openjdk.org/jdk21u-dev/pull/413.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/413#issuecomment-2031670389)