### PR TITLE
8318854: [macos14] Running any AWT app prints Secure coding warning

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -841,7 +841,7 @@ AWT_ASSERT_APPKIT_THREAD;
         isDisabled = !awtWindow.isEnabled;
     }
 
-    if (menuBar == nil) {
+    if (menuBar == nil && [ApplicationDelegate sharedDelegate] != nil) {
         menuBar = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
         isDisabled = NO;
     }
@@ -1230,7 +1230,7 @@ JNI_COCOA_ENTER(env);
         window.javaMenuBar = menuBar;
 
         CMenuBar* actualMenuBar = menuBar;
-        if (actualMenuBar == nil) {
+        if (actualMenuBar == nil && [ApplicationDelegate sharedDelegate] != nil) {
             actualMenuBar = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
         }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
@@ -210,9 +210,11 @@ static BOOL sSetupHelpMenu = NO;
         // In theory, this might cause flickering if the window gaining focus
         // has its own menu. However, I couldn't reproduce it on practice, so
         // perhaps this is a non issue.
-        CMenuBar* defaultMenu = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
-        if (defaultMenu != nil) {
-            [CMenuBar activate:defaultMenu modallyDisabled:NO];
+        if ([ApplicationDelegate sharedDelegate] != nil) {
+            CMenuBar* defaultMenu = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
+            if (defaultMenu != nil) {
+                [CMenuBar activate:defaultMenu modallyDisabled:NO];
+            }
         }
     }
 }

--- a/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
@@ -200,6 +200,21 @@
     } copy]];
 }
 
+
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
+{
+    static BOOL checked = NO;
+    static BOOL supportsSecureState = YES;
+
+    if (checked == NO) {
+        checked = YES;
+        if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
+            supportsSecureState = NO;
+        }
+    }
+    return supportsSecureState;
+}
+
 - (void)processQueuedEventsWithTargetDelegate:(id <NSApplicationDelegate>)delegate
 {
     self.realDelegate = delegate;


### PR DESCRIPTION
Backport of [JDK-8318854](https://bugs.openjdk.org/browse/JDK-8318854)

Testing
- Local: Passed on `MacOS 14.4.1 (23E224)`
  - When running the program 
    - `dev-8318854-21/build/macosx-aarch64-server-slowdebug/images/jdk/demo/jfc/SwingSet2/SwingSet2.jar`
  - Without this PR, we see the message
    -  `WARNING: Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES.`
  - With this PR, the warning is gone
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-16,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318854](https://bugs.openjdk.org/browse/JDK-8318854) needs maintainer approval

### Issue
 * [JDK-8318854](https://bugs.openjdk.org/browse/JDK-8318854): [macos14] Running any AWT app prints Secure coding warning (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/489/head:pull/489` \
`$ git checkout pull/489`

Update a local copy of the PR: \
`$ git checkout pull/489` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 489`

View PR using the GUI difftool: \
`$ git pr show -t 489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/489.diff">https://git.openjdk.org/jdk21u-dev/pull/489.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/489#issuecomment-2049171429)