### PR TITLE
8327998: Enable java/lang/ProcessBuilder/JspawnhelperProtocol.java on Mac

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @bug 8307990
- * @requires (os.family == "linux") | (os.family == "aix")
+ * @requires (os.family == "linux") | (os.family == "aix") | (os.family == "mac")
  * @requires vm.debug
  * @requires vm.flagless
  * @library /test/lib


### PR DESCRIPTION
Clean backport to enable running JspawnhelperProtocol.java on MacOS.

GHA tested.
Additionally ran the test on macos.

```
Test report is stored in build/macosx-x86_64-server-fastdebug/test-results/jtreg_test_jdk_java_lang_ProcessBuilder_JspawnhelperProtocol_java

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
                                                         1     1     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'macosx-x86_64-server-fastdebug'
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327998](https://bugs.openjdk.org/browse/JDK-8327998) needs maintainer approval

### Issue
 * [JDK-8327998](https://bugs.openjdk.org/browse/JDK-8327998): Enable java/lang/ProcessBuilder/JspawnhelperProtocol.java on Mac (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/415/head:pull/415` \
`$ git checkout pull/415`

Update a local copy of the PR: \
`$ git checkout pull/415` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 415`

View PR using the GUI difftool: \
`$ git pr show -t 415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/415.diff">https://git.openjdk.org/jdk21u-dev/pull/415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/415#issuecomment-2023134273)