### PR TITLE
8320945: problemlist tests failing on latest Windows 11 update

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -567,6 +567,7 @@ java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-a
 java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
 
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
+java/nio/file/Files/probeContentType/Basic.java                 8320943 windows-all
 
 ############################################################################
 
@@ -655,6 +656,7 @@ javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 7105441 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
+javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8320944 windows-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all


### PR DESCRIPTION
I backport this for parity with 21.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320945](https://bugs.openjdk.org/browse/JDK-8320945) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320945](https://bugs.openjdk.org/browse/JDK-8320945): problemlist tests failing on latest Windows 11 update (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/647/head:pull/647` \
`$ git checkout pull/647`

Update a local copy of the PR: \
`$ git checkout pull/647` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 647`

View PR using the GUI difftool: \
`$ git pr show -t 647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/647.diff">https://git.openjdk.org/jdk21u-dev/pull/647.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/647#issuecomment-2144338785)