### PR TITLE
8329995: Restricted access to `/proc` can cause JFR initialization to crash

### DIFF
--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -847,7 +847,7 @@ SystemProcessInterface::SystemProcesses::ProcessIterator::ProcessIterator() {
 bool SystemProcessInterface::SystemProcesses::ProcessIterator::initialize() {
   _dir = os::opendir("/proc");
   _entry = nullptr;
-  _valid = true;
+  _valid = _dir != nullptr; // May be null if /proc is not accessible.
   next_process();
 
   return true;


### PR DESCRIPTION
Backport of JDK-8329995

The call to os::opendir("/proc") may return nulltptr if the /proc is not accessible due to restrictions placed by the SELinux. In that case the ProcessIterator will SIGSEG because it assumes the _dir, which is the variable storing the result of the os::opendir("/proc") call to be non-null.

The patch is missing regression test because it is very hard to simulate /proc not being accessible to the test process.

**Testing**
All Tier 1, tier2, jdk_jfr, hotspot_gc tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329995](https://bugs.openjdk.org/browse/JDK-8329995) needs maintainer approval

### Issue
 * [JDK-8329995](https://bugs.openjdk.org/browse/JDK-8329995): Restricted access to `/proc` can cause JFR initialization to crash (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/634/head:pull/634` \
`$ git checkout pull/634`

Update a local copy of the PR: \
`$ git checkout pull/634` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 634`

View PR using the GUI difftool: \
`$ git pr show -t 634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/634.diff">https://git.openjdk.org/jdk21u-dev/pull/634.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/634#issuecomment-2142545071)