### PR TITLE
8323682: C2: guard check is not generated in Arrays.copyOfRange intrinsic when allocation is eliminated by EA

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4272,11 +4272,15 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
       length = _gvn.transform(new SubINode(end, start));
     }
 
-    // Bail out if length is negative.
+    // Bail out if length is negative (i.e., if start > end).
     // Without this the new_array would throw
     // NegativeArraySizeException but IllegalArgumentException is what
     // should be thrown
     generate_negative_guard(length, bailout, &length);
+
+    // Bail out if start is larger than the original length
+    Node* orig_tail = _gvn.transform(new SubINode(orig_length, start));
+    generate_negative_guard(orig_tail, bailout, &orig_tail);
 
     if (bailout->req() > 1) {
       PreserveJVMState pjvms(this);
@@ -4287,8 +4291,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
 
     if (!stopped()) {
       // How many elements will we copy from the original?
-      // The answer is MinI(orig_length - start, length).
-      Node* orig_tail = _gvn.transform(new SubINode(orig_length, start));
+      // The answer is MinI(orig_tail, length).
       Node* moved = generate_min_max(vmIntrinsics::_min, orig_tail, length);
 
       // Generate a direct call to the right arraycopy function(s).
@@ -4336,7 +4339,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
       if (!stopped()) {
         newcopy = new_array(klass_node, length, 0);  // no arguments to push
 
-        ArrayCopyNode* ac = ArrayCopyNode::make(this, true, original, start, newcopy, intcon(0), moved, true, false,
+        ArrayCopyNode* ac = ArrayCopyNode::make(this, true, original, start, newcopy, intcon(0), moved, true, true,
                                                 load_object_klass(original), klass_node);
         if (!is_copyOfRange) {
           ac->set_copyof(validated);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1266,7 +1266,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     generate_arraycopy(ac, alloc, &ctrl, merge_mem, &io,
                        adr_type, T_OBJECT,
                        src, src_offset, dest, dest_offset, length,
-                       true, !ac->is_copyofrange());
+                       true, ac->has_negative_length_guard());
 
     return;
   }

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyOfRangeGuards.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyOfRangeGuards.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8323682
+ * @summary Test that the appropriate guards are generated for the copyOfRange
+ *          intrinsic, even if the result of the array copy is not used.
+ *
+ * @run main/othervm -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestArrayCopyOfRangeGuards::test
+ *                   -Xbatch
+ *                   compiler.arraycopy.TestArrayCopyOfRangeGuards
+ */
+
+package compiler.arraycopy;
+
+import java.util.Arrays;
+
+public class TestArrayCopyOfRangeGuards {
+    static int counter = 0;
+
+    public static void main(String[] args) {
+        Object[] array = new Object[10];
+        for (int i = 0; i < 50_000; i++) {
+            test(array);
+        }
+        if (counter != 50_000) {
+            throw new RuntimeException("Test failed");
+        }
+    }
+
+    static void test(Object[] array) {
+        try {
+            Arrays.copyOfRange(array, 15, 20, Object[].class);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            // Expected
+            counter++;
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of [JDK-8323682](https://bugs.openjdk.org/browse/JDK-8323682).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323682](https://bugs.openjdk.org/browse/JDK-8323682) needs maintainer approval

### Issue
 * [JDK-8323682](https://bugs.openjdk.org/browse/JDK-8323682): C2: guard check is not generated in Arrays.copyOfRange intrinsic when allocation is eliminated by EA (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/704/head:pull/704` \
`$ git checkout pull/704`

Update a local copy of the PR: \
`$ git checkout pull/704` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 704`

View PR using the GUI difftool: \
`$ git pr show -t 704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/704.diff">https://git.openjdk.org/jdk21u-dev/pull/704.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/704#issuecomment-2162887423)