### PR TITLE
8332818: ubsan: archiveHeapLoader.cpp:70:27: runtime error: applying non-zero offset 18446744073707454464 to null pointer

### DIFF
--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -59,6 +59,9 @@ ptrdiff_t ArchiveHeapLoader::_mapped_heap_delta = 0;
 
 // Every mapped region is offset by _mapped_heap_delta from its requested address.
 // See FileMapInfo::heap_region_requested_address().
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
 void ArchiveHeapLoader::init_mapped_heap_relocation(ptrdiff_t delta, int dumptime_oop_shift) {
   assert(!_mapped_heap_relocation_initialized, "only once");
   if (!UseCompressedOops) {


### PR DESCRIPTION
Hi @shipilev ,

This pull request contains a backport of commit [6861766b](https://git.openjdk.org/jdk/commit/6861766b638c5135ba40f261d78d9731954ce5ab) from the [master](https://github.com/openjdk/jdk) repository.

The commit being backported was authored by Matthias Baesken on 14 Jun 2024.

Thanks！

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332818](https://bugs.openjdk.org/browse/JDK-8332818) needs maintainer approval

### Issue
 * [JDK-8332818](https://bugs.openjdk.org/browse/JDK-8332818): ubsan: archiveHeapLoader.cpp:70:27: runtime error: applying non-zero offset 18446744073707454464 to null pointer (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/836/head:pull/836` \
`$ git checkout pull/836`

Update a local copy of the PR: \
`$ git checkout pull/836` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 836`

View PR using the GUI difftool: \
`$ git pr show -t 836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/836.diff">https://git.openjdk.org/jdk21u-dev/pull/836.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/836#issuecomment-2224252901)