### PR TITLE
8332253: Linux arm32 build fails after 8292591

### DIFF
--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -41,6 +41,8 @@
   #define SYS_membarrier 365
   #elif defined(AARCH64)
   #define SYS_membarrier 283
+  #elif defined(ARM32)
+  #define SYS_membarrier 389
   #elif defined(ALPHA)
   #define SYS_membarrier 517
   #else


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [95f79c67](https://github.com/openjdk/jdk/commit/95f79c678737fb8de9ed45c516761d4d818869ef) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 16 May 2024 and was reviewed by Thomas Stuefe, David Holmes and Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332253](https://bugs.openjdk.org/browse/JDK-8332253) needs maintainer approval

### Issue
 * [JDK-8332253](https://bugs.openjdk.org/browse/JDK-8332253): Linux arm32 build fails after 8292591 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/576/head:pull/576` \
`$ git checkout pull/576`

Update a local copy of the PR: \
`$ git checkout pull/576` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 576`

View PR using the GUI difftool: \
`$ git pr show -t 576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/576.diff">https://git.openjdk.org/jdk21u-dev/pull/576.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/576#issuecomment-2116243513)