### PR TITLE
8336474: Problemlist compiler/interpreter/Test6833129 on x86_32

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -75,6 +75,8 @@ compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
 compiler/codecache/CheckLargePages.java 8319795 linux-x64
 
+compiler/interpreter/Test6833129.java 8335266 generic-i586
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Clean backport to make GHA testing less noisy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8336474](https://bugs.openjdk.org/browse/JDK-8336474) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336474](https://bugs.openjdk.org/browse/JDK-8336474): Problemlist compiler/interpreter/Test6833129 on x86_32 (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/851/head:pull/851` \
`$ git checkout pull/851`

Update a local copy of the PR: \
`$ git checkout pull/851` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 851`

View PR using the GUI difftool: \
`$ git pr show -t 851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/851.diff">https://git.openjdk.org/jdk21u-dev/pull/851.diff</a>

</details>
