### PR TITLE
8318071: IgnoreUnrecognizedVMOptions flag still causes failure in ArchiveHeapTestClass

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchiveHeapTestClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchiveHeapTestClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @test
  * @bug 8214781 8293187
  * @summary Test for the -XX:ArchiveHeapTestClass flag
- * @requires vm.cds.write.archived.java.heap
+ * @requires vm.debug == true & vm.cds.write.archived.java.heap
  * @modules java.base/sun.invoke.util java.logging
  * @library /test/jdk/lib/testlibrary /test/lib
  *          /test/hotspot/jtreg/runtime/cds/appcds
@@ -61,11 +61,7 @@ public class ArchiveHeapTestClass {
     static final String ARCHIVE_TEST_FIELD_NAME = "archivedObjects";
 
     public static void main(String[] args) throws Exception {
-        if (Platform.isDebugBuild()) {
-            testDebugBuild();
-        } else {
-            testProductBuild();
-        }
+        testDebugBuild();
     }
 
     static OutputAnalyzer dumpHelloOnly(String... extraOpts) throws Exception {
@@ -168,13 +164,6 @@ public class ArchiveHeapTestClass {
             output = dumpBootAndHello(CDSTestClassG_name);
             mustSucceed(output);
         }
-    }
-
-    static void testProductBuild() throws Exception {
-        OutputAnalyzer output;
-
-        output = dumpHelloOnly("-XX:-IgnoreUnrecognizedVMOptions", "-XX:ArchiveHeapTestClass=NoSuchClass");
-        mustFail(output, "VM option 'ArchiveHeapTestClass' is develop and is available only in debug version of VM.");
     }
 }
 


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8318071](https://bugs.openjdk.org/browse/JDK-8318071) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318071](https://bugs.openjdk.org/browse/JDK-8318071): IgnoreUnrecognizedVMOptions flag still causes failure in ArchiveHeapTestClass (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/714/head:pull/714` \
`$ git checkout pull/714`

Update a local copy of the PR: \
`$ git checkout pull/714` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 714`

View PR using the GUI difftool: \
`$ git pr show -t 714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/714.diff">https://git.openjdk.org/jdk21u-dev/pull/714.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/714#issuecomment-2164866224)