### PR TITLE
8329840: Fix ZPhysicalMemorySegment::_end type

### DIFF
--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -133,6 +133,10 @@ inline bool operator<(zoffset first, zoffset_end second) {
   return untype(first) < untype(second);
 }
 
+inline bool operator<=(zoffset_end first, zoffset second) {
+  return untype(first) <= untype(second);
+}
+
 inline bool operator>(zoffset first, zoffset_end second) {
   return untype(first) > untype(second);
 }

--- a/src/hotspot/share/gc/z/zPhysicalMemory.hpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.hpp
@@ -32,16 +32,16 @@
 
 class ZPhysicalMemorySegment : public CHeapObj<mtGC> {
 private:
-  zoffset _start;
-  zoffset _end;
-  bool    _committed;
+  zoffset     _start;
+  zoffset_end _end;
+  bool        _committed;
 
 public:
   ZPhysicalMemorySegment();
   ZPhysicalMemorySegment(zoffset start, size_t size, bool committed);
 
   zoffset start() const;
-  zoffset end() const;
+  zoffset_end end() const;
   size_t size() const;
 
   bool is_committed() const;

--- a/src/hotspot/share/gc/z/zPhysicalMemory.inline.hpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.inline.hpp
@@ -31,19 +31,19 @@
 
 inline ZPhysicalMemorySegment::ZPhysicalMemorySegment()
   : _start(zoffset(UINTPTR_MAX)),
-    _end(zoffset(UINTPTR_MAX)),
+    _end(zoffset_end(UINTPTR_MAX)),
     _committed(false) {}
 
 inline ZPhysicalMemorySegment::ZPhysicalMemorySegment(zoffset start, size_t size, bool committed)
   : _start(start),
-    _end(start + size),
+    _end(to_zoffset_end(start, size)),
     _committed(committed) {}
 
 inline zoffset ZPhysicalMemorySegment::start() const {
   return _start;
 }
 
-inline zoffset ZPhysicalMemorySegment::end() const {
+inline zoffset_end ZPhysicalMemorySegment::end() const {
   return _end;
 }
 


### PR DESCRIPTION
Clean backport of fixing type of ZPhysicalMemorySegment::_end type

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329840](https://bugs.openjdk.org/browse/JDK-8329840) needs maintainer approval

### Issue
 * [JDK-8329840](https://bugs.openjdk.org/browse/JDK-8329840): Fix ZPhysicalMemorySegment::_end type (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/583/head:pull/583` \
`$ git checkout pull/583`

Update a local copy of the PR: \
`$ git checkout pull/583` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 583`

View PR using the GUI difftool: \
`$ git pr show -t 583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/583.diff">https://git.openjdk.org/jdk21u-dev/pull/583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/583#issuecomment-2117060026)