### PR TITLE
8331518: Tests should not use the "Classpath" exception form of the legal header

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestUninitializedKlassField.java
+++ b/test/hotspot/jtreg/compiler/c2/TestUninitializedKlassField.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
test/hotspot/jtreg/compiler/codegen/TestConvertImplicitNullCheck.java
test/micro/org/openjdk/bench/java/lang/foreign/libToJavaString.c
test/micro/org/openjdk/bench/vm/compiler/MergeStores.java
have not been added, so ignore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331518](https://bugs.openjdk.org/browse/JDK-8331518) needs maintainer approval

### Issue
 * [JDK-8331518](https://bugs.openjdk.org/browse/JDK-8331518): Tests should not use the "Classpath" exception form of the legal header (**Bug** - P5 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/821/head:pull/821` \
`$ git checkout pull/821`

Update a local copy of the PR: \
`$ git checkout pull/821` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 821`

View PR using the GUI difftool: \
`$ git pr show -t 821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/821.diff">https://git.openjdk.org/jdk21u-dev/pull/821.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/821#issuecomment-2208429372)