### PR TITLE
8315804: Open source several Swing JTabbedPane JTextArea JTextField tests

### DIFF
--- a/test/jdk/javax/swing/JTabbedPane/GetComponentAtTest.java
+++ b/test/jdk/javax/swing/JTabbedPane/GetComponentAtTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4122109
+ * @summary Ensure SwingUtilities.getDeepestComponentAt() works correctly
+ *    (in this particular case, with JTabbedPane)
+ * @key headful
+ * @run main GetComponentAtTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
+public class GetComponentAtTest {
+   static JFrame f;
+
+   public static void main(String[] args) throws Exception {
+      try {
+         Robot robot = new Robot();
+         SwingUtilities.invokeAndWait(() -> {
+            f = new JFrame("GetComponentAtTest");
+            JTabbedPane tabbedpane = new JTabbedPane();
+            f.getContentPane().add(tabbedpane, BorderLayout.CENTER);
+
+            JPanel panel1 = new JPanel();
+            panel1.setName("Panel 1");
+            panel1.setLayout(new BorderLayout());
+            tabbedpane.add(panel1);
+            JPanel subPanel = new JPanel();
+            subPanel.setName("Sub-Panel");
+            subPanel.setBackground(Color.green);
+            panel1.add(subPanel); // add sub panel to 1st tab
+
+            JPanel panel2 = new JPanel();
+            panel2.setName("Panel 2");
+            tabbedpane.add(panel2);
+
+            f.setSize(150, 150);
+            f.setVisible(true);
+
+            robot.delay(1000);
+
+            tabbedpane.setSelectedIndex(1); // display 2nd tab
+            tabbedpane.invalidate();
+            tabbedpane.validate();
+            if (SwingUtilities.getDeepestComponentAt(tabbedpane, 50, 50) != panel2) {
+               throw new RuntimeException("SwingUtilities.getDeepestComponentAt() " +
+                       "returned incorrect component! (1)");
+            }
+
+            tabbedpane.setSelectedIndex(0); // display 1st tab
+            tabbedpane.invalidate();
+            tabbedpane.validate();
+            if (SwingUtilities.getDeepestComponentAt(tabbedpane, 50, 50) != subPanel) {
+               throw new RuntimeException("SwingUtilities.getDeepestComponentAt() " +
+                       "returned incorrect component! (2)");
+            }
+         });
+      } finally {
+         SwingUtilities.invokeAndWait(() -> {
+            if (f != null) {
+               f.dispose();
+            }
+         });
+      }
+
+   }
+}

