### PR TITLE
8331999: BasicDirectoryModel/LoaderThreadCount.java frequently fails on Windows in CI

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java
@@ -164,7 +164,7 @@ public final class LoaderThreadCount extends ThreadGroup {
             System.out.println("  = 1: " + ones);
             System.out.println("  = 2: " + twos);
             System.out.println("  > 2: " + count);
-            if (count > 0) {
+            if (count > loaderCount.size() / 2) {
                 throw new RuntimeException("Detected " + count + " snapshots "
                                            + "with several loading threads");
             }


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331999](https://bugs.openjdk.org/browse/JDK-8331999) needs maintainer approval

### Issue
 * [JDK-8331999](https://bugs.openjdk.org/browse/JDK-8331999): BasicDirectoryModel/LoaderThreadCount.java frequently fails on Windows in CI (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/741/head:pull/741` \
`$ git checkout pull/741`

Update a local copy of the PR: \
`$ git checkout pull/741` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 741`

View PR using the GUI difftool: \
`$ git pr show -t 741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/741.diff">https://git.openjdk.org/jdk21u-dev/pull/741.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/741#issuecomment-2175502713)