### PR TITLE
8332675: test/hotspot/jtreg/gc/testlibrary/Helpers.java compileClass javadoc does not match after 8321812

### DIFF
--- a/test/hotspot/jtreg/gc/testlibrary/Helpers.java
+++ b/test/hotspot/jtreg/gc/testlibrary/Helpers.java
@@ -88,7 +88,7 @@ public class Helpers {
      * @param className class name
      * @param root      root directory - where .java and .class files will be put
      * @param source    class source
-     * @throws IOException if cannot write file to specified directory
+     * @throws Exception if cannot write file to specified directory
      */
     public static void compileClass(String className, Path root, String source) throws Exception {
         Path sourceFile = root.resolve(className + ".java");


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8332675](https://bugs.openjdk.org/browse/JDK-8332675) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332675](https://bugs.openjdk.org/browse/JDK-8332675): test/hotspot/jtreg/gc/testlibrary/Helpers.java compileClass javadoc does not match after 8321812 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/673/head:pull/673` \
`$ git checkout pull/673`

Update a local copy of the PR: \
`$ git checkout pull/673` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 673`

View PR using the GUI difftool: \
`$ git pr show -t 673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/673.diff">https://git.openjdk.org/jdk21u-dev/pull/673.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/673#issuecomment-2152842601)