### PR TITLE
8316240: Open source several add/remove MenuBar manual tests

### DIFF
--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4028130
+ * @summary Test dynamically adding and removing a menu bar
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AddRemoveMenuBarTest_1
+ */
+
+public class AddRemoveMenuBarTest_1 {
+
+    private static final String INSTRUCTIONS = """
+        An initially empty frame should appear.
+
+        Click anywhere in the frame to add a menu bar at the top of the frame.
+
+        Click again to replace the menu bar with another menu bar.
+
+        Each menu bar has one (empty) menu, labelled with the
+        number of the menu bar appearing.
+
+        After a menubar is added, the frame should not be resized nor repositioned
+        on the screen;
+
+        it should have the same size and position.
+
+        Upon test completion, click Pass or Fail appropriately.
+        """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("AddRemoveMenuBarTest_1 Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(18)
+                .columns(45)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            AddRemoveMenuBar_1 frame = new AddRemoveMenuBar_1();
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}
+
+class AddRemoveMenuBar_1 extends Frame {
+    int menuCount;
+
+    AddRemoveMenuBar_1() {
+        super("AddRemoveMenuBar_1");
+        setSize(200, 200);
+        menuCount = 0;
+
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                setMenuBar();
+            }
+        });
+    }
+
+    void setMenuBar() {
+        MenuBar bar = new MenuBar();
+        bar.add(new Menu(Integer.toString(menuCount++)));
+        setMenuBar(bar);
+    }
+}

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4028130
+ * @key headful
+ * @summary Test dynamically adding and removing a menu bar
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AddRemoveMenuBarTest_2
+ */
+
+public class AddRemoveMenuBarTest_2 {
+    private static final String INSTRUCTIONS = """
+            A frame with a menu bar appears.
+
+            Click anywhere in the frame to replace the menu bar with
+            another one.
+
+            Each menu bar has one (empty) menu, 'foo'.
+
+            After the menu bar replacement, the containing frame
+            should not be resized nor repositioned on the screen.
+
+            Upon test completion, click Pass or Fail appropriately.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("AddRemoveMenuBarTest_2 Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(15)
+                .columns(45)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            AddRemoveMenuBar_2 frame = new AddRemoveMenuBar_2();
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}
+
+class AddRemoveMenuBar_2 extends Frame {
+    AddRemoveMenuBar_2() {
+        super("AddRemoveMenuBar_2");
+        setSize(200, 200);
+        setMenuBar();
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                setMenuBar();
+            }
+        });
+    }
+
+    int count = 0;
+
+    void setMenuBar() {
+        MenuBar bar = new MenuBar();
+        bar.add(new Menu("foo " + count++));
+        super.setMenuBar(bar);
+    }
+}

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Checkbox;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.Panel;
+import java.awt.Rectangle;
+import java.awt.TextField;
+import java.awt.event.ActionListener;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4017504
+ * @summary Test dynamically adding and removing a menu bar
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AddRemoveMenuBarTest_3
+ */
+
+public class AddRemoveMenuBarTest_3  {
+    private static final String INSTRUCTIONS = """
+            A frame at (100,100) contains two (2) rows of three (3) text
+            fields each, and under this, a checkbox labelled 'Use menubar'.
+
+            The first row's text fields pertain to the x coordinates and
+            the second row's text fields pertain to the y coordinates.
+
+            The first column, 'request', is an input only field for frame
+            location. (press enter to apply).
+
+            The second column, 'reported', is an output only
+            field reporting frame location.
+
+            The third column, 'inset', is an output only field reporting
+            the frame's inset values.
+
+            You can click the 'Use menubar' checkbox to alternately add
+            and remove a menu bar containing an (empty) 'Help' menu.
+
+            After a menubar is added or removed, the frame should not
+            have been resized nor repositioned on the screen and the
+            y inset should accurately reflect the presence or absence
+            of the menubar within the inset.
+
+            The insets always include the window manager's title and border
+            decorations, if any.
+
+            Upon test completion, click Pass or Fail appropriately.
+            """;
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("AddRemoveMenuBarTest_3 Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(30)
+                .columns(38)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            AddRemoveMenuBar_3 frame = new AddRemoveMenuBar_3();
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(null,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}
+
+class AddRemoveMenuBar_3 extends Frame {
+    TextField xfield;
+    TextField yfield;
+
+    TextField xfield_out;
+    TextField yfield_out;
+    TextField xinset_out;
+    TextField yinset_out;
+
+    Checkbox menu_checkbox;
+    MenuBar menubar;
+
+    public AddRemoveMenuBar_3() {
+        super("AddRemoveMenuBar_3");
+
+        menubar = new MenuBar();
+        menubar.setHelpMenu(new Menu("Help"));
+
+        setLayout(new BorderLayout());
+        Panel p = new Panel();
+        add("Center", p);
+        p.setLayout(new GridLayout(3, 3));
+
+        menu_checkbox = new Checkbox("Use menubar");
+        add("South", menu_checkbox);
+
+        xfield = new TextField();
+        yfield = new TextField();
+        xfield_out = new TextField();
+        xfield_out.setEditable(false);
+        xfield_out.setFocusable(false);
+        yfield_out = new TextField();
+        yfield_out.setEditable(false);
+        yfield_out.setFocusable(false);
+
+        xinset_out = new TextField();
+        xinset_out.setEditable(false);
+        xinset_out.setFocusable(false);
+        yinset_out = new TextField();
+        yinset_out.setEditable(false);
+        yinset_out.setFocusable(false);
+
+        p.add(new Label("request"));
+        p.add(new Label("reported"));
+        p.add(new Label("inset"));
+
+        p.add(xfield);
+        p.add(xfield_out);
+        p.add(xinset_out);
+
+        p.add(yfield);
+        p.add(yfield_out);
+        p.add(yinset_out);
+
+        setSize(200, 200);
+        setLocation(100, 100);
+
+        addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentMoved(ComponentEvent e) {
+                xfield_out.setText(Integer.toString(getLocation().x));
+                yfield_out.setText(Integer.toString(getLocation().y));
+
+                xinset_out.setText(Integer.toString(getInsets().left));
+                yinset_out.setText(Integer.toString(getInsets().top));
+            }
+        });
+
+        ActionListener setLocationListener = e -> {
+            Rectangle r = getBounds();
+            try {
+                r.x = Integer.parseInt(xfield.getText());
+                r.y = Integer.parseInt(yfield.getText());
+            } catch (java.lang.NumberFormatException ignored) {
+            }
+
+            setLocation(r.x, r.y);
+        };
+
+        xfield.addActionListener(setLocationListener);
+        yfield.addActionListener(setLocationListener);
+
+        menu_checkbox.addItemListener(e -> {
+            if (menu_checkbox.getState()) {
+                setMenuBar(menubar);
+            } else {
+                setMenuBar(null);
+            }
+
+            validate();
+            xinset_out.setText(Integer.toString(getInsets().left));
+            yinset_out.setText(Integer.toString(getInsets().top));
+        });
+    }
+}

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4071086
+ * @key headful
+ * @summary Test dynamically adding and removing a menu bar
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AddRemoveMenuBarTest_4
+ */
+
+public class AddRemoveMenuBarTest_4 {
+
+    private static final String INSTRUCTIONS = """
+            There is a frame with a menubar and a single button.
+
+            The button is labelled 'Add new MenuBar'.
+
+            If you click the button, the menubar is replaced with another menubar.
+            This can be done repeatedly.
+
+            The <n>-th menubar contains one menu, 'TestMenu<n>',
+            with two items, 'one <n>' and 'two <n>'.
+
+            Click again to replace the menu bar with another menu bar.
+
+            After a menubar has been replaced with another menubar,
+            the frame should not be resized nor repositioned on the screen.
+
+            Upon test completion, click Pass or Fail appropriately.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("AddRemoveMenuBarTest_4 Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(18)
+                .columns(45)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            AddRemoveMenuBar_4 frame = new AddRemoveMenuBar_4();
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}
+
+class AddRemoveMenuBar_4 extends Frame {
+    int count = 1;
+    MenuBar mb = null;
+
+    AddRemoveMenuBar_4() {
+        super("AddRemoveMenuBar_4");
+        setLayout(new FlowLayout());
+
+        Button b = new Button("Add new MenuBar");
+        b.addActionListener((e) -> createMenuBar());
+        add(b);
+
+        createMenuBar();
+
+        setSize(300, 300);
+    }
+
+    void createMenuBar() {
+        if (mb != null) {
+            remove(mb);
+        }
+
+        mb = new MenuBar();
+        Menu m = new Menu("TestMenu" + count);
+        m.add(new MenuItem("one " + count));
+        m.add(new MenuItem("two " + count));
+        count++;
+        mb.add(m);
+        setMenuBar(mb);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316240](https://bugs.openjdk.org/browse/JDK-8316240) needs maintainer approval

### Issue
 * [JDK-8316240](https://bugs.openjdk.org/browse/JDK-8316240): Open source several add/remove MenuBar manual tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/691/head:pull/691` \
`$ git checkout pull/691`

Update a local copy of the PR: \
`$ git checkout pull/691` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 691`

View PR using the GUI difftool: \
`$ git pr show -t 691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/691.diff">https://git.openjdk.org/jdk21u-dev/pull/691.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/691#issuecomment-2159858844)