### PR TITLE
8331421: ubsan: vmreg.cpp checking error member call on misaligned address

### DIFF
--- a/src/hotspot/share/code/vmreg.cpp
+++ b/src/hotspot/share/code/vmreg.cpp
@@ -30,7 +30,7 @@
 // used by SA and jvmti, but it's a leaky abstraction: SA and jvmti
 // "know" that stack0 is an integer masquerading as a pointer. For the
 // sake of those clients, we preserve this interface.
-VMReg VMRegImpl::stack0 = (VMReg)VMRegImpl::stack_0()->value();
+VMReg VMRegImpl::stack0 = (VMReg)(intptr_t)FIRST_STACK;
 
 // VMRegs are 4 bytes wide on all platforms
 const int VMRegImpl::stack_slot_size = 4;

--- a/src/hotspot/share/code/vmreg.hpp
+++ b/src/hotspot/share/code/vmreg.hpp
@@ -53,7 +53,8 @@ friend class OptoReg;
 // friend class Location;
 private:
   enum {
-    BAD_REG = -1
+    BAD_REG = -1,
+    FIRST_STACK = (ConcreteRegisterImpl::number_of_registers + 7) & ~7
   };
 
   // Despite being private, this field is exported to the
@@ -70,7 +71,7 @@ private:
 public:
 
   static constexpr VMReg stack_0() {
-    return first() + ((ConcreteRegisterImpl::number_of_registers + 7) & ~7);
+    return first() + FIRST_STACK;
   }
 
   static VMReg as_VMReg(int val, bool bad_ok = false) {


### PR DESCRIPTION
Backport of [JDK-8331421](https://bugs.openjdk.org/browse/JDK-8331421). Clean except a difference in replaced code because [JDK-8309685](https://bugs.openjdk.org/browse/JDK-8309685) is not in 21u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331421](https://bugs.openjdk.org/browse/JDK-8331421) needs maintainer approval

### Issue
 * [JDK-8331421](https://bugs.openjdk.org/browse/JDK-8331421): ubsan: vmreg.cpp checking error member call on misaligned address (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/686/head:pull/686` \
`$ git checkout pull/686`

Update a local copy of the PR: \
`$ git checkout pull/686` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 686`

View PR using the GUI difftool: \
`$ git pr show -t 686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/686.diff">https://git.openjdk.org/jdk21u-dev/pull/686.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/686#issuecomment-2158772550)