### PR TITLE
8331077: nroff man page update for jar tool

### DIFF
--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -186,7 +186,8 @@ created or a non-modular JAR file being updated.
 Specifies the location of module dependence for generating the hash.
 .TP
 \f[V]\[at]\f[R]\f[I]file\f[R]
-Reads \f[V]jar\f[R] options and file names from a text file.
+Reads \f[V]jar\f[R] options and file names from a text file as if they
+were supplied on the command line
 .SH OPERATION MODIFIERS VALID ONLY IN CREATE, UPDATE, AND GENERATE-INDEX MODES
 .PP
 You can use the following options to customize the actions of the create
@@ -330,11 +331,14 @@ class files from the file \f[V]classes.list\f[R].
 .PP
 \f[B]Note:\f[R]
 .PP
-To shorten or simplify the \f[V]jar\f[R] command, you can specify
-arguments in a separate text file and pass it to the \f[V]jar\f[R]
-command with the at sign (\f[V]\[at]\f[R]) as a prefix.
+To shorten or simplify the \f[V]jar\f[R] command, you can provide an arg
+file that lists the files to include in the JAR file and pass it to the
+\f[V]jar\f[R] command with the at sign (\f[V]\[at]\f[R]) as a prefix.
 .RS
 .PP
 \f[V]jar --create --file my.jar \[at]classes.list\f[R]
 .RE
+.PP
+If one or more entries in the arg file cannot be found then the jar
+command fails without creating the JAR file.
 .RE


### PR DESCRIPTION
Clean backport of [JDK-8331077](https://bugs.openjdk.org/browse/JDK-8331077).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331077](https://bugs.openjdk.org/browse/JDK-8331077) needs maintainer approval

### Issue
 * [JDK-8331077](https://bugs.openjdk.org/browse/JDK-8331077): nroff man page update for jar tool (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/643/head:pull/643` \
`$ git checkout pull/643`

Update a local copy of the PR: \
`$ git checkout pull/643` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 643`

View PR using the GUI difftool: \
`$ git pr show -t 643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/643.diff">https://git.openjdk.org/jdk21u-dev/pull/643.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/643#issuecomment-2142874791)