### PR TITLE
8323122: AArch64: Increase itable stub size estimate

### DIFF
--- a/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
@@ -197,7 +197,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
                                   temp_reg, temp_reg2, itable_index, L_no_such_interface);
 
   // Reduce "estimate" such that "padding" does not drop below 8.
-  const ptrdiff_t estimate = 124;
+  const ptrdiff_t estimate = 144;
   const ptrdiff_t codesize = __ pc() - start_pc;
   slop_delta  = (int)(estimate - codesize);
   slop_bytes += slop_delta;


### PR DESCRIPTION
This is a tiny safety follow-up to JDK-8307352 (AARCH64: Improve itable_stub). Original change applies cleanly.

Testing: jtreg tier1,2 on linux-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8323122](https://bugs.openjdk.org/browse/JDK-8323122) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323122](https://bugs.openjdk.org/browse/JDK-8323122): AArch64: Increase itable stub size estimate (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/711/head:pull/711` \
`$ git checkout pull/711`

Update a local copy of the PR: \
`$ git checkout pull/711` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 711`

View PR using the GUI difftool: \
`$ git pr show -t 711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/711.diff">https://git.openjdk.org/jdk21u-dev/pull/711.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/711#issuecomment-2163846134)