### PR TITLE
8334239: Introduce macro for ubsan method/function exclusions

### DIFF
--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -33,6 +33,7 @@
 #include "memory/iterator.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
+#include "sanitizers/ub.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/copy.hpp"
 
@@ -59,9 +60,7 @@ ptrdiff_t ArchiveHeapLoader::_mapped_heap_delta = 0;
 
 // Every mapped region is offset by _mapped_heap_delta from its requested address.
 // See FileMapInfo::heap_region_requested_address().
-#if defined(__clang__) || defined(__GNUC__)
-__attribute__((no_sanitize("undefined")))
-#endif
+ATTRIBUTE_NO_UBSAN
 void ArchiveHeapLoader::init_mapped_heap_relocation(ptrdiff_t delta, int dumptime_oop_shift) {
   assert(!_mapped_heap_relocation_initialized, "only once");
   if (!UseCompressedOops) {

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -55,6 +55,7 @@
 #include "runtime/threadSMR.hpp"
 #include "runtime/vmOperations.hpp"
 #include "runtime/vm_version.hpp"
+#include "sanitizers/ub.hpp"
 #include "services/threadService.hpp"
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
@@ -221,9 +222,7 @@ public:
 
   // we use this method at some places for writing to 0 e.g. to cause a crash;
   // ubsan does not know that this is the desired behavior
-#if defined(__clang__) || defined(__GNUC__)
-__attribute__((no_sanitize("undefined")))
-#endif
+  ATTRIBUTE_NO_UBSAN
   void put(T x) {
     GuardUnsafeAccess guard(_thread);
     *addr() = normalize_for_write(x);

--- a/src/hotspot/share/sanitizers/ub.hpp
+++ b/src/hotspot/share/sanitizers/ub.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_SANITIZERS_UB_HPP
+#define SHARE_SANITIZERS_UB_HPP
+
+// ATTRIBUTE_NO_UBSAN
+//
+// Function attribute which informs the compiler to disable UBSan checks in the
+// following function or method.
+// Useful if the function or method is known to do something special or even 'dangerous', for
+// example causing desired signals/crashes.
+#if defined(__clang__) || defined(__GNUC__)
+#define ATTRIBUTE_NO_UBSAN __attribute__((no_sanitize("undefined")))
+#endif
+
+#ifndef ATTRIBUTE_NO_UBSAN
+#define ATTRIBUTE_NO_UBSAN
+#endif
+
+#endif // SHARE_SANITIZERS_UB_HPP

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -59,6 +59,7 @@
 #include "runtime/vmOperations.hpp"
 #include "runtime/vm_version.hpp"
 #include "services/memTracker.hpp"
+#include "sanitizers/ub.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/decoder.hpp"
 #include "utilities/defaultStream.hpp"
@@ -2062,9 +2063,7 @@ typedef void (*voidfun_t)();
 // compared to one generated with raise (asynchronous vs synchronous). See JDK-8065895.
 volatile int sigfpe_int = 0;
 
-#if defined(__clang__) || defined(__GNUC__)
-__attribute__((no_sanitize("undefined")))
-#endif
+ATTRIBUTE_NO_UBSAN
 static void ALWAYSINLINE crash_with_sigfpe() {
 
   // generate a native synchronous SIGFPE where possible;


### PR DESCRIPTION
hi  @shipilev ,

This pull request contains a backport of commit [ff30240](https://git.openjdk.org/jdk/commit/ff30240926224b2f98e173bcd606c157af788919) from the [master](https://github.com/openjdk/jdk) repository.

The commit being backported was authored by Matthias Baesken on 20 Jun 2024.

Thanks！

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334239](https://bugs.openjdk.org/browse/JDK-8334239) needs maintainer approval

### Issue
 * [JDK-8334239](https://bugs.openjdk.org/browse/JDK-8334239): Introduce macro for ubsan method/function exclusions (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/834/head:pull/834` \
`$ git checkout pull/834`

Update a local copy of the PR: \
`$ git checkout pull/834` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 834`

View PR using the GUI difftool: \
`$ git pr show -t 834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/834.diff">https://git.openjdk.org/jdk21u-dev/pull/834.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/834#issuecomment-2221926782)