### PR TITLE
8333099: Missing check for is_LoadVector in StoreNode::Identity

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2759,7 +2759,7 @@ Node* StoreNode::Identity(PhaseGVN* phase) {
       val->in(MemNode::Memory )->eqv_uncast(mem) &&
       val->as_Load()->store_Opcode() == Opcode()) {
     // Ensure vector type is the same
-    if (!is_StoreVector() || as_StoreVector()->vect_type() == mem->as_LoadVector()->vect_type()) {
+    if (!is_StoreVector() || (mem->is_LoadVector() && as_StoreVector()->vect_type() == mem->as_LoadVector()->vect_type())) {
       result = mem;
     }
   }

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIsLoadVector.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIsLoadVector.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+/*
+ * @test
+ * @bug 8333099
+ * @summary We should check for is_LoadVector before checking for equality between vector types
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.vectorapi.TestIsLoadVector::test -Xcomp compiler.vectorapi.TestIsLoadVector
+ */
+
+public class TestIsLoadVector {
+    static int[] iArrFld = new int[400];
+
+    static void test() {
+        int i13, i16 = 3;
+        short s = 50;
+        for (int i = 0; i < 4; i++) {
+            for (int i12 = 0; i12 < 8; ++i12) {
+                for (int i14 = 2; 82 > i14; i14++) {
+                    s <<= 90;
+                    do {
+                        try {
+                            i13 = 0;
+                        } catch (ArithmeticException a_e) {
+                        }
+                    } while (++i16 < 2);
+                }
+            }
+        }
+        int i18 = 1;
+        while (++i18 < 41) {
+            iArrFld[i18] >>= s;
+        }
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 100; i++) {
+            test();
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of [JDK-8333099](https://bugs.openjdk.org/browse/JDK-8333099). The included test fails without the fix and passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333099](https://bugs.openjdk.org/browse/JDK-8333099) needs maintainer approval

### Issue
 * [JDK-8333099](https://bugs.openjdk.org/browse/JDK-8333099): Missing check for is_LoadVector in StoreNode::Identity (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/787/head:pull/787` \
`$ git checkout pull/787`

Update a local copy of the PR: \
`$ git checkout pull/787` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 787`

View PR using the GUI difftool: \
`$ git pr show -t 787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/787.diff">https://git.openjdk.org/jdk21u-dev/pull/787.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/787#issuecomment-2186080426)