### PR TITLE
8330815: Use pattern matching for instanceof in KeepAliveCache

### DIFF
--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,9 +389,9 @@ class KeepAliveKey {
      */
     @Override
     public boolean equals(Object obj) {
-        if ((obj instanceof KeepAliveKey) == false)
+        if (!(obj instanceof KeepAliveKey kae))
             return false;
-        KeepAliveKey kae = (KeepAliveKey)obj;
+
         return host.equals(kae.host)
             && (port == kae.port)
             && protocol.equals(kae.protocol)
@@ -405,7 +405,7 @@ class KeepAliveKey {
     @Override
     public int hashCode() {
         String str = protocol+host+port;
-        return this.obj == null? str.hashCode() :
+        return this.obj == null ? str.hashCode() :
             str.hashCode() + this.obj.hashCode();
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8330815](https://bugs.openjdk.org/browse/JDK-8330815), commit [0ec3c0b1](https://github.com/openjdk/jdk22u/commit/0ec3c0b1e698f7ad39b4da2edb062721e4670f58) from the [openjdk/jdk22u](https://git.openjdk.org/jdk22u) repository.

The commit being backported was authored by Christoph Langer on 7 May 2024 and had no reviewers.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330815](https://bugs.openjdk.org/browse/JDK-8330815) needs maintainer approval

### Issue
 * [JDK-8330815](https://bugs.openjdk.org/browse/JDK-8330815): Use pattern matching for instanceof in KeepAliveCache (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/559/head:pull/559` \
`$ git checkout pull/559`

Update a local copy of the PR: \
`$ git checkout pull/559` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 559`

View PR using the GUI difftool: \
`$ git pr show -t 559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/559.diff">https://git.openjdk.org/jdk21u-dev/pull/559.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/559#issuecomment-2099339019)