### PR TITLE
8321933: TestCDSVMCrash.java spawns two processes

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -31,42 +31,37 @@
  * @bug 8306583
  */
 
- import jdk.test.lib.cds.CDSTestUtils;
- import jdk.test.lib.process.OutputAnalyzer;
- import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
- public class TestCDSVMCrash {
+public class TestCDSVMCrash {
 
-     public static void main(String[] args) throws Exception {
-         if (args.length == 1) {
-             // This should guarantee to throw:
-             // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
-             try {
-                 Object[] oa = new Object[Integer.MAX_VALUE];
-                 throw new Error("OOME not triggered");
-             } catch (OutOfMemoryError err) {
-                 throw new Error("OOME didn't abort JVM!");
-             }
-         }
-         // else this is the main test
-         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
-                  "-XX:-CreateCoredumpOnCrash", "-Xmx128m", "-Xshare:on", TestCDSVMCrash.class.getName(),"throwOOME");
-         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-         // executeAndLog should throw an exception in the VM crashed
-         try {
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            // This should guarantee to throw:
+            // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
+            try {
+                Object[] oa = new Object[Integer.MAX_VALUE];
+                throw new Error("OOME not triggered");
+            } catch (OutOfMemoryError err) {
+                throw new Error("OOME didn't abort JVM!");
+            }
+        }
+        // else this is the main test
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
+                                                                             "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
+                                                                             "-Xshare:on", TestCDSVMCrash.class.getName(),
+                                                                             "throwOOME");
+        // executeAndLog should throw an exception in the VM crashed
+        try {
             CDSTestUtils.executeAndLog(pb, "cds_vm_crash");
             throw new Error("Expected VM to crash");
-         } catch(RuntimeException e) {
+        } catch(RuntimeException e) {
             if (!e.getMessage().equals("Hotspot crashed")) {
-              throw new Error("Expected message: Hotspot crashed");
+                throw new Error("Expected message: Hotspot crashed");
             }
-         }
-         int exitValue = output.getExitValue();
-         if (0 == exitValue) {
-             //expecting a non zero value
-             throw new Error("Expected to get non zero exit value");
-         }
-        output.shouldContain("A fatal error has been detected by the Java Runtime Environment");
+        }
         System.out.println("PASSED");
-     }
- }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8321933](https://bugs.openjdk.org/browse/JDK-8321933)

Testing
- Local: Test passed
  - `TestCDSVMCrash.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-21`
  - `jtreg_hotspot_tier1`: runtime/cds/TestCDSVMCrash.java: SUCCESSFUL GitHub 📊⏲ - [4,012 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321933](https://bugs.openjdk.org/browse/JDK-8321933) needs maintainer approval

### Issue
 * [JDK-8321933](https://bugs.openjdk.org/browse/JDK-8321933): TestCDSVMCrash.java spawns two processes (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/755/head:pull/755` \
`$ git checkout pull/755`

Update a local copy of the PR: \
`$ git checkout pull/755` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 755`

View PR using the GUI difftool: \
`$ git pr show -t 755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/755.diff">https://git.openjdk.org/jdk21u-dev/pull/755.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/755#issuecomment-2177750205)