### PR TITLE
8323577: C2 SuperWord: remove AlignVector restrictions on IR tests added in JDK-8305055

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -58,10 +58,7 @@ public class TestVectorizeTypeConversion {
     // Mixing types of different sizes has the effect that some vectors are shorter than the type allows.
     @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0",
                   IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0",
-                  IRNode.STORE_VECTOR, ">0"},
-        // The vectorization of some conversions may fail when `+AlignVector`.
-        // We can remove the condition after JDK-8303827.
-        applyIf = {"AlignVector", "false"})
+                  IRNode.STORE_VECTOR, ">0"})
     private static void testConvI2D(double[] d, int[] a) {
         for(int i = 0; i < d.length; i++) {
             d[i] = (double) (a[i]);

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
@@ -143,9 +143,6 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        // The vectorization of some conversions may fail when `+AlignVector`.
-        // We can remove the condition after JDK-8303827.
-        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0"})
     public double[] convertIntToDouble() {
         double[] res = new double[SIZE];
@@ -233,9 +230,6 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
-        // The vectorization of some conversions may fail when `+AlignVector`.
-        // We can remove the condition after JDK-8303827.
-        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE + "min(max_float, max_long)", ">0"})
     public long[] convertFloatToLong() {
         long[] res = new long[SIZE];
@@ -317,9 +311,6 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     // ---------------- Convert Between F & D ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        // The vectorization of some conversions may fail when `+AlignVector`.
-        // We can remove the condition after JDK-8303827.
-        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_F2D, IRNode.VECTOR_SIZE + "min(max_float, max_double)", ">0"})
     public double[] convertFloatToDouble() {
         double[] res = new double[SIZE];


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323577](https://bugs.openjdk.org/browse/JDK-8323577) needs maintainer approval

### Issue
 * [JDK-8323577](https://bugs.openjdk.org/browse/JDK-8323577): C2 SuperWord: remove AlignVector restrictions on IR tests added in JDK-8305055 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/628/head:pull/628` \
`$ git checkout pull/628`

Update a local copy of the PR: \
`$ git checkout pull/628` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 628`

View PR using the GUI difftool: \
`$ git pr show -t 628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/628.diff">https://git.openjdk.org/jdk21u-dev/pull/628.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/628#issuecomment-2141572568)