### PR TITLE
8323782: Race: Thread::interrupt vs. AbstractInterruptibleChannel.begin

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1712,20 +1712,21 @@ public class Thread implements Runnable {
     public void interrupt() {
         if (this != Thread.currentThread()) {
             checkAccess();
+        }
 
-            // thread may be blocked in an I/O operation
+        // Setting the interrupt status must be done before reading nioBlocker.
+        interrupted = true;
+        interrupt0();  // inform VM of interrupt
+
+        // thread may be blocked in an I/O operation
+        if (this != Thread.currentThread()) {
             synchronized (interruptLock) {
                 Interruptible b = nioBlocker;
                 if (b != null) {
-                    interrupted = true;
-                    interrupt0();  // inform VM of interrupt
                     b.interrupt(this);
-                    return;
                 }
             }
         }
-        interrupted = true;
-        interrupt0();  // inform VM of interrupt
     }
 
     /**

--- a/test/jdk/java/nio/channels/Selector/LotsOfInterrupts.java
+++ b/test/jdk/java/nio/channels/Selector/LotsOfInterrupts.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=platform
+ * @bug 8323782
+ * @summary Stress test Thread.interrupt on a target Thread doing a selection operation
+ * @run main LotsOfInterrupts 200000
+ */
+
+/*
+ * @test id=virtual
+ * @run main/othervm -DthreadFactory=virtual LotsOfInterrupts 200000
+ */
+
+import java.nio.channels.Selector;
+import java.time.Instant;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.ThreadFactory;
+
+public class LotsOfInterrupts {
+
+    public static void main(String[] args) throws Exception {
+        int iterations;
+        if (args.length > 0) {
+            iterations = Integer.parseInt(args[0]);
+        } else {
+            iterations = 500_000;
+        }
+
+        ThreadFactory factory;
+        String value = System.getProperty("threadFactory");
+        if ("virtual".equals(value)) {
+            factory = Thread.ofVirtual().factory();
+        } else {
+            factory = Thread.ofPlatform().factory();
+        }
+
+        var phaser = new Phaser(2);
+
+        Thread thread = factory.newThread(() -> {
+            try (Selector sel = Selector.open()) {
+                for (int i = 0; i < iterations; i++) {
+                    phaser.arriveAndAwaitAdvance();
+                    sel.select();
+
+                    // clear interrupt status and consume wakeup
+                    Thread.interrupted();
+                    sel.selectNow();
+                }
+            } catch (Throwable ex) {
+                ex.printStackTrace();
+            }
+        });
+        thread.start();
+
+        long lastTimestamp = System.currentTimeMillis();
+        for (int i = 0; i < iterations; i++) {
+            phaser.arriveAndAwaitAdvance();
+            thread.interrupt();
+
+            long currentTime = System.currentTimeMillis();
+            if ((currentTime - lastTimestamp) > 500) {
+                System.out.format("%s %d iterations remaining ...%n", Instant.now(), (iterations - i));
+                lastTimestamp = currentTime;
+            }
+        }
+
+        thread.join();
+    }
+}


### PR DESCRIPTION
I'd like to do the backport because jdk 21 is affected by the issue. The included test hangs without the change.
Besides it will reduce the noise in jck tests we're doing regularily (the test api/java_net/ServerSocket/AcceptInterruptibleTests_PlatformThreads fails sometimes because of the issue).

I'd consider the risk low-medium.

Tested with the included test.

The fix passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests (also with ParallelGC).
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323782](https://bugs.openjdk.org/browse/JDK-8323782) needs maintainer approval

### Issue
 * [JDK-8323782](https://bugs.openjdk.org/browse/JDK-8323782): Race: Thread::interrupt vs. AbstractInterruptibleChannel.begin (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/578/head:pull/578` \
`$ git checkout pull/578`

Update a local copy of the PR: \
`$ git checkout pull/578` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 578`

View PR using the GUI difftool: \
`$ git pr show -t 578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/578.diff">https://git.openjdk.org/jdk21u-dev/pull/578.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/578#issuecomment-2151649699)