### PR TITLE
8329103: assert(!thread->in_asgct()) failed during multi-mode profiling

### DIFF
--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -646,15 +646,17 @@ protected:
 class ThreadInAsgct {
  private:
   Thread* _thread;
+  bool _saved_in_asgct;
  public:
   ThreadInAsgct(Thread* thread) : _thread(thread) {
     assert(thread != nullptr, "invariant");
-    assert(!thread->in_asgct(), "invariant");
+    // Allow AsyncGetCallTrace to be reentrant - save the previous state.
+    _saved_in_asgct = thread->in_asgct();
     thread->set_in_asgct(true);
   }
   ~ThreadInAsgct() {
     assert(_thread->in_asgct(), "invariant");
-    _thread->set_in_asgct(false);
+    _thread->set_in_asgct(_saved_in_asgct);
   }
 };
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329103](https://bugs.openjdk.org/browse/JDK-8329103) needs maintainer approval

### Issue
 * [JDK-8329103](https://bugs.openjdk.org/browse/JDK-8329103): assert(!thread-&gt;in_asgct()) failed during multi-mode profiling (**Bug** - P4 - Approved)


### Reviewers
 * [Johannes Bechberger](https://openjdk.org/census#jbechberger) (@parttimenerd - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/790/head:pull/790` \
`$ git checkout pull/790`

Update a local copy of the PR: \
`$ git checkout pull/790` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 790`

View PR using the GUI difftool: \
`$ git pr show -t 790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/790.diff">https://git.openjdk.org/jdk21u-dev/pull/790.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/790#issuecomment-2186676917)