### PR TITLE
8315969: compiler/rangechecks/TestRangeCheckHoistingScaledIV.java: make flagless

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -51,8 +51,6 @@ compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
 compiler/loopopts/TestUnreachableInnerLoop.java 8288981 linux-s390x
 
-compiler/rangechecks/TestRangeCheckHoistingScaledIV.java 8315969 generic-all
-
 compiler/rtm/locking/TestRTMAbortRatio.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestRTMAbortThreshold.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestRTMAfterNonRTMDeopt.java 8183263 generic-x64,generic-i586

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -51,6 +51,8 @@ compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
 compiler/loopopts/TestUnreachableInnerLoop.java 8288981 linux-s390x
 
+compiler/rangechecks/TestRangeCheckHoistingScaledIV.java 8315969 generic-all
+
 compiler/rtm/locking/TestRTMAbortRatio.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestRTMAbortThreshold.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestRTMAfterNonRTMDeopt.java 8183263 generic-x64,generic-i586

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8289996
  * @summary Test range check hoisting for some scaled iv at array index
  * @library /test/lib /
+ * @requires vm.flagless
  * @requires vm.debug & vm.compiler2.enabled & (os.simpleArch == "x64" | os.arch == "aarch64")
  * @modules jdk.incubator.vector
  * @compile --enable-preview -source ${jdk.version} TestRangeCheckHoistingScaledIV.java


### PR DESCRIPTION
Backport of [JDK-8315969](https://bugs.openjdk.org/browse/JDK-8315969)
- The change on file `TestRangeCheckHoistingScaledIV.java` is clean, because it is auto done by `git patch` command
- The `test/hotspot/jtreg/ProblemList.txt` file in the original commit is ignored, because the line does not exist
- So this PR can be `considered as clean`

Testing
- Local: Test passed
  - `TestRangeCheckHoistingScaledIV.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-23`
  - `jtreg_hotspot_tier2`: compiler/rangechecks/TestRangeCheckHoistingScaledIV.java: SUCCESSFUL GitHub 📊⏲ - [4,593 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315969](https://bugs.openjdk.org/browse/JDK-8315969) needs maintainer approval

### Issue
 * [JDK-8315969](https://bugs.openjdk.org/browse/JDK-8315969): compiler/rangechecks/TestRangeCheckHoistingScaledIV.java: make flagless (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/752/head:pull/752` \
`$ git checkout pull/752`

Update a local copy of the PR: \
`$ git checkout pull/752` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 752`

View PR using the GUI difftool: \
`$ git pr show -t 752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/752.diff">https://git.openjdk.org/jdk21u-dev/pull/752.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/752#issuecomment-2177448355)