### PR TITLE
7022325: TEST_BUG: test/java/util/zip/ZipFile/ReadLongZipFileName.java leaks files if it fails

### DIFF
--- a/test/jdk/java/util/zip/ZipFile/ReadLongZipFileName.java
+++ b/test/jdk/java/util/zip/ZipFile/ReadLongZipFileName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,114 +21,80 @@
  * questions.
  */
 
-/**
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*
  * @test
  * @bug 6374379
- * @library /test/lib
- * @build jdk.test.lib.Platform
- *        jdk.test.lib.util.FileUtils
- * @run main ReadLongZipFileName
  * @summary Verify that we can read zip file names > 255 chars long
+ * @run junit ReadLongZipFileName
  */
-
-import java.io.*;
-import java.util.jar.*;
-import java.util.Stack;
-import jdk.test.lib.util.FileUtils;
-
 public class ReadLongZipFileName {
-    private static String entryName = "testFile.txt";;
+    private static final String ENTRY_NAME = "testFile.txt";
+    private static final String LONG_DIR_NAME = "abcdefghijklmnopqrstuvwx"; // 24 chars
+    private static final String JAR_FILE_NAME = "areallylargejarfilename.jar"; // 27 chars
 
-    public static void realMain(String args[]) {
-        String longDirName = "abcdefghijklmnopqrstuvwx"; // 24 chars.
-        String jarFileName = "areallylargejarfilename.jar";    // 27 chars.
-        File file = null;
-        File myJarFile = null;
-        int currentFileLength = 0;
-        int minRequiredLength = 600; // long enough to definitely fail.
-        Stack<File> directories = new Stack<File>();
+    /*
+     * Creates a jar file at a path whose path name length and jar file name length
+     * combined is large. Then use the java.util.jar.JarFile APIs to open and read the jar file
+     * to verify the APIs work against those jar/zip files.
+     */
+    @Test
+    public void testOpenAndReadJarFile() throws Exception {
+        int minRequiredPathLength = 600; // long enough to definitely fail.
+        Path tmpDir = Files.createTempDirectory(Path.of("."), "ReadLongZipFileName-test")
+                .normalize().toAbsolutePath();
+        // Create a directory structure long enough that the filename will
+        // put us over the minRequiredLength.
+        int currentPathLength = 0;
+        Path jarFileDir = tmpDir;
+        do {
+            jarFileDir = jarFileDir.resolve(LONG_DIR_NAME);
+            Files.createDirectories(jarFileDir);
+            currentPathLength = jarFileDir.toFile().getCanonicalPath().length();
+        } while (currentPathLength < (minRequiredPathLength - JAR_FILE_NAME.length()));
 
-        String filename = "." + File.separator;
-        try {
-            // Create a directory structure long enough that the filename will
-            // put us over the minRequiredLength.
-            do {
-                filename = filename + longDirName + File.separator;
-                file = new File(filename);
-                file.mkdir();
-                currentFileLength = file.getCanonicalPath().length();
-                directories.push(file);
-            } while (currentFileLength < (minRequiredLength - jarFileName.length()));
-
-            // Create a new Jar file: use jar instead of zip to make sure long
-            // names work for both zip and jar subclass.
-            filename = filename + jarFileName;
-            JarOutputStream out = new JarOutputStream(
-                new BufferedOutputStream(
-                    new FileOutputStream(filename.toString())));
-            out.putNextEntry(new JarEntry(entryName));
+        // Create a new Jar file: use jar instead of zip to make sure long
+        // names work for both zip and jar subclass.
+        Path jarFilePath = jarFileDir.resolve(JAR_FILE_NAME);
+        System.out.println("creating a jar file at " + jarFilePath);
+        try (JarOutputStream out = new JarOutputStream(
+                new BufferedOutputStream(Files.newOutputStream(jarFilePath)))) {
+            out.putNextEntry(new JarEntry(ENTRY_NAME));
             out.write(1);
-            out.close();
-            myJarFile = new File(filename.toString());
-            currentFileLength = myJarFile.getCanonicalPath().length();
-            if (!myJarFile.exists()) {
-                fail("Jar file does not exist.");
-            }
-        } catch (IOException e) {
-            unexpected(e, "Problem creating the Jar file.");
         }
+        assertTrue(Files.isRegularFile(jarFilePath),
+                "jar file " + jarFilePath + " does not exist or is not a file");
 
-        try {
-            JarFile readJarFile = new JarFile(myJarFile);
-            JarEntry je = readJarFile.getJarEntry(entryName);
-            check(je != null);
-            DataInputStream dis = new DataInputStream(
-                readJarFile.getInputStream(je));
+        try (JarFile readJarFile = new JarFile(jarFilePath.toFile())) {
+            JarEntry je = readJarFile.getJarEntry(ENTRY_NAME);
+            assertNotNull(je, "missing jar entry: " + ENTRY_NAME + " in jar file " + jarFilePath);
+            DataInputStream dis = new DataInputStream(readJarFile.getInputStream(je));
             byte val = dis.readByte();
-            check(val == 1);
+            assertEquals(1, val, "unexpected byte " + val + " read from entry " + ENTRY_NAME);
             try {
                 dis.readByte();
-                fail("Read past expected EOF");
+                Assertions.fail("Read past expected EOF");
             } catch (IOException e) {
-                pass();
-            }
-            readJarFile.close();
-            pass("Opened Jar file for reading with a name " + currentFileLength
-                 + " characters long");
-        } catch (IOException e) {
-            unexpected(e, "Test failed - problem reading the Jar file back in.");
-        }
-
-        if (myJarFile != null) {
-            check(myJarFile.delete());
-        }
-
-        while (! directories.empty()) {
-            File f = directories.pop();
-            try {
-                FileUtils.deleteFileWithRetry(f.toPath());
-            } catch (IOException e) {
-                unexpected(e, "Fail to clean up directory, " + f);
-                break;
+                // expected
+                System.out.println("received the expected exception: " + e);
             }
         }
+        System.out.println("Successfully opened and read contents from a jar file with a name "
+                + jarFilePath.toFile().getCanonicalPath().length() + " characters long");
     }
-
-    //--------------------- Infrastructure ---------------------------
-    static volatile int passed = 0, failed = 0;
-    static void pass() {passed++;}
-    static void pass(String msg) {System.out.println(msg); passed++;}
-    static void fail() {failed++; Thread.dumpStack();}
-    static void fail(String msg) {System.out.println(msg); fail();}
-    static void unexpected(Throwable t) {failed++; t.printStackTrace();}
-    static void unexpected(Throwable t, String msg) {
-        System.out.println(msg); failed++; t.printStackTrace();}
-    static void check(boolean cond) {if (cond) pass(); else fail();}
-    static void equal(Object x, Object y) {
-        if (x == null ? y == null : x.equals(y)) pass();
-        else fail(x + " not equal to " + y);}
-    public static void main(String[] args) throws Throwable {
-        try {realMain(args);} catch (Throwable t) {unexpected(t);}
-        System.out.println("\nPassed = " + passed + " failed = " + failed);
-        if (failed > 0) throw new AssertionError("Some tests failed");}
 }


### PR DESCRIPTION
Backport of [JDK-7022325](https://bugs.openjdk.org/browse/JDK-7022325)
- The git patch is `clean`

Testing
- Local: Test passed on MacOS 14.5
  - `ReadLongZipFileName.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-21`
  - `jtreg_jdk_tier1`: java/util/zip/ZipFile/ReadLongZipFileName.java: SUCCESSFUL GitHub 📊⏲ - [5,793 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-7022325](https://bugs.openjdk.org/browse/JDK-7022325) needs maintainer approval

### Issue
 * [JDK-7022325](https://bugs.openjdk.org/browse/JDK-7022325): TEST_BUG: test/java/util/zip/ZipFile/ReadLongZipFileName.java leaks files if it fails (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/709/head:pull/709` \
`$ git checkout pull/709`

Update a local copy of the PR: \
`$ git checkout pull/709` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 709`

View PR using the GUI difftool: \
`$ git pr show -t 709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/709.diff">https://git.openjdk.org/jdk21u-dev/pull/709.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/709#issuecomment-2163783361)