### PR TITLE
8327971: Multiple ASAN errors reported for metaspace

### DIFF
--- a/src/hotspot/share/memory/metaspace/metachunk.cpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,6 +34,7 @@
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
 
 namespace metaspace {
@@ -285,7 +286,9 @@ void Metachunk::verify() const {
   const size_t required_alignment = word_size() * sizeof(MetaWord);
   assert_is_aligned(base(), required_alignment);
 
-  // Test accessing the committed area.
+  // Test accessing the committed area. But not for ASAN. We don't know which portions
+  // of the chunk are still poisoned.
+#if !INCLUDE_ASAN
   SOMETIMES(
     if (_committed_words > 0) {
       for (const MetaWord* p = _base; p < _base + _committed_words; p += os::vm_page_size()) {
@@ -294,6 +297,7 @@ void Metachunk::verify() const {
       dummy = *(_base + _committed_words - 1);
     }
   )
+#endif // !INCLUDE_ASAN
 }
 #endif // ASSERT
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -73,6 +73,7 @@
 #include "utilities/count_trailing_zeros.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/events.hpp"
+#include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 #ifndef _WINDOWS
@@ -1144,6 +1145,8 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
     return;
   }
 
+#if !INCLUDE_ASAN
+
   bool accessible = is_readable_pointer(addr);
 
   // Check if addr is a JNI handle.
@@ -1230,7 +1233,10 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
     return;
   }
 
+#endif // !INCLUDE_ASAN
+
   st->print_cr(INTPTR_FORMAT " is an unknown value", p2i(addr));
+
 }
 
 bool is_pointer_bad(intptr_t* ptr) {

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -40,6 +40,7 @@
 #include "services/mallocTracker.hpp"
 #include "services/memTracker.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/vmError.hpp"
 
@@ -198,6 +199,8 @@ void MallocTracker::deaccount(MallocHeader::FreeInfo free_info) {
 bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
   assert(MemTracker::enabled(), "NMT not enabled");
 
+#if !INCLUDE_ASAN
+
   address addr = (address)p;
 
   // Carefully feel your way upwards and try to find a malloc header. Then check if
@@ -275,5 +278,8 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
     }
     return true;
   }
+
+#endif // !INCLUDE_ASAN
+
   return false;
 }

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -635,4 +635,10 @@
 #define NOT_CDS_JAVA_HEAP_RETURN_(code) { return code; }
 #endif
 
+#ifdef ADDRESS_SANITIZER
+#define INCLUDE_ASAN 1
+#else
+#define INCLUDE_ASAN 0
+#endif
+
 #endif // SHARE_UTILITIES_MACROS_HPP

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -34,6 +34,7 @@
 #include "memory/metaspace/virtualSpaceNode.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "sanitizers/address.hpp"
+#include "utilities/macros.hpp"
 #include "utilities/debug.hpp"
 //#define LOG_PLEASE
 #include "metaspaceGtestCommon.hpp"
@@ -155,6 +156,11 @@ class VirtualSpaceNodeTest {
 
       // The chunk should be as far committed as was requested
       EXPECT_GE(c->committed_words(), request_commit_words);
+
+      // At the VirtualSpaceNode level, all memory is still poisoned.
+      // Since we bypass the normal way of allocating chunks (ChunkManager::get_chunk), we
+      // need to unpoison this chunk.
+      ASAN_UNPOISON_MEMORY_REGION(c->base(), c->committed_words() * BytesPerWord);
 
       // Zap committed portion.
       DEBUG_ONLY(zap_range(c->base(), c->committed_words());)

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -26,10 +26,13 @@
 #include "memory/allocation.hpp"
 #include "runtime/os.hpp"
 #include "services/memTracker.hpp"
+#include "sanitizers/address.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
 #include "testutils.hpp"
+
+#if !INCLUDE_ASAN
 
 // This prefix shows up on any c heap corruption NMT detects. If unsure which assert will
 // come, just use this one.
@@ -161,3 +164,5 @@ TEST_VM(NMT, test_realloc) {
     }
   }
 }
+
+#endif // !INCLUDE_ASAN

--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/os.hpp"
+#include "sanitizers/address.hpp"
 #include "services/mallocHeader.inline.hpp"
 #include "services/mallocTracker.hpp"
 #include "services/memTracker.hpp"
@@ -37,6 +38,9 @@ static void check_expected_malloc_header(const void* payload, MEMFLAGS type, siz
   EXPECT_EQ(hdr->size(), size);
   EXPECT_EQ(hdr->flags(), type);
 }
+
+// ASAN complains about allocating very large sizes
+#if !INCLUDE_ASAN
 
 // Check that a malloc with an overflowing size is rejected.
 TEST_VM(NMT, malloc_failure1) {
@@ -85,6 +89,7 @@ TEST_VM(NMT, realloc_failure_overflowing_size) {
 TEST_VM(NMT, realloc_failure_gigantic_size) {
   check_failing_realloc(SIZE_MAX - M);
 }
+#endif // !INCLUDE_ASAN
 
 static void* do_realloc(void* p, size_t old_size, size_t new_size, uint8_t old_content, bool check_nmt_header) {
 

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/os.hpp"
+#include "sanitizers/address.hpp"
 #include "services/mallocHeader.inline.hpp"
 #include "services/memTracker.hpp"
 #include "unittest.hpp"
@@ -32,6 +33,8 @@
 // Uncomment to get test output
 //#define LOG_PLEASE
 #include "testutils.hpp"
+
+#if !INCLUDE_ASAN
 
 using ::testing::HasSubstr;
 
@@ -121,3 +124,5 @@ static void test_for_mmap(size_t sz, ssize_t offset) {
 
 TEST_VM(NMT, location_printing_mmap_1) { test_for_mmap(os::vm_page_size(), 0);  }
 TEST_VM(NMT, location_printing_mmap_2) { test_for_mmap(os::vm_page_size(), os::vm_page_size() - 1);  }
+
+#endif // !INCLUDE_ASAN


### PR DESCRIPTION
Hi all, 

This PR contains a backport of [9e566d76d1d8acca27d8f69fffcbeb0b49b060ba](https://github.com/openjdk/jdk/commit/9e566d76d1d8acca27d8f69fffcbeb0b49b060ba). 

Patch is not clean because of differences with #include statements. 

Testing:
- [x] Verified fastdebug build failed with ```--enable-asan``` prior to backport
- [x] Verified fastdebug build succeeded with ```--enable-asan``` after backport
- [x] Verified NMT gtests passed after backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8327971](https://bugs.openjdk.org/browse/JDK-8327971) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327988](https://bugs.openjdk.org/browse/JDK-8327988) needs maintainer approval

### Issues
 * [JDK-8327971](https://bugs.openjdk.org/browse/JDK-8327971): Multiple ASAN errors reported for metaspace (**Bug** - P4 - Approved)
 * [JDK-8327988](https://bugs.openjdk.org/browse/JDK-8327988): When running ASAN, disable dangerous NMT test (**Bug** - P4 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/504/head:pull/504` \
`$ git checkout pull/504`

Update a local copy of the PR: \
`$ git checkout pull/504` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 504`

View PR using the GUI difftool: \
`$ git pr show -t 504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/504.diff">https://git.openjdk.org/jdk21u-dev/pull/504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/504#issuecomment-2059367090)