### PR TITLE
8314614: jdk/jshell/ImportTest.java failed with "InternalError: Failed remote listen"

### DIFF
--- a/test/langtools/jdk/jshell/AnalyzeSnippetTest.java
+++ b/test/langtools/jdk/jshell/AnalyzeSnippetTest.java
@@ -64,6 +64,7 @@ public class AnalyzeSnippetTest {
         state = JShell.builder()
                 .out(new PrintStream(new ByteArrayOutputStream()))
                 .err(new PrintStream(new ByteArrayOutputStream()))
+                .executionEngine(Presets.TEST_DEFAULT_EXECUTION)
                 .build();
         sca = state.sourceCodeAnalysis();
     }

--- a/test/langtools/jdk/jshell/CustomInputToolBuilder.java
+++ b/test/langtools/jdk/jshell/CustomInputToolBuilder.java
@@ -90,7 +90,8 @@ public class CustomInputToolBuilder extends KullaTesting {
                     .interactiveTerminal(interactiveTerminal)
                     .promptCapture(true)
                     .persistence(new HashMap<>())
-                    .start("--no-startup");
+                    .start("--no-startup",
+                           "--execution", Presets.TEST_DEFAULT_EXECUTION);
 
             String actual = new String(out.toByteArray());
             List<String> actualLines = Arrays.asList(actual.split("\\R"));

--- a/test/langtools/jdk/jshell/ExecutionControlTestBase.java
+++ b/test/langtools/jdk/jshell/ExecutionControlTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,28 +25,14 @@ import javax.tools.Diagnostic;
 
 import org.testng.annotations.Test;
 import jdk.jshell.VarSnippet;
-import java.net.InetAddress;
 
 import static jdk.jshell.Snippet.Status.VALID;
 import static jdk.jshell.Snippet.SubKind.*;
 
 public class ExecutionControlTestBase extends KullaTesting {
 
-    String standardListenSpec() {
-        String loopback = InetAddress.getLoopbackAddress().getHostAddress();
-        return "jdi:hostname(" + loopback + ")";
-    }
-
-    String standardLaunchSpec() {
-        return "jdi:launch(true)";
-    }
-
-    String standardJdiSpec() {
-        return "jdi";
-    }
-
-    String standardSpecs() {
-        return "5(" + standardListenSpec() + "), 6(" + standardLaunchSpec() + "), 7(" + standardJdiSpec() + ")";
+    String alwaysPassingSpec() {
+        return "5(local)";
     }
 
     @Test

--- a/test/langtools/jdk/jshell/FailOverDirectExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/FailOverDirectExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,9 +129,7 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
         Map<String, String> pm = provider.defaultParameters();
         pm.put("0", "alwaysFailing");
         pm.put("1", "alwaysFailing");
-        pm.put("2", standardListenSpec());
-        pm.put("3", standardLaunchSpec());
-        pm.put("4", standardJdiSpec());
+        pm.put("2", "local");
         setUp(builder -> builder.executionEngine(provider, pm));
     }
 
@@ -159,9 +157,7 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
         assertTrue(log.contains("This operation intentionally broken"), log);
         log = logged.get(Level.FINEST).get(0);
         assertTrue(
-                log.contains("Success failover -- 2 = " + standardListenSpec())
-                || log.contains("Success failover -- 3 = " + standardLaunchSpec())
-                || log.contains("Success failover -- 4 = " + standardJdiSpec()),
+                log.contains("Success failover -- 2 = local"),
                 log);
     }
 }

--- a/test/langtools/jdk/jshell/FailOverExecutionControlDyingLaunchTest.java
+++ b/test/langtools/jdk/jshell/FailOverExecutionControlDyingLaunchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,6 @@ public class FailOverExecutionControlDyingLaunchTest extends ExecutionControlTes
     public void setUp() {
         setUp(builder -> builder.executionEngine(
                 "failover:0(jdi:remoteAgent(DyingRemoteAgent),launch(true)), "
-                    + standardSpecs()));
+                    + alwaysPassingSpec()));
     }
 }

--- a/test/langtools/jdk/jshell/FailOverExecutionControlHangingLaunchTest.java
+++ b/test/langtools/jdk/jshell/FailOverExecutionControlHangingLaunchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,6 @@ public class FailOverExecutionControlHangingLaunchTest extends ExecutionControlT
     public void setUp() {
         setUp(builder -> builder.executionEngine(
                 "failover:0(jdi:remoteAgent(HangingRemoteAgent),launch(true)), "
-                        + standardSpecs()));
+                        + alwaysPassingSpec()));
     }
 }

