### PR TITLE
8321278: C2: Partial peeling fails with assert "last_peel <- first_not_peeled"

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8321278
+ * @summary C2: Partial peeling fails with assert "last_peel <- first_not_peeled"
+ * @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,TestPartialPeelingAtSingleInputRegion::test
+ *                   -XX:-TieredCompilation -Xbatch -XX:PerMethodTrapLimit=0 TestPartialPeelingAtSingleInputRegion
+ *
+ */
+
+public class TestPartialPeelingAtSingleInputRegion {
+
+    static void test() {
+        for (int i = 100; i > 10; --i) {
+            for (int j = i; j < 10; ++j) {
+                switch (j) {
+                case 1:
+                    if (j != 0) {
+                        return;
+                    }
+                }
+             }
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; ++i) {
+            test();
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of [JDK-8321278](https://bugs.openjdk.org/browse/JDK-8321278).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8321278](https://bugs.openjdk.org/browse/JDK-8321278) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321278](https://bugs.openjdk.org/browse/JDK-8321278): C2: Partial peeling fails with assert "last_peel &lt;- first_not_peeled" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/718/head:pull/718` \
`$ git checkout pull/718`

Update a local copy of the PR: \
`$ git checkout pull/718` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 718`

View PR using the GUI difftool: \
`$ git pr show -t 718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/718.diff">https://git.openjdk.org/jdk21u-dev/pull/718.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/718#issuecomment-2165996561)