### PR TITLE
8317677: Specialize Vtablestubs::entry_for() for VtableBlob

### DIFF
--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -561,15 +561,14 @@ void CompiledIC::compute_monomorphic_entry(const methodHandle& method,
 
 bool CompiledIC::is_icholder_entry(address entry) {
   CodeBlob* cb = CodeCache::find_blob(entry);
-  if (cb != nullptr && cb->is_adapter_blob()) {
+  if (cb == nullptr) {
+    return false;
+  }
+  if (cb->is_adapter_blob()) {
     return true;
+  } else if (cb->is_vtable_blob()) {
+    return VtableStubs::is_icholder_entry(entry);
   }
-  // itable stubs also use CompiledICHolder
-  if (cb != nullptr && cb->is_vtable_blob()) {
-    VtableStub* s = VtableStubs::entry_point(entry);
-    return (s != nullptr) && s->is_itable_stub();
-  }
-
   return false;
 }
 

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -284,6 +284,13 @@ VtableStub* VtableStubs::entry_point(address pc) {
   return (s == stub) ? s : nullptr;
 }
 
+bool VtableStubs::is_icholder_entry(address pc) {
+  assert(contains(pc), "must contain all vtable blobs");
+  VtableStub* stub = (VtableStub*)(pc - VtableStub::entry_offset());
+  // itable stubs use CompiledICHolder.
+  return stub->is_itable_stub();
+}
+
 bool VtableStubs::contains(address pc) {
   // simple solution for now - we may want to use
   // a faster way if this function is called often

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -105,6 +105,7 @@ class VtableStubs : AllStatic {
   static address     find_itable_stub(int itable_index) { return find_stub(false, itable_index); }
 
   static VtableStub* entry_point(address pc);                        // vtable stub entry point for a pc
+  static bool        is_icholder_entry(address pc);                  // is the blob containing pc (which must be a vtable blob) an icholder?
   static bool        contains(address pc);                           // is pc within any stub?
   static VtableStub* stub_containing(address pc);                    // stub containing pc or nullptr
   static int         number_of_vtable_stubs() { return _number_of_vtable_stubs; }


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8317677](https://bugs.openjdk.org/browse/JDK-8317677) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317677](https://bugs.openjdk.org/browse/JDK-8317677): Specialize Vtablestubs::entry_for() for VtableBlob (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/432/head:pull/432` \
`$ git checkout pull/432`

Update a local copy of the PR: \
`$ git checkout pull/432` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 432`

View PR using the GUI difftool: \
`$ git pr show -t 432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/432.diff">https://git.openjdk.org/jdk21u-dev/pull/432.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/432#issuecomment-2031291536)