### PR TITLE
8328703: Illegal accesses in Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibraryImpl_ioctl0

### DIFF
--- a/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
@@ -150,20 +150,20 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibr
   (JNIEnv *env, jobject, jint fd, jint cmd, jobject data) {
     winsize ws;
 
-    ws.ws_row = env->GetIntField(data, ws_row);
-    ws.ws_col = env->GetIntField(data, ws_col);
-    ws.ws_xpixel = env->GetIntField(data, ws_xpixel);
-    ws.ws_ypixel = env->GetIntField(data, ws_ypixel);
+    ws.ws_row = env->GetShortField(data, ws_row);
+    ws.ws_col = env->GetShortField(data, ws_col);
+    ws.ws_xpixel = env->GetShortField(data, ws_xpixel);
+    ws.ws_ypixel = env->GetShortField(data, ws_ypixel);
 
     if (ioctl(fd, cmd, &ws) != 0) {
         throw_errno(env);
         return ;
     }
 
-    env->SetIntField(data, ws_row, ws.ws_row);
-    env->SetIntField(data, ws_col, ws.ws_col);
-    env->SetIntField(data, ws_xpixel, ws.ws_xpixel);
-    env->SetIntField(data, ws_ypixel, ws.ws_ypixel);
+    env->SetShortField(data, ws_row, ws.ws_row);
+    env->SetShortField(data, ws_col, ws.ws_col);
+    env->SetShortField(data, ws_xpixel, ws.ws_xpixel);
+    env->SetShortField(data, ws_ypixel, ws.ws_ypixel);
 }
 
 /*

--- a/src/jdk.internal.le/macosx/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/macosx/native/lible/CLibrary.cpp
@@ -154,20 +154,20 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_osx_CLibrar
   (JNIEnv *env, jobject, jint fd, jlong cmd, jobject data) {
     winsize ws;
 
-    ws.ws_row = env->GetIntField(data, ws_row);
-    ws.ws_col = env->GetIntField(data, ws_col);
-    ws.ws_xpixel = env->GetIntField(data, ws_xpixel);
-    ws.ws_ypixel = env->GetIntField(data, ws_ypixel);
+    ws.ws_row = env->GetShortField(data, ws_row);
+    ws.ws_col = env->GetShortField(data, ws_col);
+    ws.ws_xpixel = env->GetShortField(data, ws_xpixel);
+    ws.ws_ypixel = env->GetShortField(data, ws_ypixel);
 
     if (ioctl(fd, cmd, &ws) != 0) {
         throw_errno(env);
         return ;
     }
 
-    env->SetIntField(data, ws_row, ws.ws_row);
-    env->SetIntField(data, ws_col, ws.ws_col);
-    env->SetIntField(data, ws_xpixel, ws.ws_xpixel);
-    env->SetIntField(data, ws_ypixel, ws.ws_ypixel);
+    env->SetShortField(data, ws_row, ws.ws_row);
+    env->SetShortField(data, ws_col, ws.ws_col);
+    env->SetShortField(data, ws_xpixel, ws.ws_xpixel);
+    env->SetShortField(data, ws_ypixel, ws.ws_ypixel);
 }
 
 /*


### PR DESCRIPTION
Fixes the JDK 21 regression. Simple fix.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `jdk/jshell` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328703](https://bugs.openjdk.org/browse/JDK-8328703) needs maintainer approval

### Issue
 * [JDK-8328703](https://bugs.openjdk.org/browse/JDK-8328703): Illegal accesses in Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibraryImpl_ioctl0 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/540/head:pull/540` \
`$ git checkout pull/540`

Update a local copy of the PR: \
`$ git checkout pull/540` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 540`

View PR using the GUI difftool: \
`$ git pr show -t 540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/540.diff">https://git.openjdk.org/jdk21u-dev/pull/540.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/540#issuecomment-2082207076)