### PR TITLE
8309752: com/sun/jdi/SetLocalWhileThreadInNative.java fails with virtual test thread factory due to OpaqueFrameException

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -29,7 +29,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
-com/sun/jdi/SetLocalWhileThreadInNative.java 8285422 generic-all
 com/sun/jdi/cds/CDSBreakpointTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSDeleteAllBkptsTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSFieldWatchpoints.java 8307778 generic-all

--- a/test/jdk/com/sun/jdi/SetLocalWhileThreadInNative.java
+++ b/test/jdk/com/sun/jdi/SetLocalWhileThreadInNative.java
@@ -163,13 +163,20 @@ public class SetLocalWhileThreadInNative extends TestScaffold {
         Asserts.assertEQ(frame.location().method().toString(), "SetLocalWhileThreadInNativeTarget.dontinline_testMethod()");
         List<LocalVariable> localVars = frame.visibleVariables();
         boolean changedLocal = false;
+        boolean caughtOFE = false;
         for (LocalVariable lv : localVars) {
             if (lv.name().equals("zero")) {
-                frame.setValue(lv, vm().mirrorOf(0)); // triggers deoptimization!
-                changedLocal = true;
+                try {
+                    frame.setValue(lv, vm().mirrorOf(0)); // triggers deoptimization!
+                    changedLocal = true;
+                } catch (OpaqueFrameException e) {
+                    caughtOFE = true;
+                }
             }
         }
-        Asserts.assertTrue(changedLocal);
+        boolean isVirtualThread = "Virtual".equals(System.getProperty("main.wrapper"));
+        Asserts.assertTrue(caughtOFE == isVirtualThread);
+        Asserts.assertTrue(changedLocal == !isVirtualThread);
 
         // signal stop
         os.write(STOP);


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

Resolved ProblemList, will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309752](https://bugs.openjdk.org/browse/JDK-8309752) needs maintainer approval

### Issue
 * [JDK-8309752](https://bugs.openjdk.org/browse/JDK-8309752): com/sun/jdi/SetLocalWhileThreadInNative.java fails with virtual test thread factory due to OpaqueFrameException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/421/head:pull/421` \
`$ git checkout pull/421`

Update a local copy of the PR: \
`$ git checkout pull/421` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 421`

View PR using the GUI difftool: \
`$ git pr show -t 421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/421.diff">https://git.openjdk.org/jdk21u-dev/pull/421.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/421#issuecomment-2025868264)