### PR TITLE
8333270: HandlersOnComplexResetUpdate and HandlersOnComplexUpdate tests fail with "Unexpected reference" if timeoutFactor is less than 1/3

### DIFF
--- a/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexResetUpdate.java
+++ b/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexResetUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class HandlersOnComplexResetUpdate {
         TIMEOUT_FACTOR = Double.parseDouble(toFactor);
     }
     static int adjustCount(int count) {
-        return (int) Math.ceil(TIMEOUT_FACTOR * count);
+        return Math.min(count, (int) Math.ceil(TIMEOUT_FACTOR * count));
     }
 
     private static final String PREFIX =
@@ -211,21 +211,20 @@ public class HandlersOnComplexResetUpdate {
 
         ReferenceQueue<Logger> queue = new ReferenceQueue();
         WeakReference<Logger> fooRef = new WeakReference<>(Logger.getLogger("com.foo"), queue);
-        if (fooRef.get() != fooChild.getParent()) {
+        if (!fooRef.refersTo(fooChild.getParent())) {
             throw new RuntimeException("Unexpected parent logger: "
                     + fooChild.getParent() +"\n\texpected: " + fooRef.get());
         }
         WeakReference<Logger> barRef = new WeakReference<>(Logger.getLogger("com.bar"), queue);
-        if (barRef.get() != barChild.getParent()) {
+        if (!barRef.refersTo(barChild.getParent())) {
             throw new RuntimeException("Unexpected parent logger: "
                     + barChild.getParent() +"\n\texpected: " + barRef.get());
         }
         Reference<? extends Logger> ref2;
-        int max = adjustCount(3);
+        int max = adjustCount(6);
         barChild = null;
-        while ((ref2 = queue.poll()) == null) {
+        while ((ref2 = queue.remove(500)) == null) {
             System.gc();
-            Thread.sleep(1000);
             if (--max == 0) break;
         }
 
@@ -347,7 +346,7 @@ public class HandlersOnComplexResetUpdate {
                     throw new RuntimeException("Unexpected reference: "
                             + ref2 +"\n\texpected: " + fooRef);
                 }
-                if (ref2.get() != null) {
+                if (!ref2.refersTo(null)) {
                     throw new RuntimeException("Referent not cleared: " + ref2.get());
                 }
                 System.out.println("Got fooRef after reset(), fooChild is " + fooChild);

--- a/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexUpdate.java
+++ b/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class HandlersOnComplexUpdate {
         TIMEOUT_FACTOR = Double.parseDouble(toFactor);
     }
     static int adjustCount(int count) {
-        return (int) Math.ceil(TIMEOUT_FACTOR * count);
+        return Math.min(count, (int) Math.ceil(TIMEOUT_FACTOR * count));
     }
 
     private static final String PREFIX =
@@ -211,21 +211,20 @@ public class HandlersOnComplexUpdate {
 
         ReferenceQueue<Logger> queue = new ReferenceQueue();
         WeakReference<Logger> fooRef = new WeakReference<>(Logger.getLogger("com.foo"), queue);
-        if (fooRef.get() != fooChild.getParent()) {
+        if (!fooRef.refersTo(fooChild.getParent())) {
             throw new RuntimeException("Unexpected parent logger: "
                     + fooChild.getParent() +"\n\texpected: " + fooRef.get());
         }
         WeakReference<Logger> barRef = new WeakReference<>(Logger.getLogger("com.bar"), queue);
-        if (barRef.get() != barChild.getParent()) {
+        if (!barRef.refersTo(barChild.getParent())) {
             throw new RuntimeException("Unexpected parent logger: "
                     + barChild.getParent() +"\n\texpected: " + barRef.get());
         }
         Reference<? extends Logger> ref2;
-        int max = adjustCount(3);
+        int max = adjustCount(6);
         barChild = null;
-        while ((ref2 = queue.poll()) == null) {
+        while ((ref2 = queue.remove(500)) == null) {
             System.gc();
-            Thread.sleep(1000);
             if (--max == 0) break;
         }
 
@@ -335,7 +334,7 @@ public class HandlersOnComplexUpdate {
                     throw new RuntimeException("Unexpected reference: "
                             + ref2 +"\n\texpected: " + fooRef);
                 }
-                if (ref2.get() != null) {
+                if (!ref2.refersTo(null)) {
                     throw new RuntimeException("Referent not cleared: " + ref2.get());
                 }
                 System.out.println("Got fooRef after reset(), fooChild is " + fooChild);


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333270](https://bugs.openjdk.org/browse/JDK-8333270) needs maintainer approval

### Issue
 * [JDK-8333270](https://bugs.openjdk.org/browse/JDK-8333270): HandlersOnComplexResetUpdate and HandlersOnComplexUpdate tests fail with "Unexpected reference" if timeoutFactor is less than 1/3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/811/head:pull/811` \
`$ git checkout pull/811`

Update a local copy of the PR: \
`$ git checkout pull/811` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 811`

View PR using the GUI difftool: \
`$ git pr show -t 811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/811.diff">https://git.openjdk.org/jdk21u-dev/pull/811.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/811#issuecomment-2202613591)