### PR TITLE
8326734: text-decoration applied to <span> lost when mixed with <u> or <s>

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -839,6 +839,18 @@ public class CSS implements Serializable {
         CssValue conv = (CssValue) valueConvertor.get(key);
         Object r = conv.parseCssValue(value);
         return r != null ? r : conv.parseCssValue(key.getDefaultValue());
+    }
+
+    static Object mergeTextDecoration(String value) {
+        boolean underline = value.contains("underline");
+        boolean strikeThrough = value.contains("line-through");
+        if (!underline && !strikeThrough) {
+            return null;
+        }
+        String newValue = underline && strikeThrough
+                          ? "underline,line-through"
+                          : (underline ? "underline" : "line-through");
+        return new StringValue().parseCssValue(newValue);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/MuxingAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/MuxingAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,16 @@
  */
 package javax.swing.text.html;
 
-import javax.swing.text.*;
 import java.io.Serializable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.swing.text.AttributeSet;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
 
 /**
  * An implementation of <code>AttributeSet</code> that can multiplex
@@ -196,15 +203,24 @@ class MuxingAttributeSet implements AttributeSet, Serializable {
      * @see AttributeSet#getAttribute
      */
     public Object getAttribute(Object key) {
-        AttributeSet[] as = getAttributes();
-        int n = as.length;
-        for (int i = 0; i < n; i++) {
-            Object o = as[i].getAttribute(key);
-            if (o != null) {
-                return o;
+        final AttributeSet[] as = getAttributes();
+        final int n = as.length;
+        if (key != CSS.Attribute.TEXT_DECORATION) {
+            for (int i = 0; i < n; i++) {
+                Object o = as[i].getAttribute(key);
+                if (o != null) {
+                    return o;
+                }
             }
+            return null;
         }
-        return null;
+
+        String values = Arrays.stream(as)
+                              .map(a -> a.getAttribute(key))
+                              .filter(Objects::nonNull)
+                              .map(Object::toString)
+                              .collect(Collectors.joining(","));
+        return CSS.mergeTextDecoration(values);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,17 +24,53 @@
  */
 package javax.swing.text.html;
 
-import sun.swing.SwingUtilities2;
-import java.util.*;
-import java.awt.*;
-import java.io.*;
-import java.net.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.EmptyStackException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Stack;
+import java.util.StringTokenizer;
+import java.util.Vector;
+
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.UIManager;
-import javax.swing.border.*;
+import javax.swing.border.BevelBorder;
+import javax.swing.border.Border;
 import javax.swing.event.ChangeListener;
-import javax.swing.text.*;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.Style;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyleContext;
+import javax.swing.text.StyledDocument;
+import javax.swing.text.View;
+
+import sun.swing.SwingUtilities2;
 
 /**
  * Support for defining the visual characteristics of
@@ -2817,10 +2853,31 @@ public class StyleSheet extends StyleContext {
             return doGetAttribute(key);
         }
 
+        /**
+         * Merges the current value of the 'text-decoration' property
+         * with the value from parent.
+         */
+        private Object getTextDecoration(Object value) {
+            AttributeSet parent = getResolveParent();
+            if (parent == null) {
+                return value;
+            }
+
+            Object parentValue = parent.getAttribute(CSS.Attribute.TEXT_DECORATION);
+            return parentValue == null
+                   ? value
+                   : CSS.mergeTextDecoration(value + "," + parentValue);
+        }
+
         Object doGetAttribute(Object key) {
             Object retValue = super.getAttribute(key);
             if (retValue != null) {
-                return retValue;
+                if (key != CSS.Attribute.TEXT_DECORATION) {
+                    return retValue;
+                } else {
+                    // Merge current value with parent
+                    return getTextDecoration(retValue);
+                }
             }
 
             if (key == CSS.Attribute.FONT_SIZE) {

--- a/test/jdk/javax/swing/text/html/HTMLDocument/HTMLStrikeOnly.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/HTMLStrikeOnly.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+import javax.swing.JEditorPane;
+import javax.swing.text.View;
+import javax.swing.text.html.CSS;
+
+/*
+ * @test
+ * @bug 8326734
+ * @summary Tests different combinations of setting 'line-through'
+ * @run main HTMLStrikeOnly
+ */
+public class HTMLStrikeOnly {
+    private static final String HTML = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>line-through</title>
+                <style>
+                    .lineThrough   { text-decoration: line-through }
+                </style>
+            </head>
+            <body>
+            <p><s><span style='text-decoration: line-through'>line-through?</span></s></p>
+            <p><strike><span style='text-decoration: line-through'>line-through?</span></strike></p>
+            <p><span style='text-decoration: line-through'><s>line-through?</s></span></p>
+            <p><span style='text-decoration: line-through'><strike>line-through?</strike></span></p>
+
+            <p><s><span class="lineThrough">line-through?</span></s></p>
+            <p><strike><span class="lineThrough">line-through?</span></strike></p>
+            <p><span class="lineThrough"><s>line-through?</s></span></p>
+            <p><span class="lineThrough"><strike>line-through?</strike></span></p>
+
+            <p style='text-decoration: line-through'><s>line-through?</s></p>
+            <p style='text-decoration: line-through'><strike>line-through?</strike></p>
+            <p style='text-decoration: line-through'><span style='text-decoration: line-through'>line-through?</span></p>
+
+            <p class="lineThrough"><s>line-through</s></p>
+            <p class="lineThrough"><strike>line-through</strike></p>
+            <p class="lineThrough"><span style='text-decoration: line-through'>line-through</span></p>
+            <p class="lineThrough"><span class="lineThrough">line-through</span></p>
+            </body>
+            </html>
+            """;
+    public static void main(String[] args) {
+        final JEditorPane html = new JEditorPane("text/html", HTML);
+        html.setEditable(false);
+
+        final Dimension size = html.getPreferredSize();
+        html.setSize(size);
+
+        BufferedImage image = new BufferedImage(size.width, size.height,
+                                                BufferedImage.TYPE_INT_RGB);
+        Graphics g = image.createGraphics();
+        // Paint the editor pane to ensure all views are created
+        html.paint(g);
+        g.dispose();
+
+        int errorCount = 0;
+        String firstError = null;
+
+        System.out.println("----- Views -----");
+        final View bodyView = html.getUI()
+                                  .getRootView(html)
+                                  .getView(1)
+                                  .getView(1);
+        for (int i = 0; i < bodyView.getViewCount(); i++) {
+            View pView = bodyView.getView(i);
+            View contentView = getContentView(pView);
+
+            String decoration =
+                    contentView.getAttributes()
+                               .getAttribute(CSS.Attribute.TEXT_DECORATION)
+                               .toString();
+
+            System.out.println(i + ": " + decoration);
+            if (!decoration.contains("line-through")
+                || decoration.contains("underline")) {
+                errorCount++;
+                if (firstError == null) {
+                    firstError = "Line " + i + ": " + decoration;
+                }
+            }
+        }
+
+        if (errorCount > 0) {
+            saveImage(image);
+            throw new RuntimeException(errorCount + " error(s) found, "
+                                       + "the first one: " + firstError);
+        }
+    }
+
+    private static View getContentView(View parent) {
+        View view = parent.getView(0);
+        return view.getViewCount() > 0
+               ? getContentView(view)
+               : view;
+    }
+
+    private static void saveImage(BufferedImage image) {
+        try {
+            ImageIO.write(image, "png",
+                          new File("html.png"));
+        } catch (IOException ignored) { }
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLDocument/HTMLTextDecoration.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/HTMLTextDecoration.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+import javax.swing.JEditorPane;
+import javax.swing.text.View;
+import javax.swing.text.html.CSS;
+
+/*
+ * @test
+ * @bug 8323801 8326734
+ * @summary Tests different combination of 'underline' and 'line-through';
+ *          the text should render with both 'underline' and 'line-through'.
+ * @run main HTMLTextDecoration
+ */
+public final class HTMLTextDecoration {
+    private static final String HTML = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>underline + line-through text</title>
+                <style>
+                    .underline   { text-decoration: underline }
+                    .lineThrough { text-decoration: line-through }
+                </style>
+            </head>
+            <body>
+            <p><u><span style='text-decoration: line-through'>underline + line-through?</span></u></p>
+            <p><s><span style='text-decoration: underline'>underline + line-through?</span></s></p>
+            <p><strike><span style='text-decoration: underline'>underline + line-through?</span></strike></p>
+
+            <p><span style='text-decoration: line-through'><u>underline + line-through?</u></span></p>
+            <p><span style='text-decoration: underline'><s>underline + line-through?</s></span></p>
+            <p><span style='text-decoration: underline'><strike>underline + line-through?</strike></span></p>
+
+            <p><span style='text-decoration: line-through'><span style='text-decoration: underline'>underline + line-through?</span></span></p>
+            <p><span style='text-decoration: underline'><span style='text-decoration: line-through'>underline + line-through?</span></span></p>
+
+            <p style='text-decoration: line-through'><u>underline + line-through?</u></p>
+            <p style='text-decoration: underline'><s>underline + line-through?</s></p>
+            <p style='text-decoration: underline'><strike>underline + line-through?</strike></p>
+
+            <p style='text-decoration: line-through'><span style='text-decoration: underline'>underline + line-through?</span></p>
+            <p style='text-decoration: underline'><span style='text-decoration: line-through'>underline + line-through?</span></p>
+
+            <p class="underline"><span class="lineThrough">underline + line-through?</span></p>
+            <p class="underline"><s>underline + line-through?</s></p>
+            <p class="underline"><strike>underline + line-through?</strike></p>
+
+            <p class="lineThrough"><span class="underline">underline + line-through?</span></p>
+            <p class="lineThrough"><u>underline + line-through?</u></p>
+
+            <div class="underline"><span class="lineThrough">underline + line-through?</span></div>
+            <div class="underline"><s>underline + line-through?</s></div>
+            <div class="underline"><strike>underline + line-through?</strike></div>
+
+            <div class="lineThrough"><span class="underline">underline + line-through?</span></div>
+            <div class="lineThrough"><u>underline + line-through?</u></div>
+
+            <div class="underline"><p class="lineThrough">underline + line-through?</p></div>
+            <div class="lineThrough"><p class="underline">underline + line-through?</p></div>
+
+            <div class="underline"><div class="lineThrough">underline + line-through?</div></div>
+            <div class="lineThrough"><div class="underline">underline + line-through?</div></div>
+            </body>
+            </html>
+            """;
+
+    public static void main(String[] args) {
+        final JEditorPane html = new JEditorPane("text/html", HTML);
+        html.setEditable(false);
+
+        final Dimension size = html.getPreferredSize();
+        html.setSize(size);
+
+        BufferedImage image = new BufferedImage(size.width, size.height,
+                                                BufferedImage.TYPE_INT_RGB);
+        Graphics g = image.createGraphics();
+        // Paint the editor pane to ensure all views are created
+        html.paint(g);
+        g.dispose();
+
+        int errorCount = 0;
+        String firstError = null;
+
+        System.out.println("----- Views -----");
+        final View bodyView = html.getUI()
+                                  .getRootView(html)
+                                  .getView(1)
+                                  .getView(1);
+        for (int i = 0; i < bodyView.getViewCount(); i++) {
+            View pView = bodyView.getView(i);
+            View contentView = getContentView(pView);
+
+            String decoration =
+                    contentView.getAttributes()
+                               .getAttribute(CSS.Attribute.TEXT_DECORATION)
+                               .toString();
+
+            System.out.println(i + ": " + decoration);
+            if (!decoration.contains("underline")
+                || !decoration.contains("line-through")) {
+                errorCount++;
+                if (firstError == null) {
+                    firstError = "Line " + i + ": " + decoration;
+                }
+            }
+        }
+
+        if (errorCount > 0) {
+            saveImage(image);
+            throw new RuntimeException(errorCount + " error(s) found, "
+                                       + "the first one: " + firstError);
+        }
+    }
+
+    private static View getContentView(View parent) {
+        View view = parent.getView(0);
+        return view.getViewCount() > 0
+               ? getContentView(view)
+               : view;
+    }
+
+    private static void saveImage(BufferedImage image) {
+        try {
+            ImageIO.write(image, "png",
+                          new File("html.png"));
+        } catch (IOException ignored) { }
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLDocument/HTMLUnderlineOnly.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/HTMLUnderlineOnly.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+import javax.swing.JEditorPane;
+import javax.swing.text.View;
+import javax.swing.text.html.CSS;
+
+/*
+ * @test
+ * @bug 8326734
+ * @summary Tests different combinations of setting 'underline'
+ * @run main HTMLUnderlineOnly
+ */
+public class HTMLUnderlineOnly {
+    private static final String HTML = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>underline</title>
+                <style>
+                    .underline   { text-decoration: underline }
+                </style>
+            </head>
+            <body>
+            <p><u><span style='text-decoration: underline'>underline?</span></u></p>
+            <p><span style='text-decoration: underline'><u>underline?</u></span></p>
+
+            <p><u><span class="underline">underline?</span></u></p>
+            <p><span class="underline"><u>underline?</u></span></p>
+
+            <p style='text-decoration: underline'><u>underline?</u></p>
+            <p style='text-decoration: underline'><span style='text-decoration: underline'>underline?</span></p>
+
+            <p class="underline"><u>underline</u></p>
+            <p class="underline"><span style='text-decoration: underline'>underline</span></p>
+            <p class="underline"><span class="underline">underline</span></p>
+            </body>
+            </html>
+            """;
+    public static void main(String[] args) {
+        final JEditorPane html = new JEditorPane("text/html", HTML);
+        html.setEditable(false);
+
+        final Dimension size = html.getPreferredSize();
+        html.setSize(size);
+
+        BufferedImage image = new BufferedImage(size.width, size.height,
+                                                BufferedImage.TYPE_INT_RGB);
+        Graphics g = image.createGraphics();
+        // Paint the editor pane to ensure all views are created
+        html.paint(g);
+        g.dispose();
+
+        int errorCount = 0;
+        String firstError = null;
+
+        System.out.println("----- Views -----");
+        final View bodyView = html.getUI()
+                                  .getRootView(html)
+                                  .getView(1)
+                                  .getView(1);
+        for (int i = 0; i < bodyView.getViewCount(); i++) {
+            View pView = bodyView.getView(i);
+            View contentView = getContentView(pView);
+
+            String decoration =
+                    contentView.getAttributes()
+                               .getAttribute(CSS.Attribute.TEXT_DECORATION)
+                               .toString();
+
+            System.out.println(i + ": " + decoration);
+            if (!decoration.contains("underline")
+                || decoration.contains("line-through")) {
+                errorCount++;
+                if (firstError == null) {
+                    firstError = "Line " + i + ": " + decoration;
+                }
+            }
+        }
+
+        if (errorCount > 0) {
+            saveImage(image);
+            throw new RuntimeException(errorCount + " error(s) found, "
+                                       + "the first one: " + firstError);
+        }
+    }
+
+    private static View getContentView(View parent) {
+        View view = parent.getView(0);
+        return view.getViewCount() > 0
+               ? getContentView(view)
+               : view;
+    }
+
+    private static void saveImage(BufferedImage image) {
+        try {
+            ImageIO.write(image, "png",
+                          new File("html.png"));
+        } catch (IOException ignored) { }
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLDocument/HTMLUnderlineStrike.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/HTMLUnderlineStrike.java
@@ -31,7 +31,7 @@ import javax.swing.text.html.HTMLEditorKit;
 
 /*
  * @test
- * @bug 8323801
+ * @bug 8323801 8326734
  * @summary Tests that '<u><s>' produce underlined and struck-through text
  */
 public final class HTMLUnderlineStrike {


### PR DESCRIPTION
Clean backport of [JDK-8326734](https://bugs.openjdk.org/browse/JDK-8326734) and [JDK-8325620](https://bugs.openjdk.org/browse/JDK-8325620) which belong together.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8325620](https://bugs.openjdk.org/browse/JDK-8325620) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326734](https://bugs.openjdk.org/browse/JDK-8326734) needs maintainer approval

### Issues
 * [JDK-8326734](https://bugs.openjdk.org/browse/JDK-8326734): text-decoration applied to &lt;span&gt; lost when mixed with &lt;u&gt; or &lt;s&gt; (**Bug** - P3 - Approved)
 * [JDK-8325620](https://bugs.openjdk.org/browse/JDK-8325620): HTMLReader uses ConvertAction instead of specified CharacterAction for &lt;b&gt;, &lt;i&gt;, &lt;u&gt; (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/664/head:pull/664` \
`$ git checkout pull/664`

Update a local copy of the PR: \
`$ git checkout pull/664` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 664`

View PR using the GUI difftool: \
`$ git pr show -t 664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/664.diff">https://git.openjdk.org/jdk21u-dev/pull/664.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/664#issuecomment-2148370037)