### PR TITLE
8330275: Crash in XMark::follow_array

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/x/xGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/x/xGlobals_aarch64.cpp
@@ -142,9 +142,11 @@
 //  * 63-48 Fixed (16-bits, always zero)
 //
 
-// Default value if probing is not implemented for a certain platform: 128TB
-static const size_t DEFAULT_MAX_ADDRESS_BIT = 47;
-// Minimum value returned, if probing fails: 64GB
+// Default value if probing is not implemented for a certain platform
+// Max address bit is restricted by implicit assumptions in the code, for instance
+// the bit layout of XForwardingEntry or Partial array entry (see XMarkStackEntry) in mark stack
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
+// Minimum value returned, if probing fails
 static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
 
 static size_t probe_valid_max_address_bit() {

--- a/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
@@ -36,9 +36,11 @@
 #include <sys/mman.h>
 #endif // LINUX
 
-// Default value if probing is not implemented for a certain platform: 128TB
-static const size_t DEFAULT_MAX_ADDRESS_BIT = 47;
-// Minimum value returned, if probing fails: 64GB
+// Default value if probing is not implemented for a certain platform
+// Max address bit is restricted by implicit assumptions in the code, for instance
+// the bit layout of XForwardingEntry or Partial array entry (see XMarkStackEntry) in mark stack
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
+// Minimum value returned, if probing fail
 static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
 
 static size_t probe_valid_max_address_bit() {


### PR DESCRIPTION
Backport of [JDK-8330275](https://bugs.openjdk.org/browse/JDK-8330275) to fix crash in ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330275](https://bugs.openjdk.org/browse/JDK-8330275) needs maintainer approval

### Issue
 * [JDK-8330275](https://bugs.openjdk.org/browse/JDK-8330275): Crash in XMark::follow_array (**Bug** - P2 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/612/head:pull/612` \
`$ git checkout pull/612`

Update a local copy of the PR: \
`$ git checkout pull/612` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 612`

View PR using the GUI difftool: \
`$ git pr show -t 612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/612.diff">https://git.openjdk.org/jdk21u-dev/pull/612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/612#issuecomment-2135462518)