### PR TITLE
8313674: (fc) java/nio/channels/FileChannel/BlockDeviceSize.java should test for more block devices

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,41 +24,47 @@
 /* @test
  * @bug 8054029 8313368
  * @requires (os.family == "linux")
- * @summary Block devices should not report size=0 on Linux
- * @run main/manual BlockDeviceSize
+ * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
  */
 
 import java.io.RandomAccessFile;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.channels.FileChannel;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.NoSuchFileException;
+import java.util.List;
+
 import static java.nio.file.StandardOpenOption.*;
 
 
 public class BlockDeviceSize {
-    private static final String BLK_FNAME = "/dev/sda1";
-    private static final Path BLK_PATH = Paths.get(BLK_FNAME);
+    private static final List<String> BLK_FNAMES = List.of("/dev/sda1", "/dev/nvme0n1", "/dev/xvda1") ;
 
     public static void main(String[] args) throws Throwable {
-        try (FileChannel ch = FileChannel.open(BLK_PATH, READ);
-             RandomAccessFile file = new RandomAccessFile(BLK_FNAME, "r")) {
+        for (String blkFname: BLK_FNAMES) {
+            Path blkPath = Path.of(blkFname);
+            try (FileChannel ch = FileChannel.open(blkPath, READ);
+                 RandomAccessFile file = new RandomAccessFile(blkFname, "r")) {
 
-            long size1 = ch.size();
-            long size2 = file.length();
-            if (size1 != size2) {
-                throw new RuntimeException("size differs when retrieved" +
-                        " in different ways: " + size1 + " != " + size2);
+                long size1 = ch.size();
+                long size2 = file.length();
+                if (size1 != size2) {
+                    throw new RuntimeException("size differs when retrieved" +
+                            " in different ways: " + size1 + " != " + size2);
+                }
+                if (size1 <= 0) {
+                    throw new RuntimeException("size() for a block device size returns zero or a negative value");
+                }
+                System.out.println("OK");
+
+            } catch (NoSuchFileException nsfe) {
+                System.err.println("File " + blkFname + " not found." +
+                        " Skipping test");
+            } catch (AccessDeniedException ade) {
+                throw new RuntimeException("Access to " + blkFname + " is denied."
+                        + " Run test as root.", ade);
             }
-            System.out.println("OK");
 
-        } catch (NoSuchFileException nsfe) {
-            System.err.println("File " + BLK_FNAME + " not found." +
-                    " Skipping test");
-        } catch (AccessDeniedException ade) {
-            throw new RuntimeException("Access to " + BLK_FNAME + " is denied."
-                    + " Run test as root.", ade);
         }
     }
 }


### PR DESCRIPTION
Backport of [JDK-8313674](https://bugs.openjdk.org/browse/JDK-8313674)

Testing
- Local: Not applicable on MacOS - `(os.family == "linux")`
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-21`
  - `jtreg_jdk_tier2`: java/nio/channels/FileChannel/BlockDeviceSize.java: SUCCESSFUL GitHub 📊⏲ - [3,134 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313674](https://bugs.openjdk.org/browse/JDK-8313674) needs maintainer approval

### Issue
 * [JDK-8313674](https://bugs.openjdk.org/browse/JDK-8313674): (fc) java/nio/channels/FileChannel/BlockDeviceSize.java should test for more block devices (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/749/head:pull/749` \
`$ git checkout pull/749`

Update a local copy of the PR: \
`$ git checkout pull/749` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 749`

View PR using the GUI difftool: \
`$ git pr show -t 749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/749.diff">https://git.openjdk.org/jdk21u-dev/pull/749.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/749#issuecomment-2177392966)