### PR TITLE
8320681: [macos] Test tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java timed out on macOS

### DIFF
--- a/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import jdk.jpackage.test.Annotations.Test;
  * @build MacAppStoreJLinkOptionsTest
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @requires (os.family == "mac")
- * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=MacAppStoreJLinkOptionsTest
  */
 public class MacAppStoreJLinkOptionsTest {


### PR DESCRIPTION
I backport this for parity with 21.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320681](https://bugs.openjdk.org/browse/JDK-8320681) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320681](https://bugs.openjdk.org/browse/JDK-8320681): [macos] Test tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java timed out on macOS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/592/head:pull/592` \
`$ git checkout pull/592`

Update a local copy of the PR: \
`$ git checkout pull/592` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 592`

View PR using the GUI difftool: \
`$ git pr show -t 592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/592.diff">https://git.openjdk.org/jdk21u-dev/pull/592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/592#issuecomment-2122008169)