### PR TITLE
8332959: C2: ZGC fails with 'Incorrect load shift' when invoking Object.clone() reflectively on an array

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4900,7 +4900,13 @@ void LibraryCallKit::copy_to_clone(Node* obj, Node* alloc_obj, Node* obj_size, b
   assert(alloc_obj->is_CheckCastPP() && raw_obj->is_Proj() && raw_obj->in(0)->is_Allocate(), "");
 
   AllocateNode* alloc = nullptr;
-  if (ReduceBulkZeroing) {
+  if (ReduceBulkZeroing &&
+      // If we are implementing an array clone without knowing its source type
+      // (can happen when compiling the array-guarded branch of a reflective
+      // Object.clone() invocation), initialize the array within the allocation.
+      // This is needed because some GCs (e.g. ZGC) might fall back in this case
+      // to a runtime clone call that assumes fully initialized source arrays.
+      (!is_array || obj->get_ptr_type()->isa_aryptr() != nullptr)) {
     // We will be completely responsible for initializing this object -
     // mark Initialize node as complete.
     alloc = AllocateNode::Ideal_allocation(alloc_obj, &_gvn);


### PR DESCRIPTION
Clean backport of [JDK-8332959](https://bugs.openjdk.org/browse/JDK-8332959).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332959](https://bugs.openjdk.org/browse/JDK-8332959) needs maintainer approval

### Issue
 * [JDK-8332959](https://bugs.openjdk.org/browse/JDK-8332959): C2: ZGC fails with 'Incorrect load shift' when invoking Object.clone() reflectively on an array (**Bug** - P3 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/706/head:pull/706` \
`$ git checkout pull/706`

Update a local copy of the PR: \
`$ git checkout pull/706` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 706`

View PR using the GUI difftool: \
`$ git pr show -t 706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/706.diff">https://git.openjdk.org/jdk21u-dev/pull/706.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/706#issuecomment-2162896415)