### PR TITLE
8313983: jmod create --target-platform should replace existing ModuleTarget attribute

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/Attributes.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Attributes.java
@@ -461,7 +461,7 @@ public class Attributes {
 
     /** Attribute mapper for the {@code ModuleResolution} attribute */
     public static final AttributeMapper<ModuleResolutionAttribute>
-            MODULE_RESOLUTION = new AbstractAttributeMapper<>(NAME_MODULE_RESOLUTION, true, Classfile.JAVA_9_VERSION) {
+            MODULE_RESOLUTION = new AbstractAttributeMapper<>(NAME_MODULE_RESOLUTION, Classfile.JAVA_9_VERSION) {
                 @Override
                 public ModuleResolutionAttribute readAttribute(AttributedElement e, ClassReader cf, int p) {
                     return new BoundAttribute.BoundModuleResolutionAttribute(cf, this, p);
@@ -475,7 +475,7 @@ public class Attributes {
 
     /** Attribute mapper for the {@code ModuleTarget} attribute */
     public static final AttributeMapper<ModuleTargetAttribute>
-            MODULE_TARGET = new AbstractAttributeMapper<>(NAME_MODULE_TARGET, true, Classfile.JAVA_9_VERSION) {
+            MODULE_TARGET = new AbstractAttributeMapper<>(NAME_MODULE_TARGET, Classfile.JAVA_9_VERSION) {
                 @Override
                 public ModuleTargetAttribute readAttribute(AttributedElement e, ClassReader cf, int p) {
                     return new BoundAttribute.BoundModuleTargetAttribute(cf, this, p);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c2e01eba](https://github.com/openjdk/jdk/commit/c2e01eba5a537acd573b7d2e6d41811c415c3f68) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Adam Sotona on 1 Sep 2023 and was reviewed by Alan Bateman and Mandy Chung.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313983](https://bugs.openjdk.org/browse/JDK-8313983) needs maintainer approval

### Issue
 * [JDK-8313983](https://bugs.openjdk.org/browse/JDK-8313983): jmod create --target-platform should replace existing ModuleTarget attribute (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/666/head:pull/666` \
`$ git checkout pull/666`

Update a local copy of the PR: \
`$ git checkout pull/666` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 666`

View PR using the GUI difftool: \
`$ git pr show -t 666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/666.diff">https://git.openjdk.org/jdk21u-dev/pull/666.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/666#issuecomment-2150789617)