### PR TITLE
8320715: Improve the tests of test/hotspot/jtreg/compiler/intrinsics/float16

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16Conversion.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16Conversion.java
@@ -309,7 +309,8 @@ public class Binary16Conversion {
                 f_prime_diff > f_prime_up_diff) {
                 errors++;
                 System.out.println("Round-to-nearest violation on converting " +
-                                   Float.toHexString(f) + "/" + Integer.toHexString(i) + " to binary16 and back: " + Integer.toHexString(0xffff & f_as_bin16) + " f_prime: " + Float.toHexString(f_prime));
+                                   Float.toHexString(f) + "/" + Integer.toHexString(i) + " to binary16 and back: " +
+                                   Integer.toHexString(0xffff & f_as_bin16) + " f_prime: " + Float.toHexString(f_prime));
             }
         }
         return errors;
@@ -326,11 +327,14 @@ public class Binary16Conversion {
              ell++) {
             float f = Float.intBitsToFloat((int)ell);
             short s1 = Float.floatToFloat16(f);
-            short s2 =    testAltFloatToFloat16(f);
+            short s2 = testAltFloatToFloat16(f);
 
             if (s1 != s2) {
                 errors++;
-                System.out.println("Different conversion of float value " + Float.toHexString(f));
+                System.out.println("Different conversion of float value (" + f + "/" +
+                                    Integer.toHexString(Float.floatToRawIntBits(f)) + "): " +
+                                    Integer.toHexString(s1 & 0xffff) + "(" + s1 + ")" + " != " +
+                                    Integer.toHexString(s2 & 0xffff) + "(" + s2 + ")");
             }
         }
 

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestAllFloat16ToFloat.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestAllFloat16ToFloat.java
@@ -53,45 +53,59 @@ public class TestAllFloat16ToFloat {
         return Float.floatToFloat16(Float.float16ToFloat(s));
     }
 
