### PR TITLE
8332905: C2 SuperWord: bad AD file, with RotateRightV and first operand not a pack

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2748,7 +2748,7 @@ bool SuperWord::output() {
         }
         vlen_in_bytes = vn->as_StoreVector()->memory_size();
       } else if (VectorNode::is_scalar_rotate(n)) {
-        Node* in1 = first->in(1);
+        Node* in1 = vector_opd(p, 1);
         Node* in2 = first->in(2);
         // If rotation count is non-constant or greater than 8bit value create a vector.
         if (!in2->is_Con() || !Matcher::supports_vector_constant_rotates(in2->get_int())) {

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8183390 8332905
  * @summary Vectorization test on bug-prone shift operation
  * @library /test/lib /
  *
@@ -48,6 +49,7 @@ import java.util.Random;
 public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     private static final int SIZE = 543;
+    private static       int size = 543;
 
     private int[] ints;
     private long[] longs;
@@ -71,7 +73,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512f", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(applyIfCPUFeature = {"avx512f", "true"},
         counts = {IRNode.ROTATE_RIGHT_V, ">0"})
@@ -84,7 +86,23 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512f", "true"},
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.STORE_VECTOR, ">0"})
+    @IR(applyIfCPUFeature = {"avx512f", "true"},
+        counts = {IRNode.ROTATE_RIGHT_V, ">0"})
+    // Requires size to not be known at compile time, otherwise the shift
+    // can get constant folded with the (iv + const) pattern from the
+    // PopulateIndex.
+    public int[] intCombinedRotateShiftWithPopulateIndex() {
+        int[] res = new int[size];
+        for (int i = 0; i < size; i++) {
+            res[i] = (i << 14) | (i >>> 18);
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
     @IR(applyIfCPUFeature = {"avx512f", "true"},
         counts = {IRNode.ROTATE_RIGHT_V, ">0"})


### PR DESCRIPTION
Clean backport of [JDK-8332905](https://bugs.openjdk.org/browse/JDK-8332905).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332905](https://bugs.openjdk.org/browse/JDK-8332905) needs maintainer approval

### Issue
 * [JDK-8332905](https://bugs.openjdk.org/browse/JDK-8332905): C2 SuperWord: bad AD file, with RotateRightV and first operand not a pack (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/707/head:pull/707` \
`$ git checkout pull/707`

Update a local copy of the PR: \
`$ git checkout pull/707` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 707`

View PR using the GUI difftool: \
`$ git pr show -t 707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/707.diff">https://git.openjdk.org/jdk21u-dev/pull/707.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/707#issuecomment-2162896922)