### PR TITLE
8320331: G1 Full GC Heap verification relies on metadata not reset before verification

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2761,7 +2761,7 @@ bool G1CollectedHeap::check_young_list_empty() {
 
 // Remove the given HeapRegion from the appropriate region set.
 void G1CollectedHeap::prepare_region_for_full_compaction(HeapRegion* hr) {
-   if (hr->is_humongous()) {
+  if (hr->is_humongous()) {
     _humongous_set.remove(hr);
   } else if (hr->is_old()) {
     _old_set.remove(hr);

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -171,6 +171,7 @@ public:
   PrepareRegionsClosure(G1FullCollector* collector) : _collector(collector) { }
 
   bool do_heap_region(HeapRegion* hr) {
+    hr->prepare_for_full_gc();
     G1CollectedHeap::heap()->prepare_region_for_full_compaction(hr);
     _collector->before_marking_update_attribute_table(hr);
     return false;

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -174,6 +174,7 @@ public:
 
   void update_bot_for_block(HeapWord* start, HeapWord* end);
 
+  void prepare_for_full_gc();
   // Update heap region that has been compacted to be consistent after Full GC.
   void reset_compacted_after_full_gc(HeapWord* new_top);
   // Update skip-compacting heap region to be consistent after Full GC.
@@ -233,11 +234,17 @@ private:
   HeapWord* volatile _top_at_mark_start;
 
   // The area above this limit is fully parsable. This limit
-  // is equal to bottom except from Remark and until the region has been
-  // scrubbed concurrently. The scrubbing ensures that all dead objects (with
-  // possibly unloaded classes) have beenreplaced with filler objects that
-  // are parsable. Below this limit the marking bitmap must be used to
-  // determine size and liveness.
+  // is equal to bottom except
+  //
+  // * from Remark and until the region has been scrubbed concurrently. The
+  //   scrubbing ensures that all dead objects (with possibly unloaded classes)
+  //   have been replaced with filler objects that are parsable.
+  // * after the marking phase in the Full GC pause until the objects have been
+  //   moved. Some (debug) code iterates over the heap after marking but before
+  //   compaction.
+  //
+  // Below this limit the marking bitmap must be used to determine size and
+  // liveness.
   HeapWord* volatile _parsable_bottom;
 
   // Amount of dead data in the region.

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -180,6 +180,13 @@ inline size_t HeapRegion::block_size(const HeapWord* p, HeapWord* const pb) cons
   return cast_to_oop(p)->size();
 }
 
+inline void HeapRegion::prepare_for_full_gc() {
+  // After marking and class unloading the heap temporarily contains dead objects
+  // with unloaded klasses. Moving parsable_bottom makes some (debug) code correctly
+  // skip dead objects.
+  _parsable_bottom = top();
+}
+
 inline void HeapRegion::reset_compacted_after_full_gc(HeapWord* new_top) {
   set_top(new_top);
   // After a compaction the mark bitmap in a movable region is invalid.
@@ -201,7 +208,7 @@ inline void HeapRegion::reset_skip_compacting_after_full_gc() {
 
 inline void HeapRegion::reset_after_full_gc_common() {
   // Everything above bottom() is parsable and live.
-  _parsable_bottom = bottom();
+  reset_parsable_bottom();
 
   // Clear unused heap memory in debug builds.
   if (ZapUnusedHeapArea) {

--- a/test/hotspot/jtreg/runtime/Metaspace/FragmentMetaspace.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/FragmentMetaspace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,16 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.compiler
  * @run main/othervm/timeout=200 -Xmx1g FragmentMetaspace
+ */
+
+/**
+ * @test id=8320331
+ * @bug 8320331
+ * @requires vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @modules java.compiler
+ * @run main/othervm/timeout=200 -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC -Xmx1g FragmentMetaspace
  */
 
 import java.io.IOException;


### PR DESCRIPTION
I backport this as prereq of [JDK-8317809](https://bugs.openjdk.org/browse/JDK-8317809).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320331](https://bugs.openjdk.org/browse/JDK-8320331) needs maintainer approval

### Issue
 * [JDK-8320331](https://bugs.openjdk.org/browse/JDK-8320331): G1 Full GC Heap verification relies on metadata not reset before verification (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/519/head:pull/519` \
`$ git checkout pull/519`

Update a local copy of the PR: \
`$ git checkout pull/519` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 519`

View PR using the GUI difftool: \
`$ git pr show -t 519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/519.diff">https://git.openjdk.org/jdk21u-dev/pull/519.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/519#issuecomment-2068879501)