### PR TITLE
8327468: Do not restart close if errno is EINTR [macOS/linux]

### DIFF
--- a/src/jdk.attach/linux/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/linux/native/libattach/VirtualMachineImpl.c
@@ -198,9 +198,8 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_checkPermissions
 JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_close
   (JNIEnv *env, jclass cls, jint fd)
 {
-    int res;
     shutdown(fd, SHUT_RDWR);
-    RESTARTABLE(close(fd), res);
+    close(fd);
 }
 
 /*

--- a/src/jdk.attach/macosx/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/macosx/native/libattach/VirtualMachineImpl.c
@@ -200,9 +200,8 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_checkPermissions
 JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_close
   (JNIEnv *env, jclass cls, jint fd)
 {
-    int res;
     shutdown(fd, SHUT_RDWR);
-    RESTARTABLE(close(fd), res);
+    close(fd);
 }
 
 /*
@@ -294,8 +293,7 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_createAttachFile
     }
 
     RESTARTABLE(chown(_path, geteuid(), getegid()), rc);
-
-    RESTARTABLE(close(fd), rc);
+    close(fd);
 
     /* release p here */
     if (isCopy) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327468](https://bugs.openjdk.org/browse/JDK-8327468) needs maintainer approval

### Issue
 * [JDK-8327468](https://bugs.openjdk.org/browse/JDK-8327468): Do not restart close if errno is EINTR [macOS/linux] (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/442/head:pull/442` \
`$ git checkout pull/442`

Update a local copy of the PR: \
`$ git checkout pull/442` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 442`

View PR using the GUI difftool: \
`$ git pr show -t 442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/442.diff">https://git.openjdk.org/jdk21u-dev/pull/442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/442#issuecomment-2034400922)