### PR TITLE
8319578: Few java/lang/instrument ignore test.java.opts and accept test.vm.opts only

### DIFF
--- a/test/jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh
+++ b/test/jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ case ${OS} in
         ;;
 esac
 
-"$JAVA" ${TESTVMOPTS} -classpath "${TESTCLASSES}" Setup "${TESTCLASSES}" Agent "${CYGWIN}"
+"$JAVA" ${TESTVMOPTS} ${TESTJAVAOPTS} -classpath "${TESTCLASSES}" Setup "${TESTCLASSES}" Agent "${CYGWIN}"
 
 BOOTDIR=`cat ${TESTCLASSES}/boot.dir`
 
@@ -94,13 +94,13 @@ echo "Creating agent jar file..."
 
 echo "Running test..."
 
-"${JAVA}" ${TESTVMOPTS} -javaagent:"${TESTCLASSES}"/Agent.jar -classpath "${TESTCLASSES}" DummyMain
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:"${TESTCLASSES}"/Agent.jar -classpath "${TESTCLASSES}" DummyMain
 result=$?
 
 echo "Cleanup..."
 
 "$JAVAC" ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} -d "${TESTCLASSES}" \
     "${TESTSRC}"/Cleanup.java
-"$JAVA" ${TESTVMOPTS} -classpath "${TESTCLASSES}" Cleanup "${BOOTDIR}"
+"$JAVA" ${TESTVMOPTS} ${TESTJAVAOPTS} -classpath "${TESTCLASSES}" Cleanup "${BOOTDIR}"
 
 exit $result

--- a/test/jdk/java/lang/instrument/ManifestTest.sh
+++ b/test/jdk/java/lang/instrument/ManifestTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -380,7 +380,7 @@ while read token; do
     echo "===== begin test case: $token ====="
     make_a_JAR "$token"
 
-    "${JAVA}" ${TESTVMOPTS} -javaagent:${AGENT}.jar \
+    "${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:${AGENT}.jar \
         -classpath "${TESTCLASSES}" ManifestTestApp > output.log 2>&1
     result=$?
 

--- a/test/jdk/java/lang/instrument/RedefineBigClass.sh
+++ b/test/jdk/java/lang/instrument/RedefineBigClass.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -62,14 +62,14 @@ JAVAC="${COMPILEJAVA}"/bin/javac
 JAVA="${TESTJAVA}"/bin/java
 
 # Does this VM support the 'detail' level of NMT?
-"${JAVA}" ${TESTVMOPTS} -XX:NativeMemoryTracking=detail -version
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -XX:NativeMemoryTracking=detail -version
 if [ "$?" = 0 ]; then
     NMT=-XX:NativeMemoryTracking=detail
 else
     NMT=-XX:NativeMemoryTracking=summary
 fi
 
-"${JAVA}" ${TESTVMOPTS} \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} \
     -Xlog:redefine+class+load=debug,redefine+class+load+exceptions=info ${NMT} \
     -javaagent:RedefineBigClassAgent.jar=BigClass.class \
     -classpath "${TESTCLASSES}" RedefineBigClassApp \

--- a/test/jdk/java/lang/instrument/RedefineClassWithNativeMethod.sh
+++ b/test/jdk/java/lang/instrument/RedefineClassWithNativeMethod.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ fi
 JAVAC="${COMPILEJAVA}"/bin/javac
 JAVA="${TESTJAVA}"/bin/java
 
-"${JAVA}" ${TESTVMOPTS} \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} \
     -javaagent:RedefineClassWithNativeMethodAgent.jar=java/lang/Thread.class \
     -classpath "${TESTCLASSES}" RedefineClassWithNativeMethodApp \
     > output.log 2>&1

--- a/test/jdk/java/lang/instrument/RedefineMethodAddInvoke.sh
+++ b/test/jdk/java/lang/instrument/RedefineMethodAddInvoke.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ cp "${TESTSRC}"/RedefineMethodAddInvokeTarget_2.java \
 mv RedefineMethodAddInvokeTarget.java RedefineMethodAddInvokeTarget_2.java
 mv RedefineMethodAddInvokeTarget.class RedefineMethodAddInvokeTarget_2.class
 
-"${JAVA}" ${TESTVMOPTS} -javaagent:RedefineMethodAddInvokeAgent.jar \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:RedefineMethodAddInvokeAgent.jar \
     -XX:+AllowRedefinitionToAddDeleteMethods \
     -classpath "${TESTCLASSES}" RedefineMethodAddInvokeApp > output.log 2>&1
 cat output.log

