### PR TITLE
8332154: Memory leak in SynchronousQueue

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
@@ -194,6 +194,8 @@ public class SynchronousQueue<E> extends AbstractQueue<E>
                     if ((m = s.await(e, ns, this,  // spin if (nearly) empty
                                      p == null || p.waiter == null)) == e)
                         unspliceLifo(s);           // cancelled
+                    else if (m != null)
+                        s.selfLinkItem();
                     break;
                 }
             }

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -666,6 +666,7 @@ public class JSR166TestCase extends TestCase {
         if (atLeastJava20()) {
             String[] java20TestClassNames = {
                 "ForkJoinPool20Test",
+                "SynchronousQueue20Test",
             };
             addNamedTestClasses(suite, java20TestClassNames);
         }

--- a/test/jdk/java/util/concurrent/tck/SynchronousQueue20Test.java
+++ b/test/jdk/java/util/concurrent/tck/SynchronousQueue20Test.java
@@ -1,0 +1,95 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * This file is available under and governed by the GNU General Public
+ * License version 2 only, as published by the Free Software Foundation.
+ * However, the following notice accompanied the original version of this
+ * file:
+ *
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+import junit.framework.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+
+public class SynchronousQueue20Test extends JSR166TestCase {
+
+    public static void main(String[] args) {
+        main(suite(), args);
+    }
+
+    public static Test suite() {
+        return newTestSuite(SynchronousQueue20Test.class);
+    }
+
+    public void testFairDoesntLeak() throws InterruptedException {
+        assertDoesntLeak(new SynchronousQueue<>(true));
+    }
+
+    public void testUnfairDoesntLeak() throws InterruptedException {
+        assertDoesntLeak(new SynchronousQueue<>(false));
+    }
+
+    private void assertDoesntLeak(SynchronousQueue<Object> queue) throws InterruptedException {
+        final int NUMBER_OF_ITEMS = 250;
+        final int ROUND_WAIT_MILLIS = 50;
+
+        class Item {}
+        final Map<Item, Void> survivors =
+                Collections.synchronizedMap(WeakHashMap.newWeakHashMap(NUMBER_OF_ITEMS));
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for(int i = 0;i < NUMBER_OF_ITEMS;++i) {
+                executor.submit(() -> {
+                    var item = new Item();
+                    survivors.put(item, null);
+                    queue.put(item);
+                    return null;
+                });
+
+                executor.submit(() -> {
+                    queue.take();
+                    return null;
+                });
+            }
+        } // Close waits until all tasks are done
+
+        while(!survivors.isEmpty()) {
+            System.gc();
+            Thread.sleep(ROUND_WAIT_MILLIS); // We don't expect interruptions
+        }
+
+        assertTrue(queue.isEmpty()); // Make sure that the queue survives until the end
+    }
+
+}

--- a/test/jdk/java/util/concurrent/tck/SynchronousQueueTest.java
+++ b/test/jdk/java/util/concurrent/tck/SynchronousQueueTest.java
@@ -652,5 +652,4 @@ public class SynchronousQueueTest extends JSR166TestCase {
         assertFalse(q.contains(null));
         assertFalse(q.remove(null));
     }
-
 }


### PR DESCRIPTION
Clean backport of [JDK-8332154](https://bugs.openjdk.org/browse/JDK-8332154).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8332154](https://bugs.openjdk.org/browse/JDK-8332154) needs maintainer approval

### Issue
 * [JDK-8332154](https://bugs.openjdk.org/browse/JDK-8332154): Memory leak in SynchronousQueue (**Bug** - P3 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/687/head:pull/687` \
`$ git checkout pull/687`

Update a local copy of the PR: \
`$ git checkout pull/687` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 687`

View PR using the GUI difftool: \
`$ git pr show -t 687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/687.diff">https://git.openjdk.org/jdk21u-dev/pull/687.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/687#issuecomment-2158783350)