### PR TITLE
8315824: Open source several Swing Text/HTML related tests

### DIFF
--- a/test/jdk/javax/swing/text/StyledEditorKit/bug4253334.java
+++ b/test/jdk/javax/swing/text/StyledEditorKit/bug4253334.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.Action;
+import javax.swing.JEditorPane;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Caret;
+import javax.swing.text.Element;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+import java.awt.event.ActionEvent;
+import java.io.StringReader;
+
+/*
+ * @test
+ * @bug 4253334
+ * @summary Tests that bold attribute unsets properly
+ */
+
+public class bug4253334 {
+
+    public static void main(String[] args) throws Exception {
+        JEditorPane ep = new JEditorPane();
+        ep.setEditable(true);
+        ep.setContentType("text/html");
+
+        HTMLEditorKit kit = (HTMLEditorKit)ep.getEditorKit();
+        HTMLDocument doc = (HTMLDocument)kit.createDefaultDocument();
+        ep.setDocument(doc);
+        String text = "<html><body>somesampletext</body></html>";
+        kit.read(new StringReader(text), doc, 0);
+
+        // make some text bold & italic
+        MutableAttributeSet attrs = new SimpleAttributeSet();
+        StyleConstants.setBold(attrs, true);
+        StyleConstants.setItalic(attrs, true);
+        doc.setCharacterAttributes(3, 9, attrs, false);
+
+        Action[] as = kit.getActions();
+        Action boldAction = null;
+
+        for (Action a : as) {
+            String s = (String) (a.getValue(Action.NAME));
+            if (s.equals("font-bold")) {
+                boldAction = a;
+            }
+        }
+        Caret caret = ep.getCaret();
+        ActionEvent event = new ActionEvent(ep, ActionEvent.ACTION_PERFORMED,
+                                            "font-bold");
+        caret.setDot(3);
+        caret.moveDot(7);
+        boldAction.actionPerformed(event);
+        caret.setDot(7);
+        caret.moveDot(12);
+        boldAction.actionPerformed(event);
+
+        Element elem = doc.getCharacterElement(9);
+        AttributeSet at = elem.getAttributes();
+        if (StyleConstants.isBold(at)) {
+            throw new RuntimeException("Test Failed: bold attribute set");
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/StyledEditorKit/bug4329418.java
+++ b/test/jdk/javax/swing/text/StyledEditorKit/bug4329418.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.text.Document;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledEditorKit;
+
+/*
+ * @test
+ * @bug 4329418
+ * @key headful
+ * @summary Tests if setCharacterAttributes() is maintained
+ *          after return in J(Editor/Text)Pane
+ */
+
+public class bug4329418 {
+    private static JFrame jf;
+    private static StyledEditorKit sek;
+
+    private static volatile boolean passed = false;
+    private static final int FONT_SIZE = 36;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+
+            SwingUtilities.invokeAndWait(bug4329418::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(500);
+
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+            robot.delay(300);
+
+            if (!passed) {
+                throw new RuntimeException("Test failed." +
+                        " setCharacterAttributes() does not work correctly");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (jf != null) {
+                    jf.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        jf = new JFrame("setCharacterAttributes Test");
+        sek = new StyledEditorKit();
+        JEditorPane jep = new JEditorPane();
+        jep.setEditorKit(sek);
+
+        MutableAttributeSet attrs = sek.getInputAttributes();
+        StyleConstants.setFontSize(attrs, FONT_SIZE);
+
+        jep.addKeyListener(new KeyAdapter() {
+            public void keyReleased(KeyEvent e) {
+                MutableAttributeSet attrs = sek.getInputAttributes();
+                passed = (StyleConstants.getFontSize(attrs) == FONT_SIZE);
+            }
+        });
+
+        jep.setText("aaa");
+        Document doc = jep.getDocument();
+        jep.setCaretPosition(doc.getLength());
+
+        jf.getContentPane().add(jep);
+        jf.setLocationRelativeTo(null);
+        jf.setSize(200, 200);
+        jf.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/text/bug4739057.java
+++ b/test/jdk/javax/swing/text/bug4739057.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFormattedTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.text.MaskFormatter;
+import java.text.ParseException;
+
+/*
+ * @test
+ * @bug 4739057
+ * @summary replaceSelection() method fails on JFormattedTextField
+ */
+
+public class bug4739057 {
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            MaskFormatter formatter;
+            try {
+                formatter = new MaskFormatter("(###) ###-####");
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+            formatter.setPlaceholderCharacter('#');
+            JFormattedTextField textField = new JFormattedTextField(formatter);
+            textField.replaceSelection("12345");
+            if (!textField.getText().equals("(123) 45#-####")) {
+                throw new RuntimeException("Test Failed! replaceSelection() didn't replace text properly");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/text/bug4763466.java
+++ b/test/jdk/javax/swing/text/bug4763466.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFormattedTextField;
+import javax.swing.text.NumberFormatter;
+import java.text.DecimalFormat;
+
+/*
+ * @test
+ * @bug 4763466
+ * @summary JFormattedTextField and the - sign
+ */
+
+public class bug4763466 {
+
+    public static void main(String[] args) throws Exception {
+        DecimalFormat decimalFormat = new DecimalFormat("##0.00");
+        NumberFormatter textFormatter = new NumberFormatter(decimalFormat);
+        textFormatter.setAllowsInvalid(false);
+        textFormatter.setValueClass(Double.class);
+
+        JFormattedTextField ftf = new JFormattedTextField(textFormatter);
+        ftf.setCaretPosition(0);
+        ftf.setValue((double) -1);
+
+        if (ftf.getCaretPosition() == 0) {
+            throw new RuntimeException("Test Failed. Caret position shouldn't be 0" +
+                    " as the sign is literal");
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/html/bug4210307.java
+++ b/test/jdk/javax/swing/text/html/bug4210307.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.html.FormView;
+
+/*
+ * @test
+ * @bug 4210307 4210308
+ * @summary Tests that FormView button text is internationalized
+ */
+
+public class bug4210307 {
+    private static final String RESET_PROPERTY = "TEST RESET";
+    private static final String SUBMIT_PROPERTY = "TEST SUBMIT";
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            Object oldReset = UIManager.put("FormView.resetButtonText",
+                    RESET_PROPERTY);
+            Object oldSubmit = UIManager.put("FormView.submitButtonText",
+                    SUBMIT_PROPERTY);
+
+            try {
+                JEditorPane ep = new JEditorPane("text/html",
+                        "<html><input type=\"submit\"></html>");
+                Document doc = ep.getDocument();
+                Element elem = findInputElement(doc.getDefaultRootElement());
+                TestView view = new TestView(elem);
+                view.test(SUBMIT_PROPERTY);
+
+                ep = new JEditorPane("text/html",
+                        "<html><input type=\"reset\"></html>");
+                doc = ep.getDocument();
+                elem = findInputElement(doc.getDefaultRootElement());
+                view = new TestView(elem);
+                view.test(RESET_PROPERTY);
+            } finally {
+                UIManager.put("FormView.resetButtonText", oldReset);
+                UIManager.put("FormView.submitButtonText", oldSubmit);
+            }
+        });
+    }
+
+    private static Element findInputElement(Element root) {
+        for (int i = 0; i < root.getElementCount(); i++) {
+            Element elem = root.getElement(i);
+            if (elem.getName().equals("input")) {
+                return elem;
+            } else {
+                Element e = findInputElement(elem);
+                if (e != null) return e;
+            }
+        }
+        return null;
+    }
+
+    static class TestView extends FormView {
+        public TestView(Element elem) {
+            super(elem);
+        }
+
+        public void test(String caption) {
+            JButton comp = (JButton) createComponent();
+            if (!comp.getText().equals(caption)) {
+                throw new RuntimeException("Failed: '" + comp.getText() +
+                        "' instead of `" + caption + "'");
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/html/bug4839739.java
+++ b/test/jdk/javax/swing/text/html/bug4839739.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.text.html.HTMLEditorKit;
+import java.awt.Component;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+/*
+ * @test
+ * @bug 4839739
+ * @key headful
+ * @summary Tests if JEditorPane works correctly with HTML comments.
+ */
+
+public class bug4839739 {
+
+    private static JFrame jFrame;
+    private static JEditorPane jep;
+    private static volatile Point p;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.delay(50);
+
+            SwingUtilities.invokeAndWait(bug4839739::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(500);
+
+            SwingUtilities.invokeAndWait(() -> p = jep.getLocationOnScreen());
+            robot.delay(200);
+
+            robot.mouseMove(p.x + 20, p.y + 20);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.delay(300);
+
+            Component comp = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
+            if (!(comp instanceof JEditorPane)) {
+                throw new RuntimeException("Test failed." +
+                        " JEditorPane doesn't work as expected with HTML comments");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (jFrame != null) {
+                    jFrame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        String text = "<html><head><body><!-- some comment -->" +
+                "some always visible text</body></html>";
+
+        jFrame = new JFrame("JEditorPane With HTML");
+        jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(text);
+        jFrame.getContentPane().add(jep);
+        jFrame.setSize(200,200);
+        jFrame.setLocationRelativeTo(null);
+        jFrame.setVisible(true);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c11f8352](https://github.com/openjdk/jdk/commit/c11f8352e96a01b39e54080716030ec96f717cae) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Harshitha Onkar on 14 Sep 2023 and was reviewed by Prasanta Sadhukhan and Alexander Zvegintsev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8315824](https://bugs.openjdk.org/browse/JDK-8315824): Open source several Swing Text/HTML related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/468/head:pull/468` \
`$ git checkout pull/468`

Update a local copy of the PR: \
`$ git checkout pull/468` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 468`

View PR using the GUI difftool: \
`$ git pr show -t 468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/468.diff">https://git.openjdk.org/jdk21u-dev/pull/468.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/468#issuecomment-2043040051)