### PR TITLE
8333716: Shenandoah: Check for disarmed method before taking the nmethod lock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -36,13 +36,19 @@
 #include "runtime/threadWXSetters.inline.hpp"
 
 bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
+  if (!is_armed(nm)) {
+    // Some other thread got here first and healed the oops
+    // and disarmed the nmethod. No need to continue.
+    return true;
+  }
+
   ShenandoahReentrantLock* lock = ShenandoahNMethod::lock_for_nmethod(nm);
   assert(lock != nullptr, "Must be");
   ShenandoahReentrantLocker locker(lock);
 
   if (!is_armed(nm)) {
-    // Some other thread got here first and healed the oops
-    // and disarmed the nmethod.
+    // Some other thread managed to complete while we were
+    // waiting for lock. No need to continue.
     return true;
   }
 


### PR DESCRIPTION
**Notes**
JDK 21 backport for [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716).

We are spending significant time on acquiring the per-nmethod as all the
threads are in same nmethod.
Adding double-check lock by calling is_armed before lock acquisition.

**Verification**
1. tier 1, tier 2, hotspot_gc and  hotspot_gc_shenandoah tests

2. Benchmarking on [c6a.12xlarge](https://aws.amazon.com/ec2/instance-types/c6a/)
**Prior to this PR:**

```
dev-dsk-neethp-jdk-2c-ad54955c % jdk21u-dev/build/linux-x86_64-server-release/images/jdk/bin/java -Xmx1g -Xms1g -XX:+UseShenandoahGC -Xlog:gc ManyThreadsStacks.java 2>&1 | grep "marking roots"
[0.679s][info][gc] GC(0) Concurrent marking roots 72.911ms
[0.787s][info][gc] GC(1) Concurrent marking roots 86.382ms
[0.884s][info][gc] GC(2) Concurrent marking roots 81.214ms
[0.980s][info][gc] GC(3) Concurrent marking roots 80.542ms
[1.074s][info][gc] GC(4) Concurrent marking roots 78.546ms
[1.297s][info][gc] GC(5) Concurrent marking roots 86.590ms
[1.435s][info][gc] GC(6) Concurrent marking roots 85.026ms
[1.575s][info][gc] GC(7) Concurrent marking roots 85.214ms
[1.721s][info][gc] GC(8) Concurrent marking roots 89.698ms
[1.862s][info][gc] GC(9) Concurrent marking roots 80.378ms
[1.996s][info][gc] GC(10) Concurrent marking roots 75.904ms
[2.129s][info][gc] GC(11) Concurrent marking roots 78.489ms
[2.253s][info][gc] GC(12) Concurrent marking roots 73.650ms
[2.393s][info][gc] GC(13) Concurrent marking roots 86.164ms
[2.525s][info][gc] GC(14) Concurrent marking roots 79.495ms
[2.656s][info][gc] GC(15) Concurrent marking roots 79.613ms
[2.792s][info][gc] GC(16) Concurrent marking roots 82.616ms
[2.932s][info][gc] GC(17) Concurrent marking roots 78.196ms
[3.058s][info][gc] GC(18) Concurrent marking roots 75.565ms
[3.196s][info][gc] GC(19) Concurrent marking roots 84.462ms
[3.336s][info][gc] GC(20) Concurrent marking roots 81.337ms
```

**After:**

```
dev-dsk-neethp-jdk-2c-ad54955c % jdk21u-dev/build/linux-x86_64-server-release/images/jdk/bin/java -Xmx1g -Xms1g -XX:+UseShenandoahGC -Xlog:gc ManyThreadsStacks.java 2>&1 | grep "marking roots"
[0.613s][info][gc] GC(0) Concurrent marking roots 4.845ms
[0.641s][info][gc] GC(1) Concurrent marking roots 3.911ms
[0.665s][info][gc] GC(2) Concurrent marking roots 3.893ms
[0.687s][info][gc] GC(3) Concurrent marking roots 3.520ms
[0.708s][info][gc] GC(4) Concurrent marking roots 3.483ms
[0.944s][info][gc] GC(5) Concurrent marking roots 3.904ms
[1.021s][info][gc] GC(6) Concurrent marking roots 3.810ms
[1.098s][info][gc] GC(7) Concurrent marking roots 3.450ms
[1.169s][info][gc] GC(8) Concurrent marking roots 2.921ms
[1.240s][info][gc] GC(9) Concurrent marking roots 3.368ms
[1.310s][info][gc] GC(10) Concurrent marking roots 3.318ms
[1.381s][info][gc] GC(11) Concurrent marking roots 3.724ms
[1.451s][info][gc] GC(12) Concurrent marking roots 2.899ms
[1.522s][info][gc] GC(13) Concurrent marking roots 3.473ms
[1.592s][info][gc] GC(14) Concurrent marking roots 2.932ms
[1.664s][info][gc] GC(15) Concurrent marking roots 3.633ms
[1.734s][info][gc] GC(16) Concurrent marking roots 3.614ms
[1.806s][info][gc] GC(17) Concurrent marking roots 3.333ms
[1.877s][info][gc] GC(18) Concurrent marking roots 3.110ms
[1.948s][info][gc] GC(19) Concurrent marking roots 3.066ms
[2.018s][info][gc] GC(20) Concurrent marking roots 3.140ms
[2.089s][info][gc] GC(21) Concurrent marking roots 3.049ms
[2.161s][info][gc] GC(22) Concurrent marking roots 3.531ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716) needs maintainer approval

### Issue
 * [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716): Shenandoah: Check for disarmed method before taking the nmethod lock (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/695/head:pull/695` \
`$ git checkout pull/695`

Update a local copy of the PR: \
`$ git checkout pull/695` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 695`

View PR using the GUI difftool: \
`$ git pr show -t 695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/695.diff">https://git.openjdk.org/jdk21u-dev/pull/695.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/695#issuecomment-2161336941)