### PR TITLE
8309871: jdk/jfr/api/consumer/recordingstream/TestSetEndTime.java timed out

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/recordingstream/TestSetEndTime.java
+++ b/test/jdk/jdk/jfr/api/consumer/recordingstream/TestSetEndTime.java
@@ -47,7 +47,7 @@ import jdk.jfr.consumer.RecordingStream;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm jdk.jfr.api.consumer.recordingstream.TestSetEndTime
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps jdk.jfr.api.consumer.recordingstream.TestSetEndTime
  */
 public final class TestSetEndTime {
 


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309871](https://bugs.openjdk.org/browse/JDK-8309871) needs maintainer approval

### Issue
 * [JDK-8309871](https://bugs.openjdk.org/browse/JDK-8309871): jdk/jfr/api/consumer/recordingstream/TestSetEndTime.java timed out (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/568/head:pull/568` \
`$ git checkout pull/568`

Update a local copy of the PR: \
`$ git checkout pull/568` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 568`

View PR using the GUI difftool: \
`$ git pr show -t 568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/568.diff">https://git.openjdk.org/jdk21u-dev/pull/568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/568#issuecomment-2109200918)