### PR TITLE
8211847: [aix] java/lang/ProcessHandle/InfoTest.java fails: "reported cputime less than expected"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -481,7 +481,6 @@ java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
 
 # jdk_lang
 
-java/lang/ProcessHandle/InfoTest.java                           8211847 aix-ppc64
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-all
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-all


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8211847](https://bugs.openjdk.org/browse/JDK-8211847), commit [4e3bfc92](https://github.com/openjdk/jdk/commit/4e3bfc926ebdf512c7b9dbddc8caa7b66e2777f7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 17 Jun 2024 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8211847](https://bugs.openjdk.org/browse/JDK-8211847) needs maintainer approval

### Issue
 * [JDK-8211847](https://bugs.openjdk.org/browse/JDK-8211847): [aix] java/lang/ProcessHandle/InfoTest.java fails: "reported cputime less than expected" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/764/head:pull/764` \
`$ git checkout pull/764`

Update a local copy of the PR: \
`$ git checkout pull/764` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 764`

View PR using the GUI difftool: \
`$ git pr show -t 764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/764.diff">https://git.openjdk.org/jdk21u-dev/pull/764.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/764#issuecomment-2179065207)