### PR TITLE
8335536: Fix assertion failure in IdealGraphPrinter when append is true

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -143,21 +143,24 @@ void IdealGraphPrinter::init(const char* file_name, bool use_multiple_files, boo
   _depth = 0;
   _current_method = nullptr;
   _network_stream = nullptr;
+  _append = append;
 
   if (file_name != nullptr) {
-    init_file_stream(file_name, use_multiple_files, append);
+    init_file_stream(file_name, use_multiple_files);
   } else {
     init_network_stream();
   }
   _xml = new (mtCompiler) xmlStream(_output);
-  if (!append) {
+  if (!_append) {
     head(TOP_ELEMENT);
   }
 }
 
 // Destructor, close file or network stream
 IdealGraphPrinter::~IdealGraphPrinter() {
-  tail(TOP_ELEMENT);
+  if (!_append) {
+    tail(TOP_ELEMENT);
+  }
 
   // tty->print_cr("Walk time: %d", (int)_walk_time.milliseconds());
   // tty->print_cr("Output time: %d", (int)_output_time.milliseconds());
@@ -830,10 +833,10 @@ void IdealGraphPrinter::print(const char *name, Node *node) {
   _xml->flush();
 }
 
-void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multiple_files, bool append) {
+void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multiple_files) {
   ThreadCritical tc;
   if (use_multiple_files && _file_count != 0) {
-    assert(!append, "append should only be used for debugging with a single file");
+    assert(!_append, "append should only be used for debugging with a single file");
     ResourceMark rm;
     stringStream st;
     const char* dot = strrchr(file_name, '.');
@@ -845,10 +848,10 @@ void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multipl
     }
     _output = new (mtCompiler) fileStream(st.as_string(), "w");
   } else {
-    _output = new (mtCompiler) fileStream(file_name, append ? "a" : "w");
+    _output = new (mtCompiler) fileStream(file_name, _append ? "a" : "w");
   }
   if (use_multiple_files) {
-    assert(!append, "append should only be used for debugging with a single file");
+    assert(!_append, "append should only be used for debugging with a single file");
     _file_count++;
   }
 }
@@ -879,9 +882,16 @@ void IdealGraphPrinter::update_compiled_method(ciMethod* current_method) {
   assert(C != nullptr, "must already be set");
   if (current_method != _current_method) {
     // If a different method, end the old and begin with the new one.
-    end_method();
-    _current_method = nullptr;
-    begin_method();
+    if (_append) {
+      // Do not call `end_method` if we are appending, just update `_current_method`,
+      // because `begin_method` is not called in the constructor in append mode.
+      _current_method = current_method;
+    } else {
+      // End the old method and begin a new one.
+      // Don't worry about `_current_method`, `end_method` will clear it.
+      end_method();
+      begin_method();
+    }
   }
 }
 

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -95,6 +95,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   bool _traverse_outs;
   Compile *C;
   double _max_freq;
+  bool _append;
 
   void print_method(ciMethod *method, int bci, InlineTree *tree);
   void print_inline_tree(InlineTree *tree);
@@ -116,7 +117,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   void head(const char *name);
   void text(const char *s);
   void init(const char* file_name, bool use_multiple_files, bool append);
-  void init_file_stream(const char* file_name, bool use_multiple_files, bool append);
+  void init_file_stream(const char* file_name, bool use_multiple_files);
   void init_network_stream();
   IdealGraphPrinter();
   ~IdealGraphPrinter();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6db4c6a7](https://github.com/openjdk/jdk/commit/6db4c6a772df856fc3099c32a5b2c102a30d360c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Qizheng Xing on 3 Jul 2024 and was reviewed by Tobias Hartmann, Christian Hagedorn and Tobias Holenstein.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8335536](https://bugs.openjdk.org/browse/JDK-8335536) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335536](https://bugs.openjdk.org/browse/JDK-8335536): Fix assertion failure in IdealGraphPrinter when append is true (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/816/head:pull/816` \
`$ git checkout pull/816`

Update a local copy of the PR: \
`$ git checkout pull/816` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 816`

View PR using the GUI difftool: \
`$ git pr show -t 816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/816.diff">https://git.openjdk.org/jdk21u-dev/pull/816.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/816#issuecomment-2207863673)