### PR TITLE
8334333: MissingResourceCauseTestRun.java fails if run by root

### DIFF
--- a/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
+++ b/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4354216 8213127
+ * @bug 4354216 8213127 8334333
  * @summary Test for the cause support when throwing a
  *          MissingResourceBundle. (This test exists under
  *          ResourceBundle/Control because bad resource bundle data can be
@@ -32,6 +32,7 @@
  * @build jdk.test.lib.JDKToolLauncher
  *        jdk.test.lib.Utils
  *        jdk.test.lib.process.ProcessTools
+ *        jdk.test.lib.Platform
  *        MissingResourceCauseTest
  *        NonResourceBundle
  *        PrivateConstructorRB
@@ -50,9 +51,14 @@ import java.nio.file.Paths;
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 public class MissingResourceCauseTestRun {
     public static void main(String[] args) throws Throwable {
+        if (Platform.isRoot() && !Platform.isWindows()) {
+            throw new SkippedException("Unable to create an unreadable properties file.");
+        }
         Path path = Paths.get("UnreadableRB.properties");
         Files.deleteIfExists(path);
         try {
@@ -98,7 +104,7 @@ public class MissingResourceCauseTestRun {
     }
 
     private static void deleteFile(Path path) throws Throwable {
-        if(path.toFile().exists()) {
+        if (path.toFile().exists()) {
             ProcessTools.executeCommand("chmod", "666", path.toString())
                         .outputTo(System.out)
                         .errorTo(System.out)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [de8ee977](https://github.com/openjdk/jdk/commit/de8ee97718d7e12b541b310cf5b67f3e10e91ad9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 20 Jun 2024 and was reviewed by Naoto Sato and Justin Lu.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334333](https://bugs.openjdk.org/browse/JDK-8334333) needs maintainer approval

### Issue
 * [JDK-8334333](https://bugs.openjdk.org/browse/JDK-8334333): MissingResourceCauseTestRun.java fails if run by root (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/770/head:pull/770` \
`$ git checkout pull/770`

Update a local copy of the PR: \
`$ git checkout pull/770` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 770`

View PR using the GUI difftool: \
`$ git pr show -t 770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/770.diff">https://git.openjdk.org/jdk21u-dev/pull/770.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/770#issuecomment-2181795603)