### PR TITLE
8326936: RISC-V: Shenandoah GC crashes due to incorrect atomic memory operations

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
@@ -39,6 +39,12 @@
 #define FULL_COMPILER_ATOMIC_SUPPORT
 #endif
 
+#if defined(__clang_major__)
+#define CORRECT_COMPILER_ATOMIC_SUPPORT
+#elif defined(__GNUC__) && (__riscv_xlen <= 32 || __GNUC__ > 13)
+#define CORRECT_COMPILER_ATOMIC_SUPPORT
+#endif
+
 template<size_t byte_size>
 struct Atomic::PlatformAdd {
   template<typename D, typename I>
@@ -114,6 +120,44 @@ inline T Atomic::PlatformCmpxchg<1>::operator()(T volatile* dest __attribute__((
 }
 #endif
 
+#ifndef CORRECT_COMPILER_ATOMIC_SUPPORT
+// The implementation of `__atomic_compare_exchange` lacks sign extensions
+// in GCC 13 and lower when using with 32-bit unsigned integers on RV64,
+// so we should implement it manually.
+// GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114130.
+// See also JDK-8326936.
+template<>
+template<typename T>
+inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest __attribute__((unused)),
+                                                T compare_value,
+                                                T exchange_value,
+                                                atomic_memory_order order) const {
+  STATIC_ASSERT(4 == sizeof(T));
+
+  int32_t old_value;
+  uint64_t rc_temp;
+
+  if (order != memory_order_relaxed) {
+    FULL_MEM_BARRIER;
+  }
+
+  __asm__ __volatile__ (
+    "1:  lr.w      %0, %2      \n\t"
+    "    bne       %0, %3, 2f  \n\t"
+    "    sc.w      %1, %4, %2  \n\t"
+    "    bnez      %1, 1b      \n\t"
+    "2:                        \n\t"
+    : /*%0*/"=&r" (old_value), /*%1*/"=&r" (rc_temp), /*%2*/"+A" (*dest)
+    : /*%3*/"r" ((int64_t)(int32_t)compare_value), /*%4*/"r" (exchange_value)
+    : "memory" );
+
+  if (order != memory_order_relaxed) {
+    FULL_MEM_BARRIER;
+  }
+  return (T)old_value;
+}
+#endif
+
 template<size_t byte_size>
 template<typename T>
 inline T Atomic::PlatformXchg<byte_size>::operator()(T volatile* dest,
@@ -149,6 +193,10 @@ inline T Atomic::PlatformCmpxchg<byte_size>::operator()(T volatile* dest __attri
 
 #ifndef FULL_COMPILER_ATOMIC_SUPPORT
   STATIC_ASSERT(byte_size >= 4);
+#endif
+
+#ifndef CORRECT_COMPILER_ATOMIC_SUPPORT
+  STATIC_ASSERT(byte_size != 4);
 #endif
 
   STATIC_ASSERT(byte_size == sizeof(T));
@@ -187,5 +235,6 @@ struct Atomic::PlatformOrderedStore<byte_size, RELEASE_X_FENCE>
 };
 
 #undef FULL_COMPILER_ATOMIC_SUPPORT
+#undef CORRECT_COMPILER_ATOMIC_SUPPORT
 
 #endif // OS_CPU_LINUX_RISCV_ATOMIC_LINUX_RISCV_HPP


### PR DESCRIPTION
The same issue reproduces for 17u and 21u too if we apply fix for JDK- 8316186 and JDK-8316893 which are both code cleanup/enhancement. So I suggest we backport JDK-8326936 and its followup fix JDK-8330242 to be safe. 

### Testing
- [x] The affected jtreg test cases all pass with jdk release built with latest gcc-13 development branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316186](https://bugs.openjdk.org/browse/JDK-8316186) needs maintainer approval
- [x] [JDK-8326936](https://bugs.openjdk.org/browse/JDK-8326936) needs maintainer approval
- [x] [JDK-8330242](https://bugs.openjdk.org/browse/JDK-8330242) needs maintainer approval

### Issues
 * [JDK-8326936](https://bugs.openjdk.org/browse/JDK-8326936): RISC-V: Shenandoah GC crashes due to incorrect atomic memory operations (**Bug** - P4 - Approved)
 * [JDK-8316186](https://bugs.openjdk.org/browse/JDK-8316186): RISC-V: Remove PlatformCmpxchg&lt;4&gt; (**Enhancement** - P5 - Approved)
 * [JDK-8330242](https://bugs.openjdk.org/browse/JDK-8330242): RISC-V: Simplify and remove CORRECT_COMPILER_ATOMIC_SUPPORT in atomic_linux_riscv.hpp (**Enhancement** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/507/head:pull/507` \
`$ git checkout pull/507`

Update a local copy of the PR: \
`$ git checkout pull/507` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 507`

View PR using the GUI difftool: \
`$ git pr show -t 507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/507.diff">https://git.openjdk.org/jdk21u-dev/pull/507.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/507#issuecomment-2062924078)