### PR TITLE
8310906: Fix -Wconversion warnings in runtime, oops and some code header files.

### DIFF
--- a/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuationFreezeThaw_aarch64.inline.hpp
@@ -217,7 +217,7 @@ template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame&
     intptr_t* heap_sp = hf.unextended_sp();
     // If caller is interpreted it already made room for the callee arguments
     int overlap = caller.is_interpreted_frame() ? ContinuationHelper::InterpretedFrame::stack_argsize(hf) : 0;
-    const int fsize = ContinuationHelper::InterpretedFrame::frame_bottom(hf) - hf.unextended_sp() - overlap;
+    const int fsize = (int)(ContinuationHelper::InterpretedFrame::frame_bottom(hf) - hf.unextended_sp() - overlap);
     const int locals = hf.interpreter_frame_method()->max_locals();
     intptr_t* frame_sp = caller.unextended_sp() - fsize;
     intptr_t* fp = frame_sp + (hf.fp() - heap_sp);

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -236,7 +236,7 @@ inline intptr_t* frame::real_fp() const {
 
 inline int frame::frame_size() const {
   return is_interpreted_frame()
-    ? sender_sp() - sp()
+    ? pointer_delta_as_int(sender_sp(), sp())
     : cb()->frame_size();
 }
 

--- a/src/hotspot/cpu/aarch64/stackChunkFrameStream_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/stackChunkFrameStream_aarch64.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,8 +116,8 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
   f.interpreted_frame_oop_map(&mask);
   return  mask.num_oops()
         + 1 // for the mirror oop
-        + ((intptr_t*)f.interpreter_frame_monitor_begin()
-            - (intptr_t*)f.interpreter_frame_monitor_end())/BasicObjectLock::size();
+        + pointer_delta_as_int((intptr_t*)f.interpreter_frame_monitor_begin(),
+              (intptr_t*)f.interpreter_frame_monitor_end())/BasicObjectLock::size();
 }
 
 template<>

--- a/src/hotspot/cpu/x86/continuationFreezeThaw_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuationFreezeThaw_x86.inline.hpp
@@ -214,7 +214,7 @@ template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame&
     intptr_t* heap_sp = hf.unextended_sp();
     // If caller is interpreted it already made room for the callee arguments
     int overlap = caller.is_interpreted_frame() ? ContinuationHelper::InterpretedFrame::stack_argsize(hf) : 0;
