### PR TITLE
8313697: [XWayland][Screencast] consequent getPixelColor calls are slow

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
@@ -324,6 +324,10 @@ final class TokenStorage {
                         return tokenItem;
                     })
                     .filter(Objects::nonNull)
+                    .sorted((t1, t2) -> //Token with more screens preferred
+                            t2.allowedScreensBounds.size()
+                            - t1.allowedScreensBounds.size()
+                    )
                     .toList();
         }
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -604,6 +604,7 @@ GtkApi* gtk3_load(JNIEnv *env, const char* lib_name)
 
         fp_g_string_new = dl_symbol("g_string_new");
         fp_g_string_erase = dl_symbol("g_string_erase");
+        fp_g_string_set_size = dl_symbol("g_string_set_size");
         fp_g_string_free = dl_symbol("g_string_free");
 
         glib_version_2_68 = !fp_glib_check_version(2, 68, 0);
@@ -3110,6 +3111,7 @@ static void gtk3_init(GtkApi* gtk) {
 
     gtk->g_string_new = fp_g_string_new;
     gtk->g_string_erase = fp_g_string_erase;
+    gtk->g_string_set_size = fp_g_string_set_size;
     gtk->g_string_free = fp_g_string_free;
     gtk->g_string_replace = fp_g_string_replace;
     gtk->g_string_printf = fp_g_string_printf;

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
@@ -758,6 +758,9 @@ static GString *(*fp_g_string_erase)(GString *string,
                                      gssize pos,
                                      gssize len);
 
+static GString *(*fp_g_string_set_size)(GString* string,
+                                        gsize len);
+
 static gchar *(*fp_g_string_free)(GString *string,
                                   gboolean free_segment);
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk_interface.h
@@ -716,6 +716,10 @@ typedef struct GtkApi {
                                gssize pos,
                                gssize len);
 
+    GString *(*g_string_set_size)(GString* string,
+                                  gsize len);
+
+
     gchar *(*g_string_free)(GString *string,
                             gboolean free_segment);
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_portal.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_portal.c
@@ -777,6 +777,10 @@ int portalScreenCastOpenPipewireRemote() {
 }
 
 void portalScreenCastCleanup() {
+    if (!portal) {
+        return;
+    }
+
     if (portal->screenCastSessionHandle) {
         gtk->g_dbus_connection_call_sync(
                 portal->connection,
@@ -796,9 +800,6 @@ void portalScreenCastCleanup() {
         portal->screenCastSessionHandle = NULL;
     }
 
-    if (!portal) {
-        return;
-    }
     if (portal->connection) {
         gtk->g_object_unref(portal->connection);
         portal->connection = NULL;


### PR DESCRIPTION
Clean backport of [JDK-8313697](https://bugs.openjdk.org/browse/JDK-8313697) and [JDK-8310334](https://bugs.openjdk.org/browse/JDK-8310334) which belong together.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8313697](https://bugs.openjdk.org/browse/JDK-8313697) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8310334](https://bugs.openjdk.org/browse/JDK-8310334) needs maintainer approval

### Issues
 * [JDK-8313697](https://bugs.openjdk.org/browse/JDK-8313697): [XWayland][Screencast] consequent getPixelColor calls are slow (**Bug** - P3 - Approved)
 * [JDK-8310334](https://bugs.openjdk.org/browse/JDK-8310334): [XWayland][Screencast] screen capture error message in debug (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/743/head:pull/743` \
`$ git checkout pull/743`

Update a local copy of the PR: \
`$ git checkout pull/743` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 743`

View PR using the GUI difftool: \
`$ git pr show -t 743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/743.diff">https://git.openjdk.org/jdk21u-dev/pull/743.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/743#issuecomment-2175987898)