### PR TITLE
8324933: ConcurrentHashTable::statistics_calculate synchronization is expensive

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1222,23 +1222,30 @@ template <typename VALUE_SIZE_FUNC>
 inline TableStatistics ConcurrentHashTable<CONFIG, F>::
   statistics_calculate(Thread* thread, VALUE_SIZE_FUNC& vs_f)
 {
+  constexpr size_t batch_size = 128;
   NumberSeq summary;
   size_t literal_bytes = 0;
   InternalTable* table = get_table();
-  for (size_t bucket_it = 0; bucket_it < table->_size; bucket_it++) {
+  size_t num_batches = table->_size / batch_size;
+  for (size_t batch_start = 0; batch_start < _table->_size; batch_start += batch_size) {
+    // We batch the use of ScopedCS here as it has been found to be quite expensive to
+    // invoke it for every single bucket.
+    size_t batch_end = MIN2(batch_start + batch_size, _table->_size);
     ScopedCS cs(thread, this);
-    size_t count = 0;
-    Bucket* bucket = table->get_bucket(bucket_it);
-    if (bucket->have_redirect() || bucket->is_locked()) {
-      continue;
+    for (size_t bucket_it = batch_start; bucket_it < batch_end; bucket_it++) {
+      size_t count = 0;
+      Bucket* bucket = table->get_bucket(bucket_it);
+      if (bucket->have_redirect() || bucket->is_locked()) {
+        continue;
+      }
+      Node* current_node = bucket->first();
+      while (current_node != nullptr) {
+        ++count;
+        literal_bytes += vs_f(current_node->value());
+        current_node = current_node->next();
+      }
+      summary.add((double)count);
     }
-    Node* current_node = bucket->first();
-    while (current_node != nullptr) {
-      ++count;
-      literal_bytes += vs_f(current_node->value());
-      current_node = current_node->next();
-    }
-    summary.add((double)count);
   }
 
   if (_stats_rate == nullptr) {


### PR DESCRIPTION
Backporting this simple performance improvement for, well, performance. Also 21.0.4-oracle parity.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324933](https://bugs.openjdk.org/browse/JDK-8324933) needs maintainer approval

### Issue
 * [JDK-8324933](https://bugs.openjdk.org/browse/JDK-8324933): ConcurrentHashTable::statistics_calculate synchronization is expensive (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/524/head:pull/524` \
`$ git checkout pull/524`

Update a local copy of the PR: \
`$ git checkout pull/524` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 524`

View PR using the GUI difftool: \
`$ git pr show -t 524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/524.diff">https://git.openjdk.org/jdk21u-dev/pull/524.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/524#issuecomment-2071848939)