### PR TITLE
8332885: Clarify failure_handler self-tests

### DIFF
--- a/make/test/BuildFailureHandler.gmk
+++ b/make/test/BuildFailureHandler.gmk
@@ -80,6 +80,10 @@ IMAGES_TARGETS += $(COPY_FH)
 # Use JTREG_TEST_OPTS for test VM options
 # Use JTREG_TESTS for jtreg tests parameter
 #
+# Most likely you want to select a specific test from test/failure_handler/test
+# and manually inspect the results. This target does not actually verify
+# anything about the failure_handler's output or even if it ran at all.
+#
 RUN_DIR := $(FH_SUPPORT)/test
 
 test:

--- a/test/failure_handler/README
+++ b/test/failure_handler/README
@@ -102,3 +102,15 @@ $ ${JTREG_HOME}/bin/jtreg -jdk:${JAVA_HOME}                                   \
  -timeoutHandler:jdk.test.failurehandler.jtreg.GatherProcessInfoTimeoutHandler\
  -observer:jdk.test.failurehandler.jtreg.GatherDiagnosticInfoObserver         \
  ${WS}/hotspot/test/
+
+TESTING
+
+There are a few make targets for testing the failure_handler itself.
+ - Everything in `test/failure_handler/Makefile`
+ - The `test-failure-handler` target in `make/RunTests.gmk`
+ - The `test` target in `make/test/BuildFailureHandler.gmk`
+All of these targets are written for manual testing only. They rely on
+manual inspection of generated artifacts and cannot be run as part of a CI.
+They are tests which timeout, crash, fail in various ways and you can check
+the failure_handler output yourself. They might also leave processes running
+on your machine so be extra careful about cleaning up.


### PR DESCRIPTION
Clean backport of [JDK-8332885](https://bugs.openjdk.org/browse/JDK-8332885).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332885](https://bugs.openjdk.org/browse/JDK-8332885) needs maintainer approval

### Issue
 * [JDK-8332885](https://bugs.openjdk.org/browse/JDK-8332885): Clarify failure_handler self-tests (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/658/head:pull/658` \
`$ git checkout pull/658`

Update a local copy of the PR: \
`$ git checkout pull/658` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 658`

View PR using the GUI difftool: \
`$ git pr show -t 658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/658.diff">https://git.openjdk.org/jdk21u-dev/pull/658.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/658#issuecomment-2145126580)