### PR TITLE
8334332: TestIOException.java fails if run by root

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
+++ b/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8164130
+ * @bug 8164130 8334332
  * @summary test IOException handling
- * @library ../../lib
+ * @library ../../lib /test/lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
  * @build javadoc.tester.*
  * @run main TestIOException
@@ -39,6 +39,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import javadoc.tester.JavadocTester;
+import jtreg.SkippedException;
 
 /**
  * Tests IO Exception handling.
@@ -61,16 +62,13 @@ public class TestIOException extends JavadocTester {
     public void testReadOnlyDirectory() {
         File outDir = new File("out1");
         if (!outDir.mkdir()) {
-            throw error(outDir, "Cannot create directory");
+            throw skip(outDir, "Cannot create directory");
         }
         if (!outDir.setReadOnly()) {
-            if (skip(outDir)) {
-                return;
-            }
-            throw error(outDir, "could not set directory read-only");
+            throw skip(outDir, "could not set directory read-only");
         }
         if (outDir.canWrite()) {
-            throw error(outDir, "directory is writable");
+            throw skip(outDir, "directory is writable");
         }
 
         try {
@@ -93,15 +91,15 @@ public class TestIOException extends JavadocTester {
     public void testReadOnlyFile() throws Exception {
         File outDir = new File("out2");
         if (!outDir.mkdir()) {
-            throw error(outDir, "Cannot create directory");
+            throw skip(outDir, "Cannot create directory");
         }
         File index = new File(outDir, "index.html");
         try (FileWriter fw = new FileWriter(index)) { }
         if (!index.setReadOnly()) {
-            throw error(index, "could not set index read-only");
+            throw skip(index, "could not set index read-only");
         }
         if (index.canWrite()) {
-            throw error(index, "index is writable");
+            throw skip(index, "index is writable");
         }
 
         try {
@@ -139,16 +137,13 @@ public class TestIOException extends JavadocTester {
         File outDir = new File("out3");
         File pkgOutDir = new File(outDir, "p");
         if (!pkgOutDir.mkdirs()) {
-            throw error(pkgOutDir, "Cannot create directory");
+            throw skip(pkgOutDir, "Cannot create directory");
         }
         if (!pkgOutDir.setReadOnly()) {
-            if (skip(pkgOutDir)) {
-                return;
-            }
-            throw error(pkgOutDir, "could not set directory read-only");
+            throw skip(pkgOutDir, "could not set directory read-only");
         }
         if (pkgOutDir.canWrite()) {
-            throw error(pkgOutDir, "directory is writable");
+            throw skip(pkgOutDir, "directory is writable");
         }
 
         // run javadoc and check results
@@ -192,16 +187,13 @@ public class TestIOException extends JavadocTester {
         File pkgOutDir = new File(outDir, "p");
         File docFilesOutDir = new File(pkgOutDir, "doc-files");
         if (!docFilesOutDir.mkdirs()) {
-            throw error(docFilesOutDir, "Cannot create directory");
+            throw skip(docFilesOutDir, "Cannot create directory");
         }
         if (!docFilesOutDir.setReadOnly()) {
-            if (skip(docFilesOutDir)) {
-                return;
-            }
-            throw error(docFilesOutDir, "could not set directory read-only");
+            throw skip(docFilesOutDir, "could not set directory read-only");
         }
         if (docFilesOutDir.canWrite()) {
-            throw error(docFilesOutDir, "directory is writable");
+            throw skip(docFilesOutDir, "directory is writable");
         }
 
         try {
@@ -219,10 +211,11 @@ public class TestIOException extends JavadocTester {
         }
     }
 
-    private Error error(File f, String message) {
+    private Error skip(File f, String message) {
+        out.print(System.getProperty("user.name"));
         out.println(f + ": " + message);
         showAllAttributes(f.toPath());
-        throw new Error(f + ": " + message);
+        throw new SkippedException(f + ": " + message);
     }
 
     private void showAllAttributes(Path p) {
@@ -241,21 +234,6 @@ public class TestIOException extends JavadocTester {
         } catch (Throwable t) {
             out.println("Error accessing attributes " + attributes + ": " + t);
         }
-    }
-
-    private boolean skip(File dir) {
-        if (isWindows()) {
-            showAllAttributes(dir.toPath());
-            out.println("Windows: cannot set directory read only:" + dir);
-            out.println("TEST CASE SKIPPED");
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private boolean isWindows() {
-        return System.getProperty("os.name").toLowerCase(Locale.US).startsWith("windows");
     }
 }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [472b935b](https://github.com/openjdk/jdk/commit/472b935b442f7f925b665c7de91eda77f3dcbe8b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 18 Jun 2024 and was reviewed by Pavel Rappo.

Only change test testcase, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334332](https://bugs.openjdk.org/browse/JDK-8334332) needs maintainer approval

### Issue
 * [JDK-8334332](https://bugs.openjdk.org/browse/JDK-8334332): TestIOException.java fails if run by root (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/742/head:pull/742` \
`$ git checkout pull/742`

Update a local copy of the PR: \
`$ git checkout pull/742` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 742`

View PR using the GUI difftool: \
`$ git pr show -t 742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/742.diff">https://git.openjdk.org/jdk21u-dev/pull/742.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/742#issuecomment-2175846555)