### PR TITLE
8322008: Exclude some CDS tests from running with -Xshare:off

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -57,6 +57,13 @@ hotspot_runtime_no_cds = \
   runtime \
   -runtime/cds
 
+hotspot_runtime_non_cds_mode = \
+  runtime \
+  -runtime/cds/CheckSharingWithDefaultArchive.java \
+  -runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java \
+  -runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java \
+  -runtime/cds/appcds/jcmd
+
 hotspot_handshake = \
   runtime/handshake
 


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322008](https://bugs.openjdk.org/browse/JDK-8322008) needs maintainer approval

### Issue
 * [JDK-8322008](https://bugs.openjdk.org/browse/JDK-8322008): Exclude some CDS tests from running with -Xshare:off (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/629/head:pull/629` \
`$ git checkout pull/629`

Update a local copy of the PR: \
`$ git checkout pull/629` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 629`

View PR using the GUI difftool: \
`$ git pr show -t 629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/629.diff">https://git.openjdk.org/jdk21u-dev/pull/629.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/629#issuecomment-2141572471)