### PR TITLE
8328037: Test java/util/Formatter/Padding.java has unnecessary high heap requirement after JDK-8326718

### DIFF
--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -23,332 +23,406 @@
 
 /*
  * @test
- * @bug 4906370 8299677 8326718
- * @summary Tests to excercise padding on int and double values,
+ * @bug 4906370 8299677 8326718 8328037
+ * @summary Tests to exercise padding on int and double values,
  *      with various flag combinations.
  * @run junit Padding
  */
 
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class Padding {
+    /* blank padding, right adjusted, optional sign */
+    static Stream<? extends Arguments> blankPaddingRightAdjustedOptionalSign() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of("12", "%1d", 12),
+            Arguments.of("12", "%2d", 12),
+            Arguments.of(" 12", "%3d", 12),
+            Arguments.of("  12", "%4d", 12),
+            Arguments.of("   12", "%5d", 12),
+            Arguments.of("        12", "%10d", 12),
+            Arguments.of(tenMillionBlanks + "12", "%10000002d", 12),
 
-    private static final String tenMillionZeros = "0".repeat(10_000_000);
-    private static final String tenMillionBlanks = " ".repeat(10_000_000);
+            Arguments.of("-12", "%1d", -12),
+            Arguments.of("-12", "%2d", -12),
+            Arguments.of("-12", "%3d", -12),
+            Arguments.of(" -12", "%4d", -12),
+            Arguments.of("  -12", "%5d", -12),
+            Arguments.of("       -12", "%10d", -12),
+            Arguments.of(tenMillionBlanks + "-12", "%10000003d", -12),
 
-    static Arguments[] padding() {
-        return new Arguments[] {
-                /* blank padding, right adjusted, optional plus sign */
-                arguments("12", "%1d", 12),
-                arguments("12", "%2d", 12),
-                arguments(" 12", "%3d", 12),
-                arguments("  12", "%4d", 12),
-                arguments("   12", "%5d", 12),
-                arguments("        12", "%10d", 12),
-                arguments(tenMillionBlanks + "12", "%10000002d", 12),
+            Arguments.of("1.2", "%1.1f", 1.2),
+            Arguments.of("1.2", "%2.1f", 1.2),
+            Arguments.of("1.2", "%3.1f", 1.2),
+            Arguments.of(" 1.2", "%4.1f", 1.2),
+            Arguments.of("  1.2", "%5.1f", 1.2),
+            Arguments.of("       1.2", "%10.1f", 1.2),
+            Arguments.of(tenMillionBlanks + "1.2", "%10000003.1f", 1.2),
 
-                arguments("-12", "%1d", -12),
-                arguments("-12", "%2d", -12),
-                arguments("-12", "%3d", -12),
-                arguments(" -12", "%4d", -12),
-                arguments("  -12", "%5d", -12),
-                arguments("       -12", "%10d", -12),
-                arguments(tenMillionBlanks + "-12", "%10000003d", -12),
-
-                arguments("1.2", "%1.1f", 1.2),
-                arguments("1.2", "%2.1f", 1.2),
-                arguments("1.2", "%3.1f", 1.2),
-                arguments(" 1.2", "%4.1f", 1.2),
-                arguments("  1.2", "%5.1f", 1.2),
-                arguments("       1.2", "%10.1f", 1.2),
-                arguments(tenMillionBlanks + "1.2", "%10000003.1f", 1.2),
-
-                arguments("-1.2", "%1.1f", -1.2),
-                arguments("-1.2", "%2.1f", -1.2),
-                arguments("-1.2", "%3.1f", -1.2),
-                arguments("-1.2", "%4.1f", -1.2),
-                arguments(" -1.2", "%5.1f", -1.2),
-                arguments("      -1.2", "%10.1f", -1.2),
-                arguments(tenMillionBlanks + "-1.2", "%10000004.1f", -1.2),
-
-                /* blank padding, right adjusted, mandatory plus sign */
-                arguments("+12", "%+1d", 12),
-                arguments("+12", "%+2d", 12),
-                arguments("+12", "%+3d", 12),
-                arguments(" +12", "%+4d", 12),
-                arguments("  +12", "%+5d", 12),
-                arguments("       +12", "%+10d", 12),
-                arguments(tenMillionBlanks + "+12", "%+10000003d", 12),
-
-                arguments("-12", "%+1d", -12),
-                arguments("-12", "%+2d", -12),
-                arguments("-12", "%+3d", -12),
-                arguments(" -12", "%+4d", -12),
-                arguments("  -12", "%+5d", -12),
-                arguments("       -12", "%+10d", -12),
-                arguments(tenMillionBlanks + "-12", "%+10000003d", -12),
-
-                arguments("+1.2", "%+1.1f", 1.2),
-                arguments("+1.2", "%+2.1f", 1.2),
-                arguments("+1.2", "%+3.1f", 1.2),
-                arguments("+1.2", "%+4.1f", 1.2),
-                arguments(" +1.2", "%+5.1f", 1.2),
-                arguments("      +1.2", "%+10.1f", 1.2),
-                arguments(tenMillionBlanks + "+1.2", "%+10000004.1f", 1.2),
-
-                arguments("-1.2", "%+1.1f", -1.2),
-                arguments("-1.2", "%+2.1f", -1.2),
-                arguments("-1.2", "%+3.1f", -1.2),
-                arguments("-1.2", "%+4.1f", -1.2),
-                arguments(" -1.2", "%+5.1f", -1.2),
-                arguments("      -1.2", "%+10.1f", -1.2),
-                arguments(tenMillionBlanks + "-1.2", "%+10000004.1f", -1.2),
-
-                /* blank padding, right adjusted, mandatory blank sign */
-                arguments(" 12", "% 1d", 12),
-                arguments(" 12", "% 2d", 12),
-                arguments(" 12", "% 3d", 12),
-                arguments("  12", "% 4d", 12),
-                arguments("   12", "% 5d", 12),
-                arguments("        12", "% 10d", 12),
-                arguments(tenMillionBlanks + "12", "% 10000002d", 12),
-
-                arguments("-12", "% 1d", -12),
-                arguments("-12", "% 2d", -12),
-                arguments("-12", "% 3d", -12),
-                arguments(" -12", "% 4d", -12),
-                arguments("  -12", "% 5d", -12),
-                arguments("       -12", "% 10d", -12),
-                arguments(tenMillionBlanks + "-12", "% 10000003d", -12),
-
-                arguments(" 1.2", "% 1.1f", 1.2),
-                arguments(" 1.2", "% 2.1f", 1.2),
-                arguments(" 1.2", "% 3.1f", 1.2),
-                arguments(" 1.2", "% 4.1f", 1.2),
-                arguments("  1.2", "% 5.1f", 1.2),
-                arguments("       1.2", "% 10.1f", 1.2),
-                arguments(tenMillionBlanks + "1.2", "% 10000003.1f", 1.2),
-
-                arguments("-1.2", "% 1.1f", -1.2),
-                arguments("-1.2", "% 2.1f", -1.2),
-                arguments("-1.2", "% 3.1f", -1.2),
-                arguments("-1.2", "% 4.1f", -1.2),
-                arguments(" -1.2", "% 5.1f", -1.2),
-                arguments("      -1.2", "% 10.1f", -1.2),
-                arguments(tenMillionBlanks + "-1.2", "% 10000004.1f", -1.2),
-
-                /* blank padding, left adjusted, optional sign */
-                arguments("12", "%-1d", 12),
-                arguments("12", "%-2d", 12),
-                arguments("12 ", "%-3d", 12),
-                arguments("12  ", "%-4d", 12),
-                arguments("12   ", "%-5d", 12),
-                arguments("12        ", "%-10d", 12),
-                arguments("12" + tenMillionBlanks, "%-10000002d", 12),
-
-                arguments("-12", "%-1d", -12),
-                arguments("-12", "%-2d", -12),
-                arguments("-12", "%-3d", -12),
-                arguments("-12 ", "%-4d", -12),
-                arguments("-12  ", "%-5d", -12),
-                arguments("-12       ", "%-10d", -12),
-                arguments("-12" + tenMillionBlanks, "%-10000003d", -12),
-
-                arguments("1.2", "%-1.1f", 1.2),
-                arguments("1.2", "%-2.1f", 1.2),
-                arguments("1.2", "%-3.1f", 1.2),
-                arguments("1.2 ", "%-4.1f", 1.2),
-                arguments("1.2  ", "%-5.1f", 1.2),
-                arguments("1.2       ", "%-10.1f", 1.2),
-                arguments("1.2" + tenMillionBlanks, "%-10000003.1f", 1.2),
-
-                arguments("-1.2", "%-1.1f", -1.2),
-                arguments("-1.2", "%-2.1f", -1.2),
-                arguments("-1.2", "%-3.1f", -1.2),
-                arguments("-1.2", "%-4.1f", -1.2),
-                arguments("-1.2 ", "%-5.1f", -1.2),
-                arguments("-1.2      ", "%-10.1f", -1.2),
-                arguments("-1.2" + tenMillionBlanks, "%-10000004.1f", -1.2),
-
-                /* blank padding, left adjusted, mandatory plus sign */
-                arguments("+12", "%-+1d", 12),
-                arguments("+12", "%-+2d", 12),
-                arguments("+12", "%-+3d", 12),
-                arguments("+12 ", "%-+4d", 12),
-                arguments("+12  ", "%-+5d", 12),
-                arguments("+12       ", "%-+10d", 12),
-                arguments("+12" + tenMillionBlanks, "%-+10000003d", 12),
-
-                arguments("-12", "%-+1d", -12),
-                arguments("-12", "%-+2d", -12),
-                arguments("-12", "%-+3d", -12),
-                arguments("-12 ", "%-+4d", -12),
-                arguments("-12  ", "%-+5d", -12),
-                arguments("-12       ", "%-+10d", -12),
-                arguments("-12" + tenMillionBlanks, "%-+10000003d", -12),
-
-                arguments("+1.2", "%-+1.1f", 1.2),
-                arguments("+1.2", "%-+2.1f", 1.2),
-                arguments("+1.2", "%-+3.1f", 1.2),
-                arguments("+1.2", "%-+4.1f", 1.2),
-                arguments("+1.2 ", "%-+5.1f", 1.2),
-                arguments("+1.2      ", "%-+10.1f", 1.2),
-                arguments("+1.2" + tenMillionBlanks, "%-+10000004.1f", 1.2),
-
-                arguments("-1.2", "%-+1.1f", -1.2),
-                arguments("-1.2", "%-+2.1f", -1.2),
-                arguments("-1.2", "%-+3.1f", -1.2),
-                arguments("-1.2", "%-+4.1f", -1.2),
-                arguments("-1.2 ", "%-+5.1f", -1.2),
-                arguments("-1.2      ", "%-+10.1f", -1.2),
-                arguments("-1.2" + tenMillionBlanks, "%-+10000004.1f", -1.2),
-
-                /* blank padding, left adjusted, mandatory blank sign */
-                arguments(" 12", "%- 1d", 12),
-                arguments(" 12", "%- 2d", 12),
-                arguments(" 12", "%- 3d", 12),
-                arguments(" 12 ", "%- 4d", 12),
-                arguments(" 12  ", "%- 5d", 12),
-                arguments(" 12       ", "%- 10d", 12),
-                arguments(" 12" + tenMillionBlanks, "%- 10000003d", 12),
-
-                arguments("-12", "%- 1d", -12),
-                arguments("-12", "%- 2d", -12),
-                arguments("-12", "%- 3d", -12),
-                arguments("-12 ", "%- 4d", -12),
-                arguments("-12  ", "%- 5d", -12),
-                arguments("-12       ", "%- 10d", -12),
-                arguments("-12" + tenMillionBlanks, "%- 10000003d", -12),
-
-                arguments(" 1.2", "%- 1.1f", 1.2),
-                arguments(" 1.2", "%- 2.1f", 1.2),
-                arguments(" 1.2", "%- 3.1f", 1.2),
-                arguments(" 1.2", "%- 4.1f", 1.2),
-                arguments(" 1.2 ", "%- 5.1f", 1.2),
-                arguments(" 1.2      ", "%- 10.1f", 1.2),
-                arguments(" 1.2" + tenMillionBlanks, "%- 10000004.1f", 1.2),
-
-                arguments("-1.2", "%- 1.1f", -1.2),
-                arguments("-1.2", "%- 2.1f", -1.2),
-                arguments("-1.2", "%- 3.1f", -1.2),
-                arguments("-1.2", "%- 4.1f", -1.2),
-                arguments("-1.2 ", "%- 5.1f", -1.2),
-                arguments("-1.2      ", "%- 10.1f", -1.2),
-                arguments("-1.2" + tenMillionBlanks, "%- 10000004.1f", -1.2),
-
-                /* zero padding, right adjusted, optional sign */
-                arguments("12", "%01d", 12),
-                arguments("12", "%02d", 12),
-                arguments("012", "%03d", 12),
-                arguments("0012", "%04d", 12),
-                arguments("00012", "%05d", 12),
-                arguments("0000000012", "%010d", 12),
-                arguments(tenMillionZeros + "12", "%010000002d", 12),
-
-                arguments("-12", "%01d", -12),
-                arguments("-12", "%02d", -12),
-                arguments("-12", "%03d", -12),
-                arguments("-012", "%04d", -12),
-                arguments("-0012", "%05d", -12),
-                arguments("-000000012", "%010d", -12),
-                arguments("-" + tenMillionZeros + "12", "%010000003d", -12),
-
-                arguments("1.2", "%01.1f", 1.2),
-                arguments("1.2", "%02.1f", 1.2),
-                arguments("1.2", "%03.1f", 1.2),
-                arguments("01.2", "%04.1f", 1.2),
-                arguments("001.2", "%05.1f", 1.2),
-                arguments("00000001.2", "%010.1f", 1.2),
-                arguments(tenMillionZeros + "1.2", "%010000003.1f", 1.2),
-
-                arguments("-1.2", "%01.1f", -1.2),
-                arguments("-1.2", "%02.1f", -1.2),
-                arguments("-1.2", "%03.1f", -1.2),
-                arguments("-1.2", "%04.1f", -1.2),
-                arguments("-01.2", "%05.1f", -1.2),
-                arguments("-0000001.2", "%010.1f", -1.2),
-                arguments("-" + tenMillionZeros + "1.2", "%010000004.1f", -1.2),
-
-                /* zero padding, right adjusted, mandatory plus sign */
-                arguments("+12", "%+01d", 12),
-                arguments("+12", "%+02d", 12),
-                arguments("+12", "%+03d", 12),
-                arguments("+012", "%+04d", 12),
-                arguments("+0012", "%+05d", 12),
-                arguments("+000000012", "%+010d", 12),
-                arguments("+" + tenMillionZeros + "12", "%+010000003d", 12),
-
-                arguments("-12", "%+01d", -12),
-                arguments("-12", "%+02d", -12),
-                arguments("-12", "%+03d", -12),
-                arguments("-012", "%+04d", -12),
-                arguments("-0012", "%+05d", -12),
-                arguments("-000000012", "%+010d", -12),
-                arguments("-" + tenMillionZeros + "12", "%+010000003d", -12),
-
-                arguments("+1.2", "%+01.1f", 1.2),
-                arguments("+1.2", "%+02.1f", 1.2),
-                arguments("+1.2", "%+03.1f", 1.2),
-                arguments("+1.2", "%+04.1f", 1.2),
-                arguments("+01.2", "%+05.1f", 1.2),
-                arguments("+0000001.2", "%+010.1f", 1.2),
-                arguments("+" + tenMillionZeros + "1.2", "%+010000004.1f", 1.2),
-
-                arguments("-1.2", "%+01.1f", -1.2),
-                arguments("-1.2", "%+02.1f", -1.2),
-                arguments("-1.2", "%+03.1f", -1.2),
-                arguments("-1.2", "%+04.1f", -1.2),
-                arguments("-01.2", "%+05.1f", -1.2),
-                arguments("-0000001.2", "%+010.1f", -1.2),
-                arguments("-" + tenMillionZeros + "1.2", "%+010000004.1f", -1.2),
-
-                /* zero padding, right adjusted, mandatory blank sign */
-                arguments(" 12", "% 01d", 12),
-                arguments(" 12", "% 02d", 12),
-                arguments(" 12", "% 03d", 12),
-                arguments(" 012", "% 04d", 12),
-                arguments(" 0012", "% 05d", 12),
-                arguments(" 000000012", "% 010d", 12),
-                arguments(" " + tenMillionZeros + "12", "% 010000003d", 12),
-
-                arguments("-12", "% 01d", -12),
-                arguments("-12", "% 02d", -12),
-                arguments("-12", "% 03d", -12),
-                arguments("-012", "% 04d", -12),
-                arguments("-0012", "% 05d", -12),
-                arguments("-000000012", "% 010d", -12),
-                arguments("-" + tenMillionZeros + "12", "% 010000003d", -12),
-
-                arguments(" 1.2", "% 01.1f", 1.2),
-                arguments(" 1.2", "% 02.1f", 1.2),
-                arguments(" 1.2", "% 03.1f", 1.2),
-                arguments(" 1.2", "% 04.1f", 1.2),
-                arguments(" 01.2", "% 05.1f", 1.2),
-                arguments(" 0000001.2", "% 010.1f", 1.2),
-                arguments(" " + tenMillionZeros + "1.2", "% 010000004.1f", 1.2),
-
-                arguments("-1.2", "% 01.1f", -1.2),
-                arguments("-1.2", "% 02.1f", -1.2),
-                arguments("-1.2", "% 03.1f", -1.2),
-                arguments("-1.2", "% 04.1f", -1.2),
-                arguments("-01.2", "% 05.1f", -1.2),
-                arguments("-0000001.2", "% 010.1f", -1.2),
-                arguments("-" + tenMillionZeros + "1.2", "% 010000004.1f", -1.2),
-
-        };
+            Arguments.of("-1.2", "%1.1f", -1.2),
+            Arguments.of("-1.2", "%2.1f", -1.2),
+            Arguments.of("-1.2", "%3.1f", -1.2),
+            Arguments.of("-1.2", "%4.1f", -1.2),
+            Arguments.of(" -1.2", "%5.1f", -1.2),
+            Arguments.of("      -1.2", "%10.1f", -1.2),
+            Arguments.of(tenMillionBlanks + "-1.2", "%10000004.1f", -1.2));
     }
 
     @ParameterizedTest
     @MethodSource