--- a/test/langtools/jdk/jshell/FailOverExecutionControlHangingListenTest.java
+++ b/test/langtools/jdk/jshell/FailOverExecutionControlHangingListenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,6 @@ public class FailOverExecutionControlHangingListenTest extends ExecutionControlT
         String loopback = InetAddress.getLoopbackAddress().getHostAddress();
          setUp(builder -> builder.executionEngine(
                 "failover:0(jdi:remoteAgent(HangingRemoteAgent),hostname(" + loopback + ")),"
-                        + standardSpecs()));
+                        + alwaysPassingSpec()));
     }
 }

--- a/test/langtools/jdk/jshell/FailOverExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/FailOverExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class FailOverExecutionControlTest extends ExecutionControlTestBase {
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine("failover:0(expectedFailureNonExistent1), 1(expectedFailureNonExistent2), "
-                + standardSpecs()));
+                + alwaysPassingSpec()));
     }
 
 }

--- a/test/langtools/jdk/jshell/IdGeneratorTest.java
+++ b/test/langtools/jdk/jshell/IdGeneratorTest.java
@@ -53,7 +53,8 @@ public class IdGeneratorTest {
         return JShell.builder()
                 .in(inStream)
                 .out(new PrintStream(outStream))
-                .err(new PrintStream(errStream));
+                .err(new PrintStream(errStream))
+                .executionEngine(Presets.TEST_DEFAULT_EXECUTION);
     }
 
     public void testTempNameGenerator() {

--- a/test/langtools/jdk/jshell/KullaTesting.java
+++ b/test/langtools/jdk/jshell/KullaTesting.java
@@ -100,7 +100,9 @@ public class KullaTesting {
     private Set<Snippet> allSnippets = new LinkedHashSet<>();
 
     static {
-        JShell js = JShell.create();
+        JShell js = JShell.builder()
+                          .executionEngine(Presets.TEST_DEFAULT_EXECUTION)
+                          .build();
         MAIN_SNIPPET = js.eval("MAIN_SNIPPET").get(0).snippet();
         js.close();
         assertTrue(MAIN_SNIPPET != null, "Bad MAIN_SNIPPET set-up -- must not be null");
@@ -192,7 +194,8 @@ public class KullaTesting {
         JShell.Builder builder = JShell.builder()
                 .in(in)
                 .out(new PrintStream(outStream))
-                .err(new PrintStream(errStream));
+                .err(new PrintStream(errStream))
+                .executionEngine(Presets.TEST_DEFAULT_EXECUTION);
         bc.accept(builder);
         state = builder.build();
         allSnippets = new LinkedHashSet<>();

--- a/test/langtools/jdk/jshell/Presets.java
+++ b/test/langtools/jdk/jshell/Presets.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.net.InetAddress;
+import java.util.*;
+
+public class Presets {
+    public static final String TEST_DEFAULT_EXECUTION;
+    public static final String TEST_STANDARD_EXECUTION;
+
+    static {
+        String loopback = InetAddress.getLoopbackAddress().getHostAddress();
+
+        TEST_DEFAULT_EXECUTION = "failover:0(jdi:hostname(" + loopback + "))," +
+                                 "1(jdi:launch(true)), 2(jdi), 3(local)";
+        TEST_STANDARD_EXECUTION = "failover:0(jdi:hostname(" + loopback + "))," +
+                                  "1(jdi:launch(true)), 2(jdi)";
+    }
+
+    public static String[] addExecutionIfMissing(String[] args) {
+        if (Arrays.stream(args).noneMatch(Presets::remoteRelatedOption)) {
+            List<String> augmentedArgs = new ArrayList<>();
+
+            augmentedArgs.add("--execution");
+            augmentedArgs.add(Presets.TEST_DEFAULT_EXECUTION);
+            augmentedArgs.addAll(List.of(args));
+
+            return augmentedArgs.toArray(s -> new String[s]);
+        }
+
+        return args;
+    }
+
+    private static boolean remoteRelatedOption(String option) {
+        return "--execution".equals(option) ||
+               "--add-modules".equals(option) ||
+               option.startsWith("-R");
+    }
+}

--- a/test/langtools/jdk/jshell/ReplToolTesting.java
+++ b/test/langtools/jdk/jshell/ReplToolTesting.java
@@ -304,7 +304,7 @@ public class ReplToolTesting {
     private void testRaw(Locale locale, String[] args,
                          String expectedErrorOutput, ReplTest... tests) {
         testRawInit(tests);
-        testRawRun(locale, args);
+        testRawRun(locale, Presets.addExecutionIfMissing(args));
         testRawCheck(locale, expectedErrorOutput);
     }
 

--- a/test/langtools/jdk/jshell/StartOptionTest.java
+++ b/test/langtools/jdk/jshell/StartOptionTest.java
@@ -81,7 +81,7 @@ public class StartOptionTest {
     protected int runShell(String... args) {
         try {
             return builder()
-                    .start(args);
+                    .start(Presets.addExecutionIfMissing(args));
         } catch (Exception ex) {
             fail("Repl tool died with exception", ex);
         }

--- a/test/langtools/jdk/jshell/ToolReloadTest.java
+++ b/test/langtools/jdk/jshell/ToolReloadTest.java
@@ -201,7 +201,7 @@ public class ToolReloadTest extends ReplToolTesting {
     }
 
     public void testEnvBadModule() {
-        test(
+        test(new String[] {"--execution", Presets.TEST_STANDARD_EXECUTION},
                 (a) -> assertVariable(a, "int", "x", "5", "5"),
                 (a) -> assertMethod(a, "int m(int z) { return z * z; }",
                         "(int)int", "m"),

--- a/test/langtools/jdk/jshell/UITesting.java
+++ b/test/langtools/jdk/jshell/UITesting.java
@@ -93,7 +93,8 @@ public class UITesting {
                         .promptCapture(true)
                         .persistence(new HashMap<>())
                         .locale(Locale.US)
-                        .run("--no-startup");
+                        .run("--no-startup",
+                             "--execution", Presets.TEST_DEFAULT_EXECUTION);
             } catch (Exception ex) {
                 throw new IllegalStateException(ex);
             }


### PR DESCRIPTION
Backport of [JDK-8312140](https://bugs.openjdk.org/browse/JDK-8312140)

Testing
- Local: Test passed on `MacOS 14.5`
  - `AnalyzeSnippetTest.java`: Test results: passed: 1
  - `CustomInputToolBuilder.java`: Test results: passed: 1
  - `FailOverDirectExecutionControlTest.java`: Test results: passed: 1
  - `FailOverExecutionControlDyingLaunchTest.java`: Test results: passed: 1
  - `FailOverExecutionControlHangingLaunchTest.java`: Test results: passed: 1
  - `FailOverExecutionControlHangingListenTest.java`: Test results: passed: 1
  - `FailOverExecutionControlTest.java`: Test results: passed: 1
  - `IdGeneratorTest.java`: Test results: passed: 1
  - `StartOptionTest.java`: Test results: passed: 1
  - `ToolReloadTest.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-21`
  - `jtreg_langtools`
    - jdk/jshell/AnalyzeSnippetTest.java: SUCCESSFUL GitHub 📊⏲ - [51,515 msec]
    - jdk/jshell/CustomInputToolBuilder.java: SUCCESSFUL GitHub 📊⏲ - [83,027 msec]
    - jdk/jshell/FailOverDirectExecutionControlTest.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - jdk/jshell/FailOverExecutionControlDyingLaunchTest.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - jdk/jshell/FailOverExecutionControlHangingLaunchTest.java: SUCCESSFUL GitHub 📊⏲ - [19,133 msec]
    - jdk/jshell/FailOverExecutionControlHangingListenTest.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - jdk/jshell/FailOverExecutionControlTest.java: SUCCESSFUL GitHub 📊⏲ - [25,344 msec]
    - jdk/jshell/IdGeneratorTest.java: SUCCESSFUL GitHub 📊⏲ - [9,098 msec]
    - jdk/jshell/StartOptionTest.java: SUCCESSFUL GitHub 📊⏲ - [16,009 msec]
    - jdk/jshell/ToolReloadTest.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312140](https://bugs.openjdk.org/browse/JDK-8312140) needs maintainer approval
- [x] [JDK-8314614](https://bugs.openjdk.org/browse/JDK-8314614) needs maintainer approval

### Issues
 * [JDK-8314614](https://bugs.openjdk.org/browse/JDK-8314614): jdk/jshell/ImportTest.java failed with "InternalError: Failed remote listen" (**Bug** - P2 - Approved)
 * [JDK-8312140](https://bugs.openjdk.org/browse/JDK-8312140): jdk/jshell tests failed with JDI socket timeouts (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/748/head:pull/748` \
`$ git checkout pull/748`

Update a local copy of the PR: \
`$ git checkout pull/748` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 748`

View PR using the GUI difftool: \
`$ git pr show -t 748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/748.diff">https://git.openjdk.org/jdk21u-dev/pull/748.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/748#issuecomment-2177384246)