### PR TITLE
8327423: C2 remove_main_post_loops: check if main-loop belongs to pre-loop, not just assert

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3413,7 +3413,6 @@ void IdealLoopTree::adjust_loop_exit_prob(PhaseIdealLoop *phase) {
   }
 }
 
-#ifdef ASSERT
 static CountedLoopNode* locate_pre_from_main(CountedLoopNode* main_loop) {
   assert(!main_loop->is_main_no_pre_loop(), "Does not have a pre loop");
   Node* ctrl = main_loop->skip_predicates();
@@ -3426,7 +3425,6 @@ static CountedLoopNode* locate_pre_from_main(CountedLoopNode* main_loop) {
   assert(pre_loop->is_pre_loop(), "No pre loop found");
   return pre_loop;
 }
-#endif
 
 // Remove the main and post loops and make the pre loop execute all
 // iterations. Useful when the pre loop is found empty.
@@ -3454,7 +3452,11 @@ void IdealLoopTree::remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *
     return;
   }
 
-  assert(locate_pre_from_main(main_head) == cl, "bad main loop");
+  // We found a main-loop after this pre-loop, but they might not belong together.
+  if (locate_pre_from_main(main_head) != cl) {
+    return;
+  }
+
   Node* main_iff = main_head->skip_predicates()->in(0);
 
   // Remove the Opaque1Node of the pre loop and make it execute all iterations

--- a/test/hotspot/jtreg/compiler/loopopts/TestEmptyPreLoopForDifferentMainLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestEmptyPreLoopForDifferentMainLoop.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8327423
+ * @summary Test empty loop removal of pre-loop, with different main-loop after it.
+ * @run main/othervm -Xcomp
+ *      -XX:CompileCommand=compileonly,compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop::test
+ *      compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop
+ * @run main compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop
+ */
+
+package compiler.loopopts;
+
+public class TestEmptyPreLoopForDifferentMainLoop {
+    static int sink;
+
+    public static void main(String args[]) {
+        test(false);
+    }
+
+    static void test(boolean flag) {
+        int x = 8;
+        for (int j = 0; j < 100; j++) {
+            for (int k = 0; k < 100; k++) {
+                if (flag) {
+                    x += k;
+                    sink = 42;
+                }
+            }
+            if (flag) {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8327423](https://bugs.openjdk.org/browse/JDK-8327423). I only had to integrate loopTransform.cpp manually due to unrelated context differences.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8327423](https://bugs.openjdk.org/browse/JDK-8327423) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327423](https://bugs.openjdk.org/browse/JDK-8327423): C2 remove_main_post_loops: check if main-loop belongs to pre-loop, not just assert (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/701/head:pull/701` \
`$ git checkout pull/701`

Update a local copy of the PR: \
`$ git checkout pull/701` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 701`

View PR using the GUI difftool: \
`$ git pr show -t 701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/701.diff">https://git.openjdk.org/jdk21u-dev/pull/701.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/701#issuecomment-2162705353)