### PR TITLE
8332473: ubsan: growableArray.hpp:290:10: runtime error: null pointer passed as argument 1, which is declared to never be null

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -278,10 +278,12 @@ public:
   }
 
   void sort(int f(E*, E*)) {
+    if (_data == nullptr) return;
     qsort(_data, length(), sizeof(E), (_sort_Fn)f);
   }
   // sort by fixed-stride sub arrays:
   void sort(int f(E*, E*), int stride) {
+    if (_data == nullptr) return;
     qsort(_data, length() / stride, sizeof(E) * stride, (_sort_Fn)f);
   }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332473](https://bugs.openjdk.org/browse/JDK-8332473) needs maintainer approval

### Issue
 * [JDK-8332473](https://bugs.openjdk.org/browse/JDK-8332473): ubsan: growableArray.hpp:290:10: runtime error: null pointer passed as argument 1, which is declared to never be null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/672/head:pull/672` \
`$ git checkout pull/672`

Update a local copy of the PR: \
`$ git checkout pull/672` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 672`

View PR using the GUI difftool: \
`$ git pr show -t 672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/672.diff">https://git.openjdk.org/jdk21u-dev/pull/672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/672#issuecomment-2152817848)