--- a/test/jdk/java/lang/instrument/RedefineMethodDelInvoke.sh
+++ b/test/jdk/java/lang/instrument/RedefineMethodDelInvoke.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ cp "${TESTSRC}"/RedefineMethodDelInvokeTarget_2.java \
 mv RedefineMethodDelInvokeTarget.java RedefineMethodDelInvokeTarget_2.java
 mv RedefineMethodDelInvokeTarget.class RedefineMethodDelInvokeTarget_2.class
 
-"${JAVA}" ${TESTVMOPTS} -javaagent:RedefineMethodDelInvokeAgent.jar \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:RedefineMethodDelInvokeAgent.jar \
     -XX:+AllowRedefinitionToAddDeleteMethods \
     -classpath "${TESTCLASSES}" RedefineMethodDelInvokeApp > output.log 2>&1
 

--- a/test/jdk/java/lang/instrument/RedefineMethodInBacktrace.sh
+++ b/test/jdk/java/lang/instrument/RedefineMethodInBacktrace.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ cp "${TESTSRC}"/RedefineMethodInBacktraceTargetB_2.java \
     RedefineMethodInBacktraceTargetB.java
 "${JAVAC}" ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} -d . RedefineMethodInBacktraceTargetB.java
 
-"${JAVA}" ${TESTVMOPTS} -javaagent:RedefineMethodInBacktraceAgent.jar \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:RedefineMethodInBacktraceAgent.jar \
     -XX:+AllowRedefinitionToAddDeleteMethods \
     -classpath "${TESTCLASSES}" RedefineMethodInBacktraceApp > output.log 2>&1
 RUN_RESULT=$?

--- a/test/jdk/java/lang/instrument/RedefineMethodWithAnnotations.sh
+++ b/test/jdk/java/lang/instrument/RedefineMethodWithAnnotations.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ cp "${TESTSRC}"/RedefineMethodWithAnnotationsAnnotations.java \
     RedefineMethodWithAnnotationsTarget.java \
     RedefineMethodWithAnnotationsAnnotations.java
 
-"${JAVA}" ${TESTVMOPTS} -javaagent:RedefineMethodWithAnnotationsAgent.jar \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:RedefineMethodWithAnnotationsAgent.jar \
     -XX:+UnlockDiagnosticVMOptions -XX:+StressLdcRewrite -XX:+IgnoreUnrecognizedVMOptions \
     -cp "${TESTCLASSES}" RedefineMethodWithAnnotationsApp > output.log 2>&1
 cat output.log

--- a/test/jdk/java/lang/instrument/RedefineSubclassWithTwoInterfaces.sh
+++ b/test/jdk/java/lang/instrument/RedefineSubclassWithTwoInterfaces.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ cp "${TESTSRC}"/RedefineSubclassWithTwoInterfacesImpl_1.java \
 "${JAVAC}" ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} \
     -cp "${TESTCLASSES}" -d . \
     RedefineSubclassWithTwoInterfacesTarget.java \
-    RedefineSubclassWithTwoInterfacesImpl.java 
+    RedefineSubclassWithTwoInterfacesImpl.java
 status="$?"
 if [ "$status" != 0 ]; then
     echo "FAIL: compile of *_1.java files failed."
@@ -87,7 +87,7 @@ mv RedefineSubclassWithTwoInterfacesImpl.class \
 
 echo "INFO: launching RedefineSubclassWithTwoInterfacesApp"
 
-"${JAVA}" ${TESTVMOPTS} \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} \
     -Xlog:redefine+class+load=trace,redefine+class+load+exceptions=trace,redefine+class+timer=trace,redefine+class+obsolete=trace,redefine+class+obsolete+metadata=trace,redefine+class+constantpool=trace \
     -javaagent:RedefineSubclassWithTwoInterfacesAgent.jar \
     -classpath "${TESTCLASSES}" \

--- a/test/jdk/java/lang/instrument/RetransformBigClass.sh
+++ b/test/jdk/java/lang/instrument/RetransformBigClass.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -62,14 +62,14 @@ JAVAC="${COMPILEJAVA}"/bin/javac
 JAVA="${TESTJAVA}"/bin/java
 
 # Does this VM support the 'detail' level of NMT?
-"${JAVA}" ${TESTVMOPTS} -XX:NativeMemoryTracking=detail -version
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -XX:NativeMemoryTracking=detail -version
 if [ "$?" = 0 ]; then
     NMT=-XX:NativeMemoryTracking=detail
 else
     NMT=-XX:NativeMemoryTracking=summary
 fi
 
