### PR TITLE
8316002: Remove unnecessary seen_dead_loader in ClassLoaderDataGraph::do_unloading

### DIFF
--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -494,7 +494,6 @@ bool ClassLoaderDataGraph::do_unloading() {
   assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
 
   ClassLoaderData* prev = nullptr;
-  bool seen_dead_loader = false;
   uint loaders_processed = 0;
   uint loaders_removed = 0;
 
@@ -505,7 +504,6 @@ bool ClassLoaderDataGraph::do_unloading() {
     } else {
       // Found dead CLD.
       loaders_removed++;
-      seen_dead_loader = true;
       data->unload();
 
       // Move dead CLD to unloading list.
@@ -523,7 +521,7 @@ bool ClassLoaderDataGraph::do_unloading() {
 
   log_debug(class, loader, data)("do_unloading: loaders processed %u, loaders removed %u", loaders_processed, loaders_removed);
 
-  return seen_dead_loader;
+  return loaders_removed != 0;
 }
 
 // There's at least one dead class loader.  Purge refererences of healthy module


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316002](https://bugs.openjdk.org/browse/JDK-8316002) needs maintainer approval

### Issue
 * [JDK-8316002](https://bugs.openjdk.org/browse/JDK-8316002): Remove unnecessary seen_dead_loader in ClassLoaderDataGraph::do_unloading (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/426/head:pull/426` \
`$ git checkout pull/426`

Update a local copy of the PR: \
`$ git checkout pull/426` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 426`

View PR using the GUI difftool: \
`$ git pr show -t 426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/426.diff">https://git.openjdk.org/jdk21u-dev/pull/426.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/426#issuecomment-2027758304)