### PR TITLE
8329559: Test javax/swing/JFrame/bug4419914.java failed because The End and Start buttons are not placed correctly and Tab focus does not move as expected

### DIFF
--- a/test/jdk/javax/swing/JFrame/bug4419914.java
+++ b/test/jdk/javax/swing/JFrame/bug4419914.java
@@ -68,7 +68,7 @@ public class bug4419914 {
         frame.enableInputMethods(false);
 
         frame.getContentPane().setComponentOrientation(
-                ComponentOrientation.RIGHT_TO_LEFT);
+                               ComponentOrientation.RIGHT_TO_LEFT);
         frame.getContentPane().setLocale(Locale.ENGLISH);
         frame.getContentPane().setLayout(new BorderLayout());
         frame.add(new JButton("SOUTH"), BorderLayout.SOUTH);

--- a/test/jdk/javax/swing/JFrame/bug4419914.java
+++ b/test/jdk/javax/swing/JFrame/bug4419914.java
@@ -53,8 +53,8 @@ public class bug4419914 {
         PassFailJFrame.builder()
                 .title("Tab movement Instructions")
                 .instructions(INSTRUCTIONS)
-                .rows(12)
-                .columns(42)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(48)
                 .testUI(bug4419914::createTestUI)
                 .build()
                 .awaitAndCheck();
@@ -65,11 +65,12 @@ public class bug4419914 {
         frame.setFocusCycleRoot(true);
         frame.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
         frame.setLocale(Locale.ENGLISH);
-
         frame.enableInputMethods(false);
-        frame.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
-        frame.setLocale(Locale.ENGLISH);
-        frame.setLayout(new BorderLayout());
+
+        frame.getContentPane().setComponentOrientation(
+                ComponentOrientation.RIGHT_TO_LEFT);
+        frame.getContentPane().setLocale(Locale.ENGLISH);
+        frame.getContentPane().setLayout(new BorderLayout());
         frame.add(new JButton("SOUTH"), BorderLayout.SOUTH);
         frame.add(new JButton("CENTER"), BorderLayout.CENTER);
         frame.add(new JButton("END"), BorderLayout.LINE_END);


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329559](https://bugs.openjdk.org/browse/JDK-8329559) needs maintainer approval

### Issue
 * [JDK-8329559](https://bugs.openjdk.org/browse/JDK-8329559): Test javax/swing/JFrame/bug4419914.java failed because The End and Start buttons are not placed correctly and Tab focus does not move as expected (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/822/head:pull/822` \
`$ git checkout pull/822`

Update a local copy of the PR: \
`$ git checkout pull/822` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 822`

View PR using the GUI difftool: \
`$ git pr show -t 822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/822.diff">https://git.openjdk.org/jdk21u-dev/pull/822.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/822#issuecomment-2208451614)