### PR TITLE
8326974: ODR violation in macroAssembler_aarch64.cpp

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -389,13 +389,13 @@ static bool offset_for(uint32_t insn1, uint32_t insn2, ptrdiff_t &byte_offset) {
   return false;
 }
 
-class Decoder : public RelocActions {
-  virtual reloc_insn adrpMem() { return &Decoder::adrpMem_impl; }
-  virtual reloc_insn adrpAdd() { return &Decoder::adrpAdd_impl; }
-  virtual reloc_insn adrpMovk() { return &Decoder::adrpMovk_impl; }
+class AArch64Decoder : public RelocActions {
+  virtual reloc_insn adrpMem() { return &AArch64Decoder::adrpMem_impl; }
+  virtual reloc_insn adrpAdd() { return &AArch64Decoder::adrpAdd_impl; }
+  virtual reloc_insn adrpMovk() { return &AArch64Decoder::adrpMovk_impl; }
 
 public:
-  Decoder(address insn_addr, uint32_t insn) : RelocActions(insn_addr, insn) {}
+  AArch64Decoder(address insn_addr, uint32_t insn) : RelocActions(insn_addr, insn) {}
 
   virtual int loadStore(address insn_addr, address &target) {
     intptr_t offset = Instruction_aarch64::sextract(_insn, 23, 5);
@@ -491,7 +491,7 @@ public:
 };
 
 address MacroAssembler::target_addr_for_insn(address insn_addr, uint32_t insn) {
-  Decoder decoder(insn_addr, insn);
+  AArch64Decoder decoder(insn_addr, insn);
   address target;
   decoder.run(insn_addr, target);
   return target;


### PR DESCRIPTION
This pull request contains a backport of commit [b972997a](https://github.com/openjdk/jdk/commit/b972997af76a506ffd79ee8c6043e7a8db836b33) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Andrew Haley on 1 Mar 2024 and was reviewed by Andrew Dinn, Aleksey Shipilev and Guoxiong Li.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326974](https://bugs.openjdk.org/browse/JDK-8326974) needs maintainer approval

### Issue
 * [JDK-8326974](https://bugs.openjdk.org/browse/JDK-8326974): ODR violation in macroAssembler_aarch64.cpp (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/534/head:pull/534` \
`$ git checkout pull/534`

Update a local copy of the PR: \
`$ git checkout pull/534` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 534`

View PR using the GUI difftool: \
`$ git pr show -t 534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/534.diff">https://git.openjdk.org/jdk21u-dev/pull/534.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/534#issuecomment-2079284750)