### PR TITLE
8332898: failure_handler: log directory of commands

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/action/ActionHelper.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/action/ActionHelper.java
@@ -164,7 +164,7 @@ public class ActionHelper {
         Stopwatch stopwatch = new Stopwatch();
         stopwatch.start();
 
-        log.printf("%s%n[%tF %<tT] %s timeout=%s%n%1$s%n", line, new Date(), pb.command(), params.timeout);
+        log.printf("%s%n[%tF %<tT] %s timeout=%s in %s%n%1$s%n", line, new Date(), pb.command(), params.timeout, pb.directory());
 
         Process process;
         KillerTask killer;


### PR DESCRIPTION
Clean backport of [JDK-8332898](https://bugs.openjdk.org/browse/JDK-8332898).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8332898](https://bugs.openjdk.org/browse/JDK-8332898) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332898](https://bugs.openjdk.org/browse/JDK-8332898): failure_handler: log directory of commands (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/657/head:pull/657` \
`$ git checkout pull/657`

Update a local copy of the PR: \
`$ git checkout pull/657` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 657`

View PR using the GUI difftool: \
`$ git pr show -t 657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/657.diff">https://git.openjdk.org/jdk21u-dev/pull/657.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/657#issuecomment-2145121864)