### PR TITLE
8315031: YoungPLABSize and OldPLABSize not aligned by ObjectAlignmentInBytes

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacStats.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacStats.cpp
@@ -133,7 +133,9 @@ G1EvacStats::G1EvacStats(const char* description, size_t default_per_thread_plab
 // Calculates plab size for current number of gc worker threads.
 size_t G1EvacStats::desired_plab_size(uint no_of_gc_workers) const {
   if (!ResizePLAB) {
-      return _default_plab_size;
+    // There is a circular dependency between the heap and PLAB initialization,
+    // so _default_plab_size can have an unaligned value.
+    return align_object_size(_default_plab_size);
   }
   return align_object_size(clamp(_desired_net_plab_size / no_of_gc_workers, min_size(), max_size()));
 }

--- a/src/hotspot/share/gc/shared/plab.cpp
+++ b/src/hotspot/share/gc/shared/plab.cpp
@@ -51,6 +51,13 @@ void PLAB::startup_initialization() {
       FLAG_SET_ERGO(OldPLABSize, MAX2(ThreadLocalAllocBuffer::min_size(), OldPLABSize));
     }
   }
+  uint obj_alignment = checked_cast<uint>(ObjectAlignmentInBytes / HeapWordSize);
+  if (!is_aligned(YoungPLABSize, obj_alignment)) {
+    FLAG_SET_ERGO(YoungPLABSize, align_up(YoungPLABSize, obj_alignment));
+  }
+  if (!is_aligned(OldPLABSize, obj_alignment)) {
+    FLAG_SET_ERGO(OldPLABSize, align_up(OldPLABSize, obj_alignment));
+  }
 }
 
 PLAB::PLAB(size_t desired_plab_sz_) :


### PR DESCRIPTION
Clean backport of YoungPLABSize and OldPLABSize not aligned by ObjectAlignmentInBytes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315031](https://bugs.openjdk.org/browse/JDK-8315031) needs maintainer approval

### Issue
 * [JDK-8315031](https://bugs.openjdk.org/browse/JDK-8315031): YoungPLABSize and OldPLABSize not aligned by ObjectAlignmentInBytes (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/646/head:pull/646` \
`$ git checkout pull/646`

Update a local copy of the PR: \
`$ git checkout pull/646` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 646`

View PR using the GUI difftool: \
`$ git pr show -t 646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/646.diff">https://git.openjdk.org/jdk21u-dev/pull/646.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/646#issuecomment-2144300887)