-    const int fsize = ContinuationHelper::InterpretedFrame::frame_bottom(hf) - hf.unextended_sp() - overlap;
+    const int fsize = (int)(ContinuationHelper::InterpretedFrame::frame_bottom(hf) - hf.unextended_sp() - overlap);
     const int locals = hf.interpreter_frame_method()->max_locals();
     intptr_t* frame_sp = caller.unextended_sp() - fsize;
     intptr_t* fp = frame_sp + (hf.fp() - heap_sp);

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -222,7 +222,7 @@ inline intptr_t* frame::real_fp() const {
 
 inline int frame::frame_size() const {
   return is_interpreted_frame()
-    ? sender_sp() - sp()
+    ? pointer_delta_as_int(sender_sp(), sp())
     : cb()->frame_size();
 }
 

--- a/src/hotspot/cpu/x86/nativeInst_x86.hpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.hpp
@@ -171,7 +171,7 @@ class NativeCall: public NativeInstruction {
     intptr_t disp = dest - return_address();
     guarantee(disp == (intptr_t)(jint)disp, "must be 32-bit offset");
 #endif // AMD64
-    set_int_at(displacement_offset, dest - return_address());
+    set_int_at(displacement_offset, (int)(dest - return_address()));
   }
   // Returns whether the 4-byte displacement operand is 4-byte aligned.
   bool  is_displacement_aligned();

--- a/src/hotspot/cpu/x86/stackChunkFrameStream_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/stackChunkFrameStream_x86.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,8 +114,8 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
   f.interpreted_frame_oop_map(&mask);
   return  mask.num_oops()
         + 1 // for the mirror oop
-        + ((intptr_t*)f.interpreter_frame_monitor_begin()
-            - (intptr_t*)f.interpreter_frame_monitor_end())/BasicObjectLock::size();
+        + pointer_delta_as_int((intptr_t*)f.interpreter_frame_monitor_begin(),
+              (intptr_t*)f.interpreter_frame_monitor_end())/BasicObjectLock::size();
 }
 
 template<>

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -132,7 +132,7 @@ template <typename T> int subsystem_file_line_contents(CgroupController* c,
   } else {
     // File consists of multiple lines in a "key value"
     // fashion, we have to find the key.
-    const int key_len = strlen(key);
+    const int key_len = (int)strlen(key);
     for (; line != nullptr; line = fgets(buf, buf_len, fp)) {
       char* key_substr = strstr(line, key);
       char after_key = line[key_len];

--- a/src/hotspot/share/c1/c1_CodeStubs.hpp
+++ b/src/hotspot/share/c1/c1_CodeStubs.hpp
@@ -443,7 +443,7 @@ class PatchingStub: public CodeStub {
     _info = info;
     _obj = obj;
     masm->bind(_patch_site_continuation);
-    _bytes_to_copy = masm->pc() - pc_start();
+    _bytes_to_copy = pointer_delta_as_int(masm->pc(), pc_start());
     if (_id == PatchingStub::access_field_id) {
       // embed a fixed offset to handle long patches which need to be offset by a word.
       // the patching code will just add the field offset field to this offset so

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -325,9 +325,9 @@ class Instruction: public CompilationResourceObj {
     void set_arg_needs_null_check(int i, bool check) {
       if (i >= 0 && i < (int)sizeof(_nonnull_state) * BitsPerByte) {
         if (check) {
-          _nonnull_state |= nth_bit(i);
+          _nonnull_state |= (int)nth_bit(i);
         } else {
-          _nonnull_state &= ~(nth_bit(i));
+          _nonnull_state &= (int)~(nth_bit(i));
         }
       }
     }

--- a/src/hotspot/share/cds/archiveHeapWriter.hpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.hpp
@@ -115,7 +115,7 @@ class ArchiveHeapWriter : AllStatic {
   // Both Java bytearray and GrowableArraty use int indices and lengths. Do a safe typecast with range check
   static int to_array_index(size_t i) {
     assert(i <= (size_t)max_jint, "must be");
-    return (size_t)i;
+    return (int)i;
   }
   static int to_array_length(size_t n) {
     return to_array_index(n);

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -501,7 +501,7 @@ public:
 
   // Convert a dp (data pointer) to a di (data index).
   int dp_to_di(address dp) {
-    return dp - ((address)_data);
+    return pointer_delta_as_int(dp, ((address)_data));
   }
 
   // Get the data at an arbitrary (sort of) data index.

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -110,9 +110,9 @@ public:
   }
 
   address cur_bcp() const       { return _bc_start; }  // Returns bcp to current instruction
-  int next_bci() const          { return _pc - _start; }
-  int cur_bci() const           { return _bc_start - _start; }
-  int instruction_size() const  { return _pc - _bc_start; }
+  int next_bci() const          { return pointer_delta_as_int(_pc, _start); }
+  int cur_bci() const           { return pointer_delta_as_int(_bc_start, _start); }
+  int instruction_size() const  { return pointer_delta_as_int(_pc, _bc_start); }
 
   Bytecodes::Code cur_bc() const{ return check_java(_bc); }
   Bytecodes::Code cur_bc_raw() const { return check_defined(_raw_bc); }

--- a/src/hotspot/share/classfile/classFileStream.hpp
+++ b/src/hotspot/share/classfile/classFileStream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ class ClassFileStream: public ResourceObj {
 
   // Buffer access
   const u1* buffer() const { return _buffer_start; }
-  int length() const { return _buffer_end - _buffer_start; }
+  int length() const { return pointer_delta_as_int(_buffer_end, _buffer_start); }
   const u1* current() const { return _current; }
   void set_current(const u1* pos) const {
     assert(pos >= _buffer_start && pos <= _buffer_end, "invariant");

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -194,9 +194,9 @@ public:
   // Sizes
   int size() const                               { return _size; }
   int header_size() const                        { return _header_size; }
-  int relocation_size() const                    { return (address) relocation_end() - (address) relocation_begin(); }
-  int content_size() const                       { return           content_end()    -           content_begin();    }
-  int code_size() const                          { return           code_end()       -           code_begin();       }
+  int relocation_size() const                    { return pointer_delta_as_int((address) relocation_end(), (address) relocation_begin()); }
+  int content_size() const                       { return pointer_delta_as_int(content_end(), content_begin()); }
+  int code_size() const                          { return pointer_delta_as_int(code_end(), code_begin()); }
   // Only used from CodeCache::free_unused_tail() after the Interpreter blob was trimmed
   void adjust_size(size_t used) {
     _size = (int)used;

--- a/src/hotspot/share/code/codeBlob.inline.hpp
+++ b/src/hotspot/share/code/codeBlob.inline.hpp
@@ -33,7 +33,7 @@
 
 inline const ImmutableOopMap* CodeBlob::oop_map_for_slot(int slot, address return_address) const {
   assert(_oop_maps != nullptr, "nope");
-  return _oop_maps->find_map_at_slot(slot, (intptr_t) return_address - (intptr_t) code_begin());
+  return _oop_maps->find_map_at_slot(slot, pointer_delta_as_int(return_address, code_begin()));
 }
 
 #endif // SHARE_CODE_CODEBLOB_INLINE_HPP

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -666,7 +666,7 @@ class DependencySignature : public ResourceObj {
   }
 
   static bool     equals(DependencySignature const& s1, DependencySignature const& s2);
-  static unsigned hash  (DependencySignature const& s1) { return s1.arg(0) >> 2; }
+  static unsigned hash  (DependencySignature const& s1) { return (unsigned)(s1.arg(0) >> 2); }
 
   int args_count()             const { return _args_count; }
   uintptr_t arg(int idx)       const { return _argument_hash[idx]; }

--- a/src/hotspot/share/code/exceptionHandlerTable.hpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.hpp
@@ -172,7 +172,7 @@ public:
   uint get_exec_offset(uint i) { assert(i < _len, "oob"); return *adr(i); }
   uint get_cont_offset(uint i) { assert(i < _len, "oob"); return *(adr(i) + 1); }
 
-  int size_in_bytes() const { return len() == 0 ? 0 : ((2 * len() + 1) * sizeof(implicit_null_entry)); }
+  int size_in_bytes() const { return len() == 0 ? 0 : ((2 * len() + 1) * (int)sizeof(implicit_null_entry)); }
 
   void copy_to(nmethod* nm);
   void copy_bytes_to(address addr, int size);

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -131,7 +131,7 @@ class VtableStub {
 
   void* operator new(size_t size, int code_size) throw();
 
-  VtableStub(bool is_vtable_stub, int index)
+  VtableStub(bool is_vtable_stub, short index)
         : _next(nullptr), _index(index), _ame_offset(-1), _npe_offset(-1),
           _is_vtable_stub(is_vtable_stub) {}
   VtableStub* next() const                       { return _next; }
@@ -152,8 +152,8 @@ class VtableStub {
 
  private:
   void set_exception_points(address npe_addr, address ame_addr) {
-    _npe_offset = npe_addr - code_begin();
-    _ame_offset = ame_addr - code_begin();
+    _npe_offset = checked_cast<short>(npe_addr - code_begin());
+    _ame_offset = checked_cast<short>(ame_addr - code_begin());
     assert(is_abstract_method_error(ame_addr),   "offset must be correct");
     assert(is_null_pointer_exception(npe_addr),  "offset must be correct");
     assert(!is_abstract_method_error(npe_addr),  "offset must be correct");

--- a/src/hotspot/share/oops/compressedOops.inline.hpp
+++ b/src/hotspot/share/oops/compressedOops.inline.hpp
@@ -156,7 +156,7 @@ inline narrowKlass CompressedKlassPointers::encode_not_null(Klass* v, address na
   assert(KlassEncodingMetaspaceMax > pd, "change encoding max if new encoding");
   uint64_t result = pd >> shift();
   assert((result & CONST64(0xffffffff00000000)) == 0, "narrow klass pointer overflow");
-  assert(decode_not_null(result, narrow_base) == v, "reversibility");
+  assert(decode_not_null((narrowKlass)result, narrow_base) == v, "reversibility");
   return (narrowKlass)result;
 }
 

--- a/src/hotspot/share/oops/methodCounters.hpp
+++ b/src/hotspot/share/oops/methodCounters.hpp
@@ -75,17 +75,17 @@ class MethodCounters : public Metadata {
       _interpreter_throwout_count++;
     }
   }
-  int  interpreter_throwout_count() const {
+  u2  interpreter_throwout_count() const {
     return _interpreter_throwout_count;
   }
-  void set_interpreter_throwout_count(int count) {
+  void set_interpreter_throwout_count(u2 count) {
     _interpreter_throwout_count = count;
   }
 #else // COMPILER2_OR_JVMCI
-  int  interpreter_throwout_count() const {
+  u2  interpreter_throwout_count() const {
     return 0;
   }
-  void set_interpreter_throwout_count(int count) {
+  void set_interpreter_throwout_count(u2 count) {
     assert(count == 0, "count must be 0");
   }
 #endif // COMPILER2_OR_JVMCI

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -389,7 +389,7 @@ inline int stackChunkOopDesc::relativize_address(intptr_t* p) const {
   assert(start_address() <= p && p <= base, "start_address: " PTR_FORMAT " p: " PTR_FORMAT " base: " PTR_FORMAT,
          p2i(start_address()), p2i(p), p2i(base));
   assert(0 <= offset && offset <= std::numeric_limits<int>::max(), "offset: " PTR_FORMAT, offset);
-  return offset;
+  return (int)offset;
 }
 
 inline void stackChunkOopDesc::relativize_frame(frame& fr) const {

--- a/src/hotspot/share/prims/jvmtiTagMapTable.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.hpp
@@ -54,7 +54,7 @@ class JvmtiTagMapKey : public CHeapObj<mtServiceability> {
 
   static unsigned get_hash(const JvmtiTagMapKey& entry) {
     assert(entry._obj != nullptr, "must lookup obj to hash");
-    return entry._obj->identity_hash();
+    return (unsigned)entry._obj->identity_hash();
   }
 
   static bool equals(const JvmtiTagMapKey& lhs, const JvmtiTagMapKey& rhs) {

--- a/src/hotspot/share/runtime/continuationHelper.inline.hpp
+++ b/src/hotspot/share/runtime/continuationHelper.inline.hpp
@@ -94,7 +94,7 @@ inline address ContinuationHelper::InterpretedFrame::return_pc(const frame& f) {
 }
 
 inline int ContinuationHelper::InterpretedFrame::size(const frame&f) {
-  return InterpretedFrame::frame_bottom(f) - InterpretedFrame::frame_top(f);
+  return pointer_delta_as_int(InterpretedFrame::frame_bottom(f), InterpretedFrame::frame_top(f));
 }
 
 inline int ContinuationHelper::InterpretedFrame::stack_argsize(const frame& f) {

--- a/src/hotspot/share/runtime/stubCodeGenerator.hpp
+++ b/src/hotspot/share/runtime/stubCodeGenerator.hpp
@@ -90,7 +90,7 @@ class StubCodeDesc: public CHeapObj<mtCode> {
   address     begin() const                      { return _begin; }
   address     end() const                        { return _end; }
   uint        disp() const                       { return _disp; }
-  int         size_in_bytes() const              { return _end - _begin; }
+  int         size_in_bytes() const              { return pointer_delta_as_int(_end, _begin); }
   bool        contains(address pc) const         { return _begin <= pc && pc < _end; }
   void        print_on(outputStream* st) const;
   void        print() const;

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -108,11 +108,11 @@ class MallocHeader {
 
   void print_block_on_error(outputStream* st, address bad_address) const;
 
-  static uint16_t build_footer(uint8_t b1, uint8_t b2) { return ((uint16_t)b1 << 8) | (uint16_t)b2; }
+  static uint16_t build_footer(uint8_t b1, uint8_t b2) { return (uint16_t)(((uint16_t)b1 << 8) | (uint16_t)b2); }
 
   uint8_t* footer_address() const   { return ((address)this) + sizeof(MallocHeader) + _size; }
   uint16_t get_footer() const       { return build_footer(footer_address()[0], footer_address()[1]); }
-  void set_footer(uint16_t v)       { footer_address()[0] = v >> 8; footer_address()[1] = (uint8_t)v; }
+  void set_footer(uint16_t v)       { footer_address()[0] = (uint8_t)(v >> 8); footer_address()[1] = (uint8_t)v; }
 
   template<typename InTypeParam, typename OutTypeParam>
   inline static OutTypeParam resolve_checked_impl(InTypeParam memblock);

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -119,7 +119,7 @@ class MallocSiteTable : AllStatic {
     assert(bucket_idx <= MAX_MALLOCSITE_TABLE_SIZE && pos_idx < MAX_BUCKET_LENGTH, "overflow");
     return (uint32_t)bucket_idx << 16 | pos_idx;
   }
-  static uint16_t bucket_idx_from_marker(uint32_t marker) { return marker >> 16; }
+  static uint16_t bucket_idx_from_marker(uint32_t marker) { return (uint16_t)(marker >> 16); }
   static uint16_t pos_idx_from_marker(uint32_t marker) { return marker & 0xFFFF; }
 
  public:

--- a/src/hotspot/share/utilities/align.hpp
+++ b/src/hotspot/share/utilities/align.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ constexpr T align_down(T size, A alignment) {
   // Convert mask to T before logical_not.  Otherwise, if alignment is unsigned
   // and smaller than T, the result of the logical_not will be zero-extended
   // by integral promotion, and upper bits of size will be discarded.
-  T result = size & ~T(alignment_mask(alignment));
+  T result = T(size & ~T(alignment_mask(alignment)));
   assert(is_aligned(result, alignment),
          "must be aligned: " UINT64_FORMAT, (uint64_t)result);
   return result;
@@ -71,7 +71,7 @@ constexpr T align_down(T size, A alignment) {
 
 template<typename T, typename A, ENABLE_IF(std::is_integral<T>::value)>
 constexpr T align_up(T size, A alignment) {
-  T adjusted = size + alignment_mask(alignment);
+  T adjusted = checked_cast<T>(size + alignment_mask(alignment));
   return align_down(adjusted, alignment);
 }
 

--- a/src/hotspot/share/utilities/elfFile.hpp
+++ b/src/hotspot/share/utilities/elfFile.hpp
@@ -255,7 +255,7 @@ class ElfFile: public CHeapObj<mtInternal> {
     }
 
     void update_null_terminator_index() {
-      _null_terminator_index = strlen(_path);
+      _null_terminator_index = checked_cast<uint16_t>(strlen(_path));
     }
 
     bool copy_to_path_index(uint16_t index_in_path, const char* src);

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -526,6 +526,14 @@ constexpr T2 checked_cast(T1 thing) {
   return result;
 }
 
+// pointer_delta_as_int is called to do pointer subtraction for nearby pointers that
+// returns a non-negative int, usually used as a size of a code buffer range.
+// This scales to sizeof(T).
+template <typename T>
+inline int pointer_delta_as_int(const volatile T* left, const volatile T* right) {
+  return checked_cast<int>(pointer_delta(left, right, sizeof(T)));
+}
+
 // Need the correct linkage to call qsort without warnings
 extern "C" {
   typedef int (*_sort_Fn)(const void *, const void *);
@@ -667,7 +675,7 @@ inline double fabsd(double value) {
 // is zero, return 0.0.
 template<typename T>
 inline double percent_of(T numerator, T denominator) {
-  return denominator != 0 ? (double)numerator / denominator * 100.0 : 0.0;
+  return denominator != 0 ? (double)numerator / (double)denominator * 100.0 : 0.0;
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/src/hotspot/share/utilities/nativeCallStack.hpp
+++ b/src/hotspot/share/utilities/nativeCallStack.hpp
@@ -120,7 +120,7 @@ public:
     for (int i = 0; i < NMT_TrackingStackDepth; i++) {
       hash += (uintptr_t)_stack[i];
     }
-    return hash;
+    return (unsigned int)hash;
   }
 
   void print_on(outputStream* out) const;

--- a/src/hotspot/share/utilities/powerOfTwo.hpp
+++ b/src/hotspot/share/utilities/powerOfTwo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,7 +117,7 @@ inline T round_up_power_of_2(T value) {
 template <typename T, ENABLE_IF(std::is_integral<T>::value)>
 inline T next_power_of_2(T value)  {
   assert(value < std::numeric_limits<T>::max(), "Overflow");
-  return round_up_power_of_2(value + 1);
+  return T(round_up_power_of_2(value + 1));
 }
 
 // Find log2 value greater than this input


### PR DESCRIPTION
Clean backport to avoid more conversion warnings, and lay the ground for subsequent clean backports.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8310906](https://bugs.openjdk.org/browse/JDK-8310906) needs maintainer approval

### Issue
 * [JDK-8310906](https://bugs.openjdk.org/browse/JDK-8310906): Fix -Wconversion warnings in runtime, oops and some code header files. (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/767/head:pull/767` \
`$ git checkout pull/767`

Update a local copy of the PR: \
`$ git checkout pull/767` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 767`

View PR using the GUI difftool: \
`$ git pr show -t 767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/767.diff">https://git.openjdk.org/jdk21u-dev/pull/767.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/767#issuecomment-2180913338)