### PR TITLE
8319376: ParallelGC: Forwarded objects found during heap inspection

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -236,7 +236,18 @@ void MutableSpace::oop_iterate(OopIterateClosure* cl) {
 void MutableSpace::object_iterate(ObjectClosure* cl) {
   HeapWord* p = bottom();
   while (p < top()) {
-    cl->do_object(cast_to_oop(p));
+    oop obj = cast_to_oop(p);
+    // When promotion-failure occurs during Young GC, eden/from space is not cleared,
+    // so we can encounter objects with "forwarded" markword.
+    // They are essentially dead, so skipping them
+    if (!obj->is_forwarded()) {
+      cl->do_object(obj);
+    }
+#ifdef ASSERT
+    else {
+      assert(obj->forwardee() != obj, "must not be self-forwarded");
+    }
+#endif
     p += cast_to_oop(p)->size();
   }
 }


### PR DESCRIPTION
Clean backport of fixing the potential self forwarding object in heap inspection of Parallel GC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8319376](https://bugs.openjdk.org/browse/JDK-8319376) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319376](https://bugs.openjdk.org/browse/JDK-8319376): ParallelGC: Forwarded objects found during heap inspection (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/544/head:pull/544` \
`$ git checkout pull/544`

Update a local copy of the PR: \
`$ git checkout pull/544` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 544`

View PR using the GUI difftool: \
`$ git pr show -t 544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/544.diff">https://git.openjdk.org/jdk21u-dev/pull/544.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/544#issuecomment-2084857564)