### PR TITLE
8321025: Enable Neoverse N1 optimizations for Neoverse V2

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -213,10 +213,11 @@ void VM_Version::initialize() {
     }
   }
 
-  // Neoverse N1, N2 and V1
+  // Neoverse N1, N2, V1, V2
   if (_cpu == CPU_ARM && ((_model == 0xd0c || _model2 == 0xd0c)
                           || (_model == 0xd49 || _model2 == 0xd49)
-                          || (_model == 0xd40 || _model2 == 0xd40))) {
+                          || (_model == 0xd40 || _model2 == 0xd40)
+			  || (_model == 0xd4f || _model2 == 0xd4f))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -215,7 +215,7 @@ void VM_Version::initialize() {
 
   // Neoverse N1, N2, V1, V2
   if (_cpu == CPU_ARM && (model_is(0xd0c) || model_is(0xd49) ||
-			  model_is(0xd40) || model_is(0xd4f))) {
+                          model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -214,10 +214,8 @@ void VM_Version::initialize() {
   }
 
   // Neoverse N1, N2, V1, V2
-  if (_cpu == CPU_ARM && ((_model == 0xd0c || _model2 == 0xd0c)
-                          || (_model == 0xd49 || _model2 == 0xd49)
-                          || (_model == 0xd40 || _model2 == 0xd40)
-			  || (_model == 0xd4f || _model2 == 0xd4f))) {
+  if (_cpu == CPU_ARM && (model_is(0xd0c) || model_is(0xd49) ||
+			  model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -152,6 +152,10 @@ enum Ampere_CPU_Model {
   static int cpu_variant()                    { return _variant; }
   static int cpu_revision()                   { return _revision; }
 
+  static bool model_is(int cpu_model) {
+    return _model == cpu_model || _model2 == cpu_model;
+  }
+
   static bool is_zva_enabled() { return 0 <= _zva_length; }
   static int zva_length() {
     assert(is_zva_enabled(), "ZVA not available");


### PR DESCRIPTION
### Notes
Backport 8321025: Enable Neoverse N1 optimizations for Neoverse V2  to jdk21 it is not a clean backport, the method ```model_is(0xd40) ``` is in jdk21, equivalent code in jdk21 is like ```(_model == 0xd40 || _model2 == 0xd40)```.

#### Verification
Not able to test it on CPU with Neoverse V2, since I don't have server supports Neoverse V2 yet, but the fix has been backported to [Amazon Corretto 21](https://github.com/corretto/corretto-21/blob/release-21.0.3.9.1/CHANGELOG.md
) since January 16, 2024, overall it should be a low risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321025](https://bugs.openjdk.org/browse/JDK-8321025) needs maintainer approval

### Issue
 * [JDK-8321025](https://bugs.openjdk.org/browse/JDK-8321025): Enable Neoverse N1 optimizations for Neoverse V2 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/720/head:pull/720` \
`$ git checkout pull/720`

Update a local copy of the PR: \
`$ git checkout pull/720` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 720`

View PR using the GUI difftool: \
`$ git pr show -t 720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/720.diff">https://git.openjdk.org/jdk21u-dev/pull/720.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/720#issuecomment-2176620282)