### PR TITLE
8317240: Promptly free OopMapEntry after fail to insert the entry to OopMapCache

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -53,6 +53,8 @@ class OopMapCacheEntry: private InterpreterOopMap {
   // Deallocate bit masks and initialize fields
   void flush();
 
+  static void deallocate(OopMapCacheEntry* const entry);
+
  private:
   void allocate_bit_mask();   // allocates the bit mask on C heap f necessary
   void deallocate_bit_mask(); // allocates the bit mask on C heap f necessary
@@ -399,6 +401,10 @@ void OopMapCacheEntry::flush() {
   initialize();
 }
 
+void OopMapCacheEntry::deallocate(OopMapCacheEntry* const entry) {
+  entry->flush();
+  FREE_C_HEAP_OBJ(entry);
+}
 
 // Implementation of OopMapCache
 
@@ -472,8 +478,7 @@ void OopMapCache::flush() {
     OopMapCacheEntry* entry = _array[i];
     if (entry != nullptr) {
       _array[i] = nullptr;  // no barrier, only called in OopMapCache destructor
-      entry->flush();
-      FREE_C_HEAP_OBJ(entry);
+      OopMapCacheEntry::deallocate(entry);
     }
   }
 }
@@ -492,8 +497,7 @@ void OopMapCache::flush_obsolete_entries() {
            entry->method()->name()->as_C_string(), entry->method()->signature()->as_C_string(), i);
       }
       _array[i] = nullptr;
-      entry->flush();
-      FREE_C_HEAP_OBJ(entry);
+      OopMapCacheEntry::deallocate(entry);
     }
   }
 }
@@ -540,8 +544,7 @@ void OopMapCache::lookup(const methodHandle& method,
     // at this time. We give the caller of lookup() a copy of the
     // interesting info via parameter entry_for, but we don't add it to
     // the cache. See the gory details in Method*.cpp.
-    tmp->flush();
-    FREE_C_HEAP_OBJ(tmp);
+    OopMapCacheEntry::deallocate(tmp);
     return;
   }
 
@@ -564,7 +567,7 @@ void OopMapCache::lookup(const methodHandle& method,
   if (put_at(probe + 0, tmp, old)) {
     enqueue_for_cleanup(old);
   } else {
-    enqueue_for_cleanup(tmp);
+    OopMapCacheEntry::deallocate(tmp);
   }
 
   assert(!entry_for->is_empty(), "A non-empty oop map should be returned");
@@ -599,8 +602,7 @@ void OopMapCache::cleanup_old_entries() {
                           entry->method()->name_and_sig_as_C_string(), entry->bci());
     }
     OopMapCacheEntry* next = entry->_next;
-    entry->flush();
-    FREE_C_HEAP_OBJ(entry);
+    OopMapCacheEntry::deallocate(entry);
     entry = next;
   }
 }
@@ -611,6 +613,5 @@ void OopMapCache::compute_one_oop_map(const methodHandle& method, int bci, Inter
   tmp->initialize();
   tmp->fill(method, bci);
   entry->resource_copy(tmp);
-  tmp->flush();
-  FREE_C_HEAP_OBJ(tmp);
+  OopMapCacheEntry::deallocate(tmp);
 }


### PR DESCRIPTION
Improves `OopMapCache` performance by skipping enqueuing when we can deallocate the entry directly. This would be even more important as we backport [JDK-8331572](https://bugs.openjdk.org/browse/JDK-8331572).

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317240](https://bugs.openjdk.org/browse/JDK-8317240) needs maintainer approval

### Issue
 * [JDK-8317240](https://bugs.openjdk.org/browse/JDK-8317240): Promptly free OopMapEntry after fail to insert the entry to OopMapCache (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/655/head:pull/655` \
`$ git checkout pull/655`

Update a local copy of the PR: \
`$ git checkout pull/655` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 655`

View PR using the GUI difftool: \
`$ git pr show -t 655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/655.diff">https://git.openjdk.org/jdk21u-dev/pull/655.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/655#issuecomment-2145868043)