### PR TITLE
8331771: ZGC: Remove OopMapCacheAlloc_lock ordering workaround

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -95,7 +95,6 @@ class CollectedHeap : public CHeapObj<mtGC> {
   friend class VMStructs;
   friend class JVMCIVMStructs;
   friend class IsGCActiveMark; // Block structured external access to _is_gc_active
-  friend class DisableIsGCActiveMark; // Disable current IsGCActiveMark
   friend class MemAllocator;
   friend class ParallelObjectIterator;
 

--- a/src/hotspot/share/gc/shared/isGCActiveMark.cpp
+++ b/src/hotspot/share/gc/shared/isGCActiveMark.cpp
@@ -42,15 +42,3 @@ IsGCActiveMark::~IsGCActiveMark() {
   assert(heap->is_gc_active(), "Sanity");
   heap->_is_gc_active = false;
 }
-
-DisableIsGCActiveMark::DisableIsGCActiveMark() {
-  CollectedHeap* heap = Universe::heap();
-  assert(heap->is_gc_active(), "Not reentrant");
-  heap->_is_gc_active = false;
-}
-
-DisableIsGCActiveMark::~DisableIsGCActiveMark() {
-  CollectedHeap* heap = Universe::heap();
-  assert(!heap->is_gc_active(), "Sanity");
-  heap->_is_gc_active = true;
-}

--- a/src/hotspot/share/gc/shared/isGCActiveMark.hpp
+++ b/src/hotspot/share/gc/shared/isGCActiveMark.hpp
@@ -36,10 +36,4 @@ class IsGCActiveMark : public StackObj {
   ~IsGCActiveMark();
 };
 
-class DisableIsGCActiveMark : public StackObj {
- public:
-  DisableIsGCActiveMark();
-  ~DisableIsGCActiveMark();
-};
-
 #endif // SHARE_GC_SHARED_ISGCACTIVEMARK_HPP

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -493,9 +493,6 @@ void ZVerify::after_mark() {
     roots_strong(true /* verify_after_old_mark */);
   }
   if (ZVerifyObjects) {
-    // Workaround OopMapCacheAlloc_lock reordering with the StackWatermark_lock
-    DisableIsGCActiveMark mark;
-
     objects(false /* verify_weaks */);
     guarantee(zverify_broken_object == zaddress::null, "Verification failed");
   }


### PR DESCRIPTION
I'd like to backport [JDK-8331771](https://bugs.openjdk.org/browse/JDK-8331771) to jdk21

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331771](https://bugs.openjdk.org/browse/JDK-8331771) needs maintainer approval

### Issue
 * [JDK-8331771](https://bugs.openjdk.org/browse/JDK-8331771): ZGC: Remove OopMapCacheAlloc_lock ordering workaround (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [3072df2a](https://git.openjdk.org/jdk21u-dev/pull/626/files/3072df2a0db82ad424d2c7c2ed8fc6242930b64c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/626/head:pull/626` \
`$ git checkout pull/626`

Update a local copy of the PR: \
`$ git checkout pull/626` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 626`

View PR using the GUI difftool: \
`$ git pr show -t 626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/626.diff">https://git.openjdk.org/jdk21u-dev/pull/626.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/626#issuecomment-2141314963)