### PR TITLE
8328110: Allow simultaneous use of PassFailJFrame with split UI and additional windows

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1333,14 +1333,6 @@ public final class PassFailJFrame {
                 position = Position.HORIZONTAL;
             }
 
-            if (panelCreator != null) {
-                if (splitUI && (testWindows != null || windowListCreator != null)) {
-                    // TODO Is it required? We can support both
-                    throw new IllegalStateException("Split UI is not allowed "
-                                                    + "with additional windows");
-                }
-            }
-
             if (positionWindows != null) {
                 if (testWindows == null && windowListCreator == null) {
                     throw new IllegalStateException("To position windows, "


### PR DESCRIPTION
Backport of [JDK-8328110](https://bugs.openjdk.org/browse/JDK-8328110)

Testing
- Local: Test passed
  - `PrintLatinCJKTest.java` (who calls `PassFailJFrame`): `Manual` Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: Not applicable, because it is for manual test
  - `java/awt/print/PrinterJob/PrintLatinCJKTest.java`: **SKIPPED** [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!printer)&(!intermittent))) & !manual & !ignore` ] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328110](https://bugs.openjdk.org/browse/JDK-8328110) needs maintainer approval

### Issue
 * [JDK-8328110](https://bugs.openjdk.org/browse/JDK-8328110): Allow simultaneous use of PassFailJFrame with split UI and additional windows (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/757/head:pull/757` \
`$ git checkout pull/757`

Update a local copy of the PR: \
`$ git checkout pull/757` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 757`

View PR using the GUI difftool: \
`$ git pr show -t 757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/757.diff">https://git.openjdk.org/jdk21u-dev/pull/757.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/757#issuecomment-2177837824)