### PR TITLE
8319197: Exclude hb-subset and hb-style from compilation

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -465,7 +465,10 @@ else
    endif
 
    # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
-   LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
+   # hb-subset and hb-style APIs are not needed, excluded to cut on compilation time.
+   LIBFONTMANAGER_EXCLUDE_FILES += hb-ft.cc hb-subset-cff-common.cc \
+       hb-subset-cff1.cc hb-subset-cff2.cc hb-subset-input.cc hb-subset-plan.cc \
+       hb-subset.cc hb-subset-instancer-solver.cc gsubgpos-context.cc hb-style.cc
 
    # list of disabled warnings and the compilers for which it was specifically added.
    # array-bounds         -> GCC 12 on Alpine Linux


### PR DESCRIPTION
Clean backport to improve JDK build times.

Yields a very reproducible improvement:

```
CONF=linux-x86_64-server-fastdebug make clean images   2484.89s user 417.72s system 2357% cpu 2:03.10 total
CONF=linux-x86_64-server-fastdebug make clean images   2481.81s user 417.23s system 2368% cpu 2:02.43 total
CONF=linux-x86_64-server-fastdebug make clean images   2487.89s user 417.50s system 2374% cpu 2:02.36 total

After:
CONF=linux-x86_64-server-fastdebug make clean images   2435.98s user 410.01s system 2538% cpu 1:52.10 total
CONF=linux-x86_64-server-fastdebug make clean images   2433.32s user 412.24s system 2546% cpu 1:51.75 total
CONF=linux-x86_64-server-fastdebug make clean images   2446.09s user 414.37s system 2535% cpu 1:52.81 total
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319197](https://bugs.openjdk.org/browse/JDK-8319197) needs maintainer approval

### Issue
 * [JDK-8319197](https://bugs.openjdk.org/browse/JDK-8319197): Exclude hb-subset and hb-style from compilation (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/769/head:pull/769` \
`$ git checkout pull/769`

Update a local copy of the PR: \
`$ git checkout pull/769` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 769`

View PR using the GUI difftool: \
`$ git pr show -t 769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/769.diff">https://git.openjdk.org/jdk21u-dev/pull/769.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/769#issuecomment-2181306512)