### PR TITLE
8321713: Harmonize executeTestJvm with create[Limited]TestJavaProcessBuilder

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestCompileThresholdScaling.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompileThresholdScaling.java
@@ -48,7 +48,7 @@ public class TestCompileThresholdScaling {
     }
 
     static void checkCompileThresholdScaling(double value, boolean fail) throws Throwable {
-        OutputAnalyzer out = ProcessTools.executeTestJvm("-XX:CompileThresholdScaling=" + value, "--version");
+        OutputAnalyzer out = ProcessTools.executeTestJava("-XX:CompileThresholdScaling=" + value, "--version");
         out.shouldHaveExitValue(0);
         String output = out.getOutput();
 

--- a/test/hotspot/jtreg/compiler/c1/TestPrintC1Statistics.java
+++ b/test/hotspot/jtreg/compiler/c1/TestPrintC1Statistics.java
@@ -44,7 +44,7 @@ public class TestPrintC1Statistics {
         options.add("-XX:+PrintC1Statistics");
         options.add("--version");
 
-        OutputAnalyzer oa = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer oa = ProcessTools.executeTestJava(options);
 
         oa.shouldHaveExitValue(0).shouldContain("C1 Runtime statistics");
     }

--- a/test/hotspot/jtreg/compiler/c2/cr7200264/TestDriver.java
+++ b/test/hotspot/jtreg/compiler/c2/cr7200264/TestDriver.java
@@ -44,7 +44,7 @@ public class TestDriver {
     }
 
     private List<String> executeApplication() throws Throwable {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
             "-Xbatch",
             "-XX:-TieredCompilation",
             "-XX:+PrintCompilation",

--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -105,9 +105,9 @@ public abstract class CiReplayBase {
 
     static {
         try {
-            CLIENT_VM_AVAILABLE = ProcessTools.executeTestJvm(CLIENT_VM_OPTION, VERSION_OPTION)
+            CLIENT_VM_AVAILABLE = ProcessTools.executeTestJava(CLIENT_VM_OPTION, VERSION_OPTION)
                     .getOutput().contains("Client");
-            SERVER_VM_AVAILABLE = ProcessTools.executeTestJvm(SERVER_VM_OPTION, VERSION_OPTION)
+            SERVER_VM_AVAILABLE = ProcessTools.executeTestJava(SERVER_VM_OPTION, VERSION_OPTION)
                     .getOutput().contains("Server");
         } catch(Throwable t) {
             throw new Error("Initialization failed: " + t, t);

--- a/test/hotspot/jtreg/compiler/compilercontrol/commands/OptionTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commands/OptionTest.java
@@ -36,13 +36,13 @@ import jdk.test.lib.process.ProcessTools;
 
 public class OptionTest {
     public static void main(String[] args) throws Exception {
-        ProcessTools.executeTestJvm("-XX:CompileCommand=option,package/class,ccstrlist,ControlIntrinsic,+_id", "-version")
+        ProcessTools.executeTestJava("-XX:CompileCommand=option,package/class,ccstrlist,ControlIntrinsic,+_id", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("CompileCommand: An error occurred during parsing")
                     .shouldContain("Error: Did not specify any method name")
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
-        ProcessTools.executeTestJvm("-XX:CompileCommand=option,*,ccstrlist,ControlIntrinsic,+_id", "-version")
+        ProcessTools.executeTestJava("-XX:CompileCommand=option,*,ccstrlist,ControlIntrinsic,+_id", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("CompileCommand: An error occurred during parsing")
                     .shouldContain("Error: Did not specify any method name")
@@ -50,35 +50,35 @@ public class OptionTest {
 
         // corner case:
         // ccstrlist could be a valid method name, so it is accepted in the well-formed case.
-        ProcessTools.executeTestJvm("-XX:CompileCommand=option,*.ccstrlist,ccstrlist,ControlIntrinsic,+_id", "-version")
+        ProcessTools.executeTestJava("-XX:CompileCommand=option,*.ccstrlist,ccstrlist,ControlIntrinsic,+_id", "-version")
                     .shouldContain("CompileCommand: ControlIntrinsic *.ccstrlist const char* ControlIntrinsic")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
-        ProcessTools.executeTestJvm("-XX:CompileCommand=option,*.*,ccstrlist,ControlIntrinsic,+_id", "-version")
+        ProcessTools.executeTestJava("-XX:CompileCommand=option,*.*,ccstrlist,ControlIntrinsic,+_id", "-version")
                     .shouldContain("CompileCommand: ControlIntrinsic *.* const char* ControlIntrinsic")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
-        ProcessTools.executeTestJvm("-XX:CompileCommand=option,class,PrintIntrinsics", "-version")
+        ProcessTools.executeTestJava("-XX:CompileCommand=option,class,PrintIntrinsics", "-version")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
         // corner case:
         // PrintIntrinsics could be a valid method name, so it is accepted in the well-formed case.
-        ProcessTools.executeTestJvm("-XX:CompileCommand=option,class.PrintIntrinsics,PrintIntrinsics", "-version")
+        ProcessTools.executeTestJava("-XX:CompileCommand=option,class.PrintIntrinsics,PrintIntrinsics", "-version")
                     .shouldContain("CompileCommand: PrintIntrinsics class.PrintIntrinsics bool PrintIntrinsics = true")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
         // corner case:
         // _dontinline_* is a valid method pattern, so it should be accepted
-        ProcessTools.executeTestJvm("-XX:CompileCommand=dontinline,*::dontinline_*", "-version")
+        ProcessTools.executeTestJava("-XX:CompileCommand=dontinline,*::dontinline_*", "-version")
                     .shouldContain("CompileCommand: dontinline *.dontinline_* bool dontinline = true")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("# A fatal error has been detected by the Java Runtime Environment");
 
-        ProcessTools.executeTestJvm("-XX:CompileCommand=dontinline,*.dontinline", "-version")
+        ProcessTools.executeTestJava("-XX:CompileCommand=dontinline,*.dontinline", "-version")
                     .shouldContain("CompileCommand: dontinline *.dontinline bool dontinline = true")
                     .shouldHaveExitValue(0)
                     .shouldNotContain("Error: Did not specify any method name")

--- a/test/hotspot/jtreg/compiler/compilercontrol/parser/HugeDirectiveUtil.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/parser/HugeDirectiveUtil.java
@@ -121,7 +121,7 @@ public final class HugeDirectiveUtil {
     protected static OutputAnalyzer execute(String fileName) {
         OutputAnalyzer output;
         try {
-            output = ProcessTools.executeTestJvm(
+            output = ProcessTools.executeTestJava(
                     "-XX:+UnlockDiagnosticVMOptions",
                     "-XX:CompilerDirectivesLimit=1000",
                     "-XX:CompilerDirectivesFile=" + fileName,

--- a/test/hotspot/jtreg/compiler/compilercontrol/parser/TestCompileOnly.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/parser/TestCompileOnly.java
@@ -46,7 +46,7 @@ public class TestCompileOnly {
     }
 
     public static void test(String compileOnlyCommand) throws Exception {
-        OutputAnalyzer output = ProcessTools.executeTestJvm("-XX:CompileOnly=" + compileOnlyCommand, "-version");
+        OutputAnalyzer output = ProcessTools.executeTestJava("-XX:CompileOnly=" + compileOnlyCommand, "-version");
         output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Executor.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Executor.java
@@ -105,7 +105,7 @@ public class Executor {
                     vmInputArgs.length + vmOptions.size());
             System.arraycopy(vmOptions.toArray(), 0, cmds, vmInputArgs.length,
                     vmOptions.size());
-            output = ProcessTools.executeTestJvm(cmds);
+            output = ProcessTools.executeTestJava(cmds);
         } catch (Throwable thr) {
             throw new Error("Execution failed: " + thr.getMessage(), thr);
         }

--- a/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java
@@ -72,7 +72,7 @@ public class TestAESIntrinsicsOnSupportedConfig extends AESIntrinsicsBase {
      * @throws Throwable
      */
     private void testUseAES() throws Throwable {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
                 prepareArguments(prepareBooleanFlag(AESIntrinsicsBase
                         .USE_AES, true)));
         final String errorMessage = "Case testUseAES failed";
@@ -103,7 +103,7 @@ public class TestAESIntrinsicsOnSupportedConfig extends AESIntrinsicsBase {
      */
     private void testUseAESUseSSE2() throws Throwable {
         if (Platform.isX86() || Platform.isX64()) {
-            OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
                     prepareArguments(prepareBooleanFlag(AESIntrinsicsBase
                                     .USE_AES_INTRINSICS, true),
                             prepareNumericFlag(AESIntrinsicsBase.USE_SSE, 2)));
@@ -132,7 +132,7 @@ public class TestAESIntrinsicsOnSupportedConfig extends AESIntrinsicsBase {
      */
     private void testNoUseAESUseSSE2() throws Throwable {
         if (Platform.isX86() || Platform.isX64()) {
-            OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
                     prepareArguments(prepareBooleanFlag(AESIntrinsicsBase
                                     .USE_AES, false),
                             prepareNumericFlag(AESIntrinsicsBase.USE_SSE, 2)));
@@ -158,7 +158,7 @@ public class TestAESIntrinsicsOnSupportedConfig extends AESIntrinsicsBase {
      * @throws Throwable
      */
     private void testNoUseAES() throws Throwable {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
                 prepareArguments(prepareBooleanFlag(AESIntrinsicsBase
                         .USE_AES, false)));
         final String errorMessage = "Case testNoUseAES failed";
@@ -180,7 +180,7 @@ public class TestAESIntrinsicsOnSupportedConfig extends AESIntrinsicsBase {
      * @throws Throwable
      */
     private void testNoUseAESIntrinsic() throws Throwable {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
                 prepareArguments(prepareBooleanFlag(AESIntrinsicsBase
                         .USE_AES_INTRINSICS, false)));
         final String errorMessage = "Case testNoUseAESIntrinsic failed";

--- a/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java
@@ -65,7 +65,7 @@ public class TestAESIntrinsicsOnUnsupportedConfig extends AESIntrinsicsBase {
      * @throws Throwable
      */
     private void testUseAESIntrinsics() throws Throwable {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
                 AESIntrinsicsBase.prepareArguments(prepareBooleanFlag(
                         AESIntrinsicsBase.USE_AES_INTRINSICS, true)));
         final String errorMessage = "Case testUseAESIntrinsics failed";
@@ -89,7 +89,7 @@ public class TestAESIntrinsicsOnUnsupportedConfig extends AESIntrinsicsBase {
      * @throws Throwable
      */
     private void testUseAES() throws Throwable {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
                 AESIntrinsicsBase.prepareArguments(prepareBooleanFlag
                         (AESIntrinsicsBase.USE_AES, true)));
         final String errorMessage = "Case testUseAES failed";

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestMembarDependencies.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestMembarDependencies.java
@@ -43,7 +43,7 @@ public class TestMembarDependencies {
     public static void main(String args[]) throws Exception {
         if (args.length == 0) {
             // For debugging, add "-XX:+TraceOptoPipelining"
-            OutputAnalyzer oa = ProcessTools.executeTestJvm("-XX:+IgnoreUnrecognizedVMOptions",
+            OutputAnalyzer oa = ProcessTools.executeTestJava("-XX:+IgnoreUnrecognizedVMOptions",
                 "-XX:-TieredCompilation", "-XX:-BackgroundCompilation", "-XX:+PrintOpto",
                 "-XX:CompileCommand=compileonly,compiler.membars.TestMembarDependencies::test*",
                 "-XX:CompileCommand=dontinline,compiler.membars.TestMembarDependencies::test_m1",

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
@@ -146,7 +146,7 @@ public class BMITestRunner {
                 new Integer(iterations).toString()
             });
 
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(vmOpts);
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(vmOpts);
 
         outputAnalyzer.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/FlagVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/FlagVMProcess.java
@@ -112,7 +112,7 @@ public class FlagVMProcess {
     private void start() {
         try {
             // Run "flag" VM with White Box access to determine the test VM flags and if IR verification should be done.
-            oa = ProcessTools.executeTestJvm(cmds);
+            oa = ProcessTools.executeTestJava(cmds);
         } catch (Exception e) {
             throw new TestRunException("Failed to execute TestFramework flag VM", e);
         }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -149,7 +149,7 @@ public class TestVMProcess {
         ProcessBuilder process = ProcessTools.createLimitedTestJavaProcessBuilder(cmds);
         try {
             // Calls 'main' of TestVM to run all specified tests with commands 'cmds'.
-            // Use executeProcess instead of executeTestJvm as we have already added the JTreg VM and
+            // Use executeProcess instead of executeTestJava as we have already added the JTreg VM and
             // Java options in prepareTestVMFlags().
             oa = ProcessTools.executeProcess(process);
         } catch (Exception e) {

--- a/test/hotspot/jtreg/compiler/loopopts/UseCountedLoopSafepointsTest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/UseCountedLoopSafepointsTest.java
@@ -59,9 +59,10 @@ public class UseCountedLoopSafepointsTest {
     private static void check(boolean enabled) {
         OutputAnalyzer oa;
         try {
-            oa = ProcessTools.executeTestJvm("-XX:+UnlockDiagnosticVMOptions", "-Xbootclasspath/a:.",
-                                             "-XX:" + (enabled ? "+" : "-") + "UseCountedLoopSafepoints",
-                                             "-XX:+WhiteBoxAPI",
+            oa = ProcessTools.executeTestJava(
+                    "-XX:+UnlockDiagnosticVMOptions", "-Xbootclasspath/a:.",
+                    "-XX:" + (enabled ? "+" : "-") + "UseCountedLoopSafepoints",
+                    "-XX:+WhiteBoxAPI",
                     "-XX:-Inline", "-Xbatch", "-XX:+PrintIdeal", "-XX:LoopUnrollLimit=0",
                     "-XX:CompileOnly=" + UseCountedLoopSafepoints.class.getName() + "::testMethod",
                     UseCountedLoopSafepoints.class.getName());

--- a/test/hotspot/jtreg/compiler/loopstripmining/CheckLoopStripMining.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/CheckLoopStripMining.java
@@ -38,7 +38,7 @@ import jdk.test.lib.process.ProcessTools;
 
 public class CheckLoopStripMining {
     public static void main(String args[]) throws Exception {
-        ProcessTools.executeTestJvm("-XX:+UnlockDiagnosticVMOptions",
+        ProcessTools.executeTestJava("-XX:+UnlockDiagnosticVMOptions",
                                     "-XX:+SafepointTimeout",
                                     "-XX:+SafepointALot",
                                     "-XX:+AbortVMOnSafepointTimeout",
@@ -54,7 +54,7 @@ public class CheckLoopStripMining {
             .shouldHaveExitValue(0)
             .stdoutShouldContain("sum: 715827882");
 
-        ProcessTools.executeTestJvm("-XX:+UnlockDiagnosticVMOptions",
+        ProcessTools.executeTestJava("-XX:+UnlockDiagnosticVMOptions",
                                     "-XX:+SafepointTimeout",
                                     "-XX:+SafepointALot",
                                     "-XX:+AbortVMOnSafepointTimeout",

--- a/test/hotspot/jtreg/compiler/oracle/PrintIdealPhaseTest.java
+++ b/test/hotspot/jtreg/compiler/oracle/PrintIdealPhaseTest.java
@@ -81,7 +81,7 @@ public class PrintIdealPhaseTest {
         options.add("-XX:CompileCommand=PrintIdealPhase," + getTestClass() + "::test," + cmdPhases);
         options.add(getTestClass());
 
-        OutputAnalyzer oa = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer oa = ProcessTools.executeTestJava(options);
         if (valid) {
             oa.shouldHaveExitValue(0)
             .shouldContain("CompileCommand: PrintIdealPhase compiler/oracle/PrintIdealPhaseTest$TestMain.test const char* PrintIdealPhase = '"+cmdPhases.replace(',', ' ')+"'")

--- a/test/hotspot/jtreg/compiler/print/CompileCommandPrintCompilation.java
+++ b/test/hotspot/jtreg/compiler/print/CompileCommandPrintCompilation.java
@@ -56,7 +56,7 @@ public class CompileCommandPrintCompilation {
         options.add("-XX:CompileCommand=PrintCompilation," + getTestMethod(include));
         options.add(getTestClass());
 
-        OutputAnalyzer oa = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer oa = ProcessTools.executeTestJava(options);
 
         oa.shouldHaveExitValue(0)
         .shouldContain(getTestMethod(include))

--- a/test/hotspot/jtreg/compiler/print/PrintCompilation.java
+++ b/test/hotspot/jtreg/compiler/print/PrintCompilation.java
@@ -47,7 +47,7 @@ public class PrintCompilation {
         options.add("-XX:CompileCommand=compileonly," + getTestClass() + "::*");
         options.add(getTestClass());
 
-        OutputAnalyzer oa = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer oa = ProcessTools.executeTestJava(options);
 
         oa.shouldHaveExitValue(0)
         .shouldContain(getTestMethod("method1"))

--- a/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
+++ b/test/hotspot/jtreg/compiler/runtime/TestConstantsInError.java
@@ -261,7 +261,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
         c1Args.addAll(List.of("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:+TracePatching"));
         c1Args.addAll(commonArgs);
 
-        OutputAnalyzer outputC1 = ProcessTools.executeTestJvm(c1Args)
+        OutputAnalyzer outputC1 = ProcessTools.executeTestJava(c1Args)
                 .shouldHaveExitValue(0);
 
         test.process(outputC1, true);
@@ -270,7 +270,7 @@ public abstract class TestConstantsInError implements OutputProcessor {
         c2Args.add("-XX:-TieredCompilation");
         c2Args.addAll(commonArgs);
 
-        OutputAnalyzer outputC2 = ProcessTools.executeTestJvm(c2Args)
+        OutputAnalyzer outputC2 = ProcessTools.executeTestJava(c2Args)
                 .shouldHaveExitValue(0);
 
         test.process(outputC2, false);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
@@ -37,42 +37,42 @@ import jdk.test.lib.process.ProcessTools;
 public class TestVectorErgonomics {
 
     public static void main(String[] args) throws Throwable {
-        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+        ProcessTools.executeTestJava("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
                                     "-XX:+EnableVectorReboxing", "-Xlog:compilation", "-version", "--enable-preview")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorReboxing=true");
 
-        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+        ProcessTools.executeTestJava("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
                                     "-XX:+EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version", "--enable-preview")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorAggressiveReboxing=true");
 
-        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+        ProcessTools.executeTestJava("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
                                     "-XX:-EnableVectorReboxing", "-Xlog:compilation", "-version", "--enable-preview")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorReboxing=false")
                     .shouldContain("EnableVectorAggressiveReboxing=false");
 
-        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+        ProcessTools.executeTestJava("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
                                     "-XX:-EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version", "--enable-preview")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorAggressiveReboxing=false");
 
-        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+        ProcessTools.executeTestJava("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
                                     "-XX:-EnableVectorSupport", "-Xlog:compilation", "-version", "--enable-preview")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorSupport=false")
                     .shouldContain("EnableVectorReboxing=false")
                     .shouldContain("EnableVectorAggressiveReboxing=false");
 
-        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+        ProcessTools.executeTestJava("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
                                     "-XX:-EnableVectorSupport", "-XX:+EnableVectorReboxing", "-Xlog:compilation", "-version", "--enable-preview")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorSupport=false")
                     .shouldContain("EnableVectorReboxing=false")
                     .shouldContain("EnableVectorAggressiveReboxing=false");
 
-        ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
+        ProcessTools.executeTestJava("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
                                     "-XX:-EnableVectorSupport", "-XX:+EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version", "--enable-preview")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorSupport=false")

--- a/test/hotspot/jtreg/gc/arguments/TestSoftMaxHeapSizeFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSoftMaxHeapSizeFlag.java
@@ -42,36 +42,36 @@ public class TestSoftMaxHeapSizeFlag {
 
     public static void main(String args[]) throws Exception {
         // Test default value
-        ProcessTools.executeTestJvm("-Xms" + Xms, "-Xmx" + Xmx,
-                                    "-XX:+PrintFlagsFinal", "-version")
+        ProcessTools.executeTestJava("-Xms" + Xms, "-Xmx" + Xmx,
+                                     "-XX:+PrintFlagsFinal", "-version")
                     .shouldMatch("SoftMaxHeapSize[ ]+=[ ]+" + Xmx)
                     .shouldHaveExitValue(0);
 
         // Test setting small value
-        ProcessTools.executeTestJvm("-Xms" + Xms, "-Xmx" + Xmx,
-                                    "-XX:SoftMaxHeapSize=" + Xms,
-                                    "-XX:+PrintFlagsFinal", "-version")
+        ProcessTools.executeTestJava("-Xms" + Xms, "-Xmx" + Xmx,
+                                     "-XX:SoftMaxHeapSize=" + Xms,
+                                     "-XX:+PrintFlagsFinal", "-version")
                     .shouldMatch("SoftMaxHeapSize[ ]+=[ ]+" + Xms)
                     .shouldHaveExitValue(0);
 
         // Test setting middle value
-        ProcessTools.executeTestJvm("-Xms" + Xms, "-Xmx" + Xmx,
-                                    "-XX:SoftMaxHeapSize=" + betweenXmsAndXmx,
-                                    "-XX:+PrintFlagsFinal", "-version")
+        ProcessTools.executeTestJava("-Xms" + Xms, "-Xmx" + Xmx,
+                                     "-XX:SoftMaxHeapSize=" + betweenXmsAndXmx,
+                                     "-XX:+PrintFlagsFinal", "-version")
                     .shouldMatch("SoftMaxHeapSize[ ]+=[ ]+" + betweenXmsAndXmx)
                     .shouldHaveExitValue(0);
 
         // Test setting largest value
-        ProcessTools.executeTestJvm("-Xms" + Xms, "-Xmx" + Xmx,
-                                    "-XX:SoftMaxHeapSize=" + Xmx,
-                                    "-XX:+PrintFlagsFinal", "-version")
+        ProcessTools.executeTestJava("-Xms" + Xms, "-Xmx" + Xmx,
+                                     "-XX:SoftMaxHeapSize=" + Xmx,
+                                     "-XX:+PrintFlagsFinal", "-version")
                     .shouldMatch("SoftMaxHeapSize[ ]+=[ ]+" + Xmx)
                     .shouldHaveExitValue(0);
 
         // Test setting a too large value
-        ProcessTools.executeTestJvm("-Xms" + Xms, "-Xmx" + Xmx,
-                                    "-XX:SoftMaxHeapSize=" + greaterThanXmx,
-                                    "-XX:+PrintFlagsFinal", "-version")
+        ProcessTools.executeTestJava("-Xms" + Xms, "-Xmx" + Xmx,
+                                     "-XX:SoftMaxHeapSize=" + greaterThanXmx,
+                                     "-XX:+PrintFlagsFinal", "-version")
                     .shouldContain("SoftMaxHeapSize must be less than or equal to the maximum heap size")
                     .shouldHaveExitValue(1);
     }

--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
@@ -129,7 +129,7 @@ public class TestIHOPErgo {
     }
 
     private static OutputAnalyzer executeTest(List<String> options) throws Throwable, RuntimeException {
-        OutputAnalyzer out = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer out = ProcessTools.executeTestJava(options);
         if (out.getExitValue() != 0) {
             System.out.println(out.getOutput());
             throw new RuntimeException("AppIHOP failed with exit code" + out.getExitValue());

--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
@@ -129,7 +129,7 @@ public class TestIHOPStatic {
         Collections.addAll(options, COMMON_OPTIONS);
         options.add(AppIHOP.class.getName());
 
-        OutputAnalyzer out = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer out = ProcessTools.executeTestJava(options);
 
         if (out.getExitValue() != 0) {
             System.out.println(out.getOutput());

--- a/test/hotspot/jtreg/gc/g1/logging/TestG1LoggingFailure.java
+++ b/test/hotspot/jtreg/gc/g1/logging/TestG1LoggingFailure.java
@@ -63,7 +63,7 @@ public class TestG1LoggingFailure {
     }
 
     private static void startVM(List<String> options) throws Throwable, RuntimeException {
-        OutputAnalyzer out = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer out = ProcessTools.executeTestJava(options);
 
         out.shouldNotContain("pure virtual method called");
 

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
@@ -108,7 +108,7 @@ public class TestPLABEvacuationFailure {
                 "-XX:" + (plabIsFixed ? "-" : "+") + "ResizePLAB",
                 "-XX:MaxHeapSize=" + heapSize + "m");
         testOptions.add(AppPLABEvacuationFailure.class.getName());
-        OutputAnalyzer out = ProcessTools.executeTestJvm(testOptions);
+        OutputAnalyzer out = ProcessTools.executeTestJava(testOptions);
 
         appPlabEvacFailureOutput = out.getOutput();
         if (out.getExitValue() != 0) {

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -116,7 +116,7 @@ public class TestPLABPromotion {
             testCase.print(System.out);
             List<String> options = PLABUtils.prepareOptions(testCase.toOptions());
             options.add(AppPLABPromotion.class.getName());
-            OutputAnalyzer out = ProcessTools.executeTestJvm(options);
+            OutputAnalyzer out = ProcessTools.executeTestJava(options);
             PLABUtils.commonCheck(out);
             output = out.getOutput();
             checkResults(testCase);

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABResize.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABResize.java
@@ -87,7 +87,7 @@ public class TestPLABResize {
             testCase.print(System.out);
             List<String> options = PLABUtils.prepareOptions(testCase.toOptions());
             options.add(AppPLABResize.class.getName());
-            OutputAnalyzer out = ProcessTools.executeTestJvm(options);
+            OutputAnalyzer out = ProcessTools.executeTestJava(options);
             PLABUtils.commonCheck(out);
             checkResults(out.getOutput(), testCase);
         }

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestExcessGCLockerCollections.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestExcessGCLockerCollections.java
@@ -173,7 +173,7 @@ public class TestExcessGCLockerCollections {
         finalArgs.addAll(Arrays.asList(args));
 
         // GC and other options obtained from test framework.
-        OutputAnalyzer output = ProcessTools.executeTestJvm(finalArgs);
+        OutputAnalyzer output = ProcessTools.executeTestJava(finalArgs);
         output.shouldHaveExitValue(0);
         //System.out.println("------------- begin stdout ----------------");
         //System.out.println(output.getStdout());

--- a/test/hotspot/jtreg/gc/x/TestHighUsage.java
+++ b/test/hotspot/jtreg/gc/x/TestHighUsage.java
@@ -85,15 +85,15 @@ public class TestHighUsage {
     }
 
     public static void main(String[] args) throws Exception {
-        ProcessTools.executeTestJvm("-XX:+UseZGC",
-                                    "-XX:-ZGenerational",
-                                    "-XX:-ZProactive",
-                                    "-Xms128M",
-                                    "-Xmx128M",
-                                    "-XX:ParallelGCThreads=1",
-                                    "-XX:ConcGCThreads=1",
-                                    "-Xlog:gc,gc+start",
-                                    Test.class.getName())
+        ProcessTools.executeTestJava("-XX:+UseZGC",
+                                     "-XX:-ZGenerational",
+                                     "-XX:-ZProactive",
+                                     "-Xms128M",
+                                     "-Xmx128M",
+                                     "-XX:ParallelGCThreads=1",
+                                     "-XX:ConcGCThreads=1",
+                                     "-Xlog:gc,gc+start",
+                                     Test.class.getName())
                     .shouldNotContain("Allocation Stall")
                     .shouldContain("High Usage")
                     .shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/z/TestHighUsage.java
+++ b/test/hotspot/jtreg/gc/z/TestHighUsage.java
@@ -86,15 +86,15 @@ public class TestHighUsage {
     }
 
     public static void main(String[] args) throws Exception {
-        ProcessTools.executeTestJvm("-XX:+UseZGC",
-                                    "-XX:+ZGenerational",
-                                    "-XX:-ZProactive",
-                                    "-Xms128M",
-                                    "-Xmx128M",
-                                    "-XX:ParallelGCThreads=1",
-                                    "-XX:ConcGCThreads=1",
-                                    "-Xlog:gc,gc+start",
-                                    Test.class.getName())
+        ProcessTools.executeTestJava("-XX:+UseZGC",
+                                     "-XX:+ZGenerational",
+                                     "-XX:-ZProactive",
+                                     "-Xms128M",
+                                     "-Xmx128M",
+                                     "-XX:ParallelGCThreads=1",
+                                     "-XX:ConcGCThreads=1",
+                                     "-Xlog:gc,gc+start",
+                                     Test.class.getName())
                     .shouldNotContain("Allocation Stall")
                     .shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/runtime/LoadLibrary/TestSunBootLibraryPath.java
+++ b/test/hotspot/jtreg/runtime/LoadLibrary/TestSunBootLibraryPath.java
@@ -46,11 +46,11 @@ public class TestSunBootLibraryPath {
             // Start a java process with this property set, and check that:
             // 1) The process failed and
             // 2) The error message was correct.
-            ProcessTools.executeTestJvm("-Dsun.boot.library.path=" + tooLongPath,
-                                        "TestSunBootLibraryPath",
-                                        "'Do-Nothing'")
-                                        .shouldNotHaveExitValue(0)
-                                        .stdoutShouldContain(expectedErrorMessage);
+            ProcessTools.executeTestJava("-Dsun.boot.library.path=" + tooLongPath,
+                                         "TestSunBootLibraryPath",
+                                         "'Do-Nothing'")
+                                         .shouldNotHaveExitValue(0)
+                                         .stdoutShouldContain(expectedErrorMessage);
         } else if (!args[0].equals("Do-Nothing")) {
             // Fail, to prevent accidental args from causing accidental test passing.
             throw new IllegalArgumentException("Test was launched with an invalid argument.");

--- a/test/hotspot/jtreg/runtime/Shutdown/ShutdownTest.java
+++ b/test/hotspot/jtreg/runtime/Shutdown/ShutdownTest.java
@@ -66,7 +66,7 @@ public class ShutdownTest {
 
     private static void startVM(String... options) throws Throwable {
         // Combine VM flags given from command-line and your additional options
-        OutputAnalyzer output = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer output = ProcessTools.executeTestJava(options);
         output.shouldContain("- ShutdownTest -");
         output.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/runtime/jni/FindClass/FindClassFromBoot.java
+++ b/test/hotspot/jtreg/runtime/jni/FindClass/FindClassFromBoot.java
@@ -42,7 +42,7 @@ public class FindClassFromBoot {
         Path patches = Paths.get(System.getProperty("test.classes"), "patches", "java.base");
         String syspaths = System.getProperty("sun.boot.library.path") +
                               File.pathSeparator + System.getProperty("java.library.path");
-        ProcessTools.executeTestJvm("-Dsun.boot.library.path=" + syspaths,
+        ProcessTools.executeTestJava("-Dsun.boot.library.path=" + syspaths,
                                     "--patch-module", "java.base=" + patches.toString(),
                                     "BootLoaderTest")
                     .shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/runtime/jni/FindClassUtf8/FindClassUtf8.java
+++ b/test/hotspot/jtreg/runtime/jni/FindClassUtf8/FindClassUtf8.java
@@ -43,10 +43,10 @@ public final class FindClassUtf8 {
     public static void main(String... args) throws Exception {
         if (args.length == 1) {
             // run java -Xcheck:jni FindClassUtf8 and check that the -Xcheck:jni message comes out.
-            ProcessTools.executeTestJvm("-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
-                                        "-Xcheck:jni",
-                                        "-XX:-CreateCoredumpOnCrash",
-                                        "FindClassUtf8")
+            ProcessTools.executeTestJava("-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                                         "-Xcheck:jni",
+                                         "-XX:-CreateCoredumpOnCrash",
+                                         "FindClassUtf8")
                       .shouldContain("JNI class name is not a valid UTF8 string")
                       .shouldNotHaveExitValue(0);  // you get a core dump from -Xcheck:jni failures
         } else {

--- a/test/hotspot/jtreg/runtime/jni/atExit/TestAtExit.java
+++ b/test/hotspot/jtreg/runtime/jni/atExit/TestAtExit.java
@@ -61,13 +61,13 @@ public class TestAtExit {
 
         String jlp = "-Djava.library.path=" + Utils.TEST_NATIVE_PATH;
         // First run will terminate via DestroyJavaVM
-        OutputAnalyzer output = ProcessTools.executeTestJvm(jlp, main);
+        OutputAnalyzer output = ProcessTools.executeTestJava(jlp, main);
         output.shouldNotContain("Unexpected");
         output.shouldHaveExitValue(0);
         output.reportDiagnosticSummary();
 
         // Second run will terminate via System.exit()
-        output = ProcessTools.executeTestJvm(jlp, main, "doExit");
+        output = ProcessTools.executeTestJava(jlp, main, "doExit");
         output.shouldNotContain("Unexpected");
         output.shouldHaveExitValue(0);
         output.reportDiagnosticSummary();

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedJniExceptionCheck.java
@@ -205,9 +205,9 @@ public class TestCheckedJniExceptionCheck {
         }
 
         // launch and check output
-        checkOuputForCorrectWarnings(ProcessTools.executeTestJvm("-Xcheck:jni",
-                                                                 "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
-                                                                 "TestCheckedJniExceptionCheck"));
+        checkOuputForCorrectWarnings(ProcessTools.executeTestJava("-Xcheck:jni",
+                                                                  "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                                                                  "TestCheckedJniExceptionCheck"));
     }
 
 }

--- a/test/hotspot/jtreg/runtime/jni/checked/TestCheckedReleaseArrayElements.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCheckedReleaseArrayElements.java
@@ -45,7 +45,7 @@ public class TestCheckedReleaseArrayElements {
         if (args == null || args.length == 0) {
             test();
         } else {
-            // Uses executeProcess() instead of executeTestJvm() to avoid passing options
+            // Uses executeProcess() instead of executeTestJava() to avoid passing options
             // that might generate output on stderr (which should be empty for this test).
             ProcessBuilder pb =
                 ProcessTools.createLimitedTestJavaProcessBuilder("-Xcheck:jni",

--- a/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
@@ -52,19 +52,19 @@ public class TestNativeStack {
     public static void main(String[] args) throws Throwable {
         // case 1: Trigger a JNI warning with Xcheck:jni
         OutputAnalyzer oa =
-            ProcessTools.executeTestJvm("-Xcheck:jni",
-                                        "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
-                                        "TestNativeStack$Main");
+            ProcessTools.executeTestJava("-Xcheck:jni",
+                                         "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                                         "TestNativeStack$Main");
         oa.shouldHaveExitValue(0);
         oa.shouldContain("WARNING in native method");
         oa.shouldContain("thread_start");
         oa.reportDiagnosticSummary();
 
         // Case 2: Trigger a JNI FatalError call
-        oa = ProcessTools.executeTestJvm("-XX:-CreateCoredumpOnCrash",
-                                         "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
-                                         "TestNativeStack$Main",
-                                         "error");
+        oa = ProcessTools.executeTestJava("-XX:-CreateCoredumpOnCrash",
+                                          "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
+                                          "TestNativeStack$Main",
+                                          "error");
         oa.shouldNotHaveExitValue(0);
         oa.shouldContain("FATAL ERROR in native method");
         oa.shouldContain("thread_start");

--- a/test/hotspot/jtreg/runtime/jni/registerNativesWarning/TestRegisterNativesWarning.java
+++ b/test/hotspot/jtreg/runtime/jni/registerNativesWarning/TestRegisterNativesWarning.java
@@ -65,17 +65,17 @@ public class TestRegisterNativesWarning {
 
         String cp = Utils.TEST_CLASS_PATH;
         String libp = Utils.TEST_NATIVE_PATH;
-        OutputAnalyzer output = ProcessTools.executeTestJvm("-Djava.library.path=" + libp,
-                                                            Tester.class.getName());
+        OutputAnalyzer output = ProcessTools.executeTestJava("-Djava.library.path=" + libp,
+                                                             Tester.class.getName());
         output.shouldContain(warning);
         output.shouldHaveExitValue(0);
         output.reportDiagnosticSummary();
 
         // If we run everything from the "boot" loader there should be no warning
-        output = ProcessTools.executeTestJvm("-Djava.library.path=" + libp,
-                                             "-Xbootclasspath/a:" + cp,
-                                             "-Dsun.boot.library.path=" + libp,
-                                             Tester.class.getName());
+        output = ProcessTools.executeTestJava("-Djava.library.path=" + libp,
+                                              "-Xbootclasspath/a:" + cp,
+                                              "-Dsun.boot.library.path=" + libp,
+                                              Tester.class.getName());
         output.shouldNotContain(warning);
         output.shouldHaveExitValue(0);
         output.reportDiagnosticSummary();

--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCleaningTest.java
@@ -58,7 +58,7 @@ public class StringTableCleaningTest {
         subargs.addAll(List.of("-Xlog:gc,gc+start,stringtable*=trace", "-Xmx1g"));
         subargs.add(Tester.class.getName());
         subargs.addAll(Arrays.asList(args));
-        OutputAnalyzer output = ProcessTools.executeTestJvm(subargs);
+        OutputAnalyzer output = ProcessTools.executeTestJava(subargs);
         output.shouldHaveExitValue(0);
         checkOutput(output);
     }

--- a/test/hotspot/jtreg/sanity/BasicVMTest.java
+++ b/test/hotspot/jtreg/sanity/BasicVMTest.java
@@ -42,7 +42,7 @@ public class BasicVMTest {
                 "-X",
                 "-help");
         for (String flag : flags) {
-            ProcessTools.executeTestJvm(flag)
+            ProcessTools.executeTestJava(flag)
                         .shouldHaveExitValue(0);
         }
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestLambdaFormRetransformation.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestLambdaFormRetransformation.java
@@ -60,7 +60,7 @@ public class TestLambdaFormRetransformation {
 
     public static void main(String args[]) throws Throwable {
         Path agent = TestLambdaFormRetransformation.buildAgent();
-        OutputAnalyzer oa = ProcessTools.executeTestJvm("-javaagent:" +
+        OutputAnalyzer oa = ProcessTools.executeTestJava("-javaagent:" +
                                 agent.toAbsolutePath().toString(), "-version");
         oa.shouldHaveExitValue(ExitCode.OK.value);
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineWithUnresolvedClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineWithUnresolvedClass.java
@@ -79,7 +79,7 @@ public class TestRedefineWithUnresolvedClass {
     }
 
     private static void launchTest() throws Throwable {
-        OutputAnalyzer output = ProcessTools.executeTestJvm(
+        OutputAnalyzer output = ProcessTools.executeTestJava(
             "-javaagent:" + testClasses + "UnresolvedClassAgent.jar",
             "-Dtest.classes=" + testClasses,
             "UnresolvedClassAgent");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Agent_OnUnload/agentonunload001/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Agent_OnUnload/agentonunload001/TestDriver.java
@@ -53,7 +53,7 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TestDriver {
     public static void main(String[] args) throws Exception {
-        OutputAnalyzer oa = ProcessTools.executeTestJvm(
+        OutputAnalyzer oa = ProcessTools.executeTestJava(
                 "-agentlib:agentonunload001=-waittime=5",
                 nsk.jvmti.Agent_OnUnload.agentonunload001.class.getName());
         oa.shouldHaveExitValue(95);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t.java
@@ -38,13 +38,13 @@ public class gf08t {
                              .skip(3)
                              .collect(Collectors.joining(" "));
 
-        OutputAnalyzer oa = ProcessTools.executeTestJvm(
+        OutputAnalyzer oa = ProcessTools.executeTestJava(
                 "-agentlib:" + libName + "=-waittime=5 setVerboseMode=yes",
                 className);
         oa.shouldHaveExitValue(95);
         oa.stdoutShouldContain(phrase);
 
-        oa = ProcessTools.executeTestJvm(
+        oa = ProcessTools.executeTestJava(
                 "-agentlib:" + libName + "=-waittime=5 setVerboseMode=no",
                 "-verbose:" + verboseType,
                 className);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA02/ma02t001/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA02/ma02t001/TestDriver.java
@@ -47,7 +47,7 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TestDriver {
     public static void main(String[] args) throws Exception {
-        OutputAnalyzer oa = ProcessTools.executeTestJvm(
+        OutputAnalyzer oa = ProcessTools.executeTestJava(
                 "-agentlib:ma02t001=-waittime=5",
                 "-agentlib:ma02t001a=-waittime=5",
                 nsk.jvmti.scenarios.multienv.MA02.ma02t001.class.getName());

--- a/test/jdk/com/sun/jdi/BadAgentPath.java
+++ b/test/jdk/com/sun/jdi/BadAgentPath.java
@@ -38,7 +38,7 @@ import jdk.test.lib.process.ProcessTools;
 public class BadAgentPath {
 
     public static void main(String[] args) throws Throwable {
-        OutputAnalyzer output = ProcessTools.executeTestJvm("-agentpath:/badAgent/agent", "-version");
+        OutputAnalyzer output = ProcessTools.executeTestJava("-agentpath:/badAgent/agent", "-version");
         output.shouldContain("Could not find agent library /badAgent/agent");
     }
 }

--- a/test/jdk/com/sun/jdi/DoubleAgentTest.java
+++ b/test/jdk/com/sun/jdi/DoubleAgentTest.java
@@ -44,7 +44,7 @@ public class DoubleAgentTest {
         String jdwpOption = "-agentlib:jdwp=transport=dt_socket"
                          + ",server=y" + ",suspend=n" + ",address=*:0";
 
-        OutputAnalyzer output = ProcessTools.executeTestJvm("-classpath",
+        OutputAnalyzer output = ProcessTools.executeTestJava("-classpath",
                 TEST_CLASSES,
                 jdwpOption, // Notice jdwpOption specified twice
                 jdwpOption,

--- a/test/jdk/com/sun/jdi/OnJcmdTest.java
+++ b/test/jdk/com/sun/jdi/OnJcmdTest.java
@@ -51,12 +51,12 @@ public class OnJcmdTest {
 
     public static void main(String[] args) throws Throwable {
         // First check if we get the expected errors.
-        OutputAnalyzer output = ProcessTools.executeTestJvm(
+        OutputAnalyzer output = ProcessTools.executeTestJava(
                 "-agentlib:jdwp=transport=dt_socket,address=any,onjcmd=y");
         output.shouldContain("Can only use onjcmd with server=y");
         output.shouldHaveExitValue(1);
 
-        output = ProcessTools.executeTestJvm(
+        output = ProcessTools.executeTestJava(
                 "-agentlib:jdwp=transport=dt_socket,address=any,onjcmd=y,onthrow=a,launch=a");
         output.shouldContain("Cannot combine onjcmd and launch suboptions");
         output.shouldHaveExitValue(1);

--- a/test/jdk/com/sun/jdi/SuspendNoFlagTest.java
+++ b/test/jdk/com/sun/jdi/SuspendNoFlagTest.java
@@ -38,7 +38,7 @@ public class SuspendNoFlagTest {
             "test.classes", ".");
 
     public static void main(String[] args) throws Throwable {
-        OutputAnalyzer output = ProcessTools.executeTestJvm("-classpath",
+        OutputAnalyzer output = ProcessTools.executeTestJava("-classpath",
                 TEST_CLASSES,
                 "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n",
                 "HelloWorld");

--- a/test/jdk/com/sun/tools/attach/BasicTests.java
+++ b/test/jdk/com/sun/tools/attach/BasicTests.java
@@ -101,7 +101,7 @@ public class BasicTests {
             testClassDir + "Agent.jar",
             testClassDir + "BadAgent.jar",
             testClassDir + "RedefineAgent.jar" };
-        OutputAnalyzer output = ProcessTools.executeTestJvm(args);
+        OutputAnalyzer output = ProcessTools.executeTestJava(args);
         output.shouldHaveExitValue(0);
     }
 

--- a/test/jdk/com/sun/tools/attach/PermissionTest.java
+++ b/test/jdk/com/sun/tools/attach/PermissionTest.java
@@ -86,7 +86,7 @@ public class PermissionTest {
             "PermissionTest$TestMain",
             Long.toString(pid),
             "true" };
-        OutputAnalyzer output = ProcessTools.executeTestJvm(args);
+        OutputAnalyzer output = ProcessTools.executeTestJava(args);
         output.shouldHaveExitValue(0);
 
         // Use a policy that will allow attach.
@@ -98,7 +98,7 @@ public class PermissionTest {
             "PermissionTest$TestMain",
             Long.toString(pid),
             "false" };
-        output = ProcessTools.executeTestJvm(args);
+        output = ProcessTools.executeTestJava(args);
         output.shouldHaveExitValue(0);
     }
 

--- a/test/jdk/com/sun/tools/attach/ProviderTest.java
+++ b/test/jdk/com/sun/tools/attach/ProviderTest.java
@@ -79,7 +79,7 @@ public class ProviderTest {
                 "-classpath",
                 classpath,
                 "ProviderTest$TestMain" };
-        OutputAnalyzer output = ProcessTools.executeTestJvm(args);
+        OutputAnalyzer output = ProcessTools.executeTestJava(args);
         output.shouldHaveExitValue(0);
     }
 

--- a/test/jdk/com/sun/tools/attach/TempDirTest.java
+++ b/test/jdk/com/sun/tools/attach/TempDirTest.java
@@ -140,7 +140,7 @@ public class TempDirTest {
                     classpath,
                     "TempDirTest$TestMain",
                     Long.toString(pid) });
-        OutputAnalyzer output = ProcessTools.executeTestJvm(args);
+        OutputAnalyzer output = ProcessTools.executeTestJava(args);
         output.shouldHaveExitValue(0);
     }
 

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -124,21 +124,21 @@ public class TempDirDoesNotExist {
     @ParameterizedTest
     @MethodSource("tempDirSource")
     public void existingMessage(List<String> options) throws Exception {
-       ProcessTools.executeTestJvm(options).shouldContain(WARNING)
+       ProcessTools.executeTestJava(options).shouldContain(WARNING)
            .shouldHaveExitValue(0);
     }
 
     @ParameterizedTest
     @MethodSource("noTempDirSource")
     public void nonexistentMessage(List<String> options) throws Exception {
-        ProcessTools.executeTestJvm(options).shouldNotContain(WARNING)
+        ProcessTools.executeTestJava(options).shouldNotContain(WARNING)
             .shouldHaveExitValue(0);
     }
 
     @ParameterizedTest
     @MethodSource("counterSource")
     public void messageCounter(List<String> options) throws Exception {
-        OutputAnalyzer originalOutput = ProcessTools.executeTestJvm(options);
+        OutputAnalyzer originalOutput = ProcessTools.executeTestJava(options);
         long count = originalOutput.asLines().stream().filter(
                 line -> line.equalsIgnoreCase(WARNING)).count();
         assertEquals(1, count,

--- a/test/jdk/java/io/FilePermission/MergeName.java
+++ b/test/jdk/java/io/FilePermission/MergeName.java
@@ -81,7 +81,7 @@ public class MergeName {
         }
         content.add("};");
         Files.write(Paths.get(file), content);
-        ProcessTools.executeTestJvm("-Djava.security.manager",
+        ProcessTools.executeTestJava("-Djava.security.manager",
                 "-Djava.security.policy=" + file,
                 "MergeName",
                 "x",

--- a/test/jdk/java/io/FilePermission/ReadFileOnPath.java
+++ b/test/jdk/java/io/FilePermission/ReadFileOnPath.java
@@ -87,7 +87,7 @@ public class ReadFileOnPath {
         cmds.addAll(List.of(
                 "x", "modules/m", "modules/m/base", "modules/m/p/child",
                 "-", "child", "/base", "../base"));
-        ProcessTools.executeTestJvm(cmds.toArray(new String[cmds.size()]))
+        ProcessTools.executeTestJava(cmds.toArray(new String[cmds.size()]))
                 .shouldHaveExitValue(0);
     }
 }

--- a/test/jdk/java/lang/ClassLoader/securityManager/ClassLoaderTest.java
+++ b/test/jdk/java/lang/ClassLoader/securityManager/ClassLoaderTest.java
@@ -241,7 +241,7 @@ public class ClassLoaderTest {
                     if (s.contains(" ")) { throw new RuntimeException("No spaces in args");}
                     return !s.isEmpty();
                 }).toArray(String[]::new);
-        String out = ProcessTools.executeTestJvm(safeArgs).getOutput();
+        String out = ProcessTools.executeTestJava(safeArgs).getOutput();
         // Handle response.
         if ("PASS".equals(status) && out.contains(msg)) {
             System.out.println("PASS: Expected Result: " + msg);

--- a/test/jdk/java/lang/RuntimeTests/shutdown/ShutdownHooks.java
+++ b/test/jdk/java/lang/RuntimeTests/shutdown/ShutdownHooks.java
@@ -61,7 +61,7 @@ public class ShutdownHooks {
         // Run in a new process in order to evaluate shutdown hook results
         String[] testCommand = new String[] {"-classpath", TEST_CLASSES,
                 ShutdownHooksProcess.class.getName()};
-        ProcessTools.executeTestJvm(testCommand).shouldHaveExitValue(0);
+        ProcessTools.executeTestJava(testCommand).shouldHaveExitValue(0);
 
         String errorMsg = "File exists despite shutdown hook has been run";
         assertFalse(Files.exists(TEST_FILE.toPath()), errorMsg);

--- a/test/jdk/java/security/Policy/ExtensiblePolicy/ExtensiblePolicyWithJarTest.java
+++ b/test/jdk/java/security/Policy/ExtensiblePolicy/ExtensiblePolicyWithJarTest.java
@@ -94,7 +94,7 @@ public class ExtensiblePolicyWithJarTest {
             "-Djava.security.manager",
             "-Djava.security.policy=" + POL,
             "ExtensiblePolicyTest_orig$TestMain"};
-            ProcessTools.executeTestJvm(cmd).shouldHaveExitValue(0);
+            ProcessTools.executeTestJava(cmd).shouldHaveExitValue(0);
         } catch (Exception ex) {
             System.out.println("ExtensiblePolicyWithJarTest Failed");
         }

--- a/test/jdk/java/security/Policy/SignedJar/SignedJarTest.java
+++ b/test/jdk/java/security/Policy/SignedJar/SignedJarTest.java
@@ -121,7 +121,7 @@ public class SignedJarTest {
         System.out.println("Test Case 1");
         //copy policy file into current directory
         String[] cmd = constructCMD("first.jar", POLICY1, "false", "true");
-        ProcessTools.executeTestJvm(cmd).shouldHaveExitValue(0);
+        ProcessTools.executeTestJava(cmd).shouldHaveExitValue(0);
 
         //test case 2, test with both.jar
         //setIO permission granted to code that was signed by first signer
@@ -131,7 +131,7 @@ public class SignedJarTest {
         //Expect no AccessControlException
         System.out.println("Test Case 2");
         cmd = constructCMD("both.jar", POLICY1, "false", "false");
-        ProcessTools.executeTestJvm(cmd).shouldHaveExitValue(0);
+        ProcessTools.executeTestJava(cmd).shouldHaveExitValue(0);
 
         //test case 3
         //setIO permission granted to code that was signed by first signer
@@ -141,7 +141,7 @@ public class SignedJarTest {
         //Expect AccessControlException for setFactory permission
         System.out.println("Test Case 3");
         cmd = constructCMD("both.jar", POLICY2, "false", "true");
-        ProcessTools.executeTestJvm(cmd).shouldHaveExitValue(0);
+        ProcessTools.executeTestJava(cmd).shouldHaveExitValue(0);
 
     }
 

--- a/test/jdk/java/security/Provider/SecurityProviderModularTest.java
+++ b/test/jdk/java/security/Provider/SecurityProviderModularTest.java
@@ -257,7 +257,7 @@ public class SecurityProviderModularTest {
             }
             return !s.isEmpty();
         }).toArray(String[]::new);
-        String out = ProcessTools.executeTestJvm(safeArgs).getOutput();
+        String out = ProcessTools.executeTestJava(safeArgs).getOutput();
         // Handle response.
         if ((msgKey != null && out.contains(MSG_MAP.get(msgKey)))) {
             System.out.printf("PASS: Expected Result: %s.%n",

--- a/test/jdk/java/security/Security/signedfirst/DynStatic.java
+++ b/test/jdk/java/security/Security/signedfirst/DynStatic.java
@@ -78,7 +78,7 @@ public class DynStatic {
         CompilerUtils.compile(DYN_SRC, TEST_CLASSES, "-classpath", "exp.jar");
 
         // Run the DynSignedProvFirst test program
-        ProcessTools.executeTestJvm("-classpath",
+        ProcessTools.executeTestJava("-classpath",
             TEST_CLASSES.toString() + File.pathSeparator + "exp.jar",
             "DynSignedProvFirst")
             .shouldContain("test passed");
@@ -87,7 +87,7 @@ public class DynStatic {
         CompilerUtils.compile(STATIC_SRC, TEST_CLASSES, "-classpath", "exp.jar");
 
         // Run the StaticSignedProvFirst test program
-        ProcessTools.executeTestJvm("-classpath",
+        ProcessTools.executeTestJava("-classpath",
             TEST_CLASSES.toString() + File.pathSeparator + "exp.jar",
             "-Djava.security.properties=file:" + STATIC_PROPS,
             "StaticSignedProvFirst")

--- a/test/jdk/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
+++ b/test/jdk/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
@@ -100,7 +100,7 @@ public class TestSPISigned {
             testRun.add(classPath);
             testRun.add(TestSPISigned.class.getSimpleName());
             testRun.add("run-test");
-            OutputAnalyzer out = ProcessTools.executeTestJvm(testRun);
+            OutputAnalyzer out = ProcessTools.executeTestJava(testRun);
             out.shouldHaveExitValue(0);
             out.shouldContain("DEBUG: Getting xx language");
         }

--- a/test/jdk/java/util/Currency/PropertiesTestRun.java
+++ b/test/jdk/java/util/Currency/PropertiesTestRun.java
@@ -116,7 +116,7 @@ public class PropertiesTestRun {
 
     // Launch a PropertiesTest method using the TEST JDK
     private static void executeTestJDKMethod(String... params) throws Throwable {
-        int exitStatus = ProcessTools.executeTestJvm(params).getExitValue();
+        int exitStatus = ProcessTools.executeTestJava(params).getExitValue();
         if (exitStatus != 0) {
             fail("Process started with: " + Arrays.toString(params) + " failed");
         }
@@ -126,7 +126,7 @@ public class PropertiesTestRun {
     private static void executeWritableJDKMethod(String... params) throws Throwable {
         // Need to include WritableJDK javapath, TEST JDK classpath
         String[] allParams = new String[3+params.length+Utils.getTestJavaOpts().length];
-        // We don't use executeTestJvm() because we want to point to separate JDK java path
+        // We don't use executeTestJava() because we want to point to separate JDK java path
         allParams[0] = WRITABLE_JDK_JAVA_PATH;
         allParams[1] = "-cp";
         allParams[2] = System.getProperty("java.class.path");

--- a/test/jdk/java/util/Locale/UseOldISOCodesTest.java
+++ b/test/jdk/java/util/Locale/UseOldISOCodesTest.java
@@ -41,7 +41,7 @@ public class UseOldISOCodesTest {
     // Ensure java.locale.useOldISOCodes is only interpreted at runtime startup
     @Test
     public void staticInitializationTest() throws Exception {
-        ProcessTools.executeTestJvm("-Djava.locale.useOldISOCodes=true", "UseOldISOCodesTest$Runner")
+        ProcessTools.executeTestJava("-Djava.locale.useOldISOCodes=true", "UseOldISOCodesTest$Runner")
                 .outputTo(System.out)
                 .errorTo(System.err)
                 .shouldHaveExitValue(0);

--- a/test/jdk/java/util/prefs/CheckUserPrefsStorage.java
+++ b/test/jdk/java/util/prefs/CheckUserPrefsStorage.java
@@ -42,7 +42,7 @@ public class CheckUserPrefsStorage {
     }
 
     public static void run(String testName) throws Exception {
-        ProcessTools.executeTestJvm("-Djava.util.prefs.userRoot=.", testName)
+        ProcessTools.executeTestJava("-Djava.util.prefs.userRoot=.", testName)
                     .outputTo(System.out)
                     .errorTo(System.out)
                     .shouldHaveExitValue(0);

--- a/test/jdk/java/util/zip/EntryCount64k.java
+++ b/test/jdk/java/util/zip/EntryCount64k.java
@@ -160,7 +160,7 @@ public class EntryCount64k {
         }
 
         // Check java -jar
-        OutputAnalyzer a = ProcessTools.executeTestJvm("-jar", zipFile.getName());
+        OutputAnalyzer a = ProcessTools.executeTestJava("-jar", zipFile.getName());
         a.shouldHaveExitValue(0);
         a.stdoutShouldMatch("\\AMain\\Z");
         a.stderrShouldMatch("\\A\\Z");

--- a/test/jdk/java/util/zip/ZipFile/DeleteTempJarTest.java
+++ b/test/jdk/java/util/zip/ZipFile/DeleteTempJarTest.java
@@ -42,7 +42,7 @@ import jdk.test.lib.Asserts;
 public class DeleteTempJarTest {
 
     public static void main(String[] args) throws Exception {
-        String tmpFile = ProcessTools.executeTestJvm(DeleteTempJar.class.getName())
+        String tmpFile = ProcessTools.executeTestJava(DeleteTempJar.class.getName())
                                      .shouldHaveExitValue(0)
                                      .getStdout();
 

--- a/test/jdk/javax/security/auth/login/modules/JaasModularClientTest.java
+++ b/test/jdk/javax/security/auth/login/modules/JaasModularClientTest.java
@@ -186,7 +186,7 @@ public class JaasModularClientTest {
             }
             return !s.isEmpty();
         }).toArray(String[]::new);
-        OutputAnalyzer out = ProcessTools.executeTestJvm(safeArgs);
+        OutputAnalyzer out = ProcessTools.executeTestJava(safeArgs);
         // Handle response.
         if (out.getExitValue() != 0) {
             System.out.printf("OUTPUT: %s", out.getOutput());

--- a/test/jdk/javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java
+++ b/test/jdk/javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java
@@ -170,7 +170,7 @@ public class JaasModularDefaultHandlerTest {
             }
             return !s.isEmpty();
         }).toArray(String[]::new);
-        OutputAnalyzer out = ProcessTools.executeTestJvm(safeArgs);
+        OutputAnalyzer out = ProcessTools.executeTestJava(safeArgs);
         // Handle response.
         if (out.getExitValue() != 0) {
             System.out.printf("OUTPUT: %s", out.getOutput());

--- a/test/jdk/jdk/internal/ref/Cleaner/ExitOnThrow.java
+++ b/test/jdk/jdk/internal/ref/Cleaner/ExitOnThrow.java
@@ -44,9 +44,9 @@ public class ExitOnThrow {
 
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
-            ProcessTools.executeTestJvm("--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED",
-                                        "ExitOnThrow",
-                                        "-executeCleaner")
+            ProcessTools.executeTestJava("--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED",
+                                         "ExitOnThrow",
+                                         "-executeCleaner")
                         .outputTo(System.out)
                         .errorTo(System.out)
                         .shouldHaveExitValue(1)

--- a/test/jdk/jdk/jfr/api/consumer/security/TestStreamingRemote.java
+++ b/test/jdk/jdk/jfr/api/consumer/security/TestStreamingRemote.java
@@ -81,7 +81,7 @@ public class TestStreamingRemote {
             c[1] = "-Djava.security.policy=" + escapeBackslashes(policy.toString());
             c[2] = Test.class.getName();
             c[3] = repository;
-            OutputAnalyzer oa = ProcessTools.executeTestJvm(c);
+            OutputAnalyzer oa = ProcessTools.executeTestJava(c);
             oa.shouldContain(SUCCESS);
         }
     }

--- a/test/jdk/jdk/jfr/event/io/TestInstrumentation.java
+++ b/test/jdk/jdk/jfr/event/io/TestInstrumentation.java
@@ -283,7 +283,7 @@ public class TestInstrumentation implements ClassFileTransformer {
             "-classpath", classpath,
             "-javaagent:" + testClassDir + "TestInstrumentation.jar",
             "jdk.jfr.event.io.TestInstrumentation$TestMain" };
-        OutputAnalyzer output = ProcessTools.executeTestJvm(args);
+        OutputAnalyzer output = ProcessTools.executeTestJava(args);
         output.shouldHaveExitValue(0);
     }
 

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdPreserveRepository.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdPreserveRepository.java
@@ -57,7 +57,7 @@ public class TestJcmdPreserveRepository {
             "-Dtest.jdk=" + System.getProperty("test.jdk"),
             TestProcess.class.getName()
         };
-        OutputAnalyzer output = ProcessTools.executeTestJvm(arguments);
+        OutputAnalyzer output = ProcessTools.executeTestJava(arguments);
         output.shouldHaveExitValue(0);
         Optional<Path> p = Files.find(path, 99, (a,b) -> a.getFileName().toString().endsWith(".jfr")).findAny();
         if (p.isEmpty()) {

--- a/test/jdk/sun/security/ssl/CertPathRestrictions/TLSRestrictions.java
+++ b/test/jdk/sun/security/ssl/CertPathRestrictions/TLSRestrictions.java
@@ -231,7 +231,7 @@ public class TLSRestrictions {
 
             // Run client on another JVM so that its properties cannot be in conflict
             // with server's.
-            OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
                     "-Dcert.dir=" + CERT_DIR,
                     "-Djava.security.debug=certpath",
                     "-classpath",

--- a/test/jdk/sun/security/ssl/EngineArgs/DebugReportsOneExtraByte.java
+++ b/test/jdk/sun/security/ssl/EngineArgs/DebugReportsOneExtraByte.java
@@ -93,7 +93,7 @@ public class DebugReportsOneExtraByte extends SSLEngineTemplate {
     public static void main(String args[]) throws Exception {
 
         if (args.length == 0) {
-            OutputAnalyzer output = ProcessTools.executeTestJvm(
+            OutputAnalyzer output = ProcessTools.executeTestJava(
                 "-Dtest.src=" + System.getProperty("test.src"),
                 "-Djavax.net.debug=all", "DebugReportsOneExtraByte", "p");
             output.shouldContain("WRITE: TLSv1 application_data, length = 8");

--- a/test/jdk/sun/security/ssl/SSLLogger/LoggingFormatConsistency.java
+++ b/test/jdk/sun/security/ssl/SSLLogger/LoggingFormatConsistency.java
@@ -50,7 +50,7 @@ public class LoggingFormatConsistency extends SSLSocketTemplate {
     public static void main(String[] args) throws Exception {
         if (args.length != 0) {
             // A non-empty set of arguments occurs when the "runTest" argument
-            // is passed to the test via ProcessTools::executeTestJvm.
+            // is passed to the test via ProcessTools::executeTestJava.
             //
             // This is done because an OutputAnalyzer is unable to read
             // the output of the current running JVM, and must therefore create
@@ -71,7 +71,7 @@ public class LoggingFormatConsistency extends SSLSocketTemplate {
 
                 System.out.println("TESTING " + expectedTLSVersion);
                 var activeTLSProtocol = "-Djdk.tls.client.protocols=" + expectedTLSVersion;
-                var output = ProcessTools.executeTestJvm(
+                var output = ProcessTools.executeTestJava(
                         testSrc,
                         activeTLSProtocol,
                         javaxNetDebug,

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/IgnorableExceptionMessages.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/IgnorableExceptionMessages.java
@@ -49,7 +49,7 @@ public class IgnorableExceptionMessages extends SSLSocketTemplate {
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
             // A non-empty set of arguments occurs when the "runTest" argument
-            // is passed to the test via ProcessTools::executeTestJvm.
+            // is passed to the test via ProcessTools::executeTestJava.
             //
             // This is done because an OutputAnalyzer is unable to read
             // the output of the current running JVM, and must therefore create
@@ -67,7 +67,7 @@ public class IgnorableExceptionMessages extends SSLSocketTemplate {
                     className,
                     extraArgument);
 
-            OutputAnalyzer output = ProcessTools.executeTestJvm(jvmArgs);
+            OutputAnalyzer output = ProcessTools.executeTestJava(jvmArgs);
 
             if (output.getExitValue() != 0) {
                 output.asLines().forEach(System.out::println); // No need to dump the output unless the test fails

--- a/test/jdk/sun/security/tools/jarsigner/multiRelease/MVJarSigningTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/multiRelease/MVJarSigningTest.java
@@ -120,7 +120,7 @@ public class MVJarSigningTest {
                 "-Djava.security.policy=" +
                 TEST_SRC + File.separator + POLICY_FILE,
                 "version.Main"};
-        ProcessTools.executeTestJvm(cmd)
+        ProcessTools.executeTestJava(cmd)
             .shouldHaveExitValue(0)
             .shouldContain(VERSION_MESSAGE);
     }

--- a/test/jdk/sun/security/util/Resources/early/EarlyResources.java
+++ b/test/jdk/sun/security/util/Resources/early/EarlyResources.java
@@ -42,7 +42,7 @@ public class EarlyResources {
         String fs = File.separator;
         String policyPath = testSrc + fs + "malformed.policy";
 
-        OutputAnalyzer out = ProcessTools.executeTestJvm(
+        OutputAnalyzer out = ProcessTools.executeTestJava(
             "-Djava.security.manager",
             "-Djava.security.policy=" + policyPath,
             "EarlyResources$TestMain");

--- a/test/lib-test/jdk/test/lib/RandomGeneratorTest.java
+++ b/test/lib-test/jdk/test/lib/RandomGeneratorTest.java
@@ -69,7 +69,7 @@ public class RandomGeneratorTest {
         jvmArgs.add(origFileName);
         int fileNameIndex = jvmArgs.size() - 1;
         String[] cmdLineArgs = jvmArgs.toArray(new String[jvmArgs.size()]);
-        ProcessTools.executeTestJvm(cmdLineArgs).shouldHaveExitValue(0);
+        ProcessTools.executeTestJava(cmdLineArgs).shouldHaveExitValue(0);
         String etalon = Utils.fileAsString(origFileName).trim();
         cmdLineArgs[fileNameIndex] = seedOpt.name();
         seedOpt.verify(etalon, cmdLineArgs);
@@ -143,7 +143,7 @@ public class RandomGeneratorTest {
             String output;
             OutputAnalyzer oa;
             try {
-                oa = ProcessTools.executeTestJvm(cmdLine);
+                oa = ProcessTools.executeTestJava(cmdLine);
             } catch (Throwable t) {
                 throw new Error("TESTBUG: Unexpedted exception during jvm execution.", t);
             }

--- a/test/lib-test/jdk/test/lib/process/ProcessToolsExecuteLimitedTestJavaTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcessToolsExecuteLimitedTestJavaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,36 +21,25 @@
  * questions.
  */
 
-/* @test
- * @bug 8187023
- * @summary Pkcs11 config file should be assumed in ISO-8859-1
+/*
+ * @test
+ * @summary Unit test for ProcessTools.executeLimitedTestJava()
  * @library /test/lib
- * @run testng/othervm ReadConfInUTF16Env
+ * @run main/othervm -Dtest.java.opts=-XX:MaxMetaspaceSize=123456789 ProcessToolsExecuteLimitedTestJavaTest
  */
 
+import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import org.testng.annotations.Test;
 
-import java.security.Provider;
-import java.security.Security;
-
-public class ReadConfInUTF16Env {
-
-    @Test
-    public void testReadConfInUTF16Env() throws Exception {
-        String[] testCommand = new String[] { "-Dfile.encoding=UTF-16",
-                TestSunPKCS11Provider.class.getName()};
-        ProcessTools.executeTestJava(testCommand).shouldHaveExitValue(0);
-    }
-
-    static class TestSunPKCS11Provider {
-        public static void main(String[] args) throws Exception {
-            Provider p = Security.getProvider("SunPKCS11");
-            if (p == null) {
-                System.out.println("Skipping test - no PKCS11 provider available");
-                return;
-            }
-            System.out.println(p.getName());
+public class ProcessToolsExecuteLimitedTestJavaTest {
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0) {
+            // Do nothing. Just let the JVM log its output.
+        } else {
+            // In comparison to executeTestJava, executeLimitedTestJava should not add the
+            // -Dtest.java.opts flags. Check that it doesn't.
+            OutputAnalyzer output = ProcessTools.executeLimitedTestJava("-XX:+PrintFlagsFinal", "-version");
+            output.stdoutShouldNotMatch(".*MaxMetaspaceSize.* = 123456789.*");
         }
     }
 }

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -608,43 +608,69 @@ public final class ProcessTools {
     }
 
     /**
-     * Executes a test jvm process, waits for it to finish and returns
+     * Executes a process using the java launcher from the jdk to
+     * be tested, waits for it to finish and returns
      * the process output.
      *
      * <p>The process is created using runtime flags set up by:
      * {@link #createTestJavaProcessBuilder(String...)}. The
      * jvm process will have exited before this method returns.
      *
-     * @param cmds User specified arguments.
+     * @param command User specified arguments.
      * @return The output from the process.
      */
-    public static OutputAnalyzer executeTestJvm(List<String> cmds) throws Exception {
-        return executeTestJvm(cmds.toArray(String[]::new));
+    public static OutputAnalyzer executeTestJava(List<String> command) throws Exception {
+        return executeTestJava(command.toArray(String[]::new));
     }
 
     /**
-     * Executes a test jvm process, waits for it to finish and returns
+     * Executes a process using the java launcher from the jdk to
+     * be tested, waits for it to finish and returns
      * the process output.
      *
      * <p>The process is created using runtime flags set up by:
      * {@link #createTestJavaProcessBuilder(String...)}. The
      * jvm process will have exited before this method returns.
      *
-     * @param cmds User specified arguments.
+     * @param command User specified arguments.
      * @return The output from the process.
      */
-    public static OutputAnalyzer executeTestJvm(String... cmds) throws Exception {
-        ProcessBuilder pb = createTestJavaProcessBuilder(cmds);
+    public static OutputAnalyzer executeTestJava(String... command) throws Exception {
+        ProcessBuilder pb = createTestJavaProcessBuilder(command);
         return executeProcess(pb);
     }
 
     /**
-     * @param cmds User specified arguments.
+     * Executes a process using the java launcher from the jdk to
+     * be tested, waits for it to finish and returns
+     * the process output.
+     *
+     * <p>The process is created using runtime flags set up by:
+     * {@link #createLimitedTestJavaProcessBuilder(String...)}. The
+     * jvm process will have exited before this method returns.
+     *
+     * @param command User specified arguments.
      * @return The output from the process.
-     * @see #executeTestJvm(String...)
      */
-    public static OutputAnalyzer executeTestJava(String... cmds) throws Exception {
-        return executeTestJvm(cmds);
+    public static OutputAnalyzer executeLimitedTestJava(List<String> command) throws Exception {
+        return executeLimitedTestJava(command.toArray(String[]::new));
+    }
+
+    /**
+     * Executes a process using the java launcher from the jdk to
+     * be tested, waits for it to finish and returns
+     * the process output.
+     *
+     * <p>The process is created using runtime flags set up by:
+     * {@link #createLimitedTestJavaProcessBuilder(String...)}. The
+     * jvm process will have exited before this method returns.
+     *
+     * @param command User specified arguments.
+     * @return The output from the process.
+     */
+    public static OutputAnalyzer executeLimitedTestJava(String... command) throws Exception {
+        ProcessBuilder pb = createLimitedTestJavaProcessBuilder(command);
+        return executeProcess(pb);
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with Oracle.

File not in 21:
test/hotspot/jtreg/compiler/compilercontrol/commands/MemLimitTest.java
was added by "8319301: Static analysis warnings after JDK-8318016" in 22.
test/hotspot/jtreg/compiler/compilercontrol/commands/MemStatTest.java
Was added by "8318671: Potential uninitialized uintx value after JDK-8317683".
"8317683 Add JIT memory statistics" was added in 22.

test/hotspot/jtreg/compiler/compilercontrol/commands/OptionTest.java
Resolved because "8282797: CompileCommand parsing errors should exit VM" is only in 22.
It has a CSR and modifies behaviour, so not a good candidate to backport as prereq.

File not in 21:
test/hotspot/jtreg/compiler/print/CompileCommandMemLimit.java
Added by "8318016: Per-compilation memory ceiling" in 22.
test/hotspot/jtreg/compiler/print/CompileCommandPrintMemStat.java
Added by "8317683 Add JIT memory statistics" in 22.

test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
Resolved because some Vector API changes are not in 21.


File not in 21:
test/hotspot/jtreg/runtime/ErrorHandling/UncaughtNativeExceptionTest.java
Added in 22 by "8310228: Improve error reporting for uncaught native exceptions on Windows"

I had to edit two additional files. 
I could not execute hotspot/jtreg/gc/z/TestHighUsage.java, but the edit is trivial enough to 
skip this.
compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java fails in an unrelated way but it is on the
ProblemList anyways.
Other tests or tests using the edited class pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8321713](https://bugs.openjdk.org/browse/JDK-8321713) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321713](https://bugs.openjdk.org/browse/JDK-8321713): Harmonize executeTestJvm with create[Limited]TestJavaProcessBuilder (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/520/head:pull/520` \
`$ git checkout pull/520`

Update a local copy of the PR: \
`$ git checkout pull/520` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 520`

View PR using the GUI difftool: \
`$ git pr show -t 520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/520.diff">https://git.openjdk.org/jdk21u-dev/pull/520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/520#issuecomment-2069716256)