### PR TITLE
8327401: Some jtreg tests fail on Wayland without any tracking bug

### DIFF
--- a/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
+++ b/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,6 +113,8 @@ public final class ChoicePopupLocation {
         robot.setAutoDelay(100);
         robot.setAutoWaitForIdle(true);
         robot.waitForIdle();
+        robot.delay(500);
+
         Point pt = choice.getLocationOnScreen();
         robot.mouseMove(pt.x + choice.getWidth() / 2,
                         pt.y + choice.getHeight() / 2);

--- a/test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
+++ b/test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,18 @@
   @run main PopupPosTest
 */
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
 
 public class PopupPosTest {
 
@@ -66,6 +76,7 @@ class TestFrame extends Frame implements ItemListener {
             robot = new Robot();
             robot.setAutoDelay(50);
             robot.waitForIdle();
+            robot.delay(500);
             // fix for 6175418. When we take "choice.getHeight()/2"
             // divider 2 is not sufficiently big to hit into the
             // small box Choice. We should use bigger divider to get
@@ -108,9 +119,9 @@ class TestFrame extends Frame implements ItemListener {
     public void mouseMoveAndPressOnChoice(int x, int y){
         openChoice();
         robot.mouseMove(x, y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(30);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
         //should close choice after each test stage
         closeChoice();
@@ -121,9 +132,9 @@ class TestFrame extends Frame implements ItemListener {
         Point pt = choice.getLocationOnScreen();
         robot.mouseMove(pt.x + choice.getWidth() - choice.getHeight()/4,
                         pt.y + choice.getHeight()/2);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(30);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
     }
     public void closeChoice(){

--- a/test/jdk/java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java
+++ b/test/jdk/java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ public class NonFocusableBlockedOwnerTest {
         }
 
         waitTillShown(dialog);
+        robot.delay(500);
         clickOn(button);
         if (frame == KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow()) {
             throw new RuntimeException("Test failed!");

--- a/test/jdk/java/awt/Focus/RowToleranceTransitivityTest.java
+++ b/test/jdk/java/awt/Focus/RowToleranceTransitivityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
   @summary   Tests for a transitivity problem with ROW_TOLERANCE in SortingFTP.
   @run       main RowToleranceTransitivityTest
 */
-import java.awt.BorderLayout;
+
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.EventQueue;
@@ -36,7 +36,6 @@ import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.KeyboardFocusManager;
-import java.awt.Panel;
 import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.FocusAdapter;
@@ -49,8 +48,6 @@ import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.lang.reflect.InvocationTargetException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RowToleranceTransitivityTest {
     static JFrame frame;
@@ -60,7 +57,7 @@ public class RowToleranceTransitivityTest {
     static GridBagConstraints gc;
     static Robot robot;
 
-    static AtomicBoolean focusGained = new AtomicBoolean(false);
+    static final AtomicBoolean focusGained = new AtomicBoolean(false);
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -121,6 +118,7 @@ public class RowToleranceTransitivityTest {
             robot.delay(1000);
             test();
         } finally {
+            robot.keyRelease(KeyEvent.VK_TAB);
             if (frame != null) {
                 frame.dispose();
             }

--- a/test/jdk/java/awt/Focus/WrongKeyTypedConsumedTest/WrongKeyTypedConsumedTest.java
+++ b/test/jdk/java/awt/Focus/WrongKeyTypedConsumedTest/WrongKeyTypedConsumedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,7 @@ public class WrongKeyTypedConsumedTest
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         Util.waitForIdle(robot);
+        robot.delay(500);
 
         if (!frame.isActive()) {
             throw new RuntimeException("Test Fialed: frame isn't active");

--- a/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
+++ b/test/jdk/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,17 +40,27 @@ public class ActiveAWTWindowTest {
     private Frame frame, frame2;
     private Button button, button2;
     private TextField textField, textField2;
-    private int eventType, eventType1;
-    private ExtendedRobot robot;
-    private Object lock1 = new Object();
-    private Object lock2 = new Object();
-    private Object lock3 = new Object();
+    private volatile int eventType;
+    private final Object lock1 = new Object();
+    private final Object lock2 = new Object();
+    private final Object lock3 = new Object();
     private boolean passed = true;
-    private int delay = 150;
+    private final int delay = 150;
 
     public static void main(String[] args) {
         ActiveAWTWindowTest test = new ActiveAWTWindowTest();
-        test.doTest();
+        try {
+            test.doTest();
+        } finally {
+            EventQueue.invokeLater(() -> {
+                if (test.frame != null) {
+                    test.frame.dispose();
+                }
+                if (test.frame2 != null) {
+                    test.frame2.dispose();
+                }
+            });
+        }
     }
 
     public ActiveAWTWindowTest() {
@@ -105,7 +115,7 @@ public class ActiveAWTWindowTest {
                 System.out.println("Undecorated Frame got Deactivated\n");
                 synchronized (lock2) {
                     try {
-                            lock2.notifyAll();
+                        lock2.notifyAll();
                     } catch (Exception ex) {
                         ex.printStackTrace();
                     }
@@ -146,6 +156,7 @@ public class ActiveAWTWindowTest {
     }
 
     public void doTest() {
+        ExtendedRobot robot;
         try {
             robot = new ExtendedRobot();
         } catch (Exception e) {
@@ -153,13 +164,14 @@ public class ActiveAWTWindowTest {
             throw new RuntimeException("Cannot create robot");
         }
 
+        robot.setAutoDelay(delay);
+        robot.setAutoWaitForIdle(true);
+
         robot.waitForIdle(5*delay);
         robot.mouseMove(button.getLocationOnScreen().x + button.getSize().width / 2,
                         button.getLocationOnScreen().y + button.getSize().height / 2);
-        robot.waitForIdle(delay);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.waitForIdle(delay);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
         if (eventType != WindowEvent.WINDOW_ACTIVATED) {
             synchronized (lock1) {
@@ -176,15 +188,12 @@ public class ActiveAWTWindowTest {
                     "undecorated frame is activated!");
         }
 
-        eventType1 = -1;
         eventType = -1;
 
         robot.mouseMove(button2.getLocationOnScreen().x + button2.getSize().width / 2,
                         button2.getLocationOnScreen().y + button2.getSize().height / 2);
-        robot.waitForIdle(delay);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.waitForIdle(delay);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
         if (eventType != WindowEvent.WINDOW_DEACTIVATED) {
             synchronized (lock2) {

--- a/test/jdk/java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemonicKeyTypedTest.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemonicKeyTypedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,34 +33,50 @@
 
 import jdk.test.lib.Platform;
 
-import java.awt.*;
-import javax.swing.*;
-import java.awt.event.*;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 
 public class ConsumeNextMnemonicKeyTypedTest {
-    Robot robot;
-    JFrame frame = new JFrame("Test Frame");
-    JTextField text = new JTextField();
-    JMenuBar bar = new JMenuBar();
-    JMenu menu = new JMenu("Menu");
-    JMenuItem item = new JMenuItem("item");
+    static Robot robot;
+    static JFrame frame;
+    static JTextField text;
+    static JMenuBar bar;
+    static JMenu menu;
+    static JMenuItem item;
 
-    public static void main(String[] args) {
-        ConsumeNextMnemonicKeyTypedTest app = new ConsumeNextMnemonicKeyTypedTest();
-        app.init();
-        app.start();
-    }
-
-    public void init() {
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(50);
         try {
-            robot = new Robot();
-            robot.setAutoDelay(50);
-        } catch (AWTException e) {
-            throw new RuntimeException("Error: unable to create robot", e);
+            SwingUtilities.invokeAndWait(ConsumeNextMnemonicKeyTypedTest::init);
+
+            robot.waitForIdle();
+            robot.delay(500);
+
+            test();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 
-    public void start() {
+    public static void init() {
+        frame = new JFrame("Test Frame");
+        text = new JTextField();
+        bar = new JMenuBar();
+        menu = new JMenu("Menu");
+        item = new JMenuItem("item");
+
         menu.setMnemonic('f');
         item.setMnemonic('i');
         menu.add(item);
@@ -72,20 +88,18 @@ public class ConsumeNextMnemonicKeyTypedTest {
 
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
-
-        test();
     }
 
-    void test() {
+    static void test() {
 
         robot.waitForIdle();
 
         if (!text.isFocusOwner()) {
             robot.mouseMove(text.getLocationOnScreen().x + 5, text.getLocationOnScreen().y + 5);
             robot.delay(100);
-            robot.mousePress(MouseEvent.BUTTON1_MASK);
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
             robot.delay(100);
-            robot.mouseRelease(MouseEvent.BUTTON1_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
 
             int iter = 10;
             while (!text.isFocusOwner() && iter-- > 0) {
@@ -146,7 +160,7 @@ public class ConsumeNextMnemonicKeyTypedTest {
 
         robot.waitForIdle();
 
-        System.err.println("Test: chracter typed with VK_A: " + text.getText());
+        System.err.println("Test: character typed with VK_A: " + text.getText());
 
         if (!charA.equals(text.getText())) {
             throw new RuntimeException("Test failed!");

--- a/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
+++ b/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,33 +32,87 @@
   @run main KeyEventsTest
 */
 
-import java.awt.*;
-import java.awt.event.*;
-import java.lang.reflect.*;
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.KeyboardFocusManager;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 
 import jdk.test.lib.Platform;
 
-public class KeyEventsTest extends Frame implements ItemListener, FocusListener, KeyListener
-{
+public class KeyEventsTest {
     TestState currentState;
     final Object LOCK = new Object();
     final int ACTION_TIMEOUT = 500;
 
-    List single = new List(3, false);
-    List multiple = new List(3, true);
+    List single;
+    List multiple;
 
-    Panel p1 = new Panel ();
-    Panel p2 = new Panel ();
+    KeyFrame keyFrame;
 
-    public static void main(final String[] args) {
+    static Robot r;
+
+    public static void main(final String[] args) throws Exception {
+        r = new Robot();
         KeyEventsTest app = new KeyEventsTest();
-        app.init();
-        app.start();
+        try {
+            EventQueue.invokeAndWait(app::initAndShowGui);
+            r.waitForIdle();
+            r.delay(500);
+            app.doTest();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (app.keyFrame != null) {
+                    app.keyFrame.dispose();
+                }
+            });
+        }
     }
 
-    public void init()
-    {
-        setLayout (new BorderLayout ());
+    class KeyFrame extends Frame implements ItemListener, FocusListener, KeyListener {
+        public void itemStateChanged(ItemEvent ie) {
+            System.out.println("itemStateChanged-" + ie);
+            currentState.setAction(true);
+        }
+
+        public void focusGained(FocusEvent e) {
+            synchronized (LOCK) {
+                LOCK.notifyAll();
+            }
+        }
+
+        public void focusLost(FocusEvent e) {
+        }
+
+        public void keyPressed(KeyEvent e) {
+            System.out.println("keyPressed-" + e);
+        }
+
+        public void keyReleased(KeyEvent e) {
+            System.out.println("keyReleased-" + e);
+        }
+
+        public void keyTyped(KeyEvent e) {
+            System.out.println("keyTyped-" + e);
+        }
+    }
+
+    public void initAndShowGui() {
+        keyFrame = new KeyFrame();
+        keyFrame.setLayout(new BorderLayout ());
+
+        single = new List(3, false);
+        multiple = new List(3, true);
 
         single.add("0");
         single.add("1");
@@ -80,161 +134,105 @@ public class KeyEventsTest extends Frame implements ItemListener, FocusListener,
         multiple.add("7");
         multiple.add("8");
 
-        single.addKeyListener(this);
-        single.addItemListener(this);
-        single.addFocusListener(this);
+        single.addKeyListener(keyFrame);
+        single.addItemListener(keyFrame);
+        single.addFocusListener(keyFrame);
+        Panel p1 = new Panel();
         p1.add(single);
-        add("North", p1);
+        keyFrame.add("North", p1);
 
-        multiple.addKeyListener(this);
-        multiple.addItemListener(this);
-        multiple.addFocusListener(this);
+        multiple.addKeyListener(keyFrame);
+        multiple.addItemListener(keyFrame);
+        multiple.addFocusListener(keyFrame);
+        Panel p2 = new Panel();
         p2.add(multiple);
-        add("South", p2);
+        keyFrame.add("South", p2);
 
-    }//End  init()
-
-    public void start ()
-    {
-
-        try{
-            setSize (200,200);
-            validate();
-            setUndecorated(true);
-            setLocationRelativeTo(null);
-            setVisible(true);
-
-            doTest();
-            System.out.println("Test passed.");
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("The test failed.");
-        }
-
-    }// start()
-
-    public void itemStateChanged (ItemEvent ie) {
-        System.out.println("itemStateChanged-"+ie);
-        this.currentState.setAction(true);
+        keyFrame.setSize(200, 200);
+        keyFrame.validate();
+        keyFrame.setUndecorated(true);
+        keyFrame.setLocationRelativeTo(null);
+        keyFrame.setVisible(true);
     }
 
-    public void focusGained(FocusEvent e){
-
+    private void test(TestState currentState) throws Exception {
         synchronized (LOCK) {
-            LOCK.notifyAll();
-        }
-
-    }
-
-    public void focusLost(FocusEvent e){
-    }
-
-    public void keyPressed(KeyEvent e){
-        System.out.println("keyPressed-"+e);
-    }
-
-    public void keyReleased(KeyEvent e){
-        System.out.println("keyReleased-"+e);
-    }
-
-    public void keyTyped(KeyEvent e){
-        System.out.println("keyTyped-"+e);
-    }
-
-    private void test(TestState currentState)
-      throws InterruptedException, InvocationTargetException {
-
-        synchronized (LOCK) {
-
             this.currentState = currentState;
             System.out.println(this.currentState);
 
             List list;
-            if (currentState.getMultiple()){
+            if (currentState.getMultiple()) {
                 list = multiple;
-            }else{
+            } else {
                 list = single;
             }
 
-            Robot r;
-            try {
-                r = new Robot();
-            } catch(AWTException e) {
-                throw new RuntimeException(e.getMessage());
-            }
-
             r.delay(10);
-            Point loc = this.getLocationOnScreen();
+            Point loc = keyFrame.getLocationOnScreen();
 
-            r.mouseMove(loc.x+10, loc.y+10);
-            r.mousePress(InputEvent.BUTTON1_MASK);
+            r.mouseMove(loc.x + 10, loc.y + 10);
+            r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             r.delay(10);
-            r.mouseRelease(InputEvent.BUTTON1_MASK);
+            r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             r.delay(10);
 
             list.requestFocusInWindow();
             LOCK.wait(ACTION_TIMEOUT);
+            r.waitForIdle();
+
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != list){
                 throw new RuntimeException("Test failed - list isn't focus owner.");
             }
 
-            list.deselect(0);
-            list.deselect(1);
-            list.deselect(2);
-            list.deselect(3);
-            list.deselect(4);
-            list.deselect(5);
-            list.deselect(6);
-            list.deselect(7);
-            list.deselect(8);
+            EventQueue.invokeAndWait(() -> {
+                list.deselect(0);
+                list.deselect(1);
+                list.deselect(2);
+                list.deselect(3);
+                list.deselect(4);
+                list.deselect(5);
+                list.deselect(6);
+                list.deselect(7);
+                list.deselect(8);
 
-            int selectIndex = 0;
-            int visibleIndex = 0;
+                int selectIndex = 0;
+                int visibleIndex = 0;
 
-            if (currentState.getScrollMoved()){
-
-                if (currentState.getKeyID() == KeyEvent.VK_PAGE_UP ||
-                    currentState.getKeyID() == KeyEvent.VK_HOME){
-                    selectIndex = 8;
-                    visibleIndex = 8;
-                }else if (currentState.getKeyID() == KeyEvent.VK_PAGE_DOWN ||
-                    currentState.getKeyID() == KeyEvent.VK_END){
-                    selectIndex = 0;
-                    visibleIndex = 0;
-                }
-
-            }else{
-
-                if (currentState.getKeyID() == KeyEvent.VK_PAGE_UP ||
-                    currentState.getKeyID() == KeyEvent.VK_HOME){
-
-                    if (currentState.getSelectedMoved()){
-                        selectIndex = 1;
-                        visibleIndex = 0;
-                    }else{
+                if (currentState.getScrollMoved()) {
+                    if (currentState.getKeyID() == KeyEvent.VK_PAGE_UP ||
+                            currentState.getKeyID() == KeyEvent.VK_HOME) {
+                        selectIndex = 8;
+                        visibleIndex = 8;
+                    } else if (currentState.getKeyID() == KeyEvent.VK_PAGE_DOWN ||
+                            currentState.getKeyID() == KeyEvent.VK_END) {
                         selectIndex = 0;
                         visibleIndex = 0;
                     }
-
-                }else if (currentState.getKeyID() == KeyEvent.VK_PAGE_DOWN ||
-                    currentState.getKeyID() == KeyEvent.VK_END){
-
-                    if (currentState.getSelectedMoved()){
-                        selectIndex = 7;
-                        visibleIndex = 8;
-                    }else{
-                        selectIndex = 8;
+                } else {
+                    if (currentState.getKeyID() == KeyEvent.VK_PAGE_UP ||
+                            currentState.getKeyID() == KeyEvent.VK_HOME) {
+                        if (currentState.getSelectedMoved()) {
+                            selectIndex = 1;
+                        } else {
+                            selectIndex = 0;
+                        }
+                        visibleIndex = 0;
+                    } else if (currentState.getKeyID() == KeyEvent.VK_PAGE_DOWN ||
+                            currentState.getKeyID() == KeyEvent.VK_END) {
+                        if (currentState.getSelectedMoved()) {
+                            selectIndex = 7;
+                        } else {
+                            selectIndex = 8;
+                        }
                         visibleIndex = 8;
                     }
-
                 }
-
-            }
-
-            list.select(selectIndex);
-            list.makeVisible(visibleIndex);
+                list.select(selectIndex);
+                list.makeVisible(visibleIndex);
+            });
 
             r.delay(10);
+            r.waitForIdle();
 
             if (currentState.getKeyID() == KeyEvent.VK_HOME ||
                 currentState.getKeyID() == KeyEvent.VK_END){
@@ -259,11 +257,9 @@ public class KeyEventsTest extends Frame implements ItemListener, FocusListener,
                 throw new RuntimeException("Test failed.");
 
         }
-
     }
 
-    private void doTest()
-      throws InterruptedException, InvocationTargetException {
+    private void doTest() throws Exception {
 
         boolean isWin = false;
         if (Platform.isWindows()) {
@@ -310,9 +306,9 @@ public class KeyEventsTest extends Frame implements ItemListener, FocusListener,
     }
 }// class KeyEventsTest
 
-class TestState{
+class TestState {
 
-    private boolean multiple;
+    private final boolean multiple;
     // after key pressing selected item moved
     private final boolean selectedMoved;
     // after key pressing scroll moved

--- a/test/jdk/java/awt/MenuBar/SeparatorsNavigation/SeparatorsNavigation.java
+++ b/test/jdk/java/awt/MenuBar/SeparatorsNavigation/SeparatorsNavigation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import java.awt.Robot;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /*
  * @test
@@ -51,6 +53,7 @@ public class SeparatorsNavigation {
     static class Listener implements ActionListener {
         public void actionPerformed(ActionEvent e) {
             SeparatorsNavigation.pressed = true;
+            latch.countDown();
         }
     }
 
@@ -61,7 +64,8 @@ public class SeparatorsNavigation {
     static Menu m3;
     static MenuItem i31;
     static Listener l = new Listener();
-    static boolean pressed = false;
+    static volatile boolean pressed = false;
+    static final CountDownLatch latch = new CountDownLatch(1);
 
     public static void main(String args[]) {
         f = new Frame();
@@ -83,27 +87,23 @@ public class SeparatorsNavigation {
         f.setVisible(true);
         try {
             Robot r = new Robot();
+            r.setAutoDelay(20);
             r.delay(1000);
             r.keyPress(KeyEvent.VK_F10);
-            r.delay(10);
             r.keyRelease(KeyEvent.VK_F10);
             r.delay(1000);
             r.keyPress(KeyEvent.VK_DOWN);
-            r.delay(10);
             r.keyRelease(KeyEvent.VK_DOWN);
             r.delay(1000);
             r.keyPress(KeyEvent.VK_RIGHT);
-            r.delay(10);
             r.keyRelease(KeyEvent.VK_RIGHT);
             r.delay(1000);
             r.keyPress(KeyEvent.VK_RIGHT);
-            r.delay(10);
             r.keyRelease(KeyEvent.VK_RIGHT);
             r.delay(1000);
             r.keyPress(KeyEvent.VK_ENTER);
-            r.delay(10);
             r.keyRelease(KeyEvent.VK_ENTER);
-            r.delay(10000);
+            latch.await(5, TimeUnit.SECONDS);
         } catch (Exception ex) {
             throw new RuntimeException("Execution interrupted by an " +
                     "exception " + ex.getLocalizedMessage());

--- a/test/jdk/java/awt/Paint/ListRepaint.java
+++ b/test/jdk/java/awt/Paint/ListRepaint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,22 +34,23 @@ import java.awt.List;
  */
 public final class ListRepaint extends List {
 
-    public static void main(final String[] args) {
+    static ListRepaint listRepaint;
+    static Frame frame;
+
+    public static void main(final String[] args) throws Exception {
         for (int i = 0; i < 10; ++i) {
-            final Frame frame = new Frame();
-            frame.setSize(300, 300);
-            frame.setLocationRelativeTo(null);
-            ListRepaint list = new ListRepaint();
-            list.add("1");
-            list.add("2");
-            list.add("3");
-            list.add("4");
-            list.select(0);
-            frame.add(list);
-            frame.setVisible(true);
-            sleep();
-            list.test();
-            frame.dispose();
+            try {
+                EventQueue.invokeLater(ListRepaint::createAndShowGUI);
+                sleep();
+                EventQueue.invokeAndWait(listRepaint::test);
+            } finally {
+                EventQueue.invokeAndWait(() -> {
+                    if (frame != null) {
+                        frame.dispose();
+                        frame = null;
+                    }
+                });
+            }
         }
     }
 
@@ -58,6 +59,22 @@ public final class ListRepaint extends List {
             Thread.sleep(2000);
         } catch (InterruptedException ignored) {
         }
+    }
+
+    static void createAndShowGUI() {
+        frame = new Frame();
+        frame.setSize(300, 300);
+        frame.setLocationRelativeTo(null);
+
+        listRepaint = new ListRepaint();
+        listRepaint.add("1");
+        listRepaint.add("2");
+        listRepaint.add("3");
+        listRepaint.add("4");
+        listRepaint.select(0);
+
+        frame.add(listRepaint);
+        frame.setVisible(true);
     }
 
     @Override

--- a/test/jdk/java/awt/Robot/ModifierRobotKey/ModifierRobotKeyTest.java
+++ b/test/jdk/java/awt/Robot/ModifierRobotKey/ModifierRobotKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class ModifierRobotKeyTest extends KeyAdapter {
 
     public ModifierRobotKeyTest() throws Exception {
         String os = System.getProperty("os.name").toLowerCase();
-        if (os.contains("os x")) {
+        if (os.contains("os x") || os.contains("linux")) {
             modifierKeys =  new int[3];
             modifierKeys[0] = KeyEvent.VK_SHIFT;
             modifierKeys[1] = KeyEvent.VK_CONTROL;

--- a/test/jdk/java/awt/TextArea/TextAreaCaretVisibilityTest/bug7129742.java
+++ b/test/jdk/java/awt/TextArea/TextAreaCaretVisibilityTest/bug7129742.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,7 @@ public class bug7129742 {
             }
         });
         robot.waitForIdle();
+        robot.delay(500);
 
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override

--- a/test/jdk/java/awt/Toolkit/DesktopProperties/rfe4758438.sh
+++ b/test/jdk/java/awt/Toolkit/DesktopProperties/rfe4758438.sh
@@ -28,20 +28,6 @@ OS=`uname`
 
 case "$OS" in
     Linux* )
-        GNOMESID=`pgrep gnome-session | head -n1`
-
-        printf "\n/* gnome-session environ\n"
-        cat "/proc/$GNOMESID/environ" | tr '\0' '\n'
-        printf "\n*/\n\n"
-
-        DBUS_SESSION_BUS_ADDRESS=`grep -z DBUS_SESSION_BUS_ADDRESS /proc/$GNOMESID/environ | cut -d= -f2-`
-        export DBUS_SESSION_BUS_ADDRESS
-
-        DISPLAY=`grep -z DISPLAY /proc/$GNOMESID/environ | cut -d= -f2-`
-        export DISPLAY
-
-        XDG_CURRENT_DESKTOP=`grep -z XDG_CURRENT_DESKTOP /proc/$GNOMESID/environ | cut -d= -f2-`
-        export XDG_CURRENT_DESKTOP
         ;;
     * )
         echo "This Feature is not to be tested on $OS"

--- a/test/jdk/java/awt/TrayIcon/ActionEventTest/ActionEventTest.java
+++ b/test/jdk/java/awt/TrayIcon/ActionEventTest/ActionEventTest.java
@@ -79,7 +79,10 @@ public class ActionEventTest {
 
     public ActionEventTest() throws Exception {
         robot = new Robot();
+        robot.setAutoDelay(25);
         EventQueue.invokeAndWait(this::initializeGUI);
+        robot.waitForIdle();
+        robot.delay(500);
     }
 
     private void initializeGUI() {
@@ -117,10 +120,6 @@ public class ActionEventTest {
     }
 
     void doTest() throws Exception {
-        robot.keyPress(KeyEvent.VK_ALT);
-        robot.keyPress(KeyEvent.VK_SHIFT);
-        robot.keyPress(KeyEvent.VK_CONTROL);
-
         Point iconPosition = SystemTrayIconHelper.getTrayIconLocation(icon);
         if (iconPosition == null) {
             throw new RuntimeException("Unable to find the icon location!");
@@ -128,6 +127,10 @@ public class ActionEventTest {
 
         robot.mouseMove(iconPosition.x, iconPosition.y);
         robot.waitForIdle();
+
+        robot.keyPress(KeyEvent.VK_ALT);
+        robot.keyPress(KeyEvent.VK_SHIFT);
+        robot.keyPress(KeyEvent.VK_CONTROL);
 
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);

--- a/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class TrayIconPopupTest {
 
     boolean actionPerformed = false;
     Object actionLock = new Object();
-    static final int ATTEMPTS = 50;
+    static final int ATTEMPTS = 10;
 
     PopupMenu popup;
     Dialog window;

--- a/test/jdk/java/awt/Window/SetWindowLocationByPlatformTest/SetWindowLocationByPlatformTest.java
+++ b/test/jdk/java/awt/Window/SetWindowLocationByPlatformTest/SetWindowLocationByPlatformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ public class SetWindowLocationByPlatformTest {
         frame2.setLocationByPlatform(true);
         frame2.setVisible(true);
         Util.waitForIdle(r);
+        r.delay(500);
 
         Point point1 = frame1.getLocationOnScreen();
         Point point2 = frame2.getLocationOnScreen();

--- a/test/jdk/javax/swing/JButton/PressedButtonRightClickTest.java
+++ b/test/jdk/javax/swing/JButton/PressedButtonRightClickTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,12 @@
 
 import java.awt.AWTException;
 import java.awt.BorderLayout;
+import java.awt.EventQueue;
 import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -46,13 +49,7 @@ public class PressedButtonRightClickTest {
 
     public static void main(String[] args) throws Throwable {
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-
-            @Override
-            public void run() {
-                constructTestUI();
-            }
-        });
+        SwingUtilities.invokeAndWait(PressedButtonRightClickTest::constructTestUI);
 
         try {
             testRobot = new Robot();
@@ -61,11 +58,14 @@ public class PressedButtonRightClickTest {
         }
 
         testRobot.waitForIdle();
+        testRobot.delay(500);
 
         // Method performing auto test operation
-        test();
-
-        disposeTestUI();
+        try {
+            test();
+        } finally {
+            EventQueue.invokeAndWait(PressedButtonRightClickTest::disposeTestUI);
+        }
     }
 
     private static void test() {
@@ -74,22 +74,27 @@ public class PressedButtonRightClickTest {
         testRobot.mouseMove((loc.x + 100), (loc.y + 100));
 
         // Press the left mouse button
+        System.out.println("press BUTTON1_DOWN_MASK");
         testRobot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         myButton.setText("Left button pressed");
-        testRobot.delay(1000);
+        testRobot.delay(500);
 
         // Press the right mouse button
+        System.out.println("press BUTTON3_DOWN_MASK");
         testRobot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
         myButton.setText("Left button pressed + Right button pressed");
-        testRobot.delay(1000);
+        testRobot.delay(500);
 
         // Release the right mouse button
+        System.out.println("release BUTTON3_DOWN_MASK");
         testRobot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
         myButton.setText("Right button released");
-        testRobot.delay(1000);
+        testRobot.waitForIdle();
+        testRobot.delay(500);
 
         // Test whether the button is still pressed
         boolean pressed = myButton.getModel().isPressed();
+        System.out.println("release BUTTON1_DOWN_MASK");
         testRobot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         if (!pressed) {
             disposeTestUI();
@@ -106,6 +111,32 @@ public class PressedButtonRightClickTest {
         myFrame = new JFrame();
         myFrame.setLayout(new BorderLayout());
         myButton = new JButton("Whatever");
+        myButton.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                System.out.println(e);
+            }
+
+            @Override
+            public void mousePressed(MouseEvent e) {
+                System.out.println(e);
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                System.out.println(e);
+            }
+
+            @Override
+            public void mouseEntered(MouseEvent e) {
+                System.out.println(e);
+            }
+
+            @Override
+            public void mouseExited(MouseEvent e) {
+                System.out.println(e);
+            }
+        });
         myFrame.add(myButton, BorderLayout.CENTER);
         myFrame.setSize(400, 300);
         myFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);

--- a/test/jdk/javax/swing/JButton/bug4490179.java
+++ b/test/jdk/javax/swing/JButton/bug4490179.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,6 @@
 
 import java.awt.Point;
 import java.awt.Robot;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -49,13 +47,16 @@ public class bug4490179 {
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
         robot.setAutoDelay(100);
+        robot.setAutoWaitForIdle(true);
         try {
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame("bug4490179");
                 button = new JButton("Button");
                 frame.getContentPane().add(button);
-                button.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
+                button.addActionListener(e -> {
+                    if ((e.getModifiers() & InputEvent.BUTTON1_MASK)
+                            != InputEvent.BUTTON1_MASK) {
+                        System.out.println("Status: Failed");
                         passed = false;
                     }
                 });
@@ -80,6 +81,8 @@ public class bug4490179 {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(500);
 
             if (!passed) {
                 throw new RuntimeException("Test Failed");

--- a/test/jdk/javax/swing/JLabel/4138746/JLabelMnemonicsTest.java
+++ b/test/jdk/javax/swing/JLabel/4138746/JLabelMnemonicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,6 +90,7 @@ public class JLabelMnemonicsTest {
                     continue;
                 }
                 robot.waitForIdle();
+                robot.delay(500);
 
                 // Verifier 1: Verifies if getDisplayedMnemonicIndex() returns the
                 // right index set with setDisplayedMnemonicIndex method for JButton

--- a/test/jdk/javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,6 +90,7 @@ public final class JComboBoxPopupLocation {
                             setup(point);
                         });
                         robot.waitForIdle();
+                        robot.delay(500);
                         test(comboBox);
                         robot.waitForIdle();
                         validate(comboBox);
@@ -110,6 +111,7 @@ public final class JComboBoxPopupLocation {
                     setup(finalLeft);
                 });
                 robot.waitForIdle();
+                robot.delay(500);
                 test(comboBox);
                 robot.waitForIdle();
                 validate(comboBox);

--- a/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import java.awt.event.KeyEvent;
 
 public class bug4983388 {
     static volatile boolean bMenuSelected = false;
+    static JFrame frame;
 
     private static class TestMenuListener implements MenuListener {
         public void menuCanceled(MenuEvent e) {}
@@ -55,8 +56,9 @@ public class bug4983388 {
         JMenu menu = new JMenu("File");
         menu.setMnemonic('F');
         menuBar.add(menu);
-        JFrame frame = new JFrame();
+        frame = new JFrame();
         frame.setJMenuBar(menuBar);
+        frame.setLocationRelativeTo(null);
         frame.pack();
         frame.setVisible(true);
         MenuListener listener = new TestMenuListener();
@@ -80,9 +82,13 @@ public class bug4983388 {
         Robot robot = new Robot();
         robot.setAutoDelay(50);
         robot.waitForIdle();
+        robot.delay(500);
+
         Util.hitMnemonics(robot, KeyEvent.VK_F);
         robot.waitForIdle();
-        robot.delay(200);
+        robot.delay(500);
+
+        SwingUtilities.invokeAndWait(() -> frame.dispose());
 
         if (!bMenuSelected) {
             throw new RuntimeException("shortcuts on menus do not work");


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327401](https://bugs.openjdk.org/browse/JDK-8327401) needs maintainer approval
- [x] [JDK-8312111](https://bugs.openjdk.org/browse/JDK-8312111) needs maintainer approval

### Issues
 * [JDK-8327401](https://bugs.openjdk.org/browse/JDK-8327401): Some jtreg tests fail on Wayland without any tracking bug (**Bug** - P4 - Approved)
 * [JDK-8312111](https://bugs.openjdk.org/browse/JDK-8312111): open/test/jdk/java/awt/Robot/ModifierRobotKey/ModifierRobotKeyTest.java fails on ubuntu 23.04 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/809/head:pull/809` \
`$ git checkout pull/809`

Update a local copy of the PR: \
`$ git checkout pull/809` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 809`

View PR using the GUI difftool: \
`$ git pr show -t 809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/809.diff">https://git.openjdk.org/jdk21u-dev/pull/809.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/809#issuecomment-2202380176)