### PR TITLE
8320349: Simplify FileChooserSymLinkTest.java by using single-window testUI

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
@@ -22,14 +22,12 @@
  */
 
 import java.awt.BorderLayout;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.Arrays;
-import java.util.List;
 
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
@@ -118,7 +116,7 @@ public class FileChooserSymLinkTest {
                       .awaitAndCheck();
     }
 
-    private static List<Window> createTestUI() {
+    private static JFrame createTestUI() {
         frame = new JFrame("JFileChooser Symbolic Link test");
         panel = new JPanel(new BorderLayout());
         multiSelection = new JCheckBox("Enable Multi-Selection");
@@ -159,6 +157,6 @@ public class FileChooserSymLinkTest {
         frame.add(panel, BorderLayout.NORTH);
         frame.add(jfc, BorderLayout.CENTER);
         frame.pack();
-        return List.of(frame);
+        return frame;
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320349](https://bugs.openjdk.org/browse/JDK-8320349) needs maintainer approval

### Issue
 * [JDK-8320349](https://bugs.openjdk.org/browse/JDK-8320349): Simplify FileChooserSymLinkTest.java by using single-window testUI (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/486/head:pull/486` \
`$ git checkout pull/486`

Update a local copy of the PR: \
`$ git checkout pull/486` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 486`

View PR using the GUI difftool: \
`$ git pr show -t 486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/486.diff">https://git.openjdk.org/jdk21u-dev/pull/486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/486#issuecomment-2047313900)