### PR TITLE
8328785: IOException: Symbol not found: C_GetInterface for PKCS11 interface prior to V3.0

### DIFF
--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -103,7 +103,6 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     /*
      * Load the PKCS #11 DLL
      */
-    dlerror(); /* clear any old error message not fetched */
 #ifdef DEBUG
     hModule = dlopen(libraryNameStr, RTLD_NOW);
 #else
@@ -123,9 +122,6 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
         free(exceptionMessage);
         goto cleanup;
     }
-
-    // clear any old error message not fetched
-    dlerror();
 
 #ifdef DEBUG
     C_GetInterfaceList = (CK_C_GetInterfaceList) dlsym(hModule,
@@ -158,47 +154,42 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     }
 #endif
 
-    if (jGetFunctionList != NULL) {
+    // if none specified, then we try 3.0 API first before trying 2.40
+    if (jGetFunctionList == NULL) {
+        C_GetInterface = (CK_C_GetInterface) dlsym(hModule, "C_GetInterface");
+        if (C_GetInterface != NULL) {
+            TRACE0("Connect: Found C_GetInterface func\n");
+            rv = (C_GetInterface)(NULL, NULL, &interface, 0L);
+            // don't use ckAssertReturnValueOK as we want to continue trying
+            // C_GetFunctionList() or method named by "getFunctionListStr"
+            if (rv == CKR_OK) {
+                goto setModuleData;
+            }
+        }
+        getFunctionListStr = "C_GetFunctionList";
+    } else {
         getFunctionListStr = (*env)->GetStringUTFChars(env,
             jGetFunctionList, 0);
         if (getFunctionListStr == NULL) {
             goto cleanup;
         }
-        C_GetFunctionList = (CK_C_GetFunctionList) dlsym(hModule,
+    }
+
+    dlerror(); // clear any old error message not fetched
+    C_GetFunctionList = (CK_C_GetFunctionList) dlsym(hModule,
             getFunctionListStr);
+    if (C_GetFunctionList == NULL) {
         if ((systemErrorMessage = dlerror()) != NULL){
+            TRACE2("Connect: error finding %s func: %s\n", getFunctionListStr,
+                systemErrorMessage);
             p11ThrowIOException(env, systemErrorMessage);
-            goto cleanup;
-        }
-        if (C_GetFunctionList == NULL) {
+        } else {
             TRACE1("Connect: No %s func\n", getFunctionListStr);
             p11ThrowIOException(env, "ERROR: C_GetFunctionList == NULL");
-            goto cleanup;
         }
-        TRACE1("Connect: Found %s func\n", getFunctionListStr);
-    } else {
-        // if none specified, then we try 3.0 API first before trying 2.40
-        C_GetInterface = (CK_C_GetInterface) dlsym(hModule, "C_GetInterface");
-        if ((C_GetInterface != NULL) && (dlerror() == NULL)) {
-            TRACE0("Connect: Found C_GetInterface func\n");
-            rv = (C_GetInterface)(NULL, NULL, &interface, 0L);
-            if (ckAssertReturnValueOK(env, rv) == CK_ASSERT_OK) {
-                goto setModuleData;
-            }
-        }
-        C_GetFunctionList = (CK_C_GetFunctionList) dlsym(hModule,
-                "C_GetFunctionList");
-        if ((systemErrorMessage = dlerror()) != NULL){
-            p11ThrowIOException(env, systemErrorMessage);
-            goto cleanup;
-        }
-        if (C_GetFunctionList == NULL) {
-            TRACE0("Connect: No C_GetFunctionList func\n");
-            p11ThrowIOException(env, "ERROR: C_GetFunctionList == NULL");
-            goto cleanup;
-        }
-        TRACE0("Connect: Found C_GetFunctionList func\n");
+        goto cleanup;
     }
+    TRACE1("Connect: Found %s func\n", getFunctionListStr);
 
 setModuleData:
     /*


### PR DESCRIPTION
Clean backport of [JDK-8328785](https://bugs.openjdk.org/browse/JDK-8328785).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8328785](https://bugs.openjdk.org/browse/JDK-8328785) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328785](https://bugs.openjdk.org/browse/JDK-8328785): IOException: Symbol not found: C_GetInterface for PKCS11 interface prior to V3.0 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/639/head:pull/639` \
`$ git checkout pull/639`

Update a local copy of the PR: \
`$ git checkout pull/639` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 639`

View PR using the GUI difftool: \
`$ git pr show -t 639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/639.diff">https://git.openjdk.org/jdk21u-dev/pull/639.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/639#issuecomment-2142856387)