### PR TITLE
8332248: (fc) java/nio/channels/FileChannel/BlockDeviceSize.java failed with RuntimeException

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -25,6 +25,7 @@
  * @bug 8054029 8313368
  * @requires (os.family == "linux")
  * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
+ * @library /test/lib
  */
 
 import java.io.RandomAccessFile;
@@ -36,6 +37,7 @@ import java.util.List;
 
 import static java.nio.file.StandardOpenOption.*;
 
+import jtreg.SkippedException;
 
 public class BlockDeviceSize {
     private static final List<String> BLK_FNAMES = List.of("/dev/sda1", "/dev/nvme0n1", "/dev/xvda1") ;
@@ -61,7 +63,7 @@ public class BlockDeviceSize {
                 System.err.println("File " + blkFname + " not found." +
                         " Skipping test");
             } catch (AccessDeniedException ade) {
-                throw new RuntimeException("Access to " + blkFname + " is denied."
+                throw new SkippedException("Access to " + blkFname + " is denied."
                         + " Run test as root.", ade);
             }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0bb5ae64](https://github.com/openjdk/jdk/commit/0bb5ae645165b97527ecccf02308df6072c363d8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. Backport parity with 21.0.5-oracle.

The commit being backported was authored by Brian Burkhalter on 14 May 2024 and was reviewed by Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332248](https://bugs.openjdk.org/browse/JDK-8332248) needs maintainer approval

### Issue
 * [JDK-8332248](https://bugs.openjdk.org/browse/JDK-8332248): (fc) java/nio/channels/FileChannel/BlockDeviceSize.java failed with RuntimeException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/791/head:pull/791` \
`$ git checkout pull/791`

Update a local copy of the PR: \
`$ git checkout pull/791` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 791`

View PR using the GUI difftool: \
`$ git pr show -t 791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/791.diff">https://git.openjdk.org/jdk21u-dev/pull/791.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/791#issuecomment-2186875110)