### PR TITLE
Backport 93feda3d9a1807422c7f47703358aabd2e8639b8

### DIFF
--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -241,8 +241,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ mov_metadata(rmethod, entry);
   __ str(rmethod, Address(rthread, JavaThread::callee_target_offset())); // just in case callee is deoptimized
 
+  __ push_cont_fastpath(rthread);
+
   __ ldr(rscratch1, Address(rmethod, Method::from_compiled_offset()));
   __ blr(rscratch1);
+
+  __ pop_cont_fastpath(rthread);
 
     // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
+++ b/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
@@ -239,9 +239,13 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ load_const_optimized(R19_method, (intptr_t)entry);
   __ std(R19_method, in_bytes(JavaThread::callee_target_offset()), R16_thread);
 
+  __ push_cont_fastpath();
+
   __ ld(call_target_address, in_bytes(Method::from_compiled_offset()), R19_method);
   __ mtctr(call_target_address);
   __ bctrl();
+
+  __ pop_cont_fastpath();
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/riscv/upcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/upcallLinker_riscv.cpp
@@ -263,8 +263,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ mov_metadata(xmethod, entry);
   __ sd(xmethod, Address(xthread, JavaThread::callee_target_offset())); // just in case callee is deoptimized
 
+  __ push_cont_fastpath(xthread);
+
   __ ld(t0, Address(xmethod, Method::from_compiled_offset()));
   __ jalr(t0);
+
+  __ pop_cont_fastpath(xthread);
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -296,7 +296,11 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ mov_metadata(rbx, entry);
   __ movptr(Address(r15_thread, JavaThread::callee_target_offset()), rbx); // just in case callee is deoptimized
 
+  __ push_cont_fastpath();
+
   __ call(Address(rbx, Method::from_compiled_offset()));
+
+  __ pop_cont_fastpath();
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -389,7 +389,7 @@ public:
   inline int size_if_fast_freeze_available();
 
 #ifdef ASSERT
-  bool interpreted_native_or_deoptimized_on_stack();
+  bool check_valid_fast_path();
 #endif
 
 protected:
@@ -1480,7 +1480,10 @@ static bool monitors_on_stack(JavaThread* thread) {
   return false;
 }
 
-bool FreezeBase::interpreted_native_or_deoptimized_on_stack() {
+// There are no interpreted frames if we're not called from the interpreter and we haven't ancountered an i2c
+// adapter or called Deoptimization::unpack_frames. As for native frames, upcalls from JNI also go through the
+// interpreter (see JavaCalls::call_helper), while the UpcallLinker explicitly sets cont_fastpath.
+bool FreezeBase::check_valid_fast_path() {
   ContinuationEntry* ce = _thread->last_continuation();
   RegisterMap map(_thread,
                   RegisterMap::UpdateMap::skip,
@@ -1488,11 +1491,11 @@ bool FreezeBase::interpreted_native_or_deoptimized_on_stack() {
                   RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
   for (frame f = freeze_start_frame(); Continuation::is_frame_in_continuation(ce, f); f = f.sender(&map)) {
-    if (f.is_interpreted_frame() || f.is_native_frame() || f.is_deoptimized_frame()) {
-      return true;
+    if (!f.is_compiled_frame() || f.is_deoptimized_frame()) {
+      return false;
     }
   }
-  return false;
+  return true;
 }
 #endif // ASSERT
 
@@ -1554,11 +1557,7 @@ static inline int freeze_internal(JavaThread* current, intptr_t* const sp) {
 
   Freeze<ConfigT> freeze(current, cont, sp);
 
-  // There are no interpreted frames if we're not called from the interpreter and we haven't ancountered an i2c
-  // adapter or called Deoptimization::unpack_frames. Calls from native frames also go through the interpreter
-  // (see JavaCalls::call_helper).
-  assert(!current->cont_fastpath()
-         || (current->cont_fastpath_thread_state() && !freeze.interpreted_native_or_deoptimized_on_stack()), "");
+  assert(!current->cont_fastpath() || freeze.check_valid_fast_path(), "");
   bool fast = UseContinuationFastPath && current->cont_fastpath();
   if (fast && freeze.size_if_fast_freeze_available() > 0) {
     freeze.freeze_fast_existing_chunk();

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -43,6 +43,7 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import jdk.test.lib.thread.VThreadRunner;
+import jdk.test.lib.thread.VThreadPinner;
 
 public class GetStackTraceALotWhenPinned {
 
@@ -65,13 +66,14 @@ public class GetStackTraceALotWhenPinned {
                 barrier.await();
 
                 Thread.yield();
-                synchronized (GetStackTraceALotWhenPinned.class) {
-                    if (timed) {
+                boolean b = timed;
+                VThreadPinner.runPinned(() -> {
+                    if (b) {
                         LockSupport.parkNanos(Long.MAX_VALUE);
                     } else {
                         LockSupport.park();
                     }
-                }
+                });
                 timed = !timed;
             }
         });


### PR DESCRIPTION
Clean backport to fix Virtual Threads and FFM interactions.

Additional testing:
 - [x] New regression testing passes before and after the fix (expected, since in JDK 21 `VThreadPinner` does not use FFM)
 - [x] MacOS AArch64 server fastdebug, `jdk_loom hotspot_loom`
 - [ ] Linux x86_64 server fastdebug, `all`