### PR TITLE
8331411: Shenandoah: Reconsider spinning duration in ShenandoahLock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -32,40 +32,49 @@
 #include "runtime/javaThread.hpp"
 #include "runtime/os.inline.hpp"
 
-// These are inline variants of Thread::SpinAcquire with optional blocking in VM.
-
-class ShenandoahNoBlockOp : public StackObj {
-public:
-  ShenandoahNoBlockOp(JavaThread* java_thread) {
-    assert(java_thread == nullptr, "Should not pass anything");
-  }
-};
-
 void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
   Thread* thread = Thread::current();
   if (allow_block_for_safepoint && thread->is_Java_thread()) {
-    contended_lock_internal<ThreadBlockInVM>(JavaThread::cast(thread));
+    contended_lock_internal<true>(JavaThread::cast(thread));
   } else {
-    contended_lock_internal<ShenandoahNoBlockOp>(nullptr);
+    contended_lock_internal<false>(nullptr);
   }
 }
 
-template<typename BlockOp>
+template<bool ALLOW_BLOCK>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
-  int ctr = 0;
-  int yields = 0;
+  assert(!ALLOW_BLOCK || java_thread != nullptr, "Must have a Java thread when allowing block.");
+  // Spin this much on multi-processor, do not spin on multi-processor.
+  int ctr = os::is_MP() ? 0xFF : 0;
+  // Apply TTAS to avoid more expensive CAS calls if the lock is still held by other thread.
   while (Atomic::load(&_state) == locked ||
          Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
-    if ((++ctr & 0xFFF) == 0) {
-      BlockOp block(java_thread);
-      if (yields > 5) {
-        os::naked_short_sleep(1);
+    if (ctr > 0 && !SafepointSynchronize::is_synchronizing()) {
+      // Lightly contended, spin a little if no safepoint is pending.
+      SpinPause();
+      ctr--;
+    } else if (ALLOW_BLOCK) {
+      ThreadBlockInVM block(java_thread);
+      if (SafepointSynchronize::is_synchronizing()) {
+        // If safepoint is pending, we want to block and allow safepoint to proceed.
+        // Normally, TBIVM above would block us in its destructor.
+        //
+        // But that blocking only happens when TBIVM knows the thread poll is armed.
+        // There is a window between announcing a safepoint and arming the thread poll
+        // during which trying to continuously enter TBIVM is counter-productive.
+        // Under high contention, we may end up going in circles thousands of times.
+        // To avoid it, we wait here until local poll is armed and then proceed
+        // to TBVIM exit for blocking. We do not SpinPause, but yield to let
+        // VM thread to arm the poll sooner.
+        while (SafepointSynchronize::is_synchronizing() &&
+               !SafepointMechanism::local_poll_armed(java_thread)) {
+          os::naked_yield();
+        }
       } else {
         os::naked_yield();
-        yields++;
       }
     } else {
-      SpinPause();
+      os::naked_yield();
     }
   }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [817edcb6](https://github.com/openjdk/jdk/commit/817edcb697cbb8c608c9292cdc4b99db4f5844dc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Xiaolong Peng on 26 Jun 2024 and was reviewed by Aleksey Shipilev, Kelvin Nilsen and William Kemper.

Additional test:
- [x] `make clean test TEST=hotspot_gc_shenandoah`
```
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg:hotspot_gc_shenandoah      261   261     0     0   
==============================
TEST SUCCESS
```

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331411](https://bugs.openjdk.org/browse/JDK-8331411) needs maintainer approval

### Issue
 * [JDK-8331411](https://bugs.openjdk.org/browse/JDK-8331411): Shenandoah: Reconsider spinning duration in ShenandoahLock (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/850/head:pull/850` \
`$ git checkout pull/850`

Update a local copy of the PR: \
`$ git checkout pull/850` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 850`

View PR using the GUI difftool: \
`$ git pr show -t 850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/850.diff">https://git.openjdk.org/jdk21u-dev/pull/850.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/850#issuecomment-2237544493)