### PR TITLE
8327007: javax/swing/JSpinner/8008657/bug8008657.java fails

### DIFF
--- a/test/jdk/javax/swing/JSpinner/8008657/bug8008657.java
+++ b/test/jdk/javax/swing/JSpinner/8008657/bug8008657.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @test
  * @key headful
  * @bug 8008657
- * @author Alexander Scherbatiy
  * @summary JSpinner setComponentOrientation doesn't affect on text orientation
  * @run main bug8008657
  */
@@ -137,6 +136,7 @@ public class bug8008657 {
         calendar.add(Calendar.YEAR, -1);
         Date earliestDate = calendar.getTime();
         calendar.add(Calendar.YEAR, 1);
+        calendar.add(Calendar.DAY_OF_MONTH, 1);
         Date latestDate = calendar.getTime();
         SpinnerModel dateModel = new SpinnerDateModel(initDate,
                 earliestDate,


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b7540df6](https://github.com/openjdk/jdk/commit/b7540df6a4279c63e69d32b9d9834f7a427478d1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 5 Mar 2024 and was reviewed by Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327007](https://bugs.openjdk.org/browse/JDK-8327007) needs maintainer approval

### Issue
 * [JDK-8327007](https://bugs.openjdk.org/browse/JDK-8327007): javax/swing/JSpinner/8008657/bug8008657.java fails (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/796/head:pull/796` \
`$ git checkout pull/796`

Update a local copy of the PR: \
`$ git checkout pull/796` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 796`

View PR using the GUI difftool: \
`$ git pr show -t 796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/796.diff">https://git.openjdk.org/jdk21u-dev/pull/796.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/796#issuecomment-2192760571)