### PR TITLE
8317635: Improve GetClassFields test to verify correctness of field order

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,9 @@
  * DESCRIPTION
  *     The test exercises JVMTI function
  *         GetClassFields(clazz, fieldCountPtr, fieldsPtr).
- *     The test checks if the function returns the expected list of fields.
- *     That is the field list contains only directly declared (not inherited)
- *     fields.
+ *     The test checks if the function returns the expected list of fields:
+ *         - the list contains only directly declared (not inherited) fields;
+ *         - fields are returned in the order they occur in the class file.
  * COMMENTS
  *     Ported from JVMDI.
  *     Test fixed due to test bug:
@@ -45,6 +45,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @modules java.base/jdk.internal.org.objectweb.asm
  * @run main/othervm/native -agentlib:getclfld007 nsk.jvmti.GetClassFields.getclfld007
  */
 


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8317635](https://bugs.openjdk.org/browse/JDK-8317635) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317635](https://bugs.openjdk.org/browse/JDK-8317635): Improve GetClassFields test to verify correctness of field order (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/721/head:pull/721` \
`$ git checkout pull/721`

Update a local copy of the PR: \
`$ git checkout pull/721` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 721`

View PR using the GUI difftool: \
`$ git pr show -t 721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/721.diff">https://git.openjdk.org/jdk21u-dev/pull/721.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/721#issuecomment-2167581364)