### PR TITLE
8319818: Address GCC 13.2.0 warnings (stringop-overflow and dangling-pointer)

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -162,6 +162,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_jvmciCodeInstaller.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_jvmtiTagMap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
+    DISABLED_WARNINGS_gcc_shenandoahLock.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_clang_arguments.cpp := missing-field-initializers, \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -88,6 +88,13 @@ DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     maybe-uninitialized missing-field-initializers parentheses \
     shift-negative-value unknown-pragmas
 
+ifeq ($(DEBUG_LEVEL), fastdebug)
+  ifeq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, aarch64)), true)
+    # False positive warnings for atomic_linux_aarch64.hpp on GCC >= 13
+    DISABLED_WARNINGS_gcc += stringop-overflow
+  endif
+endif
+
 DISABLED_WARNINGS_clang := ignored-qualifiers sometimes-uninitialized \
     missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas
 

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -88,13 +88,6 @@ DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     maybe-uninitialized missing-field-initializers parentheses \
     shift-negative-value unknown-pragmas
 
-ifeq ($(DEBUG_LEVEL), fastdebug)
-  ifeq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, aarch64)), true)
-    # False positive warnings for atomic_linux_aarch64.hpp on GCC >= 13
-    DISABLED_WARNINGS_gcc += stringop-overflow
-  endif
-endif
-
 DISABLED_WARNINGS_clang := ignored-qualifiers sometimes-uninitialized \
     missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas
 
@@ -164,8 +157,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_ad_$(HOTSPOT_TARGET_CPU_ARCH).cpp := nonnull, \
     DISABLED_WARNINGS_gcc_cgroupV1Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
+    DISABLED_WARNINGS_gcc_handshake.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_interp_masm_x86.cpp := uninitialized, \
+    DISABLED_WARNINGS_gcc_jvmciCodeInstaller.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_jvmtiTagMap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
+    DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_clang_arguments.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_codeBuffer.cpp := tautological-undefined-compare, \

--- a/src/hotspot/share/memory/resourceArea.cpp
+++ b/src/hotspot/share/memory/resourceArea.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,18 @@ void ResourceArea::bias_to(MEMFLAGS new_flags) {
 }
 
 #ifdef ASSERT
+
+ResourceMark::ResourceMark(ResourceArea* area, Thread* thread) :
+    _impl(area),
+    _thread(thread),
+    _previous_resource_mark(nullptr)
+{
+  if (_thread != nullptr) {
+    assert(_thread == Thread::current(), "not the current thread");
+    _previous_resource_mark = _thread->current_resource_mark();
+    _thread->set_current_resource_mark(this);
+  }
+}
 
 void ResourceArea::verify_has_resource_mark() {
   if (_nesting <= 0 && !VMError::is_error_reported()) {

--- a/src/hotspot/share/memory/resourceArea.hpp
+++ b/src/hotspot/share/memory/resourceArea.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,17 +191,7 @@ class ResourceMark: public StackObj {
 #ifndef ASSERT
   ResourceMark(ResourceArea* area, Thread* thread) : _impl(area) {}
 #else
-  ResourceMark(ResourceArea* area, Thread* thread) :
-    _impl(area),
-    _thread(thread),
-    _previous_resource_mark(nullptr)
-  {
-    if (_thread != nullptr) {
-      assert(_thread == Thread::current(), "not the current thread");
-      _previous_resource_mark = _thread->current_resource_mark();
-      _thread->set_current_resource_mark(this);
-    }
-  }
+  ResourceMark(ResourceArea* area, Thread* thread);
 #endif // ASSERT
 
 public:


### PR DESCRIPTION
This batch of fixes improves the warnings handling for newer GCCs. These issues are a bit interdependent contextually, so I opted to pick them up in one batch, making it abundantly clear what are we adding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319818](https://bugs.openjdk.org/browse/JDK-8319818) needs maintainer approval
- [x] [JDK-8320212](https://bugs.openjdk.org/browse/JDK-8320212) needs maintainer approval
- [x] [JDK-8326717](https://bugs.openjdk.org/browse/JDK-8326717) needs maintainer approval

### Issues
 * [JDK-8319818](https://bugs.openjdk.org/browse/JDK-8319818): Address GCC 13.2.0 warnings (stringop-overflow and dangling-pointer) (**Enhancement** - P4 - Approved)
 * [JDK-8320212](https://bugs.openjdk.org/browse/JDK-8320212): Disable GCC stringop-overflow warning for affected files (**Bug** - P4 - Approved)
 * [JDK-8326717](https://bugs.openjdk.org/browse/JDK-8326717): Disable stringop-overflow in shenandoahLock.cpp (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/797/head:pull/797` \
`$ git checkout pull/797`

Update a local copy of the PR: \
`$ git checkout pull/797` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 797`

View PR using the GUI difftool: \
`$ git pr show -t 797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/797.diff">https://git.openjdk.org/jdk21u-dev/pull/797.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/797#issuecomment-2194131523)