### PR TITLE
8325587: Shenandoah: ShenandoahLock should allow blocking in VM

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -885,7 +885,11 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
 }
 
 HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req, bool& in_new_region) {
-  ShenandoahHeapLocker locker(lock());
+  // If we are dealing with mutator allocation, then we may need to block for safepoint.
+  // We cannot block for safepoint for GC allocations, because there is a high chance
+  // we are already running at safepoint or from stack watermark machinery, and we cannot
+  // block again.
+  ShenandoahHeapLocker locker(lock(), req.is_mutator_alloc());
   return _free_set->allocate(req, in_new_region);
 }
 


### PR DESCRIPTION
Clean backport of fixing rare long hand shake while mutator threads in heavy contention on ShenandoahLock.

Additional testing:
- [x] Linux aarch64 server fastdebug, hotspot/jtreg/tier1 with +UseShenandoahGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587) needs maintainer approval

### Issue
 * [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587): Shenandoah: ShenandoahLock should allow blocking in VM (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/560/head:pull/560` \
`$ git checkout pull/560`

Update a local copy of the PR: \
`$ git checkout pull/560` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 560`

View PR using the GUI difftool: \
`$ git pr show -t 560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/560.diff">https://git.openjdk.org/jdk21u-dev/pull/560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/560#issuecomment-2101991300)