### PR TITLE
8328592: hprof tests fail with -XX:-CompactStrings

### DIFF
--- a/test/lib/jdk/test/lib/hprof/model/JavaObject.java
+++ b/test/lib/jdk/test/lib/hprof/model/JavaObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,9 +190,14 @@ public class JavaObject extends JavaLazyReadObject {
 
     public String toString() {
         if (getClazz().isString()) {
+            JavaThing coder = getField("coder");
+            boolean compact = false;
+            if (coder instanceof JavaByte) {
+                compact = ((JavaByte)coder).value == 0;
+            }
             JavaThing value = getField("value");
             if (value instanceof JavaValueArray) {
-                return ((JavaValueArray)value).valueAsString();
+                return ((JavaValueArray)value).valueAsString(compact);
             } else {
                 return "null";
             }

--- a/test/lib/jdk/test/lib/hprof/model/JavaValueArray.java
+++ b/test/lib/jdk/test/lib/hprof/model/JavaValueArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@
 package jdk.test.lib.hprof.model;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.util.Objects;
 
 /**
@@ -350,15 +351,37 @@ public class JavaValueArray extends JavaLazyReadObject
         return result.toString();
     }
 
+    private static final int STRING_HI_BYTE_SHIFT;
+    private static final int STRING_LO_BYTE_SHIFT;
+    static {
+        if (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) {
+            STRING_HI_BYTE_SHIFT = 8;
+            STRING_LO_BYTE_SHIFT = 0;
+        } else {
+            STRING_HI_BYTE_SHIFT = 0;
+            STRING_LO_BYTE_SHIFT = 8;
+        }
+    }
+
     // Tries to represent the value as string (used by JavaObject.toString).
-    public String valueAsString() {
+    public String valueAsString(boolean compact) {
         if (getElementType() == 'B')  {
             JavaThing[] things = getValue();
-            byte[] bytes = new byte[things.length];
-            for (int i = 0; i < things.length; i++) {
-                bytes[i] = ((JavaByte)things[i]).value;
+            if (compact) {
+                byte[] bytes = new byte[things.length];
+                for (int i = 0; i < things.length; i++) {
+                    bytes[i] = ((JavaByte)things[i]).value;
+                }
+                return new String(bytes);
+            } else {
+                char[] chars = new char[things.length / 2];
+                for (int i = 0; i < things.length; i += 2) {
+                    int b1 = ((JavaByte)things[i]).value     << STRING_HI_BYTE_SHIFT;
+                    int b2 = ((JavaByte)things[i + 1]).value << STRING_LO_BYTE_SHIFT;
+                    chars[i / 2] = (char)(b1 | b2);
+                }
+                return new String(chars);
             }
-            return new String(bytes);
         }
         // fallback
         return valueString();


### PR DESCRIPTION
See the bug for symptoms. The tests are failing because hprof test library is confused about non-compact strings.

Additional testing:
 - [x] `serviceability/HeapDump lib-test:all` with `-XX:-CompactStrings` now pass
 - [x]  `serviceability/HeapDump lib-test:all` with `-XX:+CompactStrings` still pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328592](https://bugs.openjdk.org/browse/JDK-8328592) needs maintainer approval

### Issue
 * [JDK-8328592](https://bugs.openjdk.org/browse/JDK-8328592): hprof tests fail with -XX:-CompactStrings (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/436.diff">https://git.openjdk.org/jdk21u-dev/pull/436.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/436#issuecomment-2032186779)