### PR TITLE
8314163: os::print_hex_dump prints incorrectly for big endian platforms and unit sizes larger than 1

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -943,6 +943,7 @@ ATTRIBUTE_NO_ASAN static bool read_safely_from(intptr_t* p, intptr_t* result) {
 }
 
 static void print_hex_location(outputStream* st, address p, int unitsize) {
+  assert(is_aligned(p, unitsize), "Unaligned");
   address pa = align_down(p, sizeof(intptr_t));
 #ifndef _LP64
   // Special handling for printing qwords on 32-bit platforms
@@ -962,10 +963,14 @@ static void print_hex_location(outputStream* st, address p, int unitsize) {
 #endif // 32-bit, qwords
   intptr_t i = 0;
   if (read_safely_from((intptr_t*)pa, &i)) {
+    // bytes:   CA FE BA BE DE AD C0 DE
+    // bytoff:   0  1  2  3  4  5  6  7
+    // LE bits:  0  8 16 24 32 40 48 56
+    // BE bits: 56 48 40 32 24 16  8  0
     const int offset = (int)(p - (address)pa);
     const int bitoffset =
       LITTLE_ENDIAN_ONLY(offset * BitsPerByte)
-      BIG_ENDIAN_ONLY((int)(sizeof(intptr_t) - 1 - offset) * BitsPerByte);
+      BIG_ENDIAN_ONLY((int)((sizeof(intptr_t) - unitsize - offset) * BitsPerByte));
     const int bitfieldsize = unitsize * BitsPerByte;
     intptr_t value = bitfield(i, bitoffset, bitfieldsize);
     switch (unitsize) {


### PR DESCRIPTION
Needed to fix gtests for big-endian platforms after [JDK-8299790](https://bugs.openjdk.org/browse/JDK-8299790) backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314163](https://bugs.openjdk.org/browse/JDK-8314163) needs maintainer approval

### Issue
 * [JDK-8314163](https://bugs.openjdk.org/browse/JDK-8314163): os::print_hex_dump prints incorrectly for big endian platforms and unit sizes larger than 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/852/head:pull/852` \
`$ git checkout pull/852`

Update a local copy of the PR: \
`$ git checkout pull/852` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 852`

View PR using the GUI difftool: \
`$ git pr show -t 852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/852.diff">https://git.openjdk.org/jdk21u-dev/pull/852.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/852#issuecomment-2238536378)