### PR TITLE
8315505: CompileTask timestamp printed can overflow

### DIFF
--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -221,13 +221,13 @@ void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, i
                              jlong time_queued, jlong time_started) {
   if (!short_form) {
     // Print current time
-    st->print("%7d ", (int)tty->time_stamp().milliseconds());
+    st->print(UINT64_FORMAT " ", (uint64_t) tty->time_stamp().milliseconds());
     if (Verbose && time_queued != 0) {
       // Print time in queue and time being processed by compiler thread
       jlong now = os::elapsed_counter();
-      st->print("%d ", (int)TimeHelper::counter_to_millis(now-time_queued));
+      st->print("%.0f ", TimeHelper::counter_to_millis(now-time_queued));
       if (time_started != 0) {
-        st->print("%d ", (int)TimeHelper::counter_to_millis(now-time_started));
+        st->print("%.0f ", TimeHelper::counter_to_millis(now-time_started));
       }
     }
   }


### PR DESCRIPTION
Backport of [JDK-8315505](https://bugs.openjdk.org/browse/JDK-8315505).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315505](https://bugs.openjdk.org/browse/JDK-8315505) needs maintainer approval

### Issue
 * [JDK-8315505](https://bugs.openjdk.org/browse/JDK-8315505): CompileTask timestamp printed can overflow (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/827/head:pull/827` \
`$ git checkout pull/827`

Update a local copy of the PR: \
`$ git checkout pull/827` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 827`

View PR using the GUI difftool: \
`$ git pr show -t 827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/827.diff">https://git.openjdk.org/jdk21u-dev/pull/827.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/827#issuecomment-2212672160)