### PR TITLE
8312014: [s390x] TestSigInfoInHsErrFile.java Failure

### DIFF
--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -27,6 +27,7 @@
 #define CPU_AARCH64_GLOBALDEFINITIONS_AARCH64_HPP
 
 const int StackAlignmentInBytes  = 16;
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
+++ b/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
@@ -26,6 +26,7 @@
 #define CPU_ARM_GLOBALDEFINITIONS_ARM_HPP
 
 const int StackAlignmentInBytes = 8;
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
@@ -31,6 +31,12 @@ const int BytesPerInstWord = 4;
 
 const int StackAlignmentInBytes = 16;
 
+#ifdef AIX
+const size_t pd_segfault_address = -1;
+#else
+const size_t pd_segfault_address = 1024;
+#endif
+
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.
 const bool CCallingConventionRequiresIntsAsLongs = true;

--- a/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
@@ -28,6 +28,7 @@
 #define CPU_RISCV_GLOBALDEFINITIONS_RISCV_HPP
 
 const int StackAlignmentInBytes = 16;
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
+++ b/src/hotspot/cpu/s390/globalDefinitions_s390.hpp
@@ -30,6 +30,10 @@
 
 const int StackAlignmentInBytes = 8;
 
+// All faults on s390x give the address only on page granularity.
+// Set Pdsegfault_address to minimum one page address.
+const size_t pd_segfault_address = 4096;
+
 #define SUPPORTS_NATIVE_CX8
 
 #define CPU_MULTI_COPY_ATOMIC

--- a/src/hotspot/cpu/x86/globalDefinitions_x86.hpp
+++ b/src/hotspot/cpu/x86/globalDefinitions_x86.hpp
@@ -26,6 +26,7 @@
 #define CPU_X86_GLOBALDEFINITIONS_X86_HPP
 
 const int StackAlignmentInBytes  = 16;
+const size_t pd_segfault_address = 1024;
 
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.

--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -43,5 +43,12 @@
 // Indicates whether the C calling conventions require that
 // 32-bit integer argument values are extended to 64 bits.
 const bool CCallingConventionRequiresIntsAsLongs = false;
+#if defined(AIX)
+const size_t pd_segfault_address = -1;
+#elif defined(S390)
+const size_t pd_segfault_address = 4096;
+#else
+const size_t pd_segfault_address = 1024;
+#endif
 
 #endif // CPU_ZERO_GLOBALDEFINITIONS_ZERO_HPP

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -100,6 +100,7 @@ const char*       VMError::_filename;
 int               VMError::_lineno;
 size_t            VMError::_size;
 const size_t      VMError::_reattempt_required_stack_headroom = 64 * K;
+const intptr_t    VMError::segfault_address = pd_segfault_address;
 
 // List of environment variables that should be reported in error log file.
 static const char* env_list[] = {

--- a/src/hotspot/share/utilities/vmError.hpp
+++ b/src/hotspot/share/utilities/vmError.hpp
@@ -207,7 +207,7 @@ public:
   DEBUG_ONLY(static void controlled_crash(int how);)
 
   // Non-null address guaranteed to generate a SEGV mapping error on read, for test purposes.
-  static constexpr intptr_t segfault_address = AIX_ONLY(-1) NOT_AIX(1 * K);
+  static const intptr_t segfault_address;
 
   // Max value for the ErrorLogPrintCodeLimit flag.
   static const int max_error_log_print_code = 10;

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestSigInfoInHsErrFile.java
@@ -69,7 +69,14 @@ public class TestSigInfoInHsErrFile {
     patterns.add(Pattern.compile("# .*VMError::controlled_crash.*"));
 
     // Crash address: see VMError::_segfault_address
-    String crashAddress = Platform.isAix() ? "0xffffffffffffffff" : "0x0*400";
+    String crashAddress = "0x0*400";
+    if (Platform.isAix()) {
+        crashAddress = "0xffffffffffffffff";
+    } else if (Platform.isS390x()) {
+        // All faults on s390x give the address only on page granularity.
+        // Hence fault address is first page address.
+        crashAddress = "0x0*1000";
+    }
     patterns.add(Pattern.compile("siginfo: si_signo: \\d+ \\(SIGSEGV\\), si_code: \\d+ \\(SEGV_.*\\), si_addr: " + crashAddress + ".*"));
 
     HsErrFileUtils.checkHsErrFileContent(f, patterns.toArray(new Pattern[] {}), true);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6f662130](https://github.com/openjdk/jdk/commit/6f6621303ad54a7dfd880c9472a387706a4466ff) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sidraya on 19 Jul 2023 and was reviewed by Thomas Stuefe, Amit Kumar and Tyler Steele.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8312014](https://bugs.openjdk.org/browse/JDK-8312014) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312014](https://bugs.openjdk.org/browse/JDK-8312014): [s390x] TestSigInfoInHsErrFile.java Failure (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/541/head:pull/541` \
`$ git checkout pull/541`

Update a local copy of the PR: \
`$ git checkout pull/541` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 541`

View PR using the GUI difftool: \
`$ git pr show -t 541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/541.diff">https://git.openjdk.org/jdk21u-dev/pull/541.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/541#issuecomment-2082892903)