### PR TITLE
8334867: Add back assertion from JDK-8325494

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2049,8 +2049,7 @@ void PhaseIdealLoop::update_main_loop_assertion_predicates(Node* ctrl, CountedLo
   if (init->is_CastII()) {
     // skip over the cast added by PhaseIdealLoop::cast_incr_before_loop() when pre/post/main loops are created because
     // it can get in the way of type propagation
-    // The 2nd part of the assertion can be enabled after JDK-8305636.
-    assert(init->as_CastII()->carry_dependency() /* && loop_head->skip_assertion_predicates_with_halt() == init->in(0) */, "casted iv phi from pre loop expected");
+    assert(init->as_CastII()->carry_dependency() && loop_head->skip_predicates() == init->in(0), "casted iv phi from pre loop expected");
     init = init->in(1);
   }
   Node* entry = ctrl;


### PR DESCRIPTION
This PR adds the assertion which has been omitted in https://github.com/openjdk/jdk21u-dev/pull/734. See the discussion there and in the JBS issue for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8334867](https://bugs.openjdk.org/browse/JDK-8334867) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334867](https://bugs.openjdk.org/browse/JDK-8334867): Add back assertion from JDK-8325494 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/789/head:pull/789` \
`$ git checkout pull/789`

Update a local copy of the PR: \
`$ git checkout pull/789` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 789`

View PR using the GUI difftool: \
`$ git pr show -t 789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/789.diff">https://git.openjdk.org/jdk21u-dev/pull/789.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/789#issuecomment-2186650162)