### PR TITLE
8327990: [macosx-aarch64] Various tests fail with -XX:+AssertWXAtThreadSync

### DIFF
--- a/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
@@ -156,6 +156,8 @@ void JfrJvmtiAgent::retransform_classes(JNIEnv* env, jobjectArray classes_array,
     return;
   }
   ResourceMark rm(THREAD);
+  // WXWrite is needed before entering the vm below and in callee methods.
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, THREAD));
   jclass* const classes = create_classes_array(classes_count, CHECK);
   assert(classes != nullptr, "invariant");
   for (jint i = 0; i < classes_count; i++) {

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -112,7 +112,9 @@ NO_TRANSITION_END
 NO_TRANSITION(void, jfr_set_enabled(JNIEnv* env, jobject jvm, jlong event_type_id, jboolean enabled))
   JfrEventSetting::set_enabled(event_type_id, JNI_TRUE == enabled);
   if (EventOldObjectSample::eventId == event_type_id) {
-    ThreadInVMfromNative transition(JavaThread::thread_from_jni_environment(env));
+    JavaThread* thread = JavaThread::thread_from_jni_environment(env);
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+    ThreadInVMfromNative transition(thread);
     if (JNI_TRUE == enabled) {
       LeakProfiler::start(JfrOptionSet::old_object_queue_size());
     } else {

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -291,6 +291,7 @@ void JfrStorage::register_full(BufferPtr buffer, Thread* thread) {
       JavaThread* jt = JavaThread::cast(thread);
       if (jt->thread_state() == _thread_in_native) {
         // Transition java thread to vm so it can issue a notify.
+        MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
         ThreadInVMfromNative transition(jt);
         _post_box.post(MSG_FULLBUFFER);
         return;

--- a/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
@@ -56,6 +56,7 @@ void* JfrIntrinsicSupport::write_checkpoint(JavaThread* jt) {
   assert(JfrThreadLocal::is_vthread(jt), "invariant");
   const u2 vthread_thread_local_epoch = JfrThreadLocal::vthread_epoch(jt);
   const u2 current_epoch = ThreadIdAccess::current_epoch();
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
   if (vthread_thread_local_epoch == current_epoch) {
     // After the epoch test in the intrinsic, the thread sampler interleaved
     // and suspended the thread. As part of taking a sample, it updated

--- a/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
+++ b/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
@@ -123,6 +123,7 @@ void JfrJavaEventWriter::flush(jobject writer, jint used, jint requested, JavaTh
   u1* const new_current_position = is_valid ? buffer->pos() + used : buffer->pos();
   assert(start_pos_offset != invalid_offset, "invariant");
   // can safepoint here
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
   ThreadInVMfromNative transition(jt);
   oop const w = JNIHandles::resolve_non_null(writer);
   assert(w != nullptr, "invariant");

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -382,6 +382,7 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
   if (JvmtiEnv::get_phase() == JVMTI_PHASE_LIVE) {
     JavaThread* current_thread = JavaThread::current();
     // transition code: native to VM
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
     ThreadInVMfromNative __tiv(current_thread);
     VM_ENTRY_BASE(jvmtiEnv*, JvmtiExport::get_jvmti_interface, current_thread)
     debug_only(VMNativeEntryWrapper __vew;)

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -130,6 +130,7 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
   thread_ptr = va_arg(ap, jthread*);
   va_end(ap);
 
+  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
   ThreadInVMfromNative tiv(current_thread);
   JvmtiVTMSTransitionDisabler disabler;
 


### PR DESCRIPTION
Hi,

this PR contains a backport of commit https://github.com/openjdk/jdk/commit/e41bc42deb22615c9b93ee639d04e9ed2bd57f64.

It did not apply cleanly because `JfrRecorderService::emit_leakprofiler_events()` does not exist in jdk 21 so I left out the hunk in `jfrRecorderService.cpp`.

Testing:
I've verified every added `WXState` change if it is actually required.
More testing with `-XX:+AssertWXAtThreadSync` is pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8327990](https://bugs.openjdk.org/browse/JDK-8327990) needs maintainer approval

### Issue
 * [JDK-8327990](https://bugs.openjdk.org/browse/JDK-8327990): [macosx-aarch64] Various tests fail with -XX:+AssertWXAtThreadSync (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/465/head:pull/465` \
`$ git checkout pull/465`

Update a local copy of the PR: \
`$ git checkout pull/465` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 465`

View PR using the GUI difftool: \
`$ git pr show -t 465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/465.diff">https://git.openjdk.org/jdk21u-dev/pull/465.diff</a>

</details>
