### PR TITLE
8335775: Remove extraneous 's' in comment of rawmonitor.cpp test file

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp
@@ -1,5 +1,4 @@
 /*
-s
  * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
A trivial backport to fix a typo (an errant 's') in test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp introduced by [JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635). It doesn't apply cleanly as 21u doesn't have  [JDK-8324681](https://bugs.openjdk.org/browse/JDK-8324681) which bumped the copyright header to 2024 (which probably should have been bumped to 2023 in 8299635!)

This was spotted by George Adams (@gdams) when backporting 8299635 to 17u, where it is now needed to support builds on newer versions of Mac OS. It's a trivial fix it makes sense to clean up everywhere.

This pull request contains a backport of commit [ff49f677](https://github.com/openjdk/jdk/commit/ff49f677ee5017019c90823bc412ceb90068ffbd) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Severin Gehwolf on 5 Jul 2024 and was reviewed by George Adams and Thomas Stuefe. Backport to 23 is in progress (https://github.com/openjdk/jdk23u/pull/15)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335775](https://bugs.openjdk.org/browse/JDK-8335775) needs maintainer approval

### Issue
 * [JDK-8335775](https://bugs.openjdk.org/browse/JDK-8335775): Remove extraneous 's' in comment of rawmonitor.cpp test file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/826/head:pull/826` \
`$ git checkout pull/826`

Update a local copy of the PR: \
`$ git checkout pull/826` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 826`

View PR using the GUI difftool: \
`$ git pr show -t 826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/826.diff">https://git.openjdk.org/jdk21u-dev/pull/826.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/826#issuecomment-2211395863)