-"${JAVA}" ${TESTVMOPTS} \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} \
     -Xlog:redefine+class+load=debug,redefine+class+load+exceptions=info ${NMT} \
     -javaagent:RetransformBigClassAgent.jar=BigClass.class \
     -classpath "${TESTCLASSES}" RetransformBigClassApp \

--- a/test/jdk/java/lang/instrument/StressGetObjectSizeTest.sh
+++ b/test/jdk/java/lang/instrument/StressGetObjectSizeTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ fi
 
 JAVA="${TESTJAVA}"/bin/java
 
-"${JAVA}" ${TESTVMOPTS} -javaagent:basicAgent.jar \
+"${JAVA}" ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:basicAgent.jar \
     -classpath "${TESTCLASSES}" StressGetObjectSizeApp StressGetObjectSizeApp \
     > output.log 2>&1
 cat output.log

--- a/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CircularityErrorTest.sh
+++ b/test/jdk/java/lang/instrument/appendToClassLoaderSearch/CircularityErrorTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -77,4 +77,4 @@ $JAR ${TESTTOOLVMOPTS} -cfm "${TESTCLASSES}"/CircularityErrorTest.jar "${MANIFES
 
 # Finally we run the test
 (cd "${TESTCLASSES}";
-  $JAVA ${TESTVMOPTS} -javaagent:CircularityErrorTest.jar CircularityErrorTest)
+  $JAVA ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:CircularityErrorTest.jar CircularityErrorTest)

--- a/test/jdk/java/lang/instrument/appendToClassLoaderSearch/ClassUnloadTest.sh
+++ b/test/jdk/java/lang/instrument/appendToClassLoaderSearch/ClassUnloadTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -80,5 +80,5 @@ $JAR ${TESTTOOLVMOPTS} -cfm "${TESTCLASSES}"/ClassUnloadTest.jar "${MANIFEST}" \
 
 # Finally we run the test
 (cd "${TESTCLASSES}"; \
-  $JAVA ${TESTVMOPTS} -Xlog:class+unload \
+  $JAVA ${TESTVMOPTS} ${TESTJAVAOPTS} -Xlog:class+unload \
     -javaagent:ClassUnloadTest.jar ClassUnloadTest "${OTHERDIR}" Bar.jar)

--- a/test/jdk/java/lang/instrument/appendToClassLoaderSearch/run_tests.sh
+++ b/test/jdk/java/lang/instrument/appendToClassLoaderSearch/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ failures=0
 
 go() {
     echo ''
-    sh -xc "$JAVA ${TESTVMOPTS} -javaagent:Agent.jar -classpath SimpleTests.jar  $1 $2 $3" 2>&1
+    sh -xc "$JAVA ${TESTVMOPTS} ${TESTJAVAOPTS} -javaagent:Agent.jar -classpath SimpleTests.jar  $1 $2 $3" 2>&1
     if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
 }
 
@@ -85,11 +85,11 @@ mv Application.class InstrumentedApplication.bytes
 cp "${TESTSRC}"/Application.java .
 "${JAVAC}" ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} -d . Application.java
 
-sh -xc "$JAVA ${TESTVMOPTS} -classpath . -javaagent:Agent.jar DynamicTest" 2>&1
+sh -xc "$JAVA ${TESTVMOPTS} ${TESTJAVAOPTS} -classpath . -javaagent:Agent.jar DynamicTest" 2>&1
 if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
 
 # Repeat test with security manager
-sh -xc "$JAVA ${TESTVMOPTS} -classpath . -javaagent:Agent.jar -Djava.security.manager DynamicTest" 2>&1
+sh -xc "$JAVA ${TESTVMOPTS} ${TESTJAVAOPTS} -classpath . -javaagent:Agent.jar -Djava.security.manager DynamicTest" 2>&1
 if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
 
 #


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8319578](https://bugs.openjdk.org/browse/JDK-8319578) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319578](https://bugs.openjdk.org/browse/JDK-8319578): Few java/lang/instrument ignore test.java.opts and accept test.vm.opts only (**Sub-task** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/462/head:pull/462` \
`$ git checkout pull/462`

Update a local copy of the PR: \
`$ git checkout pull/462` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 462`

View PR using the GUI difftool: \
`$ git pr show -t 462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/462.diff">https://git.openjdk.org/jdk21u-dev/pull/462.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/462#issuecomment-2039451606)