### PR TITLE
8320675: PrinterJob/SecurityDialogTest.java hangs

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/SecurityDialogTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/SecurityDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,210 +21,110 @@
  * questions.
  */
 
-/**
+import java.awt.Frame;
+import java.awt.print.PageFormat;
+import java.awt.print.PrinterJob;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.print.PrintService;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+
+/*
  * @test
  * @bug 4937672 5100706 6252456
  * @key printer
- * @run main/othervm/manual -Djava.security.manager=allow SecurityDialogTest
+ * @summary Verifies "Print to file" option is disable if reading/writing files
+ *          is not allowed by Security Manager.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual/othervm -Djava.security.manager=allow SecurityDialogTest
  */
-
-import java.awt.* ;
-import java.awt.print.* ;
-import java.io.*;
-import java.security.*;
-import javax.print.*;
-import javax.print.attribute.*;
-
 public class SecurityDialogTest {
+    private static final String INSTRUCTIONS =
+            "This test brings up a native and cross-platform page and print dialogs.\n" +
+            "\n" +
+            "If the dialog has an option to save to file, the option ought " +
+            "to be disabled.\n" +
+            "\n" +
+            "Press the Pass button if the \"Print to file\" option was disabled in\n" +
+            "all the dialogs where it was present.\n" +
+            "Otherwise, press the Fail button.\n" +
+            "\n" +
+            "The dialogs should be displayed even when " +
+            "there is no queuePrintJob permission.";
 
+    private static JLabel dialogType;
 
-    public static void main ( String args[] ) {
-
-        String[] instructions =
-           {
-            "You must have a printer available to perform this test.",
-            "This test brings up a native and cross-platform page and",
-            "print dialogs.",
-            "The dialogs should be displayed even when ",
-            "there is no queuePrintJob permission.",
-            "If the dialog has an option to save to file, the option ought",
-            "to be disabled if there is no read/write file permission.",
-            "You should test this by trying different policy files."
-          };
-
-         Sysout.createDialog( );
-         Sysout.printInstructions( instructions );
-
-        SecurityDialogTest pjc = new SecurityDialogTest() ;
-    }
-
-
-  public SecurityDialogTest() {
-
-      PrinterJob pj = PrinterJob.getPrinterJob() ;
-
-      // Install a security manager which does not allow reading and
-      // writing of files.
-      //PrintTestSecurityManager ptsm = new PrintTestSecurityManager();
-      SecurityManager ptsm = new SecurityManager();
-
-      try {
-          System.setSecurityManager(ptsm);
-      } catch (SecurityException e) {
-          System.out.println("Could not run test - security exception");
-      }
-
-      try {
-          PrintJob pjob = Toolkit.getDefaultToolkit().getPrintJob(new Frame(), "Printing", null, null);
-          Sysout.println("If the value of pjob is null, the test fails.\n");
-          Sysout.println("        pjob = "+pjob);
-      } catch (SecurityException e) {
-      }
-
-      PrintService[] services = PrinterJob.lookupPrintServices();
-      for (int i=0; i<services.length; i++) {
-          System.out.println("SecurityDialogTest service "+i+" : "+services[i]);
-      }
-
-      PrintService defservice = pj.getPrintService();
-      System.out.println("SecurityDialogTest default service : "+defservice);
-
-      System.out.println("SecurityDialogTest native PageDialog ");
-      PageFormat pf1 = pj.pageDialog(new PageFormat());
-
-      System.out.println("SecurityDialogTest swing PageDialog ");
-      PrintRequestAttributeSet attributes = new HashPrintRequestAttributeSet();
-      PageFormat pf2 = pj.pageDialog(attributes);
-
-      // With the security manager installed, save to file should now
-      // be denied.
-      System.out.println("SecurityDialogTest native printDialog ");
-      pj.printDialog();
-
-      System.out.println("SecurityDialogTest swing printDialog ");
-      pj.printDialog(attributes);
-  }
-
-
-    class PrintTestSecurityManager extends SecurityManager {
-        public void checkPackageAccess(String pkg) {
-        }
-        public void checkPropertyAccess(String key) {
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
         }
 
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .splitUIBottom(SecurityDialogTest::createTestUI)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
+
+        displayDialogs();
+
+        passFailJFrame.awaitAndCheck();
     }
 
+    private static JComponent createTestUI() {
+        dialogType = new JLabel(" ");
+
+        Box main = Box.createVerticalBox();
+        main.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        main.add(new JLabel("Current Dialog:"));
+        main.add(Box.createVerticalStrut(4));
+        main.add(dialogType);
+        return main;
+    }
+
+    private static void displayDialogs()
+            throws InterruptedException, InvocationTargetException {
+        final PrinterJob pj = PrinterJob.getPrinterJob();
+
+        // Install a security manager which does not allow reading and
+        // writing of files.
+        SecurityManager ptsm = new SecurityManager();
+        System.setSecurityManager(ptsm);
+
+        PrintService[] services = PrinterJob.lookupPrintServices();
+        for (int i = 0; i < services.length; i++) {
+            System.out.println("SecurityDialogTest service " + i + " : " + services[i]);
+        }
+
+        System.out.println("SecurityDialogTest default service : " + pj.getPrintService());
+
+        setDialogType("Native Page Dialog");
+        pj.pageDialog(new PageFormat());
+
+        setDialogType("Swing Page Dialog");
+        PrintRequestAttributeSet attributes = new HashPrintRequestAttributeSet();
+        pj.pageDialog(attributes);
+
+        // With the security manager installed, save to file should now
+        // be denied.
+        setDialogType("Native Print Dialog");
+        pj.printDialog();
+
+        setDialogType("Swing Print Dialog");
+        pj.printDialog(attributes);
+
+        setDialogType("Test completed");
+    }
+
+    private static void setDialogType(String type)
+            throws InterruptedException, InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> dialogType.setText(type));
+    }
 }
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320675](https://bugs.openjdk.org/browse/JDK-8320675) needs maintainer approval

### Issue
 * [JDK-8320675](https://bugs.openjdk.org/browse/JDK-8320675): PrinterJob/SecurityDialogTest.java hangs (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/813/head:pull/813` \
`$ git checkout pull/813`

Update a local copy of the PR: \
`$ git checkout pull/813` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 813`

View PR using the GUI difftool: \
`$ git pr show -t 813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/813.diff">https://git.openjdk.org/jdk21u-dev/pull/813.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/813#issuecomment-2202654190)