### PR TITLE
8330011: [s390x] update block-comments to make code consistent

### DIFF
--- a/src/hotspot/cpu/s390/downcallLinker_s390.cpp
+++ b/src/hotspot/cpu/s390/downcallLinker_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -166,10 +166,10 @@ void DowncallStubGenerator::generate() {
   locs.set(StubLocations::TARGET_ADDRESS, _abi._scratch2);
 
   if (_captured_state_mask != 0) {
-    __ block_comment("{ _captured_state_mask is set");
+    __ block_comment("_captured_state_mask_is_set {");
     locs.set_frame_data(StubLocations::CAPTURED_STATE_BUFFER, allocated_frame_size);
     allocated_frame_size += BytesPerWord;
-    __ block_comment("} _captured_state_mask is set");
+    __ block_comment("} _captured_state_mask_is_set");
   }
 
   allocated_frame_size = align_up(allocated_frame_size, StackAlignmentInBytes);
@@ -184,7 +184,7 @@ void DowncallStubGenerator::generate() {
   _frame_complete = __ pc() - start;  // frame build complete.
 
   if (_needs_transition) {
-    __ block_comment("{ thread java2native");
+    __ block_comment("thread_java2native {");
     __ get_PC(Z_R1_scratch);
     address the_pc = __ pc();
     __ set_last_Java_frame(Z_SP, Z_R1_scratch);
@@ -194,18 +194,18 @@ void DowncallStubGenerator::generate() {
 
     // State transition
     __ set_thread_state(_thread_in_native);
-    __ block_comment("} thread java2native");
+    __ block_comment("} thread_java2native");
   }
-  __ block_comment("{ argument shuffle");
+  __ block_comment("argument_shuffle {");
   arg_shuffle.generate(_masm, shuffle_reg, frame::z_jit_out_preserve_size, _abi._shadow_space_bytes, locs);
-  __ block_comment("} argument shuffle");
+  __ block_comment("} argument_shuffle");
 
   __ call(as_Register(locs.get(StubLocations::TARGET_ADDRESS)));
 
   //////////////////////////////////////////////////////////////////////////////
 
   if (_captured_state_mask != 0) {
-    __ block_comment("{ save thread local");
+    __ block_comment("save_thread_local {");
 
       out_reg_spiller.generate_spill(_masm, spill_offset);
 
@@ -216,7 +216,7 @@ void DowncallStubGenerator::generate() {
 
       out_reg_spiller.generate_fill(_masm, spill_offset);
 
-    __ block_comment("} save thread local");
+    __ block_comment("} save_thread_local");
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -227,7 +227,7 @@ void DowncallStubGenerator::generate() {
   Label L_after_reguard;
 
   if (_needs_transition) {
-    __ block_comment("{ thread native2java");
+    __ block_comment("thread_native2java {");
     __ set_thread_state(_thread_in_native_trans);
 
     if (!UseSystemMemoryBarrier) {
@@ -244,14 +244,16 @@ void DowncallStubGenerator::generate() {
     // change thread state
     __ set_thread_state(_thread_in_Java);
 
-    __ block_comment("reguard stack check");
-    __ z_cli(Address(Z_thread, JavaThread::stack_guard_state_offset() + in_ByteSize(sizeof(StackOverflow::StackGuardState) - 1)),
-        StackOverflow::stack_guard_yellow_reserved_disabled);
+    __ block_comment("reguard_stack_check {");
+    __ z_cli(Address(Z_thread,
+                     JavaThread::stack_guard_state_offset() + in_ByteSize(sizeof(StackOverflow::StackGuardState) - 1)),
+                     StackOverflow::stack_guard_yellow_reserved_disabled);
     __ z_bre(L_reguard);
+    __ block_comment("} reguard_stack_check");
     __ bind(L_after_reguard);
 
     __ reset_last_Java_frame();
-    __ block_comment("} thread native2java");
+    __ block_comment("} thread_native2java");
   }
 
   __ pop_frame();
@@ -261,7 +263,7 @@ void DowncallStubGenerator::generate() {
   //////////////////////////////////////////////////////////////////////////////
 
   if (_needs_transition) {
-    __ block_comment("{ L_safepoint_poll_slow_path");
+    __ block_comment("L_safepoint_poll_slow_path {");
     __ bind(L_safepoint_poll_slow_path);
 
       // Need to save the native result registers around any runtime calls.
@@ -277,7 +279,7 @@ void DowncallStubGenerator::generate() {
     __ block_comment("} L_safepoint_poll_slow_path");
 
     //////////////////////////////////////////////////////////////////////////////
-    __ block_comment("{ L_reguard");
+    __ block_comment("L_reguard {");
     __ bind(L_reguard);
 
       // Need to save the native result registers around any runtime calls.

--- a/src/hotspot/cpu/s390/upcallLinker_s390.cpp
+++ b/src/hotspot/cpu/s390/upcallLinker_s390.cpp
@@ -63,7 +63,7 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
 
   int offset = reg_save_area_offset;
 
-  __ block_comment("{ preserve_callee_saved_regs ");
+  __ block_comment("preserve_callee_saved_regs {");
   for (int i = 0; i < Register::number_of_registers; i++) {
     Register reg = as_Register(i);
     // Z_SP saved/restored by prologue/epilogue
@@ -82,7 +82,7 @@ static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDesc
     }
   }
 
-  __ block_comment("} preserve_callee_saved_regs ");
+  __ block_comment("} preserve_callee_saved_regs");
 }
 
 static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
@@ -92,7 +92,7 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
 
   int offset = reg_save_area_offset;
 
-  __ block_comment("{ restore_callee_saved_regs ");
+  __ block_comment("restore_callee_saved_regs {");
   for (int i = 0; i < Register::number_of_registers; i++) {
     Register reg = as_Register(i);
     // Z_SP saved/restored by prologue/epilogue
@@ -111,7 +111,7 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
     }
   }
 
-  __ block_comment("} restore_callee_saved_regs ");
+  __ block_comment("} restore_callee_saved_regs");
 }
 
 static const int upcall_stub_code_base_size = 1024; // depends on GC (resolve_jobject)
@@ -199,7 +199,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   // Java methods won't preserve them, so save them here:
   preserve_callee_saved_registers(_masm, abi, reg_save_area_offset);
 
-  __ block_comment("{ on_entry");
+  __ block_comment("on_entry {");
   __ load_const_optimized(call_target_address, CAST_FROM_FN_PTR(uint64_t, UpcallLinker::on_entry));
   __ z_aghik(Z_ARG1, Z_SP, frame_data_offset);
   __ call(call_target_address);
@@ -207,14 +207,14 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ block_comment("} on_entry");
 
   arg_spiller.generate_fill(_masm, arg_save_area_offset);
-  __ block_comment("{ argument shuffle");
+  __ block_comment("argument_shuffle {");
   arg_shuffle.generate(_masm, shuffle_reg, abi._shadow_space_bytes, frame::z_jit_out_preserve_size, locs);
-  __ block_comment("} argument shuffle");
+  __ block_comment("} argument_shuffle");
 
-  __ block_comment("{ receiver ");
+  __ block_comment("receiver {");
   __ load_const_optimized(Z_ARG1, (intptr_t)receiver);
   __ resolve_jobject(Z_ARG1, Z_tmp_1, Z_tmp_2);
-  __ block_comment("} receiver ");
+  __ block_comment("} receiver");
 
   __ load_const_optimized(Z_method, (intptr_t)entry);
   __ z_stg(Z_method, Address(Z_thread, in_bytes(JavaThread::callee_target_offset())));
@@ -250,7 +250,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 
   result_spiller.generate_spill(_masm, res_save_area_offset);
 
-  __ block_comment("{ on_exit");
+  __ block_comment("on_exit {");
   __ load_const_optimized(call_target_address, CAST_FROM_FN_PTR(uint64_t, UpcallLinker::on_exit));
   __ z_aghik(Z_ARG1, Z_SP, frame_data_offset);
   __ call(call_target_address);
@@ -266,7 +266,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
 
   //////////////////////////////////////////////////////////////////////////////
 
-  __ block_comment("{ exception handler");
+  __ block_comment("exception_handler {");
 
   intptr_t exception_handler_offset = __ pc() - start;
 
@@ -277,7 +277,7 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ call_c(call_target_address);
   __ should_not_reach_here();
 
-  __ block_comment("} exception handler");
+  __ block_comment("} exception_handler");
 
   _masm->flush();
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [01bda278](https://github.com/openjdk/jdk/commit/01bda278d6a498ca89c0bc5218680cd51a04e9d3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 17 Apr 2024 and was reviewed by Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330011](https://bugs.openjdk.org/browse/JDK-8330011) needs maintainer approval

### Issue
 * [JDK-8330011](https://bugs.openjdk.org/browse/JDK-8330011): [s390x] update block-comments to make code consistent (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/539/head:pull/539` \
`$ git checkout pull/539`

Update a local copy of the PR: \
`$ git checkout pull/539` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 539`

View PR using the GUI difftool: \
`$ git pr show -t 539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/539.diff">https://git.openjdk.org/jdk21u-dev/pull/539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/539#issuecomment-2080378445)