### PR TITLE
8333093: Incorrect comment in zAddress_aarch64.cpp

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
@@ -38,7 +38,7 @@
 
 // Default value if probing is not implemented for a certain platform
 // Max address bit is restricted by implicit assumptions in the code, for instance
-// the bit layout of XForwardingEntry or Partial array entry (see XMarkStackEntry) in mark stack
+// the bit layout of ZForwardingEntry or Partial array entry (see ZMarkStackEntry) in mark stack
 static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
 // Minimum value returned, if probing fail
 static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [51ae08f7](https://github.com/openjdk/jdk/commit/51ae08f72b879bc611177ea643cd88e36185d9e8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ashutosh Mehra on 28 May 2024 and was reviewed by Stefan Karlsson.

It is a trivial change to fix the comments.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333093](https://bugs.openjdk.org/browse/JDK-8333093) needs maintainer approval

### Issue
 * [JDK-8333093](https://bugs.openjdk.org/browse/JDK-8333093): Incorrect comment in zAddress_aarch64.cpp (**Bug** - P5 - Approved)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/613/head:pull/613` \
`$ git checkout pull/613`

Update a local copy of the PR: \
`$ git checkout pull/613` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 613`

View PR using the GUI difftool: \
`$ git pr show -t 613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/613.diff">https://git.openjdk.org/jdk21u-dev/pull/613.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/613#issuecomment-2135897736)