### PR TITLE
8325494: C2: Broken graph after not skipping CastII node anymore for Assertion Predicates after JDK-8309902

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2046,6 +2046,12 @@ bool IdealLoopTree::is_invariant(Node* n) const {
 // to the new stride.
 void PhaseIdealLoop::update_main_loop_assertion_predicates(Node* ctrl, CountedLoopNode* loop_head, Node* init,
                                                            const int stride_con) {
+  if (init->is_CastII()) {
+    // skip over the cast added by PhaseIdealLoop::cast_incr_before_loop() when pre/post/main loops are created because
+    // it can get in the way of type propagation
+    assert(init->as_CastII()->carry_dependency() && loop_head->skip_assertion_predicates_with_halt() == init->in(0), "casted iv phi from pre loop expected");
+    init = init->in(1);
+  }
   Node* entry = ctrl;
   Node* prev_proj = ctrl;
   LoopNode* outer_loop_head = loop_head->skip_strip_mined();

--- a/test/hotspot/jtreg/compiler/predicates/TestAssertionPredicateDoesntConstantFold.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestAssertionPredicateDoesntConstantFold.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8325494
+ * @summary C2: Broken graph after not skipping CastII node anymore for Assertion Predicates after JDK-8309902
+ * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:CompileOnly=TestAssertionPredicateDoesntConstantFold::test TestAssertionPredicateDoesntConstantFold
+ *
+ */
+
+public class TestAssertionPredicateDoesntConstantFold {
+    static boolean bFld;
+    static int iArrFld[];
+    static long lArrFld[];
+
+    public static void main(String[] strArr) {
+        try {
+            test();
+        } catch (NullPointerException npe) {}
+    }
+
+    static long test() {
+        int i6 = 1, i7, i11;
+        do {
+            for (i7 = 1; i7 < 9; ++i7) {
+                for (i11 = 2; i6 < i11; i11 -= 2) {
+                    if (bFld) {
+                        break;
+                    }
+
+                    lArrFld[i11 + 1] = 6;
+                    iArrFld[i11 % 20] = 3;
+                }
+            }
+        } while (++i6 < 8);
+
+        return i6;
+    }
+}
+


### PR DESCRIPTION
WIP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8325494](https://bugs.openjdk.org/browse/JDK-8325494) needs maintainer approval

### Issue
 * [JDK-8325494](https://bugs.openjdk.org/browse/JDK-8325494): C2: Broken graph after not skipping CastII node anymore for Assertion Predicates after JDK-8309902 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/509/head:pull/509` \
`$ git checkout pull/509`

Update a local copy of the PR: \
`$ git checkout pull/509` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 509`

View PR using the GUI difftool: \
`$ git pr show -t 509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/509.diff">https://git.openjdk.org/jdk21u-dev/pull/509.diff</a>

</details>
