### PR TITLE
8331942: On Linux aarch64, CDS archives should be using 64K alignment by default

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -190,6 +190,17 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
   fi
   AC_SUBST(INCLUDE_SA)
 
+  # Setup default CDS alignment. On platforms where one build may run on machines with different
+  # page sizes, the JVM choses a compatible alignment to fit all possible page sizes. This slightly
+  # increases archive size.
+  # The only platform having this problem at the moment is Linux on aarch64, which may encounter
+  # three different page sizes: 4K, 64K, and if run on Mac m1 hardware, 16K.
+  COMPATIBLE_CDS_ALIGNMENT_DEFAULT=false
+  if test "x$OPENJDK_TARGET_OS" = "xlinux" && test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+    COMPATIBLE_CDS_ALIGNMENT_DEFAULT=true
+  fi
+  AC_SUBST(COMPATIBLE_CDS_ALIGNMENT_DEFAULT)
+
   # Compress jars
   COMPRESS_JARS=false
 
@@ -673,7 +684,7 @@ AC_DEFUN([JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE],
 #
 AC_DEFUN([JDKOPT_ENABLE_DISABLE_COMPATIBLE_CDS_ALIGNMENT],
 [
-  UTIL_ARG_ENABLE(NAME: compatible-cds-alignment, DEFAULT: false,
+  UTIL_ARG_ENABLE(NAME: compatible-cds-alignment, DEFAULT: $COMPATIBLE_CDS_ALIGNMENT_DEFAULT,
       RESULT: ENABLE_COMPATIBLE_CDS_ALIGNMENT,
       DESC: [enable use alternative compatible cds core region alignment],
       DEFAULT_DESC: [disabled],


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d2d37c91](https://github.com/openjdk/jdk/commit/d2d37c913e5b55f7aec2c7a6b5a2328348ded223) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 10 May 2024 and was reviewed by Andrew Haley and Ioi Lam.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331942](https://bugs.openjdk.org/browse/JDK-8331942) needs maintainer approval

### Issue
 * [JDK-8331942](https://bugs.openjdk.org/browse/JDK-8331942): On Linux aarch64, CDS archives should be using 64K alignment by default (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/561/head:pull/561` \
`$ git checkout pull/561`

Update a local copy of the PR: \
`$ git checkout pull/561` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 561`

View PR using the GUI difftool: \
`$ git pr show -t 561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/561.diff">https://git.openjdk.org/jdk21u-dev/pull/561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/561#issuecomment-2104716118)