### PR TITLE
8328812: Update and move siphash license

### DIFF
--- a/src/java.base/share/legal/siphash.md
+++ b/src/java.base/share/legal/siphash.md
@@ -4,12 +4,12 @@
 SipHash reference C implementation
 
 ```
-   Copyright (c) 2012-2021 Jean-Philippe Aumasson
-   <jeanphilippe.aumasson@gmail.com>
-   Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+   Copyright (c) 2016 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+
    To the extent possible under law, the author(s) have dedicated all copyright
    and related and neighboring rights to this software to the public domain
    worldwide. This software is distributed without any warranty.
+
    You should have received a copy of the CC0 Public Domain Dedication along
    with
    this software. If not, see


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328812](https://bugs.openjdk.org/browse/JDK-8328812) needs maintainer approval

### Issue
 * [JDK-8328812](https://bugs.openjdk.org/browse/JDK-8328812): Update and move siphash license (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/424/head:pull/424` \
`$ git checkout pull/424`

Update a local copy of the PR: \
`$ git checkout pull/424` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 424`

View PR using the GUI difftool: \
`$ git pr show -t 424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/424.diff">https://git.openjdk.org/jdk21u-dev/pull/424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/424#issuecomment-2026541642)