### PR TITLE
Backport a7f60164063bdf95437326e7550fd65ff91b5566

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -44,7 +44,7 @@
 #include "utilities/ostream.hpp"
 #include "utilities/vmError.hpp"
 
-size_t MallocMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(MallocMemorySnapshot, size_t)];
+MallocMemorySnapshot MallocMemorySummary::_snapshot;
 
 void MemoryCounter::update_peak(size_t size, size_t cnt) {
   size_t peak_sz = peak_size();
@@ -79,9 +79,7 @@ void MallocMemorySnapshot::make_adjustment() {
 }
 
 void MallocMemorySummary::initialize() {
-  assert(sizeof(_snapshot) >= sizeof(MallocMemorySnapshot), "Sanity Check");
   // Uses placement new operator to initialize static area.
-  ::new ((void*)_snapshot)MallocMemorySnapshot();
   MallocLimitHandler::initialize(MallocLimit);
 }
 

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -140,7 +140,7 @@ class MallocMemorySummary;
 
 // A snapshot of malloc'd memory, includes malloc memory
 // usage by types and memory used by tracking itself.
-class MallocMemorySnapshot : public ResourceObj {
+class MallocMemorySnapshot {
   friend class MallocMemorySummary;
 
  private:
@@ -198,7 +198,7 @@ class MallocMemorySnapshot : public ResourceObj {
 class MallocMemorySummary : AllStatic {
  private:
   // Reserve memory for placement of MallocMemorySnapshot object
-  static size_t _snapshot[CALC_OBJ_SIZE_IN_TYPE(MallocMemorySnapshot, size_t)];
+  static MallocMemorySnapshot _snapshot;
   static bool _have_limits;
 
   // Called when a total limit break was detected.
@@ -245,7 +245,7 @@ class MallocMemorySummary : AllStatic {
    }
 
   static MallocMemorySnapshot* as_snapshot() {
-    return (MallocMemorySnapshot*)_snapshot;
+    return &_snapshot;
   }
 
   // MallocLimit: returns true if allocating s bytes on f would trigger

--- a/src/hotspot/share/services/nmtCommon.hpp
+++ b/src/hotspot/share/services/nmtCommon.hpp
@@ -31,8 +31,6 @@
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#define CALC_OBJ_SIZE_IN_TYPE(obj, type) (align_up(sizeof(obj), sizeof(type))/sizeof(type))
-
 // Native memory tracking level
 //
 // The meaning of the different states:

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -32,7 +32,7 @@
 #include "services/virtualMemoryTracker.hpp"
 #include "utilities/ostream.hpp"
 
-size_t VirtualMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(VirtualMemorySnapshot, size_t)];
+VirtualMemorySnapshot VirtualMemorySummary::_snapshot;
 
 void VirtualMemory::update_peak(size_t size) {
   size_t peak_sz = peak_size();
@@ -44,12 +44,6 @@ void VirtualMemory::update_peak(size_t size) {
       peak_sz = old_sz;
     }
   }
-}
-
-void VirtualMemorySummary::initialize() {
-  assert(sizeof(_snapshot) >= sizeof(VirtualMemorySnapshot), "Sanity Check");
-  // Use placement operator new to initialize static data area.
-  ::new ((void*)_snapshot) VirtualMemorySnapshot();
 }
 
 void VirtualMemorySummary::snapshot(VirtualMemorySnapshot* s) {
@@ -334,7 +328,6 @@ address ReservedMemoryRegion::thread_stack_uncommitted_bottom() const {
 bool VirtualMemoryTracker::initialize(NMT_TrackingLevel level) {
   assert(_reserved_regions == nullptr, "only call once");
   if (level >= NMT_summary) {
-    VirtualMemorySummary::initialize();
     _reserved_regions = new (std::nothrow, mtNMT)
       SortedLinkedList<ReservedMemoryRegion, compare_reserved_region_base>();
     return (_reserved_regions != nullptr);

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -134,7 +134,6 @@ class VirtualMemorySnapshot : public ResourceObj {
 
 class VirtualMemorySummary : AllStatic {
  public:
-  static void initialize();
 
   static inline void record_reserved_memory(size_t size, MEMFLAGS flag) {
     as_snapshot()->by_type(flag)->reserve_memory(size);
@@ -169,11 +168,11 @@ class VirtualMemorySummary : AllStatic {
   static void snapshot(VirtualMemorySnapshot* s);
 
   static VirtualMemorySnapshot* as_snapshot() {
-    return (VirtualMemorySnapshot*)_snapshot;
+    return &_snapshot;
   }
 
  private:
-  static size_t _snapshot[CALC_OBJ_SIZE_IN_TYPE(VirtualMemorySnapshot, size_t)];
+  static VirtualMemorySnapshot _snapshot;
 };
 
 


### PR DESCRIPTION
Clean backport to improve NMT initialization and provide cleanliness for other backports.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `runtime/NMT`