### PR TITLE
8332424: Update IANA Language Subtag Registry to Version 2024-05-16

### DIFF
--- a/src/java.base/share/data/lsrdata/language-subtag-registry.txt
+++ b/src/java.base/share/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2024-03-07
+File-Date: 2024-05-16
 %%
 Type: language
 Subtag: aa
@@ -9402,6 +9402,7 @@ Macrolanguage: doi
 %%
 Type: language
 Subtag: dgr
+Description: Tlicho
 Description: Dogrib
 Description: Tłı̨chǫ
 Added: 2005-10-16
@@ -15253,6 +15254,11 @@ Type: language
 Subtag: isu
 Description: Isu (Menchum Division)
 Added: 2009-07-29
+%%
+Type: language
+Subtag: isv
+Description: Interslavic
+Added: 2024-05-15
 %%
 Type: language
 Subtag: itb

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8025703 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702 8318322
- *      8327631
+ *      8327631 8332424
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2024-03-07) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2024-05-16) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332424](https://bugs.openjdk.org/browse/JDK-8332424) needs maintainer approval

### Issue
 * [JDK-8332424](https://bugs.openjdk.org/browse/JDK-8332424): Update IANA Language Subtag Registry to Version 2024-05-16 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/838/head:pull/838` \
`$ git checkout pull/838`

Update a local copy of the PR: \
`$ git checkout pull/838` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 838`

View PR using the GUI difftool: \
`$ git pr show -t 838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/838.diff">https://git.openjdk.org/jdk21u-dev/pull/838.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/838#issuecomment-2224993357)