### PR TITLE
8314573: G1: Heap resizing at Remark does not take existing eden regions into account

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
@@ -217,7 +217,14 @@ size_t G1HeapSizingPolicy::full_collection_resize_amount(bool& expand) {
   // Capacity, free and used after the GC counted as full regions to
   // include the waste in the following calculations.
   const size_t capacity_after_gc = _g1h->capacity();
-  const size_t used_after_gc = capacity_after_gc - _g1h->unused_committed_regions_in_bytes();
+  const size_t used_after_gc = capacity_after_gc -
+                               _g1h->unused_committed_regions_in_bytes() -
+                               // Discount space used by current Eden to establish a
+                               // situation during Remark similar to at the end of full
+                               // GC where eden is empty. During Remark there can be an
+                               // arbitrary number of eden regions which would skew the
+                               // results.
+                               _g1h->eden_regions_count() * HeapRegion::GrainBytes;
 
   size_t minimum_desired_capacity = target_heap_capacity(used_after_gc, MinHeapFreeRatio);
   size_t maximum_desired_capacity = target_heap_capacity(used_after_gc, MaxHeapFreeRatio);


### PR DESCRIPTION
Clean backport of fix of G1 Heap resizing heuristics at remark

Additional testing:
 - [x] Linux aarch64 server release/fastdebug, test/hotspot/jtreg/gc with +UseG1GC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8314573](https://bugs.openjdk.org/browse/JDK-8314573) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314573](https://bugs.openjdk.org/browse/JDK-8314573): G1: Heap resizing at Remark does not take existing eden regions into account (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/429/head:pull/429` \
`$ git checkout pull/429`

Update a local copy of the PR: \
`$ git checkout pull/429` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 429`

View PR using the GUI difftool: \
`$ git pr show -t 429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/429.diff">https://git.openjdk.org/jdk21u-dev/pull/429.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/429#issuecomment-2029442560)