### PR TITLE
8325754: Dead AbstractQueuedSynchronizer$ConditionNodes survive minor garbage collections

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -1127,13 +1127,18 @@ public abstract class AbstractQueuedLongSynchronizer
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null)
                     lastWaiter = null;
+                else
+                    first.nextWaiter = null; // GC assistance
+
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
                     enqueue(first);
                     if (!all)
                         break;
                 }
+
                 first = next;
             }
         }

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -1506,13 +1506,18 @@ public abstract class AbstractQueuedSynchronizer
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null)
                     lastWaiter = null;
+                else
+                    first.nextWaiter = null; // GC assistance
+
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
                     enqueue(first);
                     if (!all)
                         break;
                 }
+
                 first = next;
             }
         }


### PR DESCRIPTION
**Notes**
Backport of [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754).

Unlink 'ConditionNode' before they are transferred to the sync queue as G1 seems to be able to collect “dead” ConditionNode instances during minor collections only if no formerly alive ConditionNode instances were promoted to the old generation and died there, which often cannot be avoided since e.g. on application startup many objects are promoted to the old generation after a few collections.

**Verification**

* jdk_util, Tier 1 & Tier 2 tests passed.
* Ran G1LoiteringConditionNodes.java (sample code from bug description) and verified that YG GC time is not increasing after full GC.

_Before PR_

```
dev-dsk-neethp-jdk-2c-ad54955c % /home/neethp/Development/jdk21u-dev/build/linux-x86_64-server-release/images/jdk/bin/java -Xms2048m -Xmx2048m -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=20 '-Xlog:gc*,gc+age*=trace' -cp . G1LoiteringConditionNodes | grep -E 'Pause.*ms'                   
[0.949s][info ][gc          ] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 103M->1M(2048M) 4.998ms
[2.550s][info ][gc          ] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 154M->1M(2048M) 2.513ms
[6.963s][info ][gc          ] GC(2) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 3.213ms
[11.362s][info ][gc          ] GC(3) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.602ms
[15.737s][info ][gc          ] GC(4) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.654ms
[20.149s][info ][gc          ] GC(5) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.192ms
[24.570s][info ][gc          ] GC(6) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.210ms
[29.003s][info ][gc          ] GC(7) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.158ms
[33.432s][info ][gc          ] GC(8) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.839ms
[37.875s][info ][gc          ] GC(9) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.261ms
[42.306s][info ][gc          ] GC(10) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.131ms
[46.743s][info ][gc          ] GC(11) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.024ms
[51.184s][info ][gc          ] GC(12) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.231ms
[55.596s][info ][gc          ] GC(13) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.842ms
[60.036s][info ][gc          ] GC(14) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.144ms
[64.478s][info ][gc          ] GC(15) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.928ms
[68.911s][info ][gc          ] GC(16) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.894ms
[73.349s][info ][gc          ] GC(17) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.780ms
[77.782s][info ][gc          ] GC(18) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.916ms
[82.223s][info ][gc          ] GC(19) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.155ms
[86.651s][info ][gc          ] GC(20) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.879ms
[91.087s][info ][gc          ] GC(21) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.120ms
[95.522s][info ][gc          ] GC(22) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.138ms
[99.941s][info ][gc          ] GC(23) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.126ms
[104.378s][info ][gc          ] GC(24) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.006ms
[108.818s][info ][gc          ] GC(25) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.086ms
[113.253s][info ][gc          ] GC(26) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.155ms
[117.674s][info ][gc          ] GC(27) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.471ms
[120.087s][info ][gc             ] GC(28) Pause Full (System.gc()) 221M->1M(2048M) 41.492ms
[124.505s][info ][gc             ] GC(29) Pause Young (Normal) (G1 Evacuation Pause) 410M->1M(2048M) 3.656ms
[128.918s][info ][gc             ] GC(30) Pause Young (Normal) (G1 Evacuation Pause) 409M->2M(2048M) 4.031ms
[133.311s][info ][gc             ] GC(31) Pause Young (Normal) (G1 Evacuation Pause) 409M->2M(2048M) 4.073ms
[137.706s][info ][gc             ] GC(32) Pause Young (Normal) (G1 Evacuation Pause) 409M->3M(2048M) 4.930ms
[142.103s][info ][gc             ] GC(33) Pause Young (Normal) (G1 Evacuation Pause) 410M->3M(2048M) 5.014ms
[146.501s][info ][gc             ] GC(34) Pause Young (Normal) (G1 Evacuation Pause) 409M->4M(2048M) 4.530ms
[150.891s][info ][gc             ] GC(35) Pause Young (Normal) (G1 Evacuation Pause) 410M->4M(2048M) 5.750ms
[155.274s][info ][gc             ] GC(36) Pause Young (Normal) (G1 Evacuation Pause) 409M->4M(2048M) 5.644ms
[159.657s][info ][gc             ] GC(37) Pause Young (Normal) (G1 Evacuation Pause) 409M->5M(2048M) 5.842ms
[164.042s][info ][gc             ] GC(38) Pause Young (Normal) (G1 Evacuation Pause) 410M->5M(2048M) 5.948ms
[168.412s][info ][gc             ] GC(39) Pause Young (Normal) (G1 Evacuation Pause) 409M->6M(2048M) 6.093ms
[172.777s][info ][gc             ] GC(40) Pause Young (Normal) (G1 Evacuation Pause) 410M->6M(2048M) 6.434ms
```


