### PR TITLE
8325382: (fc) FileChannel.transferTo throws IOException when position equals size

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -759,20 +759,18 @@ public class FileChannelImpl
         if (position > sz)
             return 0;
 
-        // Now position <= sz so remaining >= 0 and
-        // remaining == 0 if and only if sz == 0
-        long remaining = sz - position;
-
-        // Adjust count only if remaining > 0, i.e.,
-        // sz > position which means sz > 0
-        if (remaining > 0 && remaining < count)
-            count = remaining;
-
         // System calls supporting fast transfers might not work on files
         // which advertise zero size such as those in Linux /proc
         if (sz > 0) {
-            // Attempt a direct transfer, if the kernel supports it, limiting
-            // the number of bytes according to which platform
+            // Now sz > 0 and position <= sz so remaining >= 0 and
+            // remaining == 0 if and only if sz == position
+            long remaining = sz - position;
+
+            if (remaining >= 0 && remaining < count)
+                count = remaining;
+
+            // Attempt a direct transfer, if the kernel supports it,
+            // limiting the number of bytes according to which platform
             int icount = (int)Math.min(count, nd.maxDirectTransferSize());
             long n;
             if ((n = transferToDirectly(position, icount, target)) >= 0)


### PR DESCRIPTION
Backport of [JDK-8325382](https://bugs.openjdk.org/browse/JDK-8325382). Not clean because of indentation. Included test has passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325382](https://bugs.openjdk.org/browse/JDK-8325382) needs maintainer approval

### Issue
 * [JDK-8325382](https://bugs.openjdk.org/browse/JDK-8325382): (fc) FileChannel.transferTo throws IOException when position equals size (**Bug** - P3 - Approved)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/631/head:pull/631` \
`$ git checkout pull/631`

Update a local copy of the PR: \
`$ git checkout pull/631` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 631`

View PR using the GUI difftool: \
`$ git pr show -t 631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/631.diff">https://git.openjdk.org/jdk21u-dev/pull/631.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/631#issuecomment-2142518031)