### PR TITLE
8325616: JFR ZGC Allocation Stall events should record stack traces

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1104,7 +1104,7 @@
     <Field type="uint" name="gcId" label="GC Identifier" relation="GcId" />
   </Event>
 
-  <Event name="ZAllocationStall" category="Java Virtual Machine, GC, Detailed" label="ZGC Allocation Stall" description="Time spent waiting for memory to become available" thread="true">
+  <Event name="ZAllocationStall" category="Java Virtual Machine, GC, Detailed" label="ZGC Allocation Stall" description="Time spent waiting for memory to become available" thread="true" stackTrace="true">
     <Field type="ZPageTypeType" name="type" label="Type" />
     <Field type="ulong" contentType="bytes" name="size" label="Size" />
   </Event>

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -807,6 +807,7 @@
 
     <event name="jdk.ZAllocationStall">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -807,6 +807,7 @@
 
     <event name="jdk.ZAllocationStall">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 


### PR DESCRIPTION
Backport of JDK-8325616

**Verification**
1. Ran jdk_jfr and hotspot_gc tests. All tests passed. (make test TEST=hotspot_gc TEST_VM_OPTS=-XX:+UseZGC)

2. Output of print jfr on a sample java program that resulted in allocation stall.

```
jdk.ZAllocationStall {
  startTime = 01:25:30.989
  duration = 508 ms
  type = "Small"
  size = 2.0 MB
  eventThread = "Thread-278" (javaThreadId = 318)
  stackTrace = [
    StressZGC.work(int, Set) line: 30
    StressZGC.work(int, Set) line: 26
    StressZGC.work(int, Set) line: 26
    StressZGC.work(int, Set) line: 26
    StressZGC.work(int, Set) line: 26
    ...
  ]
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325616](https://bugs.openjdk.org/browse/JDK-8325616) needs maintainer approval

### Issue
 * [JDK-8325616](https://bugs.openjdk.org/browse/JDK-8325616): JFR ZGC Allocation Stall events should record stack traces (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/656/head:pull/656` \
`$ git checkout pull/656`

Update a local copy of the PR: \
`$ git checkout pull/656` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 656`

View PR using the GUI difftool: \
`$ git pr show -t 656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/656.diff">https://git.openjdk.org/jdk21u-dev/pull/656.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/656#issuecomment-2145099837)