-    void padding(String expected, String format, Object value) {
+    void blankPaddingRightAdjustedOptionalSign(String expected, String format, Object value) {
         assertEquals(expected, String.format(Locale.US, format, value));
     }
 
+    /* blank padding, right adjusted, mandatory sign */
+    static Stream<? extends Arguments> blankPaddingRightAdjustedMandatorySign() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of("+12", "%+1d", 12),
+            Arguments.of("+12", "%+2d", 12),
+            Arguments.of("+12", "%+3d", 12),
+            Arguments.of(" +12", "%+4d", 12),
+            Arguments.of("  +12", "%+5d", 12),
+            Arguments.of("       +12", "%+10d", 12),
+            Arguments.of(tenMillionBlanks + "+12", "%+10000003d", 12),
+
+            Arguments.of("-12", "%+1d", -12),
+            Arguments.of("-12", "%+2d", -12),
+            Arguments.of("-12", "%+3d", -12),
+            Arguments.of(" -12", "%+4d", -12),
+            Arguments.of("  -12", "%+5d", -12),
+            Arguments.of("       -12", "%+10d", -12),
+            Arguments.of(tenMillionBlanks + "-12", "%+10000003d", -12),
+
+            Arguments.of("+1.2", "%+1.1f", 1.2),
+            Arguments.of("+1.2", "%+2.1f", 1.2),
+            Arguments.of("+1.2", "%+3.1f", 1.2),
+            Arguments.of("+1.2", "%+4.1f", 1.2),
+            Arguments.of(" +1.2", "%+5.1f", 1.2),
+            Arguments.of("      +1.2", "%+10.1f", 1.2),
+            Arguments.of(tenMillionBlanks + "+1.2", "%+10000004.1f", 1.2),
+
+            Arguments.of("-1.2", "%+1.1f", -1.2),
+            Arguments.of("-1.2", "%+2.1f", -1.2),
+            Arguments.of("-1.2", "%+3.1f", -1.2),
+            Arguments.of("-1.2", "%+4.1f", -1.2),
+            Arguments.of(" -1.2", "%+5.1f", -1.2),
+            Arguments.of("      -1.2", "%+10.1f", -1.2),
+            Arguments.of(tenMillionBlanks + "-1.2", "%+10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingRightAdjustedMandatorySign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* blank padding, right adjusted, mandatory blank sign */
+    static Stream<? extends Arguments> blankPaddingRightAdjustedMandatoryBlank() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of(" 12", "% 1d", 12),
+            Arguments.of(" 12", "% 2d", 12),
+            Arguments.of(" 12", "% 3d", 12),
+            Arguments.of("  12", "% 4d", 12),
+            Arguments.of("   12", "% 5d", 12),
+            Arguments.of("        12", "% 10d", 12),
+            Arguments.of(tenMillionBlanks + "12", "% 10000002d", 12),
+
+            Arguments.of("-12", "% 1d", -12),
+            Arguments.of("-12", "% 2d", -12),
+            Arguments.of("-12", "% 3d", -12),
+            Arguments.of(" -12", "% 4d", -12),
+            Arguments.of("  -12", "% 5d", -12),
+            Arguments.of("       -12", "% 10d", -12),
+            Arguments.of(tenMillionBlanks + "-12", "% 10000003d", -12),
+
+            Arguments.of(" 1.2", "% 1.1f", 1.2),
+            Arguments.of(" 1.2", "% 2.1f", 1.2),
+            Arguments.of(" 1.2", "% 3.1f", 1.2),
+            Arguments.of(" 1.2", "% 4.1f", 1.2),
+            Arguments.of("  1.2", "% 5.1f", 1.2),
+            Arguments.of("       1.2", "% 10.1f", 1.2),
+            Arguments.of(tenMillionBlanks + "1.2", "% 10000003.1f", 1.2),
+
+            Arguments.of("-1.2", "% 1.1f", -1.2),
+            Arguments.of("-1.2", "% 2.1f", -1.2),
+            Arguments.of("-1.2", "% 3.1f", -1.2),
+            Arguments.of("-1.2", "% 4.1f", -1.2),
+            Arguments.of(" -1.2", "% 5.1f", -1.2),
+            Arguments.of("      -1.2", "% 10.1f", -1.2),
+            Arguments.of(tenMillionBlanks + "-1.2", "% 10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingRightAdjustedMandatoryBlank(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* blank padding, left adjusted, optional sign */
+    static Stream<? extends Arguments> blankPaddingLeftAdjustedOptionalSign() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of("12", "%-1d", 12),
+            Arguments.of("12", "%-2d", 12),
+            Arguments.of("12 ", "%-3d", 12),
+            Arguments.of("12  ", "%-4d", 12),
+            Arguments.of("12   ", "%-5d", 12),
+            Arguments.of("12        ", "%-10d", 12),
+            Arguments.of("12" + tenMillionBlanks, "%-10000002d", 12),
+
+            Arguments.of("-12", "%-1d", -12),
+            Arguments.of("-12", "%-2d", -12),
+            Arguments.of("-12", "%-3d", -12),
+            Arguments.of("-12 ", "%-4d", -12),
+            Arguments.of("-12  ", "%-5d", -12),
+            Arguments.of("-12       ", "%-10d", -12),
+            Arguments.of("-12" + tenMillionBlanks, "%-10000003d", -12),
+
+            Arguments.of("1.2", "%-1.1f", 1.2),
+            Arguments.of("1.2", "%-2.1f", 1.2),
+            Arguments.of("1.2", "%-3.1f", 1.2),
+            Arguments.of("1.2 ", "%-4.1f", 1.2),
+            Arguments.of("1.2  ", "%-5.1f", 1.2),
+            Arguments.of("1.2       ", "%-10.1f", 1.2),
+            Arguments.of("1.2" + tenMillionBlanks, "%-10000003.1f", 1.2),
+
+            Arguments.of("-1.2", "%-1.1f", -1.2),
+            Arguments.of("-1.2", "%-2.1f", -1.2),
+            Arguments.of("-1.2", "%-3.1f", -1.2),
+            Arguments.of("-1.2", "%-4.1f", -1.2),
+            Arguments.of("-1.2 ", "%-5.1f", -1.2),
+            Arguments.of("-1.2      ", "%-10.1f", -1.2),
+            Arguments.of("-1.2" + tenMillionBlanks, "%-10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingLeftAdjustedOptionalSign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* blank padding, left adjusted, mandatory sign */
+    static Stream<? extends Arguments> blankPaddingLeftAdjustedMandatorySign() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of("+12", "%-+1d", 12),
+            Arguments.of("+12", "%-+2d", 12),
+            Arguments.of("+12", "%-+3d", 12),
+            Arguments.of("+12 ", "%-+4d", 12),
+            Arguments.of("+12  ", "%-+5d", 12),
+            Arguments.of("+12       ", "%-+10d", 12),
+            Arguments.of("+12" + tenMillionBlanks, "%-+10000003d", 12),
+
+            Arguments.of("-12", "%-+1d", -12),
+            Arguments.of("-12", "%-+2d", -12),
+            Arguments.of("-12", "%-+3d", -12),
+            Arguments.of("-12 ", "%-+4d", -12),
+            Arguments.of("-12  ", "%-+5d", -12),
+            Arguments.of("-12       ", "%-+10d", -12),
+            Arguments.of("-12" + tenMillionBlanks, "%-+10000003d", -12),
+
+            Arguments.of("+1.2", "%-+1.1f", 1.2),
+            Arguments.of("+1.2", "%-+2.1f", 1.2),
+            Arguments.of("+1.2", "%-+3.1f", 1.2),
+            Arguments.of("+1.2", "%-+4.1f", 1.2),
+            Arguments.of("+1.2 ", "%-+5.1f", 1.2),
+            Arguments.of("+1.2      ", "%-+10.1f", 1.2),
+            Arguments.of("+1.2" + tenMillionBlanks, "%-+10000004.1f", 1.2),
+
+            Arguments.of("-1.2", "%-+1.1f", -1.2),
+            Arguments.of("-1.2", "%-+2.1f", -1.2),
+            Arguments.of("-1.2", "%-+3.1f", -1.2),
+            Arguments.of("-1.2", "%-+4.1f", -1.2),
+            Arguments.of("-1.2 ", "%-+5.1f", -1.2),
+            Arguments.of("-1.2      ", "%-+10.1f", -1.2),
+            Arguments.of("-1.2" + tenMillionBlanks, "%-+10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingLeftAdjustedMandatorySign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* blank padding, left adjusted, mandatory blank sign */
+    static Stream<? extends Arguments> blankPaddingLeftAdjustedMandatoryBlank() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of(" 12", "%- 1d", 12),
+            Arguments.of(" 12", "%- 2d", 12),
+            Arguments.of(" 12", "%- 3d", 12),
+            Arguments.of(" 12 ", "%- 4d", 12),
+            Arguments.of(" 12  ", "%- 5d", 12),
+            Arguments.of(" 12       ", "%- 10d", 12),
+            Arguments.of(" 12" + tenMillionBlanks, "%- 10000003d", 12),
+
+            Arguments.of("-12", "%- 1d", -12),
+            Arguments.of("-12", "%- 2d", -12),
+            Arguments.of("-12", "%- 3d", -12),
+            Arguments.of("-12 ", "%- 4d", -12),
+            Arguments.of("-12  ", "%- 5d", -12),
+            Arguments.of("-12       ", "%- 10d", -12),
+            Arguments.of("-12" + tenMillionBlanks, "%- 10000003d", -12),
+
+            Arguments.of(" 1.2", "%- 1.1f", 1.2),
+            Arguments.of(" 1.2", "%- 2.1f", 1.2),
+            Arguments.of(" 1.2", "%- 3.1f", 1.2),
+            Arguments.of(" 1.2", "%- 4.1f", 1.2),
+            Arguments.of(" 1.2 ", "%- 5.1f", 1.2),
+            Arguments.of(" 1.2      ", "%- 10.1f", 1.2),
+            Arguments.of(" 1.2" + tenMillionBlanks, "%- 10000004.1f", 1.2),
+
+            Arguments.of("-1.2", "%- 1.1f", -1.2),
+            Arguments.of("-1.2", "%- 2.1f", -1.2),
+            Arguments.of("-1.2", "%- 3.1f", -1.2),
+            Arguments.of("-1.2", "%- 4.1f", -1.2),
+            Arguments.of("-1.2 ", "%- 5.1f", -1.2),
+            Arguments.of("-1.2      ", "%- 10.1f", -1.2),
+            Arguments.of("-1.2" + tenMillionBlanks, "%- 10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingLeftAdjustedMandatoryBlank(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* zero padding, right adjusted, optional sign */
+    static Stream<? extends Arguments> zeroPaddingRightAdjustedOptionalSign() {
+        var tenMillionZeros = "0".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of("12", "%01d", 12),
+            Arguments.of("12", "%02d", 12),
+            Arguments.of("012", "%03d", 12),
+            Arguments.of("0012", "%04d", 12),
+            Arguments.of("00012", "%05d", 12),
+            Arguments.of("0000000012", "%010d", 12),
+            Arguments.of(tenMillionZeros + "12", "%010000002d", 12),
+
+            Arguments.of("-12", "%01d", -12),
+            Arguments.of("-12", "%02d", -12),
+            Arguments.of("-12", "%03d", -12),
+            Arguments.of("-012", "%04d", -12),
+            Arguments.of("-0012", "%05d", -12),
+            Arguments.of("-000000012", "%010d", -12),
+            Arguments.of("-" + tenMillionZeros + "12", "%010000003d", -12),
+
+            Arguments.of("1.2", "%01.1f", 1.2),
+            Arguments.of("1.2", "%02.1f", 1.2),
+            Arguments.of("1.2", "%03.1f", 1.2),
+            Arguments.of("01.2", "%04.1f", 1.2),
+            Arguments.of("001.2", "%05.1f", 1.2),
+            Arguments.of("00000001.2", "%010.1f", 1.2),
+            Arguments.of(tenMillionZeros + "1.2", "%010000003.1f", 1.2),
+
+            Arguments.of("-1.2", "%01.1f", -1.2),
+            Arguments.of("-1.2", "%02.1f", -1.2),
+            Arguments.of("-1.2", "%03.1f", -1.2),
+            Arguments.of("-1.2", "%04.1f", -1.2),
+            Arguments.of("-01.2", "%05.1f", -1.2),
+            Arguments.of("-0000001.2", "%010.1f", -1.2),
+            Arguments.of("-" + tenMillionZeros + "1.2", "%010000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void zeroPaddingRightAdjustedOptionalSign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* zero padding, right adjusted, mandatory sign */
+    static Stream<? extends Arguments> zeroPaddingRightAdjustedMandatorySign() {
+        var tenMillionZeros = "0".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of("+12", "%+01d", 12),
+            Arguments.of("+12", "%+02d", 12),
+            Arguments.of("+12", "%+03d", 12),
+            Arguments.of("+012", "%+04d", 12),
+            Arguments.of("+0012", "%+05d", 12),
+            Arguments.of("+000000012", "%+010d", 12),
+            Arguments.of("+" + tenMillionZeros + "12", "%+010000003d", 12),
+
+            Arguments.of("-12", "%+01d", -12),
+            Arguments.of("-12", "%+02d", -12),
+            Arguments.of("-12", "%+03d", -12),
+            Arguments.of("-012", "%+04d", -12),
+            Arguments.of("-0012", "%+05d", -12),
+            Arguments.of("-000000012", "%+010d", -12),
+            Arguments.of("-" + tenMillionZeros + "12", "%+010000003d", -12),
+
+            Arguments.of("+1.2", "%+01.1f", 1.2),
+            Arguments.of("+1.2", "%+02.1f", 1.2),
+            Arguments.of("+1.2", "%+03.1f", 1.2),
+            Arguments.of("+1.2", "%+04.1f", 1.2),
+            Arguments.of("+01.2", "%+05.1f", 1.2),
+            Arguments.of("+0000001.2", "%+010.1f", 1.2),
+            Arguments.of("+" + tenMillionZeros + "1.2", "%+010000004.1f", 1.2),
+
+            Arguments.of("-1.2", "%+01.1f", -1.2),
+            Arguments.of("-1.2", "%+02.1f", -1.2),
+            Arguments.of("-1.2", "%+03.1f", -1.2),
+            Arguments.of("-1.2", "%+04.1f", -1.2),
+            Arguments.of("-01.2", "%+05.1f", -1.2),
+            Arguments.of("-0000001.2", "%+010.1f", -1.2),
+            Arguments.of("-" + tenMillionZeros + "1.2", "%+010000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void zeroPaddingRightAdjustedMandatorySign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* zero padding, right adjusted, mandatory blank sign */
+    static Stream<? extends Arguments> zeroPaddingRightAdjustedMandatoryBlank() {
+        var tenMillionZeros = "0".repeat(10_000_000);
+        return Stream.of(
+            Arguments.of(" 12", "% 01d", 12),
+            Arguments.of(" 12", "% 02d", 12),
+            Arguments.of(" 12", "% 03d", 12),
+            Arguments.of(" 012", "% 04d", 12),
+            Arguments.of(" 0012", "% 05d", 12),
+            Arguments.of(" 000000012", "% 010d", 12),
+            Arguments.of(" " + tenMillionZeros + "12", "% 010000003d", 12),
+
+            Arguments.of("-12", "% 01d", -12),
+            Arguments.of("-12", "% 02d", -12),
+            Arguments.of("-12", "% 03d", -12),
+            Arguments.of("-012", "% 04d", -12),
+            Arguments.of("-0012", "% 05d", -12),
+            Arguments.of("-000000012", "% 010d", -12),
+            Arguments.of("-" + tenMillionZeros + "12", "% 010000003d", -12),
+
+            Arguments.of(" 1.2", "% 01.1f", 1.2),
+            Arguments.of(" 1.2", "% 02.1f", 1.2),
+            Arguments.of(" 1.2", "% 03.1f", 1.2),
+            Arguments.of(" 1.2", "% 04.1f", 1.2),
+            Arguments.of(" 01.2", "% 05.1f", 1.2),
+            Arguments.of(" 0000001.2", "% 010.1f", 1.2),
+            Arguments.of(" " + tenMillionZeros + "1.2", "% 010000004.1f", 1.2),
+
+            Arguments.of("-1.2", "% 01.1f", -1.2),
+            Arguments.of("-1.2", "% 02.1f", -1.2),
+            Arguments.of("-1.2", "% 03.1f", -1.2),
+            Arguments.of("-1.2", "% 04.1f", -1.2),
+            Arguments.of("-01.2", "% 05.1f", -1.2),
+            Arguments.of("-0000001.2", "% 010.1f", -1.2),
+            Arguments.of("-" + tenMillionZeros + "1.2", "% 010000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void zeroPaddingRightAdjustedMandatoryBlank(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
 }


### PR DESCRIPTION
I backport this as follow-up of 8325718

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328037](https://bugs.openjdk.org/browse/JDK-8328037) needs maintainer approval

### Issue
 * [JDK-8328037](https://bugs.openjdk.org/browse/JDK-8328037): Test java/util/Formatter/Padding.java has unnecessary high heap requirement after JDK-8326718 (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/474/head:pull/474` \
`$ git checkout pull/474`

Update a local copy of the PR: \
`$ git checkout pull/474` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 474`

View PR using the GUI difftool: \
`$ git pr show -t 474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/474.diff">https://git.openjdk.org/jdk21u-dev/pull/474.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/474#issuecomment-2042627707)