### PR TITLE
8331863: DUIterator_Fast used before it is constructed

### DIFF
--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1525,8 +1525,8 @@ Node* Node::last_out(DUIterator_Last& i) const {
 class SimpleDUIterator : public StackObj {
  private:
   Node* node;
-  DUIterator_Fast i;
   DUIterator_Fast imax;
+  DUIterator_Fast i;
  public:
   SimpleDUIterator(Node* n): node(n), i(n->fast_outs(imax)) {}
   bool has_next() { return i < imax; }


### PR DESCRIPTION
Clean backport of [JDK-8331863](https://bugs.openjdk.org/browse/JDK-8331863).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331863](https://bugs.openjdk.org/browse/JDK-8331863) needs maintainer approval

### Issue
 * [JDK-8331863](https://bugs.openjdk.org/browse/JDK-8331863): DUIterator_Fast used before it is constructed (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/703/head:pull/703` \
`$ git checkout pull/703`

Update a local copy of the PR: \
`$ git checkout pull/703` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 703`

View PR using the GUI difftool: \
`$ git pr show -t 703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/703.diff">https://git.openjdk.org/jdk21u-dev/pull/703.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/703#issuecomment-2162720123)