### PR TITLE
8332490: JMH org.openjdk.bench.java.util.zip.InflaterInputStreams.inflaterInputStreamRead OOM

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
@@ -108,7 +108,10 @@ public class InflaterInputStreams {
     @Benchmark
     public void inflaterInputStreamRead() throws IOException {
         deflated.reset();
-        InflaterInputStream iis = new InflaterInputStream(deflated);
-        while (iis.read(inflated, 0, inflated.length) != -1);
+        // We close the InflaterInputStream to release underlying native resources of the Inflater.
+        // The "deflated" ByteArrayInputStream remains unaffected.
+        try (InflaterInputStream iis = new InflaterInputStream(deflated)) {
+            while (iis.read(inflated, 0, inflated.length) != -1);
+        }
     }
 }


### PR DESCRIPTION
Hi all,
  This clean backport of [JDK-8332490](https://bugs.openjdk.org/browse/JDK-8332490), to closes the InflaterInputStream when the reads complete. The change has been verified. Only change the JMH testcase, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332490](https://bugs.openjdk.org/browse/JDK-8332490) needs maintainer approval

### Issue
 * [JDK-8332490](https://bugs.openjdk.org/browse/JDK-8332490): JMH org.openjdk.bench.java.util.zip.InflaterInputStreams.inflaterInputStreamRead OOM (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/596/head:pull/596` \
`$ git checkout pull/596`

Update a local copy of the PR: \
`$ git checkout pull/596` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 596`

View PR using the GUI difftool: \
`$ git pr show -t 596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/596.diff">https://git.openjdk.org/jdk21u-dev/pull/596.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/596#issuecomment-2126038366)