### PR TITLE
8316756: C2 EA fails with "missing memory path" when encountering unsafe_arraycopy stub call

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3513,6 +3513,13 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
       if (n == nullptr) {
         continue;
       }
+    } else if (n->is_CallLeaf()) {
+      // Runtime calls with narrow memory input (no MergeMem node)
+      // get the memory projection
+      n = n->as_Call()->proj_out_or_null(TypeFunc::Memory);
+      if (n == nullptr) {
+        continue;
+      }
     } else if (n->Opcode() == Op_StrCompressedCopy ||
                n->Opcode() == Op_EncodeISOArray) {
       // get the memory projection
@@ -3555,7 +3562,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
           continue;
         }
         memnode_worklist.append_if_missing(use);
-      } else if (use->is_MemBar()) {
+      } else if (use->is_MemBar() || use->is_CallLeaf()) {
         if (use->in(TypeFunc::Memory) == n) { // Ignore precedent edge
           memnode_worklist.append_if_missing(use);
         }

--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeArrayCopy.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8316756
+ * @summary Test UNSAFE.copyMemory in combination with Escape Analysis
+ * @library /test/lib
+ *
+ * @modules java.base/jdk.internal.misc
+ *
+ * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,compiler.unsafe.UnsafeArrayCopy::test*
+ *                   compiler.unsafe.UnsafeArrayCopy
+ */
+
+package compiler.unsafe;
+
+import java.lang.reflect.*;
+import java.util.*;
+
+import jdk.internal.misc.Unsafe;
+
+
+public class UnsafeArrayCopy {
+
+    private static Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    static long SRC_BASE = UNSAFE.allocateMemory(4);
+    static long DST_BASE = UNSAFE.allocateMemory(4);
+
+    static class MyClass {
+        int x;
+    }
+
+    static int test() {
+        MyClass obj = new MyClass(); // Non-escaping to trigger Escape Analysis
+        UNSAFE.copyMemory(null, SRC_BASE, null, DST_BASE, 4);
+        obj.x = 42;
+        return obj.x;
+    }
+
+    static int[] test2() {
+         int[] src = new int[4];
+         int[] dst = new int[4];
+         MyClass obj = new MyClass();
+         UNSAFE.copyMemory(src, 0, dst, 0, 4);
+         obj.x = 42;
+         dst[1] = obj.x;
+         return dst;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; ++i) {
+            test();
+            test2();
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of [JDK-8316756](https://bugs.openjdk.org/browse/JDK-8316756).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316756](https://bugs.openjdk.org/browse/JDK-8316756) needs maintainer approval

### Issue
 * [JDK-8316756](https://bugs.openjdk.org/browse/JDK-8316756): C2 EA fails with "missing memory path" when encountering unsafe_arraycopy stub call (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/697/head:pull/697` \
`$ git checkout pull/697`

Update a local copy of the PR: \
`$ git checkout pull/697` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 697`

View PR using the GUI difftool: \
`$ git pr show -t 697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/697.diff">https://git.openjdk.org/jdk21u-dev/pull/697.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/697#issuecomment-2162553653)