### PR TITLE
8335743: jhsdb jstack cannot print some information on the waiting thread

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public abstract class JavaVFrame extends VFrame {
     // then print out the receiver. Locals are not always available,
     // e.g., compiled native frames have no scope so there are no locals.
     if (frameCount == 0) {
-      if (getMethod().getName().asString().equals("wait") &&
+      if (getMethod().getName().asString().equals("wait0") &&
           getMethod().getMethodHolder().getName().asString().equals("java/lang/Object")) {
         String waitState = "waiting on"; // assume we are waiting
         // If earlier in the output we reported java.lang.Thread.State ==

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import jdk.test.lib.apps.LingeredApp;
 
 
 public class LingeredAppWithLock extends LingeredApp {
+    private static Object lockObj = new Object();
 
     public static void lockMethod(Object lock) {
         synchronized (lock) {
@@ -36,16 +37,28 @@ public class LingeredAppWithLock extends LingeredApp {
         }
     }
 
+    public static void waitMethod() {
+        synchronized (lockObj) {
+            try {
+                lockObj.wait(300000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     public static void main(String args[]) {
         Thread classLock1 = new Thread(() -> lockMethod(LingeredAppWithLock.class));
         Thread classLock2 = new Thread(() -> lockMethod(LingeredAppWithLock.class));
         Thread objectLock = new Thread(() -> lockMethod(classLock1));
         Thread primitiveLock = new Thread(() -> lockMethod(int.class));
+        Thread objectWait = new Thread(() -> waitMethod());
 
         classLock1.start();
         classLock2.start();
         objectLock.start();
         primitiveLock.start();
+        objectWait.start();
 
         // Wait until all threads have reached their blocked or timed wait state
         while ((classLock1.getState() != Thread.State.BLOCKED &&
@@ -53,7 +66,8 @@ public class LingeredAppWithLock extends LingeredApp {
                (classLock2.getState() != Thread.State.BLOCKED &&
                 classLock2.getState() != Thread.State.TIMED_WAITING) ||
                (objectLock.getState() != Thread.State.TIMED_WAITING) ||
-               (primitiveLock.getState() != Thread.State.TIMED_WAITING)) {
+               (primitiveLock.getState() != Thread.State.TIMED_WAITING) ||
+               (objectWait.getState() != Thread.State.TIMED_WAITING)) {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException ex) {

--- a/test/hotspot/jtreg/serviceability/sa/TestClhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestClhsdbJstackLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import jtreg.SkippedException;
 
 /**
  * @test
+ * @bug 8185796 8335743
  * @requires vm.hasSA
  * @library /test/lib
  * @run main/othervm TestClhsdbJstackLock
@@ -57,7 +58,8 @@ public class TestClhsdbJstackLock {
                 "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$",
                 "^\\s+- waiting to lock <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$",
                 "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Thread\\)$",
-                "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$"));
+                "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$",
+                "^\\s+- waiting on <0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)$"));
             unExpStrMap.put("jstack", List.of(
                 "missing reason for "));
             test.run(app.getPid(), cmds, expStrMap, unExpStrMap);

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import jdk.test.lib.Utils;
 
 /**
  * @test
+ * @bug 8185796 8335743
  * @requires vm.hasSA
  * @library /test/lib
  * @run driver TestJhsdbJstackLock
@@ -64,6 +65,7 @@ public class TestJhsdbJstackLock {
             out.shouldMatch("^\\s+- waiting to lock <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$");
             out.shouldMatch("^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Thread\\)$");
             out.shouldMatch("^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$");
+            out.shouldMatch("^\\s+- waiting on <0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)$");
 
             out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
 


### PR DESCRIPTION
Hi all,
This pull request is the backport of JDK-8335743.
It is clean, but JDK-8336284 reports that the tests fails due to JDK-8335743. I think that JDK-8335743 and JDK-8336284 should be backported at the same time.
I created the pull request https://github.com/openjdk/jdk21u-dev/pull/854 which  backports JDK-8336284.

Testing:
hotspot/jtreg/serviceability/sa and  jdk/sun/tools/jhsdb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8335743](https://bugs.openjdk.org/browse/JDK-8335743) needs maintainer approval
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8335743: jhsdb jstack cannot print some information on the waiting thread`

### Issue
 * [JDK-8335743](https://bugs.openjdk.org/browse/JDK-8335743): jhsdb jstack cannot print some information on the waiting thread (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/853/head:pull/853` \
`$ git checkout pull/853`

Update a local copy of the PR: \
`$ git checkout pull/853` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 853`

View PR using the GUI difftool: \
`$ git pr show -t 853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/853.diff">https://git.openjdk.org/jdk21u-dev/pull/853.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/853#issuecomment-2238717937)