### PR TITLE
8311881: jdk/javax/swing/ProgressMonitor/ProgressTest.java does not show the ProgressMonitorInputStream all the time

### DIFF
--- a/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
@@ -30,11 +30,11 @@
  */
 
 import java.io.InputStream;
-
+import java.awt.EventQueue;
 import javax.swing.ProgressMonitorInputStream;
 
 public class ProgressTest {
-
+    static volatile long total = 0;
     private static final String instructionsText =
             "A ProgressMonitor will be shown.\n" +
             " If it shows blank progressbar after 2048MB bytes read,\n"+
@@ -69,15 +69,20 @@ public class ProgressTest {
             public void run() {
                 byte[] buffer = new byte[512];
                 int nb = 0;
-                long total = 0;
                 while (true) {
                     try {
                         nb = pmis.read(buffer);
                     } catch (Exception e){}
                     if (nb == 0) break;
                     total += nb;
-
-                    pmis.getProgressMonitor().setNote(total/(1024*1024)+" MB Read");
+                    System.out.println("total " + total);
+                    if ((total % (1024*1024)) == 0) {
+                        try {
+                            EventQueue.invokeAndWait(() -> {
+                                pmis.getProgressMonitor().setNote(total/(1024*1024)+" MB Read");
+                            });
+                        } catch (Exception e) {}
+                    }
                 }
             }
         };


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

Ran manual test on win and linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311881](https://bugs.openjdk.org/browse/JDK-8311881) needs maintainer approval

### Issue
 * [JDK-8311881](https://bugs.openjdk.org/browse/JDK-8311881): jdk/javax/swing/ProgressMonitor/ProgressTest.java does not show the ProgressMonitorInputStream all the time (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/460/head:pull/460` \
`$ git checkout pull/460`

Update a local copy of the PR: \
`$ git checkout pull/460` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 460`

View PR using the GUI difftool: \
`$ git pr show -t 460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/460.diff">https://git.openjdk.org/jdk21u-dev/pull/460.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/460#issuecomment-2039375350)