### PR TITLE
8328938: C2 SuperWord: disable vectorization for large stride and scale

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -4210,7 +4210,7 @@ SWPointer::SWPointer(MemNode* mem, SuperWord* slp, Node_Stack *nstack, bool anal
   // allows us to keep the rest of the autovectorization code much simpler, since we
   // do not have to deal with overflows.
   jlong long_scale  = _scale;
-  jlong long_stride = slp->iv_stride();
+  jlong long_stride = slp->lp()->stride_is_con() ? slp->iv_stride() : 0;
   jlong max_val = 1 << 30;
   if (abs(long_scale) >= max_val ||
       abs(long_stride) >= max_val ||

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -4200,6 +4200,25 @@ SWPointer::SWPointer(MemNode* mem, SuperWord* slp, Node_Stack *nstack, bool anal
   NOT_PRODUCT(if(_slp->is_trace_alignment()) _tracer.restore_depth();)
   NOT_PRODUCT(_tracer.ctor_6(mem);)
 
+  // In the pointer analysis, and especially the AlignVector, analysis we assume that
+  // stride and scale are not too large. For example, we multiply "scale * stride",
+  // and assume that this does not overflow the int range. We also take "abs(scale)"
+  // and "abs(stride)", which would overflow for min_int = -(2^31). Still, we want
+  // to at least allow small and moderately large stride and scale. Therefore, we
+  // allow values up to 2^30, which is only a factor 2 smaller than the max/min int.
+  // Normal performance relevant code will have much lower values. And the restriction
+  // allows us to keep the rest of the autovectorization code much simpler, since we
+  // do not have to deal with overflows.
+  jlong long_scale  = _scale;
+  jlong long_stride = slp->iv_stride();
+  jlong max_val = 1 << 30;
+  if (abs(long_scale) >= max_val ||
+      abs(long_stride) >= max_val ||
+      abs(long_scale * long_stride) >= max_val) {
+    assert(!valid(), "adr stride*scale is too large");
+    return;
+  }
+
   _base = base;
   _adr  = adr;
   assert(valid(), "Usable");

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestLargeScaleAndStride.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestLargeScaleAndStride.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=vanilla
+ * @bug 8328938
+ * @summary Test autovectorization with large scale and stride
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @run main compiler.loopopts.superword.TestLargeScaleAndStride
+ */
+
+/*
+ * @test id=AlignVector
+ * @bug 8328938
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:+AlignVector compiler.loopopts.superword.TestLargeScaleAndStride
+ */
+
+package compiler.loopopts.superword;
+
+import jdk.internal.misc.Unsafe;
+
+public class TestLargeScaleAndStride {
+    static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    static int RANGE = 100_000;
+
+    public static void main(String[] args) {
+        byte[] a = new byte[100];
+        fill(a);
+
+        byte[] gold1a = a.clone();
+        byte[] gold1b = a.clone();
+        byte[] gold2a = a.clone();
+        byte[] gold2b = a.clone();
+        byte[] gold2c = a.clone();
+        byte[] gold2d = a.clone();
+        byte[] gold3  = a.clone();
+        test1a(gold1a);
+        test1b(gold1b);
+        test2a(gold2a);
+        test2b(gold2b);
+        test2c(gold2c);
+        test2d(gold2d);
+        test3(gold3);
+
+        for (int i = 0; i < 100; i++) {
+            byte[] c = a.clone();
+            test1a(c);
+            verify(c, gold1a);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            byte[] c = a.clone();
+            test1b(c);
+            verify(c, gold1b);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            byte[] c = a.clone();
+            test2a(c);
+            verify(c, gold2a);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            byte[] c = a.clone();
+            test2b(c);
+            verify(c, gold2b);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            byte[] c = a.clone();
+            test2c(c);
+            verify(c, gold2c);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            byte[] c = a.clone();
+            test2d(c);
+            verify(c, gold2d);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            byte[] c = a.clone();
+            test3(c);
+            verify(c, gold3);
+        }
+    }
+
+    static void fill(byte[] a) {
+        for (int i = 0; i < a.length; i++) {
+          a[i] = (byte)i;
+        }
+    }
+
+    static void verify(byte[] a, byte[] b) {
+        for (int i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) {
+                throw new RuntimeException("wrong value: " + i + ": " + a[i] + " != " + b[i]);
+            }
+        }
+    }
+
+    static void test1a(byte[] a) {
+        int scale = 1 << 31;
+        for (int i = 0; i < RANGE; i+=2) {
+            long base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            // i is a multiple of 2
+            // 2 * (1 >> 31) -> overflow to zero
+            int j = scale * i; // always zero
+            byte v0 = UNSAFE.getByte(a, base + (int)(j + 0));
+            byte v1 = UNSAFE.getByte(a, base + (int)(j + 1));
+            byte v2 = UNSAFE.getByte(a, base + (int)(j + 2));
+            byte v3 = UNSAFE.getByte(a, base + (int)(j + 3));
+            UNSAFE.putByte(a, base + (int)(j + 0), (byte)(v0 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 1), (byte)(v1 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 2), (byte)(v2 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 3), (byte)(v3 + 1));
+        }
+    }
+
+    static void test1b(byte[] a) {
+        int scale = 1 << 31;
+        for (int i = RANGE-2; i >= 0; i-=2) {
+            long base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            // i is a multiple of 2
+            // 2 * (1 >> 31) -> overflow to zero
+            int j = scale * i; // always zero
+            byte v0 = UNSAFE.getByte(a, base + (int)(j + 0));
+            byte v1 = UNSAFE.getByte(a, base + (int)(j + 1));
+            byte v2 = UNSAFE.getByte(a, base + (int)(j + 2));
+            byte v3 = UNSAFE.getByte(a, base + (int)(j + 3));
+            UNSAFE.putByte(a, base + (int)(j + 0), (byte)(v0 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 1), (byte)(v1 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 2), (byte)(v2 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 3), (byte)(v3 + 1));
+        }
+    }
+
+    static void test2a(byte[] a) {
+        int scale = 1 << 30;
+        for (int i = 0; i < RANGE; i+=4) {
+            long base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            // i is a multiple of 4
+            // 4 * (1 >> 30) -> overflow to zero
+            int j = scale * i; // always zero
+            byte v0 = UNSAFE.getByte(a, base + (int)(j + 0));
+            byte v1 = UNSAFE.getByte(a, base + (int)(j + 1));
+            byte v2 = UNSAFE.getByte(a, base + (int)(j + 2));
+            byte v3 = UNSAFE.getByte(a, base + (int)(j + 3));
+            UNSAFE.putByte(a, base + (int)(j + 0), (byte)(v0 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 1), (byte)(v1 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 2), (byte)(v2 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 3), (byte)(v3 + 1));
+        }
+    }
+
+
+    static void test2b(byte[] a) {
+        int scale = 1 << 30;
+        for (int i = RANGE-4; i >= 0; i-=4) {
+            long base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            // i is a multiple of 4
+            // 4 * (1 >> 30) -> overflow to zero
+            int j = scale * i; // always zero
+            byte v0 = UNSAFE.getByte(a, base + (int)(j + 0));
+            byte v1 = UNSAFE.getByte(a, base + (int)(j + 1));
+            byte v2 = UNSAFE.getByte(a, base + (int)(j + 2));
+            byte v3 = UNSAFE.getByte(a, base + (int)(j + 3));
+            UNSAFE.putByte(a, base + (int)(j + 0), (byte)(v0 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 1), (byte)(v1 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 2), (byte)(v2 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 3), (byte)(v3 + 1));
+        }
+    }
+
+    static void test2c(byte[] a) {
+        int scale = -(1 << 30);
+        for (int i = 0; i < RANGE; i+=4) {
+            long base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            // i is a multiple of 4
+            // 4 * (1 >> 30) -> overflow to zero
+            int j = scale * i; // always zero
+            byte v0 = UNSAFE.getByte(a, base + (int)(j + 0));
+            byte v1 = UNSAFE.getByte(a, base + (int)(j + 1));
+            byte v2 = UNSAFE.getByte(a, base + (int)(j + 2));
+            byte v3 = UNSAFE.getByte(a, base + (int)(j + 3));
+            UNSAFE.putByte(a, base + (int)(j + 0), (byte)(v0 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 1), (byte)(v1 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 2), (byte)(v2 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 3), (byte)(v3 + 1));
+        }
+    }
+
+    static void test2d(byte[] a) {
+        int scale = -(1 << 30);
+        for (int i = RANGE-4; i >= 0; i-=4) {
+            long base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            // i is a multiple of 4
+            // 4 * (1 >> 30) -> overflow to zero
+            int j = scale * i; // always zero
+            byte v0 = UNSAFE.getByte(a, base + (int)(j + 0));
+            byte v1 = UNSAFE.getByte(a, base + (int)(j + 1));
+            byte v2 = UNSAFE.getByte(a, base + (int)(j + 2));
+            byte v3 = UNSAFE.getByte(a, base + (int)(j + 3));
+            UNSAFE.putByte(a, base + (int)(j + 0), (byte)(v0 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 1), (byte)(v1 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 2), (byte)(v2 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 3), (byte)(v3 + 1));
+        }
+    }
+
+    static void test3(byte[] a) {
+        int scale =   1 << 28;
+        int stride =  1 << 4;
+        int start = -(1 << 30);
+        int end =     1 << 30;
+        for (int i = start; i < end; i+=stride) {
+            long base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            int j = scale * i; // always zero
+            byte v0 = UNSAFE.getByte(a, base + (int)(j + 0));
+            byte v1 = UNSAFE.getByte(a, base + (int)(j + 1));
+            byte v2 = UNSAFE.getByte(a, base + (int)(j + 2));
+            byte v3 = UNSAFE.getByte(a, base + (int)(j + 3));
+            UNSAFE.putByte(a, base + (int)(j + 0), (byte)(v0 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 1), (byte)(v1 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 2), (byte)(v2 + 1));
+            UNSAFE.putByte(a, base + (int)(j + 3), (byte)(v3 + 1));
+        }
+    }
+}


### PR DESCRIPTION
Unclean backport to prevent accidents in C2 loop optimizations. The patch is unclean, because JDK 21u misses major SuperWord refactorings. I applied the hunk by hand in the similar place, and also used `slp->iv_stride()` in one place to get this thing to work.

@eme64, if you want to take a look at this?

Additional testing:
 - [x] New regression test fails without the patch, passes with it
 - [x] Linux x86_64 server fastdebug, `all`
 - [x] Linux x86_64 server fastdebug, 100K Fuzzer tests
 - [x] Linux x86_64 server fastdebug, Maven CTW

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328938](https://bugs.openjdk.org/browse/JDK-8328938) needs maintainer approval

### Issue
 * [JDK-8328938](https://bugs.openjdk.org/browse/JDK-8328938): C2 SuperWord: disable vectorization for large stride and scale (**Bug** - P3 - Approved)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - Committer)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/495/head:pull/495` \
`$ git checkout pull/495`

Update a local copy of the PR: \
`$ git checkout pull/495` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 495`

View PR using the GUI difftool: \
`$ git pr show -t 495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/495.diff">https://git.openjdk.org/jdk21u-dev/pull/495.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/495#issuecomment-2056079704)