### PR TITLE
8329109: Threads::print_on() tries to print CPU time for terminated GC threads

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1317,10 +1317,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
   }
 
   PrintOnClosure cl(st);
-  cl.do_thread(VMThread::vm_thread());
-  Universe::heap()->gc_threads_do(&cl);
-  cl.do_thread(WatcherThread::watcher_thread());
-  cl.do_thread(AsyncLogWriter::instance());
+  non_java_threads_do(&cl);
 
   st->flush();
 }


### PR DESCRIPTION
Clean backport of fixing crash on Threads::print_on() .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329109](https://bugs.openjdk.org/browse/JDK-8329109) needs maintainer approval

### Issue
 * [JDK-8329109](https://bugs.openjdk.org/browse/JDK-8329109): Threads::print_on() tries to print CPU time for terminated GC threads (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/585/head:pull/585` \
`$ git checkout pull/585`

Update a local copy of the PR: \
`$ git checkout pull/585` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 585`

View PR using the GUI difftool: \
`$ git pr show -t 585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/585.diff">https://git.openjdk.org/jdk21u-dev/pull/585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/585#issuecomment-2117099203)