### PR TITLE
8331405: Shenandoah: Optimize ShenandoahLock with TTAS

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -54,7 +54,8 @@ template<typename BlockOp>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
   int ctr = 0;
   int yields = 0;
-  while (Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
+  while (Atomic::load(&_state) == locked ||
+         Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
     if ((++ctr & 0xFFF) == 0) {
       BlockOp block(java_thread);
       if (yields > 5) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c4fe5bf9](https://github.com/openjdk/jdk/commit/c4fe5bf90c2d368c29714de63a90eca444fb3ece) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository, is is preparation of next backport for https://bugs.openjdk.org/browse/JDK-8331411.

The commit being backported was authored by Aleksey Shipilev on 2 May 2024 and was reviewed by Zhengyu Gu and Y. Srinivas Ramakrishna.


Additional tests:
- [x] `make clean test CONF=macosx-aarch64-server-fastdebug TEST=hotspot_gc_shenandoah`:
```
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg:hotspot_gc_shenandoah      261   261     0     0   
==============================
TEST SUCCESS

```

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405) needs maintainer approval

### Issue
 * [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405): Shenandoah: Optimize ShenandoahLock with TTAS (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/842/head:pull/842` \
`$ git checkout pull/842`

Update a local copy of the PR: \
`$ git checkout pull/842` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 842`

View PR using the GUI difftool: \
`$ git pr show -t 842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/842.diff">https://git.openjdk.org/jdk21u-dev/pull/842.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/842#issuecomment-2229755266)