### PR TITLE
8327474: Review use of java.io.tmpdir in jdk tests

### DIFF
--- a/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
+++ b/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import java.io.FileWriter;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
 import java.util.Map;
 import jdk.test.lib.process.ProcessTools;
 import sun.tools.attach.HotSpotVirtualMachine;
@@ -53,7 +54,7 @@ public class CheckOrigin {
         if (args.length == 0) {
             // start a process that has options set in a number of different ways
 
-            File flagsFile = File.createTempFile("CheckOriginFlags", null);
+            File flagsFile = File.createTempFile("CheckOriginFlags", null, Path.of(".").toFile());
             try (PrintWriter pw =
                    new PrintWriter(new FileWriter(flagsFile))) {
                 pw.println("+PrintCodeCache");

--- a/test/jdk/java/io/File/CheckPermission.java
+++ b/test/jdk/java/io/File/CheckPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -362,13 +362,13 @@ public class CheckPermission {
                 "getFileSystemAttributes");
 
         prepare();
-        File tmpFile = File.createTempFile(CHECK_PERMISSION_TEST, null);
+        File tmpFile = File.createTempFile(CHECK_PERMISSION_TEST, null, new File("."));
         assertOnlyCheckOperation(tmpFile, EnumSet.of(FileOperation.WRITE));
         tmpFile.delete();
         assertCheckOperation(tmpFile, EnumSet.of(FileOperation.DELETE));
 
         prepare();
-        tmpFile = File.createTempFile(CHECK_PERMISSION_TEST, null, null);
+        tmpFile = File.createTempFile(CHECK_PERMISSION_TEST, null, new File("."));
         assertOnlyCheckOperation(tmpFile, EnumSet.of(FileOperation.WRITE));
         tmpFile.delete();
         assertCheckOperation(tmpFile, EnumSet.of(FileOperation.DELETE));

--- a/test/jdk/java/io/FileInputStream/NegativeAvailable.java
+++ b/test/jdk/java/io/FileInputStream/NegativeAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,28 +46,31 @@ public class NegativeAvailable {
 
         // Create a temporary file with size of 10 bytes.
         Path tmp = Files.createTempFile(null, null);
-        try (BufferedWriter writer =
-            Files.newBufferedWriter(tmp, Charset.defaultCharset())) {
-            for (int i = 0; i < SIZE; i++) {
-                writer.write('1');
+        try {
+            try (BufferedWriter writer =
+                         Files.newBufferedWriter(tmp, Charset.defaultCharset())) {
+                for (int i = 0; i < SIZE; i++) {
+                    writer.write('1');
+                }
             }
-        }
 
-        File tempFile = tmp.toFile();
-        try (FileInputStream fis = new FileInputStream(tempFile)) {
-            if (tempFile.length() != SIZE) {
-                throw new RuntimeException("unexpected file size = "
-                                           + tempFile.length());
+            File tempFile = tmp.toFile();
+            try (FileInputStream fis = new FileInputStream(tempFile)) {
+                if (tempFile.length() != SIZE) {
+                    throw new RuntimeException("unexpected file size = "
+                            + tempFile.length());
+                }
+                long space = skipBytes(fis, SKIP, SIZE);
+                space = skipBytes(fis, NEGATIVE_SKIP, space);
+                space = skipBytes(fis, SKIP, space);
+                space = skipBytes(fis, SKIP, space);
+                space = skipBytes(fis, SKIP, space);
+                space = skipBytes(fis, NEGATIVE_SKIP, space);
+                space = skipBytes(fis, NEGATIVE_SKIP, space);
             }
-            long space = skipBytes(fis, SKIP, SIZE);
-            space = skipBytes(fis, NEGATIVE_SKIP, space);
-            space = skipBytes(fis, SKIP, space);
-            space = skipBytes(fis, SKIP, space);
-            space = skipBytes(fis, SKIP, space);
-            space = skipBytes(fis, NEGATIVE_SKIP, space);
-            space = skipBytes(fis, NEGATIVE_SKIP, space);
+        } finally {
+            Files.deleteIfExists(tmp);
         }
-        Files.deleteIfExists(tmp);
     }
 
     /**

--- a/test/jdk/java/nio/channels/unixdomain/NonBlockingAccept.java
+++ b/test/jdk/java/nio/channels/unixdomain/NonBlockingAccept.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,11 @@
  */
 
 import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+
 import jtreg.SkippedException;
 
 public class NonBlockingAccept {
@@ -48,17 +51,23 @@ public class NonBlockingAccept {
     public static void main(String[] args) throws Exception {
 
         checkSupported();
+        UnixDomainSocketAddress addr = null;
 
         try (ServerSocketChannel serverSocketChannel =
                                  ServerSocketChannel.open(StandardProtocolFamily.UNIX)) {
             //non blocking mode
             serverSocketChannel.configureBlocking(false);
             serverSocketChannel.bind(null);
+            addr = (UnixDomainSocketAddress) serverSocketChannel.getLocalAddress();
             SocketChannel socketChannel = serverSocketChannel.accept();
             System.out.println("The socketChannel is : expected Null " + socketChannel);
             if (socketChannel != null)
                 throw new RuntimeException("expected null");
             // or exception could be thrown otherwise
+        } finally {
+            if (addr != null) {
+                Files.deleteIfExists(addr.getPath());
+            }
         }
     }
 }

--- a/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
+++ b/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 
 package jdk.jfr.api.consumer.filestream;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -35,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import jdk.jfr.Event;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.EventStream;
+import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -148,7 +148,7 @@ public class TestOrdered {
                 e.join();
             }
             r.stop();
-            Path p = Files.createTempFile("recording", ".jfr");
+            Path p = Utils.createTempFile("recording", ".jfr");
             r.dump(p);
             return p;
         }

--- a/test/jdk/jdk/jfr/api/consumer/filestream/TestReuse.java
+++ b/test/jdk/jdk/jfr/api/consumer/filestream/TestReuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import jdk.jfr.Event;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.EventStream;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -118,7 +119,7 @@ public class TestReuse {
             }
             r.stop();
             rotation.close();
-            Path p = Files.createTempFile("recording", ".jfr");
+            Path p = Utils.createTempFile("recording", ".jfr");
             r.dump(p);
             return p;
         }

--- a/test/jdk/jdk/jfr/threading/TestManyVirtualThreads.java
+++ b/test/jdk/jdk/jfr/threading/TestManyVirtualThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedThread;
 import jdk.jfr.consumer.RecordingFile;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -78,7 +79,7 @@ public class TestManyVirtualThreads {
             }
 
             r.stop();
-            Path p = Files.createTempFile("test", ".jfr");
+            Path p = Utils.createTempFile("test", ".jfr");
             r.dump(p);
             long size = Files.size(p);
             Asserts.assertLessThan(size, 100_000_000L, "Size of recording looks suspiciously large");

--- a/test/jdk/jdk/nio/zipfs/ZeroDate.java
+++ b/test/jdk/jdk/nio/zipfs/ZeroDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,42 +44,48 @@ import java.util.Collections;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import jdk.test.lib.Utils;
+
 /* @test
  * @bug 8184940 8186227 8188869
  * @summary JDK 9 rejects zip files where the modified day or month is 0
  *          or otherwise represent an invalid date, such as 1980-02-30 24:60:60
  * @author Liam Miller-Cushon
  * @modules jdk.zipfs
+ * @library /test/lib
  */
 public class ZeroDate {
 
     public static void main(String[] args) throws Exception {
         // create a zip file, and read it in as a byte array
-        Path path = Files.createTempFile("bad", ".zip");
-        try (OutputStream os = Files.newOutputStream(path);
-                ZipOutputStream zos = new ZipOutputStream(os)) {
-            ZipEntry e = new ZipEntry("x");
-            zos.putNextEntry(e);
-            zos.write((int) 'x');
-        }
-        int len = (int) Files.size(path);
-        byte[] data = new byte[len];
-        try (InputStream is = Files.newInputStream(path)) {
-            is.read(data);
-        }
-        Files.delete(path);
+        Path path = Utils.createTempFile("bad", ".zip");
+        try {
+            try (OutputStream os = Files.newOutputStream(path);
+                 ZipOutputStream zos = new ZipOutputStream(os)) {
+                ZipEntry e = new ZipEntry("x");
+                zos.putNextEntry(e);
+                zos.write((int) 'x');
+            }
+            int len = (int) Files.size(path);
+            byte[] data = new byte[len];
+            try (InputStream is = Files.newInputStream(path)) {
+                is.read(data);
+            }
 
-        // year, month, day are zero
-        testDate(data.clone(), 0, LocalDate.of(1979, 11, 30).atStartOfDay());
-        // only year is zero
-        testDate(data.clone(), 0 << 25 | 4 << 21 | 5 << 16, LocalDate.of(1980, 4, 5).atStartOfDay());
-        // month is greater than 12
-        testDate(data.clone(), 0 << 25 | 13 << 21 | 1 << 16, LocalDate.of(1981, 1, 1).atStartOfDay());
-        // 30th of February
-        testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16, LocalDate.of(1980, 3, 1).atStartOfDay());
-        // 30th of February, 24:60:60
-        testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16 | 24 << 11 | 60 << 5 | 60 >> 1,
-                LocalDateTime.of(1980, 3, 2, 1, 1, 0));
+            // year, month, day are zero
+            testDate(data.clone(), 0, LocalDate.of(1979, 11, 30).atStartOfDay());
+            // only year is zero
+            testDate(data.clone(), 0 << 25 | 4 << 21 | 5 << 16, LocalDate.of(1980, 4, 5).atStartOfDay());
+            // month is greater than 12
+            testDate(data.clone(), 0 << 25 | 13 << 21 | 1 << 16, LocalDate.of(1981, 1, 1).atStartOfDay());
+            // 30th of February
+            testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16, LocalDate.of(1980, 3, 1).atStartOfDay());
+            // 30th of February, 24:60:60
+            testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16 | 24 << 11 | 60 << 5 | 60 >> 1,
+                    LocalDateTime.of(1980, 3, 2, 1, 1, 0));
+        } finally {
+            Files.delete(path);
+        }
     }
 
     private static void testDate(byte[] data, int date, LocalDateTime expected) throws IOException {
@@ -91,7 +97,7 @@ public class ZeroDate {
         writeU32(data, locpos + LOCTIM, date);
 
         // ensure that the archive is still readable, and the date is 1979-11-30
-        Path path = Files.createTempFile("out", ".zip");
+        Path path = Utils.createTempFile("out", ".zip");
         try (OutputStream os = Files.newOutputStream(path)) {
             os.write(data);
         }

--- a/test/jdk/sun/security/pkcs12/P12SecretKey.java
+++ b/test/jdk/sun/security/pkcs12/P12SecretKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
 import java.util.Arrays;
@@ -66,24 +67,29 @@ public class P12SecretKey {
         ks.setEntry(ALIAS, ske, kspp);
 
         File ksFile = File.createTempFile("test", ".test");
-        try (FileOutputStream fos = new FileOutputStream(ksFile)) {
-            ks.store(fos, pw);
-            fos.flush();
-        }
 
-        // now see if we can get it back
-        try (FileInputStream fis = new FileInputStream(ksFile)) {
-            KeyStore ks2 = KeyStore.getInstance(keystoreType);
-            ks2.load(fis, pw);
-            KeyStore.Entry entry = ks2.getEntry(ALIAS, kspp);
-            SecretKey keyIn = ((KeyStore.SecretKeyEntry)entry).getSecretKey();
-            if (Arrays.equals(key.getEncoded(), keyIn.getEncoded())) {
-                System.err.println("OK: worked just fine with " + keystoreType +
-                                   " keystore");
-            } else {
-                System.err.println("ERROR: keys are NOT equal after storing in "
-                                   + keystoreType + " keystore");
+        try {
+            try (FileOutputStream fos = new FileOutputStream(ksFile)) {
+                ks.store(fos, pw);
+                fos.flush();
             }
+
+            // now see if we can get it back
+            try (FileInputStream fis = new FileInputStream(ksFile)) {
+                KeyStore ks2 = KeyStore.getInstance(keystoreType);
+                ks2.load(fis, pw);
+                KeyStore.Entry entry = ks2.getEntry(ALIAS, kspp);
+                SecretKey keyIn = ((KeyStore.SecretKeyEntry) entry).getSecretKey();
+                if (Arrays.equals(key.getEncoded(), keyIn.getEncoded())) {
+                    System.err.println("OK: worked just fine with " + keystoreType +
+                            " keystore");
+                } else {
+                    System.err.println("ERROR: keys are NOT equal after storing in "
+                            + keystoreType + " keystore");
+                }
+            }
+        } finally {
+            Files.deleteIfExists(ksFile.toPath());
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8327474](https://bugs.openjdk.org/browse/JDK-8327474) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327474](https://bugs.openjdk.org/browse/JDK-8327474): Review use of java.io.tmpdir in jdk tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/514/head:pull/514` \
`$ git checkout pull/514`

Update a local copy of the PR: \
`$ git checkout pull/514` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 514`

View PR using the GUI difftool: \
`$ git pr show -t 514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/514.diff">https://git.openjdk.org/jdk21u-dev/pull/514.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/514#issuecomment-2066937123)