### PR TITLE
8316154: Opensource JTextArea manual tests

### DIFF
--- a/test/jdk/javax/swing/JTextArea/bug4265784.java
+++ b/test/jdk/javax/swing/JTextArea/bug4265784.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4265784 4267291
+ * @summary Tests work of TAB key in JTextArea
+ * @key headful
+ * @run main bug4265784
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+public class bug4265784 {
+    static JFrame frame;
+    static JTextArea ta;
+    static volatile Point p;
+    static volatile int pos;
+    static volatile int pos1;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4265784");
+                ta = new JTextArea();
+                frame.getContentPane().add(ta);
+                frame.pack();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                p = ta.getLocationOnScreen();
+            });
+            robot.mouseMove(p.x + 10, p.y + 10);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            SwingUtilities.invokeAndWait(() -> {
+                pos = ta.getCaretPosition();
+            });
+            System.out.println(pos);
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                pos1 = ta.getCaretPosition();
+            });
+            System.out.println(pos1);
+            if (pos == pos1) {
+                throw new RuntimeException("TAB ignored");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [33c62e4f](https://github.com/openjdk/jdk/commit/33c62e4fffe33a7593fd0c01de53507bfd01dc3b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 14 Sep 2023 and was reviewed by Abhishek Kumar and Jayathirth D V.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8316154](https://bugs.openjdk.org/browse/JDK-8316154) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316154](https://bugs.openjdk.org/browse/JDK-8316154): Opensource JTextArea manual tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/469/head:pull/469` \
`$ git checkout pull/469`

Update a local copy of the PR: \
`$ git checkout pull/469` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 469`

View PR using the GUI difftool: \
`$ git pr show -t 469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/469.diff">https://git.openjdk.org/jdk21u-dev/pull/469.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/469#issuecomment-2043043409)