### PR TITLE
8331575: C2: crash when ConvL2I is split thru phi at LongCountedLoop

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -48,8 +48,9 @@
 //------------------------------split_thru_phi---------------------------------
 // Split Node 'n' through merge point if there is enough win.
 Node* PhaseIdealLoop::split_thru_phi(Node* n, Node* region, int policy) {
-  if (n->Opcode() == Op_ConvI2L && n->bottom_type() != TypeLong::LONG) {
-    // ConvI2L may have type information on it which is unsafe to push up
+  if ((n->Opcode() == Op_ConvI2L && n->bottom_type() != TypeLong::LONG) ||
+      (n->Opcode() == Op_ConvL2I && n->bottom_type() != TypeInt::INT)) {
+    // ConvI2L/ConvL2I may have type information on it which is unsafe to push up
     // so disable this for now
     return nullptr;
   }

--- a/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331575
+ * @summary C2: crash when ConvL2I is split thru phi at LongCountedLoop
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=92643864 TestLongCountedLoopConvL2I
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestLongCountedLoopConvL2I
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestLongCountedLoopConvL2I
+ */
+
+public class TestLongCountedLoopConvL2I {
+    private static volatile int volatileField;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            testHelper1(42);
+            test1(0);
+        }
+    }
+
+    private static int test1(int res) {
+        int k = 1;
+        for (; k < 2; k *= 2) {
+        }
+        long i = testHelper1(k);
+        for (; i > 0; i--) {
+            res += 42 / ((int) i);
+            for (int j = 1; j < 10; j *= 2) {
+
+            }
+        }
+        return res;
+    }
+
+    private static long testHelper1(int k) {
+        if (k == 2) {
+            return 100;
+        } else {
+            return 99;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I2.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I2.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331575
+ * @summary C2: crash when ConvL2I is split thru phi at LongCountedLoop
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestLongCountedLoopConvL2I2.* TestLongCountedLoopConvL2I2
+ */
+
+public class TestLongCountedLoopConvL2I2 {
+    static int x = 34;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 2; i++) {
+            test();
+        }
+    }
+
+    static int test() {
+        int a = 5, b = 6;
+        long lArr[] = new long[2];
+
+        for (long i = 159; i > 1; i -= 3) {
+            a += 3;
+            for (int j = 1; j < 4; j++) {
+                if (a == 9) {
+                    if (x == 73) {
+                        try {
+                            b = 10 / (int) i;
+                        } catch (ArithmeticException a_e) {
+                        }
+                    }
+                }
+            }
+        }
+        return b;
+    }
+}


### PR DESCRIPTION
Clean backport of [JDK-8331575](https://bugs.openjdk.org/browse/JDK-8331575).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331575](https://bugs.openjdk.org/browse/JDK-8331575) needs maintainer approval

### Issue
 * [JDK-8331575](https://bugs.openjdk.org/browse/JDK-8331575): C2: crash when ConvL2I is split thru phi at LongCountedLoop (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/719/head:pull/719` \
`$ git checkout pull/719`

Update a local copy of the PR: \
`$ git checkout pull/719` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 719`

View PR using the GUI difftool: \
`$ git pr show -t 719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/719.diff">https://git.openjdk.org/jdk21u-dev/pull/719.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/719#issuecomment-2166029396)