### PR TITLE
8323584: AArch64: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe

### DIFF
--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -28,7 +28,6 @@
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "gc/shared/collectedHeap.hpp"
-#include "memory/resourceArea.hpp"
 #include "nativeInst_aarch64.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.hpp"
@@ -189,8 +188,6 @@ void NativeCall::set_destination_mt_safe(address dest, bool assert_lock) {
          CompiledICLocker::is_safe(addr_at(0)),
          "concurrent code patching");
 
-  ResourceMark rm;
-  int code_size = NativeInstruction::instruction_size;
   address addr_call = addr_at(0);
   bool reachable = Assembler::reachable_from_branch_at(addr_call, dest);
   assert(NativeCall::is_call_at(addr_call), "unexpected code at call site");


### PR DESCRIPTION
Backport of [JDK-8323584](https://bugs.openjdk.org/browse/JDK-8323584)

### Verifications
- [x] tier1 test
``` make test TEST=test/hotspot/jtreg/:tier1 CONF=linux-aarch64-server-fastdebug ```
```
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg:tier1                     2465  2465     0     0   
==============================
TEST SUCCESS
```
- [x] tier2 test
```
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg:tier2                      738   738     0     0   
==============================
TEST SUCCESS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323584](https://bugs.openjdk.org/browse/JDK-8323584) needs maintainer approval

### Issue
 * [JDK-8323584](https://bugs.openjdk.org/browse/JDK-8323584): AArch64: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/772/head:pull/772` \
`$ git checkout pull/772`

Update a local copy of the PR: \
`$ git checkout pull/772` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 772`

View PR using the GUI difftool: \
`$ git pr show -t 772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/772.diff">https://git.openjdk.org/jdk21u-dev/pull/772.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/772#issuecomment-2190122756)