### PR TITLE
Backport fe8a2aff3129b515c2a0f3ab96f5e3ad6cef7b70

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -29,9 +29,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
-com/sun/jdi/cds/CDSBreakpointTest.java 8307778 generic-all
-com/sun/jdi/cds/CDSDeleteAllBkptsTest.java 8307778 generic-all
-com/sun/jdi/cds/CDSFieldWatchpoints.java 8307778 generic-all
 
 sun/tools/jcmd/JcmdOutputEncodingTest.java 8308033 generic-all
 sun/tools/jstack/BasicJStackTest.java 8308033 generic-all

--- a/test/jdk/com/sun/jdi/cds/CDSJDITest.java
+++ b/test/jdk/com/sun/jdi/cds/CDSJDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class CDSJDITest {
             // pass them to the subprocess it will create for the debuggee. This
             // is how the -javaopts are passed to the debuggee. See
             // VMConnection.getDebuggeeVMOptions().
-            getPropOpt("test.classes"),
+            getPropOpt("test.class.path"),
             getPropOpt("test.java.opts"),
             getPropOpt("test.vm.opts"),
             // Pass -showversion to the JDI test just so we get a bit of trace output.


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.