### PR TITLE
8326129: Java Record Pattern Match leads to infinite loop

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -908,6 +908,7 @@ public class TransPatterns extends TreeTranslator {
             } else if (currentBinding != null &&
                        commonBinding.type.tsym == currentBinding.type.tsym &&
                        !previousNullable &&
+                       !currentNullable &&
                        new TreeDiffer(List.of(commonBinding), List.of(currentBinding))
                                .scan(commonNestedExpression, currentNestedExpression)) {
                 accummulator.add(c.head);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326129](https://bugs.openjdk.org/browse/JDK-8326129) needs maintainer approval

### Issue
 * [JDK-8326129](https://bugs.openjdk.org/browse/JDK-8326129): Java Record Pattern Match leads to infinite loop (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/835/head:pull/835` \
`$ git checkout pull/835`

Update a local copy of the PR: \
`$ git checkout pull/835` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 835`

View PR using the GUI difftool: \
`$ git pr show -t 835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/835.diff">https://git.openjdk.org/jdk21u-dev/pull/835.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/835#issuecomment-2222270680)