### PR TITLE
8327136: javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java fails on libgraal

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
@@ -176,7 +176,7 @@ public class NotifReconnectDeadlockTest {
 
     // serverTimeout increased to avoid occasional problems with initial connect.
     // Not using Utils.adjustTimeout to avoid accidentally making it too long.
-    private static final long serverTimeout = 2000;
+    private static final long serverTimeout = 3000;
     private static final long listenerSleep = serverTimeout*6;
 
     private volatile static String clientState = null;


### PR DESCRIPTION
Backport of [JDK-8327136](https://bugs.openjdk.org/browse/JDK-8327136)

Testing
- Local: Test passed on `MacOS 14.4.1`
  - `NotifReconnectDeadlockTest.java`: Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-16,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327136](https://bugs.openjdk.org/browse/JDK-8327136) needs maintainer approval

### Issue
 * [JDK-8327136](https://bugs.openjdk.org/browse/JDK-8327136): javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java fails on libgraal (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/503/head:pull/503` \
`$ git checkout pull/503`

Update a local copy of the PR: \
`$ git checkout pull/503` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 503`

View PR using the GUI difftool: \
`$ git pr show -t 503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/503.diff">https://git.openjdk.org/jdk21u-dev/pull/503.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/503#issuecomment-2052458599)