### PR TITLE
8321176: [Screencast] make a second attempt on screencast failure

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/fp_pipewire.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/fp_pipewire.h
@@ -58,7 +58,7 @@ void (*fp_pw_stream_destroy)(struct pw_stream *stream);
 
 
 void (*fp_pw_init)(int *argc, char **argv[]);
-
+void (*fp_pw_deinit)(void);
 
 struct pw_core *
 (*fp_pw_context_connect_fd)(struct pw_context *context,


### PR DESCRIPTION
Clean backport of [JDK-8321176](https://bugs.openjdk.org/browse/JDK-8321176).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321176](https://bugs.openjdk.org/browse/JDK-8321176) needs maintainer approval

### Issue
 * [JDK-8321176](https://bugs.openjdk.org/browse/JDK-8321176): [Screencast] make a second attempt on screencast failure (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/786/head:pull/786` \
`$ git checkout pull/786`

Update a local copy of the PR: \
`$ git checkout pull/786` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 786`

View PR using the GUI difftool: \
`$ git pr show -t 786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/786.diff">https://git.openjdk.org/jdk21u-dev/pull/786.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/786#issuecomment-2186080954)