### PR TITLE
8318585: Rename CodeCache::UnloadingScope to UnlinkingScope

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1024,7 +1024,7 @@ void CodeCache::increment_unloading_cycle() {
   }
 }
 
-CodeCache::UnloadingScope::UnloadingScope(BoolObjectClosure* is_alive)
+CodeCache::UnlinkingScope::UnlinkingScope(BoolObjectClosure* is_alive)
   : _is_unloading_behaviour(is_alive)
 {
   _saved_behaviour = IsUnloadingBehaviour::current();
@@ -1033,7 +1033,7 @@ CodeCache::UnloadingScope::UnloadingScope(BoolObjectClosure* is_alive)
   DependencyContext::cleaning_start();
 }
 
-CodeCache::UnloadingScope::~UnloadingScope() {
+CodeCache::UnlinkingScope::~UnlinkingScope() {
   IsUnloadingBehaviour::set_current(_saved_behaviour);
   DependencyContext::cleaning_end();
 }

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -179,14 +179,17 @@ class CodeCache : AllStatic {
 
   // GC support
   static void verify_oops();
-  // Scope object managing code cache unloading behavior.
-  class UnloadingScope: StackObj {
+
+  // Helper scope object managing code cache unlinking behavior, i.e. sets and
+  // restores the closure that determines which nmethods are going to be removed
+  // during the unlinking part of code cache unloading.
+  class UnlinkingScope : StackObj {
     ClosureIsUnloadingBehaviour _is_unloading_behaviour;
     IsUnloadingBehaviour*       _saved_behaviour;
 
   public:
-    UnloadingScope(BoolObjectClosure* is_alive);
-    ~UnloadingScope();
+    UnlinkingScope(BoolObjectClosure* is_alive);
+    ~UnlinkingScope();
   };
 
   // Code cache unloading heuristics

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1685,7 +1685,7 @@ void G1ConcurrentMark::weak_refs_work() {
   if (ClassUnloadingWithConcurrentMark) {
     GCTraceTime(Debug, gc, phases) debug("Class Unloading", _gc_timer_cm);
     {
-      CodeCache::UnloadingScope scope(&g1_is_alive);
+      CodeCache::UnlinkingScope scope(&g1_is_alive);
       bool unloading_occurred = SystemDictionary::do_unloading(_gc_timer_cm);
       _g1h->complete_cleaning(unloading_occurred);
     }

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -320,7 +320,7 @@ void G1FullCollector::phase1_mark_live_objects() {
   if (ClassUnloading) {
     GCTraceTime(Debug, gc, phases) debug("Phase 1: Class Unloading and Cleanup", scope()->timer());
     {
-      CodeCache::UnloadingScope unloading_scope(&_is_alive);
+      CodeCache::UnlinkingScope unloading_scope(&_is_alive);
       // Unload classes and purge the SystemDictionary.
       bool unloading_occurred = SystemDictionary::do_unloading(scope()->timer());
       _heap->complete_cleaning(unloading_occurred);

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2055,7 +2055,7 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
 
     bool unloading_occurred;
     {
-      CodeCache::UnloadingScope scope(is_alive_closure());
+      CodeCache::UnlinkingScope scope(is_alive_closure());
 
       // Follow system dictionary roots and unload classes.
       unloading_occurred = SystemDictionary::do_unloading(&_gc_timer);

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -198,7 +198,7 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
 
     bool unloading_occurred;
     {
-      CodeCache::UnloadingScope scope(&is_alive);
+      CodeCache::UnlinkingScope scope(&is_alive);
 
       // Unload classes and purge the SystemDictionary.
       unloading_occurred = SystemDictionary::do_unloading(gc_timer());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1774,7 +1774,7 @@ void ShenandoahHeap::stw_unload_classes(bool full_gc) {
                                           ShenandoahPhaseTimings::degen_gc_purge_class_unload;
     ShenandoahIsAliveSelector is_alive;
     {
-      CodeCache::UnloadingScope scope(is_alive.is_alive_closure());
+      CodeCache::UnlinkingScope scope(is_alive.is_alive_closure());
       ShenandoahGCPhase gc_phase(phase);
       ShenandoahGCWorkerPhase worker_phase(phase);
       bool unloading_occurred = SystemDictionary::do_unloading(gc_timer());


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318585](https://bugs.openjdk.org/browse/JDK-8318585) needs maintainer approval

### Issue
 * [JDK-8318585](https://bugs.openjdk.org/browse/JDK-8318585): Rename CodeCache::UnloadingScope to UnlinkingScope (**Enhancement** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/455/head:pull/455` \
`$ git checkout pull/455`

Update a local copy of the PR: \
`$ git checkout pull/455` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 455`

View PR using the GUI difftool: \
`$ git pr show -t 455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/455.diff">https://git.openjdk.org/jdk21u-dev/pull/455.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/455#issuecomment-2039189774)