--- a/test/jdk/javax/swing/JTabbedPane/ReplaceCompTab.java
+++ b/test/jdk/javax/swing/JTabbedPane/ReplaceCompTab.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4213896 4228439
+ * @summary Ensure that inserting a new tab with a component
+ * where that component already exists as another tab is handled
+ * properly. The old tab should be removed and the new tab added.
+ * @key headful
+ * @run main ReplaceCompTab
+ */
+
+import java.awt.BorderLayout;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
+public class ReplaceCompTab {
+    static JFrame f;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                f = new JFrame("ReplaceCompTab");
+                JTabbedPane tabbedpane = new JTabbedPane();
+                f.getContentPane().add(tabbedpane, BorderLayout.CENTER);
+
+                JPanel comp = new JPanel();
+
+                // Add first tab
+                tabbedpane.addTab("First(temp)", comp);
+
+                // Add second tab with same component (should just replace first one)
+                tabbedpane.insertTab("First", null, comp, "component added next", 0);
+
+                // Check to ensure only a single tab exists
+                if (tabbedpane.getTabCount() > 1) {
+                    throw new RuntimeException("Only one tab should exist");
+                }
+                // Check to make sure second tab correctly replaced the first
+                if (!(tabbedpane.getTitleAt(0).equals("First"))) {
+                    throw new RuntimeException("Tab not replaced correctly");
+                }
+                // Check to make sure adding null continues to work
+                try {
+                    tabbedpane.addTab("Second", null);
+                } catch (Exception e) {
+                    throw new RuntimeException("Adding first null " +
+                            "component failed:", e);
+                }
+                try {
+                    tabbedpane.addTab("Third", null);
+                } catch (Exception e) {
+                    throw new RuntimeException("Adding subsequent null " +
+                            "component failed: ", e);
+                }
+                try {
+                    tabbedpane.setComponentAt(1, new JLabel("Second Component"));
+                    tabbedpane.setComponentAt(2, new JLabel("Third Component"));
+                } catch (Exception e) {
+                    throw new RuntimeException("Setting null component " +
+                            "to non-null failed: ", e);
+                }
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTabbedPane/bug4703690.java
+++ b/test/jdk/javax/swing/JTabbedPane/bug4703690.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4703690
+ * @summary JTabbedPane should focus proper component at the tab container
+ * @key headful
+ * @run main bug4703690
+ */
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
+public class bug4703690 {
+    static JFrame frame;
+    static JTabbedPane tabbedPane;
+    static JButton one, two;
+
+    static final CountDownLatch focusButtonTwo = new CountDownLatch(1);
+    static final CountDownLatch switchToTabTwo = new CountDownLatch(1);
+    static final CountDownLatch focusButtonOne = new CountDownLatch(1);
+    static Robot robot;
+
+    static Point p;
+    static Rectangle rect;
+
+    public static void main(String[] args) throws Exception {
+        bug4703690 test = new bug4703690();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4703690");
+
+                JPanel panel = new JPanel();
+                one = new JButton("Button 1");
+                panel.add(one);
+                two = new JButton("Button 2");
+                panel.add(two);
+
+                tabbedPane = new JTabbedPane();
+                frame.getContentPane().add(tabbedPane);
+                tabbedPane.addTab("Tab one", panel);
+                tabbedPane.addTab("Tab two", new JPanel());
+
+                two.addFocusListener(new FocusAdapter() {
+                    public void focusGained(FocusEvent e) {
+                        focusButtonTwo.countDown();
+                    }
+                });
+
+                tabbedPane.addChangeListener(e -> {
+                    if (tabbedPane.getSelectedIndex() == 1) {
+                        switchToTabTwo.countDown();
+                    }
+                });
+
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+            test.execute();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void execute() throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(50);
+
+        SwingUtilities.invokeAndWait(two::requestFocus);
+
+        if (!focusButtonTwo.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Button two didn't receive focus");
+        }
+
+        one.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent e) {
+                focusButtonOne.countDown();
+            }
+        });
+
+        // Switch to tab two
+        SwingUtilities.invokeAndWait(() -> {
+            p = tabbedPane.getLocationOnScreen();
+            rect = tabbedPane.getBoundsAt(1);
+        });
+        robot.mouseMove(p.x + rect.x + rect.width / 2,
+                p.y + rect.y + rect.height / 2);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        if (!switchToTabTwo.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Switching to tab two failed");
+        }
+
+        // Switch to tab one
+        SwingUtilities.invokeAndWait(() -> {
+            p = tabbedPane.getLocationOnScreen();
+            rect = tabbedPane.getBoundsAt(0);
+        });
+        robot.mouseMove(p.x + rect.x + rect.width / 2,
+                p.y + rect.y + rect.height / 2);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        if (!focusButtonOne.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("The 'Button 1' button doesn't have focus");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTextArea/bug4849868.java
+++ b/test/jdk/javax/swing/JTextArea/bug4849868.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4849868
+ * @summary Tests if JTextArea.getSelectionEnd works correctly
+ * @key headful
+ * @run main bug4849868
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+
+public class bug4849868 {
+
+    private static volatile boolean passed = false;
+
+    private static JTextArea textArea;
+    private static JFrame f;
+    private static Point p;
+
+    private static int end;
+    private static int len;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.setAutoWaitForIdle(true);
+
+            SwingUtilities.invokeAndWait(() -> {
+                f = new JFrame("bug4849868");
+                textArea = new JTextArea("1234");
+                textArea.setLineWrap(true);
+                JScrollPane pane = new JScrollPane(textArea,
+                        JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                        JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+                f.getContentPane().add(pane);
+                f.setSize(300, 300);
+                f.setLocationRelativeTo(null);
+                f.setVisible(true);
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() ->
+                    p = textArea.getLocationOnScreen());
+
+            robot.mouseMove(p.x, p.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseMove(p.x + 350, p.y);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                end = textArea.getSelectionEnd();
+                len = textArea.getDocument().getLength();
+            });
+            passed = (end <= len);
+
+            System.out.println("end: " + end);
+            System.out.println("len: " + len);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+
+        if (!passed) {
+            throw new RuntimeException("Test failed.");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTextField/bug4244613.java
+++ b/test/jdk/javax/swing/JTextField/bug4244613.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4244613
+ * @summary Tests that JTextField has setAction(Action) constructor
+ * @run main bug4244613
+ */
+
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JTextField;
+
+public class bug4244613 {
+    /** Auxilliary class implementing Action
+    */
+    static class NullAction extends AbstractAction {
+        @Override
+        public void actionPerformed(ActionEvent e) {}
+        public Object getValue(String key) { return null; }
+        public boolean isEnabled() { return false; }
+    }
+
+    public static void main(String[] args) {
+        JTextField tf = new JTextField("bug4244613");
+        Action action = new NullAction();
+        tf.setAction(action);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315804](https://bugs.openjdk.org/browse/JDK-8315804) needs maintainer approval

### Issue
 * [JDK-8315804](https://bugs.openjdk.org/browse/JDK-8315804): Open source several Swing JTabbedPane JTextArea JTextField tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/653/head:pull/653` \
`$ git checkout pull/653`

Update a local copy of the PR: \
`$ git checkout pull/653` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 653`

View PR using the GUI difftool: \
`$ git pr show -t 653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/653.diff">https://git.openjdk.org/jdk21u-dev/pull/653.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/653#issuecomment-2144608712)