### PR TITLE
8331167: UBSan enabled build fails in adlc on macOS

### DIFF
--- a/src/hotspot/share/adlc/adlparse.cpp
+++ b/src/hotspot/share/adlc/adlparse.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5192,7 +5192,7 @@ void ADLParser::skipws_common(bool do_preproc) {
     if (*_ptr == '\n') {                   // keep proper track of new lines
       if (!do_preproc)  break;             // let caller handle the newline
       next_line();
-      _ptr = _curline; next = _ptr + 1;
+      _ptr = _curline; if (_ptr != nullptr) next = _ptr + 1;
     }
     else if ((*_ptr == '/') && (*next == '/'))      // C++ comment
       do { _ptr++; next++; } while(*_ptr != '\n');  // So go to end of line


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331167](https://bugs.openjdk.org/browse/JDK-8331167) needs maintainer approval

### Issue
 * [JDK-8331167](https://bugs.openjdk.org/browse/JDK-8331167): UBSan enabled build fails in adlc on macOS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/556/head:pull/556` \
`$ git checkout pull/556`

Update a local copy of the PR: \
`$ git checkout pull/556` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 556`

View PR using the GUI difftool: \
`$ git pr show -t 556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/556.diff">https://git.openjdk.org/jdk21u-dev/pull/556.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/556#issuecomment-2096085307)