### PR TITLE
8319955: Improve dependencies removal during class unloading

### DIFF
--- a/src/hotspot/share/code/dependencyContext.hpp
+++ b/src/hotspot/share/code/dependencyContext.hpp
@@ -75,6 +75,7 @@ class DependencyContext : public StackObj {
   volatile uint64_t*       _last_cleanup_addr;
 
   bool claim_cleanup();
+  static bool delete_on_release();
   void set_dependencies(nmethodBucket* b);
   nmethodBucket* dependencies();
   nmethodBucket* dependencies_not_unloading();


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319955](https://bugs.openjdk.org/browse/JDK-8319955) needs maintainer approval

### Issue
 * [JDK-8319955](https://bugs.openjdk.org/browse/JDK-8319955): Improve dependencies removal during class unloading (**Enhancement** - P4 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/456/head:pull/456` \
`$ git checkout pull/456`

Update a local copy of the PR: \
`$ git checkout pull/456` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 456`

View PR using the GUI difftool: \
`$ git pr show -t 456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/456.diff">https://git.openjdk.org/jdk21u-dev/pull/456.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/456#issuecomment-2039202934)