_After this change_

```
dev-dsk-neethp-jdk-2c-ad54955c % /home/neethp/Development/jdk21u-dev/build/linux-x86_64-server-release/images/jdk/bin/java -Xms2048m -Xmx2048m -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=20 '-Xlog:gc*,gc+age*=trace' -cp . G1LoiteringConditionNodes | grep -E 'Pause.*ms'                    
[0.954s][info ][gc          ] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 103M->1M(2048M) 4.906ms
[2.552s][info ][gc          ] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 154M->1M(2048M) 2.103ms
[6.967s][info ][gc          ] GC(2) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.472ms
[11.350s][info ][gc          ] GC(3) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.441ms
[15.728s][info ][gc          ] GC(4) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.479ms
[20.134s][info ][gc          ] GC(5) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.238ms
[24.554s][info ][gc          ] GC(6) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.242ms
[28.973s][info ][gc          ] GC(7) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.512ms
[33.402s][info ][gc          ] GC(8) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.101ms
[37.838s][info ][gc          ] GC(9) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.191ms
[42.264s][info ][gc          ] GC(10) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.122ms
[46.698s][info ][gc          ] GC(11) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.254ms
[51.147s][info ][gc          ] GC(12) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.323ms
[55.577s][info ][gc          ] GC(13) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.385ms
[60.015s][info ][gc          ] GC(14) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.286ms
[64.457s][info ][gc          ] GC(15) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.165ms
[68.900s][info ][gc          ] GC(16) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.696ms
[73.338s][info ][gc          ] GC(17) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.808ms
[77.776s][info ][gc          ] GC(18) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.127ms
[82.201s][info ][gc          ] GC(19) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.935ms
[86.637s][info ][gc          ] GC(20) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.885ms
[91.074s][info ][gc          ] GC(21) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.108ms
[95.507s][info ][gc          ] GC(22) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.956ms
[99.933s][info ][gc          ] GC(23) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.820ms
[104.365s][info ][gc          ] GC(24) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.260ms
[108.790s][info ][gc          ] GC(25) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.850ms
[113.220s][info ][gc          ] GC(26) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.993ms
[117.653s][info ][gc          ] GC(27) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.025ms
[120.099s][info ][gc             ] GC(28) Pause Full (System.gc()) 223M->1M(2048M) 51.761ms
[124.509s][info ][gc             ] GC(29) Pause Young (Normal) (G1 Evacuation Pause) 410M->1M(2048M) 1.862ms
[128.920s][info ][gc             ] GC(30) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.050ms
[133.320s][info ][gc             ] GC(31) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.914ms
[137.729s][info ][gc             ] GC(32) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.112ms
[142.139s][info ][gc             ] GC(33) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.903ms
[146.540s][info ][gc             ] GC(34) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.911ms
[150.938s][info ][gc             ] GC(35) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.168ms
[155.335s][info ][gc             ] GC(36) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.045ms
[159.735s][info ][gc             ] GC(37) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.068ms
[164.140s][info ][gc             ] GC(38) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.358ms
[168.551s][info ][gc             ] GC(39) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.233ms
[172.955s][info ][gc             ] GC(40) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.153ms
[177.355s][info ][gc             ] GC(41) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.276ms
[181.758s][info ][gc             ] GC(42) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.836ms
[186.163s][info ][gc             ] GC(43) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.350ms
[190.564s][info ][gc             ] GC(44) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.396ms
[194.966s][info ][gc             ] GC(45) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.000ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754): Dead AbstractQueuedSynchronizer$ConditionNodes survive minor garbage collections (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/735/head:pull/735` \
`$ git checkout pull/735`

Update a local copy of the PR: \
`$ git checkout pull/735` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 735`

View PR using the GUI difftool: \
`$ git pr show -t 735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/735.diff">https://git.openjdk.org/jdk21u-dev/pull/735.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/735#issuecomment-2176077488)