### PR TITLE
8321163: [test] OutputAnalyzer.getExitValue() unnecessarily logs even when process has already completed

### DIFF
--- a/test/lib/jdk/test/lib/process/OutputBuffer.java
+++ b/test/lib/jdk/test/lib/process/OutputBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,6 +120,7 @@ public interface OutputBuffer {
     private final StreamTask outTask;
     private final StreamTask errTask;
     private final Process p;
+    private volatile Integer exitValue; // null implies we don't yet know
 
     private final void logProgress(String state) {
         System.out.println("[" + Instant.now().toString() + "] " + state
@@ -146,14 +147,17 @@ public interface OutputBuffer {
 
     @Override
     public int getExitValue() {
+      if (exitValue != null) {
+        return exitValue;
+      }
       try {
           logProgress("Waiting for completion");
           boolean aborted = true;
           try {
-              int result = p.waitFor();
+              exitValue = p.waitFor();
               logProgress("Waiting for completion finished");
               aborted = false;
-              return result;
+              return exitValue;
           } finally {
               if (aborted) {
                   logProgress("Waiting for completion FAILED");


### PR DESCRIPTION
I backport this to streamline testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321163](https://bugs.openjdk.org/browse/JDK-8321163) needs maintainer approval

### Issue
 * [JDK-8321163](https://bugs.openjdk.org/browse/JDK-8321163): [test] OutputAnalyzer.getExitValue() unnecessarily logs even when process has already completed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/458/head:pull/458` \
`$ git checkout pull/458`

Update a local copy of the PR: \
`$ git checkout pull/458` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 458`

View PR using the GUI difftool: \
`$ git pr show -t 458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/458.diff">https://git.openjdk.org/jdk21u-dev/pull/458.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/458#issuecomment-2039267385)