### PR TITLE
8322330: JavadocHelperTest.java OOMEs with Parallel GC and ZGC

### DIFF
--- a/test/langtools/jdk/internal/shellsupport/doc/JavadocHelperTest.java
+++ b/test/langtools/jdk/internal/shellsupport/doc/JavadocHelperTest.java
@@ -30,7 +30,7 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/jdk.internal.shellsupport.doc
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
- * @run testng/timeout=900/othervm JavadocHelperTest
+ * @run testng/timeout=900/othervm -Xmx1024m JavadocHelperTest
  */
 
 import java.io.IOException;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [52c7ff1d](https://github.com/openjdk/jdk/commit/52c7ff1d81940d6d0d1e3dd7ad0447c80708161c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Schatzl on 9 Jan 2024 and was reviewed by Albert Mingkun Yang and Axel Boldt-Christmas.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322330](https://bugs.openjdk.org/browse/JDK-8322330) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322330](https://bugs.openjdk.org/browse/JDK-8322330): JavadocHelperTest.java OOMEs with Parallel GC and ZGC (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/625/head:pull/625` \
`$ git checkout pull/625`

Update a local copy of the PR: \
`$ git checkout pull/625` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 625`

View PR using the GUI difftool: \
`$ git pr show -t 625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/625.diff">https://git.openjdk.org/jdk21u-dev/pull/625.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/625#issuecomment-2144101082)