-    public static void verify(short sVal, float fVal, short sRes) {
+    public static int verify(short sVal, float fVal, short sRes, String prefix) {
+        int errors = 0;
         if (sRes != sVal) {
             if (!Float.isNaN(fVal) || ((sRes & ~0x0200) != (sVal & ~0x0200)) ) {
+                errors++;
                 String fVal_hex = Integer.toHexString(Float.floatToRawIntBits(fVal));
                 String sRes_hex = Integer.toHexString(sRes & 0xffff);
                 String sVal_hex = Integer.toHexString(sVal & 0xffff);
-              throw new RuntimeException("Inconsistent result for Float.floatToFloat16(" + fVal + "/" + fVal_hex + "): " + sRes_hex + " != " + sVal_hex);
+                System.out.println(prefix + "Inconsistent result for Float.floatToFloat16(" + fVal + "/" + fVal_hex + "): " +
+                                   sRes_hex + "(" + sRes + ")" + " != " + sVal_hex + "(" + sVal + ")");
            }
         }
+        return errors;
     }
 
-    public static void run() {
+    public static int run() {
+        int errors = 0;
         // Testing all float16 values.
         for (short sVal = Short.MIN_VALUE; sVal < Short.MAX_VALUE; ++sVal) {
             float fVal = Float.float16ToFloat(sVal);
             short sRes = testFloatToFloat16(fVal);
-            verify(sVal, fVal, sRes);
+            errors += verify(sVal, fVal, sRes, "testFloatToFloat16: ");
             float fRes = testFloat16ToFloat(sVal);
             if (!Float.isNaN(fRes) && fRes != fVal) {
+                errors++;
                 String sVal_hex = Integer.toHexString(sVal & 0xffff);
                 String fRes_hex = Integer.toHexString(Float.floatToRawIntBits(fRes));
                 String fVal_hex = Integer.toHexString(Float.floatToRawIntBits(fVal));
-                throw new RuntimeException("Inconsistent result for Float.float16ToFloat(" + sVal_hex + "): " + fRes + "/" + fRes_hex + " != " + fVal + "/" + fVal_hex);
+                System.out.println("Non-NaN res: " + "Inconsistent result for Float.float16ToFloat(" + sVal_hex + "): " +
+                                   fRes + "/" + fRes_hex + " != " + fVal + "/" + fVal_hex);
             }
             sRes = testRoundTrip(sVal);
-            verify(sVal, fVal, sRes);
+            errors += verify(sVal, fVal, sRes, "testRoundTrip: ");
             if (Float.floatToFloat16(fRes) != Float.floatToFloat16(fVal)) {
+                errors++;
                 String sVal_hex = Integer.toHexString(sVal & 0xffff);
                 String sfRes_hex = Integer.toHexString(Float.floatToFloat16(fRes) & 0xffff);
-                String sfVal_hex = Integer.toHexString(Float.floatToFloat16(fVal)& 0xffff);
-                throw new RuntimeException("Inconsistent result for Float.float16ToFloat(" + sVal_hex + "): " + sfRes_hex + " != " + sfVal_hex);
+                String sfVal_hex = Integer.toHexString(Float.floatToFloat16(fVal) & 0xffff);
+                System.out.println("Float16 not equal: " + "Inconsistent result for Float.float16ToFloat(" + sVal_hex + "): " +
+                                   sfRes_hex + " != " + sfVal_hex);
             }
         }
+        return errors;
     }
 
     public static void main(String[] args) {
+        int errors = 0;
         // Run twice to trigger compilation
         for (int i = 0; i < 2; i++) {
-            run();
+            errors += run();
+        }
+        if (errors > 0) {
+            throw new RuntimeException(errors + " errors");
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestConstFloat16ToFloat.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestConstFloat16ToFloat.java
@@ -127,7 +127,8 @@ public class TestConstFloat16ToFloat {
         sRes[13] = Float.floatToFloat16(BinaryF16.POSITIVE_INFINITY);
     }
 
-    public static void run() {
+    public static int run() {
+        int errors = 0;
         short s = Float.floatToFloat16(0.0f); // Load Float class
         // Testing constant float16 values.
         float[] fRes = new float[sCon.length];
@@ -135,10 +136,12 @@ public class TestConstFloat16ToFloat {
         for (int i = 0; i < sCon.length; i++) {
             float fVal = Float.float16ToFloat(sCon[i]);
             if (Float.floatToRawIntBits(fRes[i]) != Float.floatToRawIntBits(fVal)) {
+                errors++;
                 String cVal_hex = Integer.toHexString(sCon[i] & 0xffff);
                 String fRes_hex = Integer.toHexString(Float.floatToRawIntBits(fRes[i]));
                 String fVal_hex = Integer.toHexString(Float.floatToRawIntBits(fVal));
-                throw new RuntimeException("Inconsistent result for Float.float16ToFloat(" + cVal_hex + "): " + fRes[i] + "/" + fRes_hex + " != " + fVal + "/" + fVal_hex);
+                System.out.println("Inconsistent result for Float.float16ToFloat(" + cVal_hex + "): " +
+                                    fRes[i] + "/" + fRes_hex + " != " + fVal + "/" + fVal_hex);
             }
         }
 
@@ -148,19 +151,26 @@ public class TestConstFloat16ToFloat {
         for (int i = 0; i < fCon.length; i++) {
             short sVal = Float.floatToFloat16(fCon[i]);
             if (sRes[i] != sVal) {
+                errors++;
                 String cVal_hex = Integer.toHexString(Float.floatToRawIntBits(fCon[i]));
                 String sRes_hex = Integer.toHexString(sRes[i] & 0xffff);
                 String sVal_hex = Integer.toHexString(sVal & 0xffff);
-                throw new RuntimeException("Inconsistent result for Float.floatToFloat16(" + fCon[i] + "/" + cVal_hex + "): " + sRes_hex + " != " + sVal_hex);
+                System.out.println("Inconsistent result for Float.floatToFloat16(" + fCon[i] + "/" + cVal_hex + "): " +
+                                    sRes_hex + "(" + sRes + ")" + " != " + sVal_hex + "(" + sVal + ")");
             }
         }
+        return errors;
 
     }
 
     public static void main(String[] args) {
+        int errors = 0;
         // Run twice to trigger compilation
         for (int i = 0; i < 2; i++) {
-            run();
+            errors += run();
+        }
+        if (errors > 0) {
+            throw new RuntimeException(errors + " errors");
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320715](https://bugs.openjdk.org/browse/JDK-8320715) needs maintainer approval

### Issue
 * [JDK-8320715](https://bugs.openjdk.org/browse/JDK-8320715): Improve the tests of test/hotspot/jtreg/compiler/intrinsics/float16 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/577/head:pull/577` \
`$ git checkout pull/577`

Update a local copy of the PR: \
`$ git checkout pull/577` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 577`

View PR using the GUI difftool: \
`$ git pr show -t 577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/577.diff">https://git.openjdk.org/jdk21u-dev/pull/577.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/577#issuecomment-2114070367)