### PR TITLE
8325255: jdk.internal.util.ReferencedKeySet::add using wrong test

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
@@ -439,4 +439,30 @@ public final class ReferencedKeyMap<K, V> implements Map<K, V> {
         return interned;
     }
 
+
+    /**
+     * Attempt to add key to map if absent.
+     *
+     * @param setMap    {@link ReferencedKeyMap} where interning takes place
+     * @param key       key to add
+     *
+     * @param <T> type of key
+     *
+     * @return true if the key was added
+     */
+    static <T> boolean internAddKey(ReferencedKeyMap<T, ReferenceKey<T>> setMap, T key) {
+        ReferenceKey<T> entryKey = setMap.entryKey(key);
+        setMap.removeStaleReferences();
+        ReferenceKey<T> existing = setMap.map.putIfAbsent(entryKey, entryKey);
+        if (existing == null) {
+            return true;
+        } else {
+            // If {@code putIfAbsent} returns non-null then was actually a
+            // {@code replace} and older key was used. In that case the new
+            // key was not used and the reference marked stale.
+            entryKey.unused();
+            return false;
+        }
+     }
+
 }

--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeySet.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeySet.java
@@ -148,7 +148,7 @@ public final class ReferencedKeySet<T> extends AbstractSet<T> {
 
     @Override
     public boolean add(T e) {
-        return intern(e) == null;
+        return ReferencedKeyMap.internAddKey(map, e);
     }
 
     @Override

--- a/test/jdk/jdk/internal/util/ReferencedKeyTest.java
+++ b/test/jdk/jdk/internal/util/ReferencedKeyTest.java
@@ -127,6 +127,12 @@ public class ReferencedKeyTest {
         assertTrue(element1 == intern1, "intern failed"); // must be same object
         assertTrue(intern2 != null, "intern failed");
         assertTrue(element3 == intern3, "intern failed");
+
+        Long value1 = Long.valueOf(BASE_KEY + 999);
+        Long value2 = Long.valueOf(BASE_KEY + 999);
+        assertTrue(set.add(value1), "key not added");
+        assertTrue(!set.add(value1), "key added after second attempt");
+        assertTrue(!set.add(value2), "key should not have been added");
     }
 
     // Borrowed from jdk.test.lib.util.ForceGC but couldn't use from java.base/jdk.internal.util


### PR DESCRIPTION
Clean backport, follow up for recent [JDK-8310913](https://bugs.openjdk.org/browse/JDK-8310913) integration. Nothing AFAICS is using the affected method except the test itself.

Additional testing:
 - [x] New regression test fails without the fix, passes with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325255](https://bugs.openjdk.org/browse/JDK-8325255) needs maintainer approval

### Issue
 * [JDK-8325255](https://bugs.openjdk.org/browse/JDK-8325255): jdk.internal.util.ReferencedKeySet::add using wrong test (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/557/head:pull/557` \
`$ git checkout pull/557`

Update a local copy of the PR: \
`$ git checkout pull/557` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 557`

View PR using the GUI difftool: \
`$ git pr show -t 557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/557.diff">https://git.openjdk.org/jdk21u-dev/pull/557.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/557#issuecomment-2097955986)