### PR TITLE
8330615: avoid signed integer overflows in zip_util.c readCen / hashN

### DIFF
--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -442,7 +442,7 @@ hash(const char *s)
 static unsigned int
 hashN(const char *s, int length)
 {
-    int h = 0;
+    unsigned int h = 0;
     while (length-- > 0)
         h = 31*h + *s++;
     return h;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330615](https://bugs.openjdk.org/browse/JDK-8330615) needs maintainer approval

### Issue
 * [JDK-8330615](https://bugs.openjdk.org/browse/JDK-8330615): avoid signed integer overflows in zip_util.c readCen / hashN (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/555/head:pull/555` \
`$ git checkout pull/555`

Update a local copy of the PR: \
`$ git checkout pull/555` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 555`

View PR using the GUI difftool: \
`$ git pr show -t 555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/555.diff">https://git.openjdk.org/jdk21u-dev/pull/555.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/555#issuecomment-2096015944)