### PR TITLE
8330576: ZYoungCompactionLimit should have range check

### DIFF
--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -37,6 +37,7 @@
                                                                             \
   product(double, ZYoungCompactionLimit, 25.0,                              \
           "Maximum allowed garbage in young pages")                         \
+          range(0, 100)                                                     \
                                                                             \
   product(double, ZCollectionIntervalMinor, -1,                             \
           "Force Minor GC at a fixed time interval (in seconds)")           \


### PR DESCRIPTION
Backport of fixing range check of ZYoungCompactionLimit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330576](https://bugs.openjdk.org/browse/JDK-8330576) needs maintainer approval

### Issue
 * [JDK-8330576](https://bugs.openjdk.org/browse/JDK-8330576): ZYoungCompactionLimit should have range check (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/597/head:pull/597` \
`$ git checkout pull/597`

Update a local copy of the PR: \
`$ git checkout pull/597` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 597`

View PR using the GUI difftool: \
`$ git pr show -t 597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/597.diff">https://git.openjdk.org/jdk21u-dev/pull/597.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/597#issuecomment-2126595790)