### PR TITLE
8329961: Buffer overflow in os::Linux::kernel_version

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -321,16 +321,9 @@ void os::Linux::kernel_version(long* major, long* minor) {
     log_warning(os)("uname(2) failed to get kernel version: %s", os::errno_name(ret));
     return;
   }
-
-  char* walker = buffer.release;
-  long* set_v = major;
-  while (*minor == -1 && walker != nullptr) {
-    if (isdigit(walker[0])) {
-      *set_v = strtol(walker, &walker, 10);
-      set_v = minor;
-    } else {
-      ++walker;
-    }
+  int nr_matched = sscanf(buffer.release, "%ld.%ld", major, minor);
+  if (nr_matched != 2) {
+    log_warning(os)("Parsing kernel version failed, expected 2 version numbers, only matched %d", nr_matched);
   }
 }
 


### PR DESCRIPTION
Follow-up fix to [JDK-8321075](https://bugs.openjdk.org/browse/JDK-8321075) which is in 21.0.4. Should be low risk and avoids the potential buffer-overrun.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8329961](https://bugs.openjdk.org/browse/JDK-8329961) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329961](https://bugs.openjdk.org/browse/JDK-8329961): Buffer overflow in os::Linux::kernel_version (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/498/head:pull/498` \
`$ git checkout pull/498`

Update a local copy of the PR: \
`$ git checkout pull/498` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 498`

View PR using the GUI difftool: \
`$ git pr show -t 498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/498.diff">https://git.openjdk.org/jdk21u-dev/pull/498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/498#issuecomment-2052156855)