### PR TITLE
8320714: java/util/Locale/LocaleProvidersRun.java and java/util/ResourceBundle/modules/visibility/VisibilityTest.java timeout after passing

### DIFF
--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -28,6 +28,7 @@
  *      8150432 8215913 8220227 8228465 8232871 8232860 8236495 8245241
  *      8246721 8248695 8257964 8261919
  * @summary tests for "java.locale.providers" system property
+ * @requires vm.flagless
  * @library /test/lib
  * @build LocaleProviders
  *        providersrc.spi.src.tznp
@@ -179,8 +180,8 @@ public class LocaleProvidersRun {
     private static void testRun(String prefList, String methodName,
             String param1, String param2, String param3) throws Throwable {
 
-        // Build process (with VM flags)
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+        // Build process (without VM flags)
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-ea", "-esa",
                 "-cp", Utils.TEST_CLASS_PATH,
                 "-Djava.util.logging.config.class=LocaleProviders$LogConfig",

--- a/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
@@ -26,6 +26,7 @@
  * @bug 8137317 8139238 8210408
  * @summary Visibility tests for ResourceBundle.getBundle with and without
  *          an unnamed module argument.
+ * @requires vm.flagless
  * @library /test/lib
  *          ..
  * @build jdk.test.lib.JDKToolLauncher
@@ -330,8 +331,8 @@ public class VisibilityTest {
     }
 
     private int runCmd(List<String> argsList) throws Throwable {
-        // Build process (with VM flags)
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+        // Build process (without VM flags)
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 Stream.concat(Stream.of("-ea", "-esa"), argsList.stream()).toList());
         // Evaluate process status
         return ProcessTools.executeCommand(pb).getExitValue();


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320714](https://bugs.openjdk.org/browse/JDK-8320714) needs maintainer approval

### Issue
 * [JDK-8320714](https://bugs.openjdk.org/browse/JDK-8320714): java/util/Locale/LocaleProvidersRun.java and java/util/ResourceBundle/modules/visibility/VisibilityTest.java timeout after passing (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/496/head:pull/496` \
`$ git checkout pull/496`

Update a local copy of the PR: \
`$ git checkout pull/496` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 496`

View PR using the GUI difftool: \
`$ git pr show -t 496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/496.diff">https://git.openjdk.org/jdk21u-dev/pull/496.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/496#issuecomment-2051252353)