### PR TITLE
8317600: VtableStubs::stub_containing() table load not ordered wrt to stores

### DIFF
--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -79,10 +79,11 @@ class VtableStubs : AllStatic {
     mask = N - 1
   };
 
+  static_assert(is_power_of_2((int)N), "N must be a power of 2");
+
  private:
   friend class VtableStub;
-  static VtableStub* _table[N];                  // table of existing stubs
-  static int         _number_of_vtable_stubs;    // number of stubs created so far (for statistics)
+  static VtableStub* volatile _table[N];                  // table of existing stubs
   static int         _vtab_stub_size;            // current size estimate for vtable stub (quasi-constant)
   static int         _itab_stub_size;            // current size estimate for itable stub (quasi-constant)
 
@@ -108,7 +109,6 @@ class VtableStubs : AllStatic {
   static bool        is_icholder_entry(address pc);                  // is the blob containing pc (which must be a vtable blob) an icholder?
   static bool        contains(address pc);                           // is pc within any stub?
   static VtableStub* stub_containing(address pc);                    // stub containing pc or nullptr
-  static int         number_of_vtable_stubs() { return _number_of_vtable_stubs; }
   static void        initialize();
   static void        vtable_stub_do(void f(VtableStub*));            // iterates over all vtable stubs
 };


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317600](https://bugs.openjdk.org/browse/JDK-8317600) needs maintainer approval

### Issue
 * [JDK-8317600](https://bugs.openjdk.org/browse/JDK-8317600): VtableStubs::stub_containing() table load not ordered wrt to stores (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/446/head:pull/446` \
`$ git checkout pull/446`

Update a local copy of the PR: \
`$ git checkout pull/446` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 446`

View PR using the GUI difftool: \
`$ git pr show -t 446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/446.diff">https://git.openjdk.org/jdk21u-dev/pull/446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/446#issuecomment-2035437923)