### PR TITLE
8316328: Test jdk/jfr/event/oldobject/TestSanityDefault.java times out for some heap sizes

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestSanityDefault.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestSanityDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
  * @summary Purpose of this test is to run leak profiler without command line tweaks or WhiteBox hacks until we succeed
- * @run main/othervm jdk.jfr.event.oldobject.TestSanityDefault
+ * @run main/othervm -Xmx1G jdk.jfr.event.oldobject.TestSanityDefault
  */
 public class TestSanityDefault {
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9b1d6d66](https://github.com/openjdk/jdk/commit/9b1d6d66b8297d53c6b96b9e2f9bd69af90ab8fb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 23 May 2024 and was reviewed by Paul Hohensee, Aleksey Shipilev and Erik Gahlin.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316328](https://bugs.openjdk.org/browse/JDK-8316328) needs maintainer approval

### Issue
 * [JDK-8316328](https://bugs.openjdk.org/browse/JDK-8316328): Test jdk/jfr/event/oldobject/TestSanityDefault.java times out for some heap sizes (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/600/head:pull/600` \
`$ git checkout pull/600`

Update a local copy of the PR: \
`$ git checkout pull/600` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 600`

View PR using the GUI difftool: \
`$ git pr show -t 600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/600.diff">https://git.openjdk.org/jdk21u-dev/pull/600.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/600#issuecomment-2128501472)