### PR TITLE
8318599: HttpURLConnection cache issues leading to crashes in JGSS w/ native GSS introduced by 8303809

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -152,7 +152,7 @@ class NegotiateAuthentication extends AuthenticationInfo {
 
     @Override
     protected boolean useAuthCache() {
-        return super.useAuthCache() && cacheSPNEGO;
+        return false;
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8318599](https://bugs.openjdk.org/browse/JDK-8318599) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318599](https://bugs.openjdk.org/browse/JDK-8318599): HttpURLConnection cache issues leading to crashes in JGSS w/ native GSS introduced by 8303809 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/508/head:pull/508` \
`$ git checkout pull/508`

Update a local copy of the PR: \
`$ git checkout pull/508` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 508`

View PR using the GUI difftool: \
`$ git pr show -t 508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/508.diff">https://git.openjdk.org/jdk21u-dev/pull/508.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/508#issuecomment-2063219295)