### PR TITLE
8332825: ubsan: guardedMemory.cpp:35:11: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/src/hotspot/share/memory/guardedMemory.cpp
+++ b/src/hotspot/share/memory/guardedMemory.cpp
@@ -33,7 +33,9 @@ void* GuardedMemory::wrap_copy(const void* ptr, const size_t len, const void* ta
   if (outerp != nullptr) {
     GuardedMemory guarded(outerp, len, tag);
     void* innerp = guarded.get_user_ptr();
-    memcpy(innerp, ptr, len);
+    if (ptr != nullptr) {
+      memcpy(innerp, ptr, len);
+    }
     return innerp;
   }
   return nullptr; // OOM


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332825](https://bugs.openjdk.org/browse/JDK-8332825) needs maintainer approval

### Issue
 * [JDK-8332825](https://bugs.openjdk.org/browse/JDK-8332825): ubsan: guardedMemory.cpp:35:11: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/726/head:pull/726` \
`$ git checkout pull/726`

Update a local copy of the PR: \
`$ git checkout pull/726` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 726`

View PR using the GUI difftool: \
`$ git pr show -t 726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/726.diff">https://git.openjdk.org/jdk21u-dev/pull/726.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/726#issuecomment-2168248875)