### PR TITLE
8329570: G1: Excessive is_obj_dead_cond calls in verification

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -608,7 +608,6 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
   template <class T>
   void do_oop_work(T* p) {
     assert(_containing_obj != nullptr, "must be");
-    assert(!G1CollectedHeap::heap()->is_obj_dead_cond(_containing_obj, _vo), "Precondition");
 
     if (num_failures() >= G1MaxVerifyFailures) {
       return;
@@ -640,6 +639,7 @@ public:
     _num_failures(0) { }
 
   void set_containing_obj(oop const obj) {
+    assert(!G1CollectedHeap::heap()->is_obj_dead_cond(obj, _vo), "Precondition");
     _containing_obj = obj;
   }
 


### PR DESCRIPTION
Simple fastdebug performance improvement fix. Risk is low, as it only moves the assert to an earlier stage.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329570](https://bugs.openjdk.org/browse/JDK-8329570) needs maintainer approval

### Issue
 * [JDK-8329570](https://bugs.openjdk.org/browse/JDK-8329570): G1: Excessive is_obj_dead_cond calls in verification (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/473/head:pull/473` \
`$ git checkout pull/473`

Update a local copy of the PR: \
`$ git checkout pull/473` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 473`

View PR using the GUI difftool: \
`$ git pr show -t 473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/473.diff">https://git.openjdk.org/jdk21u-dev/pull/473.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/473#issuecomment-2042025512)