### PR TITLE
8332431: NullPointerException in JTable of SwingSet2

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
+++ b/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
@@ -265,13 +265,19 @@ public final class ToolTipManager extends MouseAdapter implements MouseMotionLis
                 toFind = new Point(screenLocation.x + preferredLocation.x,
                         screenLocation.y + preferredLocation.y);
             } else {
-                toFind = mouseEvent.getLocationOnScreen();
+                if (mouseEvent != null) {
+                    toFind = mouseEvent.getLocationOnScreen();
+                } else {
+                    toFind = screenLocation;
+                }
             }
 
             GraphicsConfiguration gc = getDrawingGC(toFind);
             if (gc == null) {
-                toFind = mouseEvent.getLocationOnScreen();
-                gc = getDrawingGC(toFind);
+                if (mouseEvent != null) {
+                    toFind = mouseEvent.getLocationOnScreen();
+                    gc = getDrawingGC(toFind);
+                }
                 if (gc == null) {
                     gc = insideComponent.getGraphicsConfiguration();
                 }
@@ -301,8 +307,12 @@ public final class ToolTipManager extends MouseAdapter implements MouseMotionLis
             location.x -= size.width;
         }
             } else {
-                location = new Point(screenLocation.x + mouseEvent.getX(),
-                        screenLocation.y + mouseEvent.getY() + 20);
+                if (mouseEvent != null) {
+                    location = new Point(screenLocation.x + mouseEvent.getX(),
+                            screenLocation.y + mouseEvent.getY() + 20);
+                } else {
+                    location = screenLocation;
+                }
         if (!leftToRight) {
             if(location.x - size.width>=0) {
                 location.x -= size.width;


### PR DESCRIPTION
Backport of 8332431

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332431](https://bugs.openjdk.org/browse/JDK-8332431) needs maintainer approval

### Issue
 * [JDK-8332431](https://bugs.openjdk.org/browse/JDK-8332431): NullPointerException in JTable of SwingSet2 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/630/head:pull/630` \
`$ git checkout pull/630`

Update a local copy of the PR: \
`$ git checkout pull/630` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 630`

View PR using the GUI difftool: \
`$ git pr show -t 630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/630.diff">https://git.openjdk.org/jdk21u-dev/pull/630.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/630#issuecomment-2141758965)