### PR TITLE
8329223: Parallel: Parallel GC resizes heap even if -Xms = -Xmx

### DIFF
--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -276,6 +276,9 @@ void GenArguments::initialize_size_info() {
   // and maximum heap size since no explicit flags exist
   // for setting the old generation maximum.
   MaxOldSize = MAX2(MaxHeapSize - max_young_size, GenAlignment);
+  MinOldSize = MIN3(MaxOldSize,
+                    InitialHeapSize - initial_young_size,
+                    MinHeapSize - MinNewSize);
 
   size_t initial_old_size = OldSize;
 
@@ -287,9 +290,8 @@ void GenArguments::initialize_size_info() {
     // with the overall heap size).  In either case make
     // the minimum, maximum and initial sizes consistent
     // with the young sizes and the overall heap sizes.
-    MinOldSize = GenAlignment;
     initial_old_size = clamp(InitialHeapSize - initial_young_size, MinOldSize, MaxOldSize);
-    // MaxOldSize has already been made consistent above.
+    // MaxOldSize and MinOldSize have already been made consistent above.
   } else {
     // OldSize has been explicitly set on the command line. Use it
     // for the initial size but make sure the minimum allow a young
@@ -304,9 +306,10 @@ void GenArguments::initialize_size_info() {
                             ", -XX:OldSize flag is being ignored",
                             MaxHeapSize);
       initial_old_size = MaxOldSize;
+    } else if (initial_old_size < MinOldSize) {
+      log_warning(gc, ergo)("Inconsistency between initial old size and minimum old size");
+      MinOldSize = initial_old_size;
     }
-
-    MinOldSize = MIN2(initial_old_size, MinHeapSize - MinNewSize);
   }
 
   // The initial generation sizes should match the initial heap size,


### PR DESCRIPTION
Clean backport of a low-risk change to address unexpected behavior with Parallel GC when Xms == Xmx
Passes local tier-1 testing on linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329223](https://bugs.openjdk.org/browse/JDK-8329223) needs maintainer approval

### Issue
 * [JDK-8329223](https://bugs.openjdk.org/browse/JDK-8329223): Parallel: Parallel GC resizes heap even if -Xms = -Xmx (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/587/head:pull/587` \
`$ git checkout pull/587`

Update a local copy of the PR: \
`$ git checkout pull/587` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 587`

View PR using the GUI difftool: \
`$ git pr show -t 587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/587.diff">https://git.openjdk.org/jdk21u-dev/pull/587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/587#issuecomment-2118280635)