### PR TITLE
8326106: Write and clear stack trace table outside of safepoint

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -569,9 +569,7 @@ void JfrRecorderService::pre_safepoint_write() {
     ObjectSampleCheckpoint::on_rotation(ObjectSampler::acquire());
   }
   write_storage(_storage, _chunkwriter);
-  if (_stack_trace_repository.is_modified()) {
-    write_stacktrace(_stack_trace_repository, _chunkwriter, false);
-  }
+  write_stacktrace(_stack_trace_repository, _chunkwriter, true);
 }
 
 void JfrRecorderService::invoke_safepoint_write() {

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -98,11 +98,10 @@ bool JfrStackTraceRepository::is_modified() const {
 }
 
 size_t JfrStackTraceRepository::write(JfrChunkWriter& sw, bool clear) {
+  MutexLocker lock(JfrStacktrace_lock, Mutex::_no_safepoint_check_flag);
   if (_entries == 0) {
     return 0;
   }
-  MutexLocker lock(JfrStacktrace_lock, Mutex::_no_safepoint_check_flag);
-  assert(_entries > 0, "invariant");
   int count = 0;
   for (u4 i = 0; i < TABLE_SIZE; ++i) {
     JfrStackTrace* stacktrace = _table[i];


### PR DESCRIPTION
Clean backport of [JDK-8326106](https://bugs.openjdk.org/browse/JDK-8326106).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326106](https://bugs.openjdk.org/browse/JDK-8326106) needs maintainer approval

### Issue
 * [JDK-8326106](https://bugs.openjdk.org/browse/JDK-8326106): Write and clear stack trace table outside of safepoint (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/615/head:pull/615` \
`$ git checkout pull/615`

Update a local copy of the PR: \
`$ git checkout pull/615` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 615`

View PR using the GUI difftool: \
`$ git pr show -t 615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/615.diff">https://git.openjdk.org/jdk21u-dev/pull/615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/615#issuecomment-2137491400)