### PR TITLE
8320924: Improve heap dump performance by optimizing archived object checks

### DIFF
--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -61,10 +61,6 @@ void Klass::set_java_mirror(Handle m) {
   _java_mirror = class_loader_data()->add_handle(m);
 }
 
-oop Klass::java_mirror_no_keepalive() const {
-  return _java_mirror.peek();
-}
-
 bool Klass::is_cloneable() const {
   return _access_flags.is_cloneable_fast() ||
          is_subtype_of(vmClasses::Cloneable_klass());

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -56,6 +56,10 @@ inline oop Klass::java_mirror() const {
   return _java_mirror.resolve();
 }
 
+inline oop Klass::java_mirror_no_keepalive() const {
+  return _java_mirror.peek();
+}
+
 inline klassVtable Klass::vtable() const {
   return klassVtable(const_cast<Klass*>(this), start_of_vtable(), vtable_length() / vtableEntry::size());
 }

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -939,13 +939,28 @@ class DumperSupport : AllStatic {
   // fixes up the current dump record and writes HPROF_HEAP_DUMP_END record
   static void end_of_dump(AbstractDumpWriter* writer);
 
-  static oop mask_dormant_archived_object(oop o) {
-    if (o != nullptr && o->klass()->java_mirror() == nullptr) {
+  static oop mask_dormant_archived_object(oop o, oop ref_obj) {
+    if (o != nullptr && o->klass()->java_mirror_no_keepalive() == nullptr) {
       // Ignore this object since the corresponding java mirror is not loaded.
       // Might be a dormant archive object.
+      report_dormant_archived_object(o, ref_obj);
       return nullptr;
     } else {
       return o;
+    }
+  }
+
+  static void report_dormant_archived_object(oop o, oop ref_obj) {
+    if (log_is_enabled(Trace, cds, heap)) {
+      ResourceMark rm;
+      if (ref_obj != nullptr) {
+        log_trace(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s) referenced by " INTPTR_FORMAT " (%s)",
+                  p2i(o), o->klass()->external_name(),
+                  p2i(ref_obj), ref_obj->klass()->external_name());
+      } else {
+        log_trace(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s)",
+                  p2i(o), o->klass()->external_name());
+      }
     }
   }
 };
@@ -1135,13 +1150,7 @@ void DumperSupport::dump_field_value(AbstractDumpWriter* writer, char type, oop 
     case JVM_SIGNATURE_CLASS :
     case JVM_SIGNATURE_ARRAY : {
       oop o = obj->obj_field_access<ON_UNKNOWN_OOP_REF | AS_NO_KEEPALIVE>(offset);
-      if (o != nullptr && log_is_enabled(Debug, cds, heap) && mask_dormant_archived_object(o) == nullptr) {
-        ResourceMark rm;
-        log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s) referenced by " INTPTR_FORMAT " (%s)",
-                             p2i(o), o->klass()->external_name(),
-                             p2i(obj), obj->klass()->external_name());
-      }
-      o = mask_dormant_archived_object(o);
+      o = mask_dormant_archived_object(o, obj);
       assert(oopDesc::is_oop_or_null(o), "Expected an oop or nullptr at " PTR_FORMAT, p2i(o));
       writer->write_objectID(o);
       break;
@@ -1473,13 +1482,7 @@ void DumperSupport::dump_object_array(AbstractDumpWriter* writer, objArrayOop ar
   // [id]* elements
   for (int index = 0; index < length; index++) {
     oop o = array->obj_at(index);
-    if (o != nullptr && log_is_enabled(Debug, cds, heap) && mask_dormant_archived_object(o) == nullptr) {
-      ResourceMark rm;
-      log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s) referenced by " INTPTR_FORMAT " (%s)",
-                           p2i(o), o->klass()->external_name(),
-                           p2i(array), array->klass()->external_name());
-    }
-    o = mask_dormant_archived_object(o);
+    o = mask_dormant_archived_object(o, array);
     writer->write_objectID(o);
   }
 
@@ -1814,8 +1817,7 @@ void HeapObjectDumper::do_object(oop o) {
     }
   }
 
-  if (DumperSupport::mask_dormant_archived_object(o) == nullptr) {
-    log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s)", p2i(o), o->klass()->external_name());
+  if (DumperSupport::mask_dormant_archived_object(o, nullptr) == nullptr) {
     return;
   }
 


### PR DESCRIPTION
Improves heap dump performance some more.

Additional testing:
 - [x] MacOS AArch64 server release, heap dump performance improved
 - [x] MacOS AArch64 server fastdebug, serviceability/ (contains heap dump tests)
 - [x] MacOS AArch64 server fastdebug, runtime/ErrorHandling (contains heap dump on failure tests)
 - [x] MacOS AArch64 server fastdebug, gc/epsilon (contains heap dump on failure tests)
 - [x] MacOS AArch64 server fastdebug, sun/tools/jhsdb (contains heap dump tests)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320924](https://bugs.openjdk.org/browse/JDK-8320924) needs maintainer approval

### Issue
 * [JDK-8320924](https://bugs.openjdk.org/browse/JDK-8320924): Improve heap dump performance by optimizing archived object checks (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/479/head:pull/479` \
`$ git checkout pull/479`

Update a local copy of the PR: \
`$ git checkout pull/479` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 479`

View PR using the GUI difftool: \
`$ git pr show -t 479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/479.diff">https://git.openjdk.org/jdk21u-dev/pull/479.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/479#issuecomment-2044326768)