### PR TITLE
8317235: Remove Access API use in nmethod class

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1700,7 +1700,7 @@ public:
 };
 
 bool nmethod::is_unloading() {
-  uint8_t state = RawAccess<MO_RELAXED>::load(&_is_unloading_state);
+  uint8_t state = Atomic::load(&_is_unloading_state);
   bool state_is_unloading = IsUnloadingState::is_unloading(state);
   if (state_is_unloading) {
     return true;
@@ -1736,7 +1736,7 @@ bool nmethod::is_unloading() {
 
 void nmethod::clear_unloading_state() {
   uint8_t state = IsUnloadingState::create(false, CodeCache::unloading_cycle());
-  RawAccess<MO_RELAXED>::store(&_is_unloading_state, state);
+  Atomic::store(&_is_unloading_state, state);
 }
 
 


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317235](https://bugs.openjdk.org/browse/JDK-8317235) needs maintainer approval

### Issue
 * [JDK-8317235](https://bugs.openjdk.org/browse/JDK-8317235): Remove Access API use in nmethod class (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/431/head:pull/431` \
`$ git checkout pull/431`

Update a local copy of the PR: \
`$ git checkout pull/431` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 431`

View PR using the GUI difftool: \
`$ git pr show -t 431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/431.diff">https://git.openjdk.org/jdk21u-dev/pull/431.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/431#issuecomment-2031266609)