### PR TITLE
8321718: ProcessTools.executeProcess calls waitFor before logging

### DIFF
--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -107,6 +107,14 @@ public final class OutputAnalyzer {
     }
 
     /**
+     * Delegate waitFor to the OutputBuffer. This ensures that
+     * the progress and timestamps are logged correctly.
+     */
+    public void waitFor() {
+        buffer.waitFor();
+    }
+
+    /**
      * Verify that the stdout contents of output buffer is empty
      *
      * @throws RuntimeException

--- a/test/lib/jdk/test/lib/process/OutputBuffer.java
+++ b/test/lib/jdk/test/lib/process/OutputBuffer.java
@@ -45,6 +45,12 @@ public interface OutputBuffer {
   }
 
   /**
+   * Waits for a process to finish, if there is one assocated with
+   * this OutputBuffer.
+   */
+  public void waitFor();
+
+  /**
    * Returns the stdout result
    *
    * @return stdout result
@@ -67,6 +73,13 @@ public interface OutputBuffer {
    * @return stderr result
    */
   public String getStderr();
+
+
+  /**
+   * Returns the exit value
+   *
+   * @return exit value
+   */
   public int getExitValue();
 
   /**
@@ -136,6 +149,31 @@ public interface OutputBuffer {
     }
 
     @Override
+    public void waitFor() {
+      if (exitValue != null) {
+        // Already waited for this process
+        return;
+      }
+
+      try {
+          logProgress("Waiting for completion");
+          boolean aborted = true;
+          try {
+              exitValue = p.waitFor();
+              logProgress("Waiting for completion finished");
+              aborted = false;
+          } finally {
+              if (aborted) {
+                  logProgress("Waiting for completion FAILED");
+              }
+          }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new OutputBufferException(e);
+      }
+    }
+
+    @Override
     public String getStdout() {
       return outTask.get();
     }
@@ -147,26 +185,8 @@ public interface OutputBuffer {
 
     @Override
     public int getExitValue() {
-      if (exitValue != null) {
-        return exitValue;
-      }
-      try {
-          logProgress("Waiting for completion");
-          boolean aborted = true;
-          try {
-              exitValue = p.waitFor();
-              logProgress("Waiting for completion finished");
-              aborted = false;
-              return exitValue;
-          } finally {
-              if (aborted) {
-                  logProgress("Waiting for completion FAILED");
-              }
-          }
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new OutputBufferException(e);
-      }
+      waitFor();
+      return exitValue;
     }
 
     @Override
@@ -184,6 +204,11 @@ public interface OutputBuffer {
       this.stdout = stdout;
       this.stderr = stderr;
       this.exitValue = exitValue;
+    }
+
+    @Override
+    public void waitFor() {
+      // Nothing to do since this buffer is not associated with a Process.
     }
 
     @Override

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -697,7 +697,10 @@ public final class ProcessTools {
             }
 
             output = new OutputAnalyzer(p, cs);
-            p.waitFor();
+
+            // Wait for the process to finish. Call through the output
+            // analyzer to get correct logging and timestamps.
+            output.waitFor();
 
             {   // Dumping the process output to a separate file
                 var fileName = String.format("pid-%d-output.log", p.pid());


### PR DESCRIPTION
I backport this to streamline tests in 21.

I ran some tests using these files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8321718](https://bugs.openjdk.org/browse/JDK-8321718) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321718](https://bugs.openjdk.org/browse/JDK-8321718): ProcessTools.executeProcess calls waitFor before logging (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/475/head:pull/475` \
`$ git checkout pull/475`

Update a local copy of the PR: \
`$ git checkout pull/475` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 475`

View PR using the GUI difftool: \
`$ git pr show -t 475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/475.diff">https://git.openjdk.org/jdk21u-dev/pull/475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/475#issuecomment-2042817254)