### PR TITLE
8328647: TestGarbageCollectorMXBean.java fails with C1-only and -Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/x/TestGarbageCollectorMXBean.java
+++ b/test/hotspot/jtreg/gc/x/TestGarbageCollectorMXBean.java
@@ -28,6 +28,7 @@ package gc.x;
  * @requires vm.gc.ZSinglegen
  * @summary Test ZGC garbage collector MXBean
  * @modules java.management
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xms256M -Xmx512M -Xlog:gc gc.x.TestGarbageCollectorMXBean 256 512
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xms512M -Xmx512M -Xlog:gc gc.x.TestGarbageCollectorMXBean 512 512
  */

--- a/test/hotspot/jtreg/gc/z/TestGarbageCollectorMXBean.java
+++ b/test/hotspot/jtreg/gc/z/TestGarbageCollectorMXBean.java
@@ -28,6 +28,7 @@ package gc.z;
  * @requires vm.gc.ZGenerational
  * @summary Test ZGC garbage collector MXBean
  * @modules java.management
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xms256M -Xmx512M -Xlog:gc gc.z.TestGarbageCollectorMXBean 256 512
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xms512M -Xmx512M -Xlog:gc gc.z.TestGarbageCollectorMXBean 512 512
  */


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328647](https://bugs.openjdk.org/browse/JDK-8328647) needs maintainer approval

### Issue
 * [JDK-8328647](https://bugs.openjdk.org/browse/JDK-8328647): TestGarbageCollectorMXBean.java fails with C1-only and -Xcomp (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/784/head:pull/784` \
`$ git checkout pull/784`

Update a local copy of the PR: \
`$ git checkout pull/784` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 784`

View PR using the GUI difftool: \
`$ git pr show -t 784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/784.diff">https://git.openjdk.org/jdk21u-dev/pull/784.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/784#issuecomment-2186062873)