### PR TITLE
8332174: Remove 2 (unpaired) RLO Unicode characters in ff_Adlm.xml

### DIFF
--- a/make/data/cldr/common/main/ff_Adlm.xml
+++ b/make/data/cldr/common/main/ff_Adlm.xml
@@ -708,7 +708,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="BS">𞤄𞤢𞤸𞤢𞤥𞤢𞥄𞤧</territory>
 			<territory type="BT">𞤄𞤵𞥅𞤼𞤢𞥄𞤲</territory>
 			<territory type="BV">𞤅𞤵𞤪𞤭𞥅𞤪𞤫 𞤄𞤵𞥅𞤾𞤫𞥅</territory>
-			<territory type="BW">‮𞤄𞤮𞤼𞤧𞤵𞤱𞤢𞥄𞤲𞤢</territory>
+			<territory type="BW">𞤄𞤮𞤼𞤧𞤵𞤱𞤢𞥄𞤲𞤢</territory>
 			<territory type="BY">𞤄𞤫𞤤𞤢𞤪𞤵𞥅𞤧</territory>
 			<territory type="BZ">𞤄𞤫𞤤𞤭𞥅𞥁</territory>
 			<territory type="CA">𞤑𞤢𞤲𞤢𞤣𞤢𞥄</territory>
@@ -8278,7 +8278,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>𞤐𞤵𞥅𞤳</exemplarCity>
 			</zone>
 			<zone type="America/Scoresbysund">
-				<exemplarCity>‮𞤋𞤼𞥆𞤮𞤳𞤮𞤪𞤼𞤮𞥅𞤪𞤥𞤭𞥅𞤼</exemplarCity>
+				<exemplarCity>𞤋𞤼𞥆𞤮𞤳𞤮𞤪𞤼𞤮𞥅𞤪𞤥𞤭𞥅𞤼</exemplarCity>
 			</zone>
 			<zone type="America/Danmarkshavn">
 				<exemplarCity>𞤁𞤢𞥄𞤲𞤥𞤢𞤪𞤳𞥃𞤢𞥄𞤾𞤲</exemplarCity>


### PR DESCRIPTION
This is a backport request for 8332174, which is not yet maintainer-approved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8332174](https://bugs.openjdk.org/browse/JDK-8332174) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332174](https://bugs.openjdk.org/browse/JDK-8332174): Remove 2 (unpaired) RLO Unicode characters in ff_Adlm.xml (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/732/head:pull/732` \
`$ git checkout pull/732`

Update a local copy of the PR: \
`$ git checkout pull/732` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 732`

View PR using the GUI difftool: \
`$ git pr show -t 732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/732.diff">https://git.openjdk.org/jdk21u-dev/pull/732.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/732#issuecomment-2173640512)