### PR TITLE
8313899: JVMCI exception Translation can fail in TranslatedException.<clinit>

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -52,6 +52,7 @@
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
 #include "prims/nativeLookup.hpp"
+#include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
@@ -584,6 +585,18 @@ C2V_VMENTRY_NULL(jobject, lookupType, (JNIEnv* env, jobject, jstring jname, ARGU
   if (class_name->utf8_length() <= 1) {
     JVMCI_THROW_MSG_0(InternalError, err_msg("Primitive type %s should be handled in Java code", str));
   }
+
+#ifdef ASSERT
+  const char* val = Arguments::PropertyList_get_value(Arguments::system_properties(), "test.jvmci.lookupTypeException");
+  if (val != nullptr) {
+    if (strstr(val, "<trace>") != nullptr) {
+      tty->print_cr("CompilerToVM.lookupType: %s", str);
+    } else if (strstr(val, str) != nullptr) {
+      THROW_MSG_0(vmSymbols::java_lang_Exception(),
+                  err_msg("lookupTypeException: %s", str));
+    }
+  }
+#endif
 
   JVMCIKlassHandle resolved_klass(THREAD);
   Klass* accessing_klass = UNPACK_PAIR(Klass, accessing_klass);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -505,8 +505,7 @@ class HotSpotToSharedLibraryExceptionTranslation : public ExceptionTranslation {
  private:
   const Handle& _throwable;
 
-  int encode(JavaThread* THREAD, jlong buffer, int buffer_size) {
-    Klass* vmSupport = SystemDictionary::resolve_or_fail(vmSymbols::jdk_internal_vm_VMSupport(), true, THREAD);
+  bool handle_pending_exception(JavaThread* THREAD, jlong buffer, int buffer_size) {
     if (HAS_PENDING_EXCEPTION) {
       Handle throwable = Handle(THREAD, PENDING_EXCEPTION);
       Symbol *ex_name = throwable->klass()->name();
@@ -523,6 +522,14 @@ class HotSpotToSharedLibraryExceptionTranslation : public ExceptionTranslation {
         JVMCI_event_1("error translating exception: %s", char_buffer);
         decode(THREAD, _encode_fail, buffer);
       }
+      return true;
+    }
+    return false;
+  }
+
+  int encode(JavaThread* THREAD, jlong buffer, int buffer_size) {
+    Klass* vmSupport = SystemDictionary::resolve_or_fail(vmSymbols::jdk_internal_vm_VMSupport(), true, THREAD);
+    if (handle_pending_exception(THREAD, buffer, buffer_size)) {
       return 0;
     }
     JavaCallArguments jargs;
@@ -534,6 +541,9 @@ class HotSpotToSharedLibraryExceptionTranslation : public ExceptionTranslation {
                             vmSupport,
                             vmSymbols::encodeThrowable_name(),
                             vmSymbols::encodeThrowable_signature(), &jargs, THREAD);
+    if (handle_pending_exception(THREAD, buffer, buffer_size)) {
+      return 0;
+    }
     return result.get_jint();
   }
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1231,11 +1231,13 @@ JNIEnv* JVMCIRuntime::init_shared_library_javavm(int* create_JavaVM_err) {
   MutexLocker locker(_lock);
   JavaVM* javaVM = _shared_library_javavm;
   if (javaVM == nullptr) {
+#ifdef ASSERT
     const char* val = Arguments::PropertyList_get_value(Arguments::system_properties(), "test.jvmci.forceEnomemOnLibjvmciInit");
     if (val != nullptr && strcmp(val, "true") == 0) {
       *create_JavaVM_err = JNI_ENOMEM;
       return nullptr;
     }
+#endif
 
     char* sl_path;
     void* sl_handle = JVMCI::get_shared_library(sl_path, true);
@@ -2059,12 +2061,14 @@ void JVMCIRuntime::compile_method(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, c
 
   JVMCIObject result_object = JVMCIENV->call_HotSpotJVMCIRuntime_compileMethod(receiver, jvmci_method, entry_bci,
                                                                      (jlong) compile_state, compile_state->task()->compile_id());
+#ifdef ASSERT
   if (JVMCIENV->has_pending_exception()) {
     const char* val = Arguments::PropertyList_get_value(Arguments::system_properties(), "test.jvmci.compileMethodExceptionIsFatal");
     if (val != nullptr && strcmp(val, "true") == 0) {
       fatal_exception(JVMCIENV, "testing JVMCI fatal exception handling");
     }
   }
+#endif
 
   if (after_compiler_upcall(JVMCIENV, compiler, method, "call_HotSpotJVMCIRuntime_compileMethod")) {
     return;

--- a/src/java.base/share/classes/jdk/internal/vm/TranslatedException.java
+++ b/src/java.base/share/classes/jdk/internal/vm/TranslatedException.java
@@ -24,6 +24,8 @@
  */
 package jdk.internal.vm;
 
+import jdk.internal.misc.VM;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -56,6 +58,7 @@ final class TranslatedException extends Exception {
      */
     private static final byte[] FALLBACK_ENCODED_THROWABLE_BYTES;
     static {
+        maybeFailClinit();
         try {
             FALLBACK_ENCODED_THROWABLE_BYTES =
                 encodeThrowable(new TranslatedException("error during encoding",
@@ -64,6 +67,22 @@ final class TranslatedException extends Exception {
                 encodeThrowable(new OutOfMemoryError(), false);
         } catch (IOException e) {
             throw new InternalError(e);
+        }
+    }
+
+    /**
+     * Helper to test exception translation.
+     */
+    private static void maybeFailClinit() {
+        String className = VM.getSavedProperty("test.jvmci.TranslatedException.clinit.throw");
+        if (className != null) {
+            try {
+                throw (Throwable) Class.forName(className).getDeclaredConstructor().newInstance();
+            } catch (RuntimeException | Error e) {
+                throw e;
+            } catch (Throwable e) {
+                throw new InternalError(e);
+            }
         }
     }
 

--- a/test/hotspot/jtreg/compiler/jvmci/TestUncaughtErrorInCompileMethod.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestUncaughtErrorInCompileMethod.java
@@ -24,7 +24,10 @@
 /*
  * @test
  * @summary Tests handling of an exception thrown by HotSpotJVMCIRuntime.compileMethod.
+ *          Requires a debug VM as it uses test.jvmci.compileMethodExceptionIsFatal
+ *          which is only read in a debug VM.
  * @requires vm.jvmci
+ * @requires vm.debug
  * @library /test/lib /
  * @modules jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          jdk.internal.vm.ci/jdk.vm.ci.code

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestHotSpotJVMCIRuntime.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestHotSpotJVMCIRuntime.java
@@ -32,6 +32,7 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.common
  * @library /compiler/jvmci/jdk.vm.ci.hotspot.test/src
  *          /compiler/jvmci/jdk.vm.ci.code.test/src
+ * @library /test/lib
  * @run testng/othervm
  *      -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler
  *      jdk.vm.ci.hotspot.test.TestHotSpotJVMCIRuntime
@@ -52,6 +53,8 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
 import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.ResolvedJavaType;
+
+import jdk.test.lib.Platform;
 
 public class TestHotSpotJVMCIRuntime {
 
@@ -157,6 +160,11 @@ public class TestHotSpotJVMCIRuntime {
 
     @Test
     public void jniEnomemTest() throws Exception {
+        if (!Platform.isDebugBuild()) {
+            // The test.jvmci.forceEnomemOnLibjvmciInit property is only
+            // read in a debug VM.
+            return;
+        }
         String[] names = {"translate", "attachCurrentThread", "registerNativeMethods"};
         for (String name : names) {
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8313899](https://bugs.openjdk.org/browse/JDK-8313899) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313899](https://bugs.openjdk.org/browse/JDK-8313899): JVMCI exception Translation can fail in TranslatedException.&lt;clinit&gt; (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/484/head:pull/484` \
`$ git checkout pull/484`

Update a local copy of the PR: \
`$ git checkout pull/484` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 484`

View PR using the GUI difftool: \
`$ git pr show -t 484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/484.diff">https://git.openjdk.org/jdk21u-dev/pull/484.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/484#issuecomment-2047156733)