### PR TITLE
8315605: G1: Add number of nmethods in code roots scanning statistics

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -123,6 +123,10 @@ G1GCPhaseTimes::G1GCPhaseTimes(STWGCTimer* gc_timer, uint max_gc_threads) :
   _gc_par_phases[MergeLB]->create_thread_work_items("Dirty Cards:", MergeLBDirtyCards);
   _gc_par_phases[MergeLB]->create_thread_work_items("Skipped Cards:", MergeLBSkippedCards);
 
+  _gc_par_phases[CodeRoots]->create_thread_work_items("Scanned Nmethods", CodeRootsScannedNMethods);
+
+  _gc_par_phases[OptCodeRoots]->create_thread_work_items("Scanned Nmethods", CodeRootsScannedNMethods);
+
   _gc_par_phases[MergePSS]->create_thread_work_items("Copied Bytes", MergePSSCopiedBytes);
   _gc_par_phases[MergePSS]->create_thread_work_items("LAB Waste", MergePSSLABWasteBytes);
   _gc_par_phases[MergePSS]->create_thread_work_items("LAB Undo Waste", MergePSSLABUndoWasteBytes);

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.hpp
@@ -134,6 +134,10 @@ class G1GCPhaseTimes : public CHeapObj<mtGC> {
     MergeLBSkippedCards
   };
 
+  enum GCCodeRootsWorkItems {
+    CodeRootsScannedNMethods
+  };
+
   enum GCMergePSSWorkItems {
     MergePSSCopiedBytes,
     MergePSSLABSize,

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -757,6 +757,25 @@ void G1RemSet::scan_heap_roots(G1ParScanThreadState* pss,
   p->record_or_add_thread_work_item(scan_phase, worker_id, cl.heap_roots_found(), G1GCPhaseTimes::ScanHRFoundRoots);
 }
 
+// Wrapper around a CodeBlobClosure to count the number of code blobs scanned.
+class G1ScanAndCountCodeBlobClosure : public CodeBlobClosure {
+  CodeBlobClosure* _cl;
+  size_t _count;
+
+public:
+  G1ScanAndCountCodeBlobClosure(CodeBlobClosure* cl) : _cl(cl), _count(0) {
+  }
+
+  void do_code_blob(CodeBlob* cb) override {
+    _cl->do_code_blob(cb);
+    _count++;
+  }
+
+  size_t count() const {
+    return _count;
+  }
+};
+
 // Heap region closure to be applied to all regions in the current collection set
 // increment to fix up non-card related roots.
 class G1ScanCollectionSetRegionClosure : public HeapRegionClosure {
@@ -767,6 +786,8 @@ class G1ScanCollectionSetRegionClosure : public HeapRegionClosure {
   G1GCPhaseTimes::GCParPhases _code_roots_phase;
 
   uint _worker_id;
+
+  size_t _code_roots_scanned;
 
   size_t _opt_roots_scanned;
   size_t _opt_refs_scanned;
@@ -798,6 +819,7 @@ public:
     _scan_phase(scan_phase),
     _code_roots_phase(code_roots_phase),
     _worker_id(worker_id),
+    _code_roots_scanned(0),
     _opt_roots_scanned(0),
     _opt_refs_scanned(0),
     _opt_refs_memory_used(0),
@@ -822,8 +844,12 @@ public:
     if (_scan_state->claim_collection_set_region(region_idx)) {
       EventGCPhaseParallel event;
       G1EvacPhaseWithTrimTimeTracker timer(_pss, _code_root_scan_time, _code_trim_partially_time);
+      G1ScanAndCountCodeBlobClosure cl(_pss->closures()->weak_codeblobs());
+
       // Scan the code root list attached to the current region
-      r->code_roots_do(_pss->closures()->weak_codeblobs());
+      r->code_roots_do(&cl);
+
+      _code_roots_scanned = cl.count();
 
       event.commit(GCId::current(), _worker_id, G1GCPhaseTimes::phase_name(_code_roots_phase));
     }
@@ -833,6 +859,8 @@ public:
 
   Tickspan code_root_scan_time() const { return _code_root_scan_time;  }
   Tickspan code_root_trim_partially_time() const { return _code_trim_partially_time; }
+
+  size_t code_roots_scanned() const { return _code_roots_scanned; }
 
   Tickspan rem_set_opt_root_scan_time() const { return _rem_set_opt_root_scan_time; }
   Tickspan rem_set_opt_trim_partially_time() const { return _rem_set_opt_trim_partially_time; }
@@ -856,6 +884,8 @@ void G1RemSet::scan_collection_set_regions(G1ParScanThreadState* pss,
   p->record_or_add_time_secs(scan_phase, worker_id, cl.rem_set_opt_trim_partially_time().seconds());
 
   p->record_or_add_time_secs(coderoots_phase, worker_id, cl.code_root_scan_time().seconds());
+  p->record_or_add_thread_work_item(coderoots_phase, worker_id, cl.code_roots_scanned(), G1GCPhaseTimes::CodeRootsScannedNMethods);
+
   p->add_time_secs(objcopy_phase, worker_id, cl.code_root_trim_partially_time().seconds());
 
   // At this time we record some metrics only for the evacuations after the initial one.


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315605](https://bugs.openjdk.org/browse/JDK-8315605) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315605](https://bugs.openjdk.org/browse/JDK-8315605): G1: Add number of nmethods in code roots scanning statistics (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/425/head:pull/425` \
`$ git checkout pull/425`

Update a local copy of the PR: \
`$ git checkout pull/425` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 425`

View PR using the GUI difftool: \
`$ git pr show -t 425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/425.diff">https://git.openjdk.org/jdk21u-dev/pull/425.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/425#issuecomment-2027754313)