### PR TITLE
8315576: compiler/codecache/CodeCacheFullCountTest.java fails after JDK-8314837

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -27,6 +27,8 @@
 #
 #############################################################################
 
+compiler/codecache/CodeCacheFullCountTest.java 8315576 generic-all
+
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
 vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java 8307462 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -27,8 +27,6 @@
 #
 #############################################################################
 
-compiler/codecache/CodeCacheFullCountTest.java 8315576 generic-all
-
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
 vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java 8307462 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -45,12 +45,20 @@ public class CodeCacheFullCountTest {
         }
     }
 
-    public static void wasteCodeCache()  throws Exception {
+    public static void wasteCodeCache() throws Throwable {
         URL url = CodeCacheFullCountTest.class.getProtectionDomain().getCodeSource().getLocation();
 
-        for (int i = 0; i < 500; i++) {
-            ClassLoader cl = new MyClassLoader(url);
-            refClass(cl.loadClass("SomeClass"));
+        try {
+            for (int i = 0; i < 500; i++) {
+                ClassLoader cl = new MyClassLoader(url);
+                refClass(cl.loadClass("SomeClass"));
+            }
+        } catch (Throwable t) {
+            // Expose the root cause of the Throwable instance.
+            while (t.getCause() != null) {
+                t = t.getCause();
+            }
+            throw t;
         }
     }
 
@@ -59,7 +67,7 @@ public class CodeCacheFullCountTest {
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         // Ignore adapter creation failures
-        if (oa.getExitValue() != 0 && !oa.getStderr().contains("Out of space in CodeCache for adapters")) {
+        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache for adapters")) {
             oa.reportDiagnosticSummary();
             throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
         }


### PR DESCRIPTION
Backport of [JDK-8315576](https://bugs.openjdk.org/browse/JDK-8315576)
- The change on the file `CodeCacheFullCountTest.java` is `clean` because it is done by `git patch` command
- The change on file `test/hotspot/jtreg/ProblemList-Xcomp.txt` is ignored, because on `jdk21u-dev` the line does not exist
- So this PR can be `considered as clean`

Testing
- Local: Test passed on `MacOS 14.5`
  - `CodeCacheFullCountTest.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-21`
  - `jtreg_hotspot_tier1`: compiler/codecache/CodeCacheFullCountTest.java: `SUCCESSFUL` GitHub 📊⏲ - [8,776 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315576](https://bugs.openjdk.org/browse/JDK-8315576) needs maintainer approval

### Issue
 * [JDK-8315576](https://bugs.openjdk.org/browse/JDK-8315576): compiler/codecache/CodeCacheFullCountTest.java fails after JDK-8314837 (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/751/head:pull/751` \
`$ git checkout pull/751`

Update a local copy of the PR: \
`$ git checkout pull/751` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 751`

View PR using the GUI difftool: \
`$ git pr show -t 751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/751.diff">https://git.openjdk.org/jdk21u-dev/pull/751.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/751#issuecomment-2177435970)