### PR TITLE
8211854: [aix] java/net/ServerSocket/AcceptInheritHandle.java fails: read times out

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -548,8 +548,6 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
-java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
-
 java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc64
 
 ############################################################################


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8211854](https://bugs.openjdk.org/browse/JDK-8211854), commit [cb3c45a6](https://github.com/openjdk/jdk/commit/cb3c45a698ccd7f61f707fa3066b9155769f4f73) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 17 Jun 2024 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8211854](https://bugs.openjdk.org/browse/JDK-8211854) needs maintainer approval

### Issue
 * [JDK-8211854](https://bugs.openjdk.org/browse/JDK-8211854): [aix] java/net/ServerSocket/AcceptInheritHandle.java fails: read times out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/814/head:pull/814` \
`$ git checkout pull/814`

Update a local copy of the PR: \
`$ git checkout pull/814` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 814`

View PR using the GUI difftool: \
`$ git pr show -t 814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/814.diff">https://git.openjdk.org/jdk21u-dev/pull/814.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/814#issuecomment-2203005835)