### PR TITLE
8316131: runtime/cds/appcds/TestParallelGCWithCDS.java fails with JNI error

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,9 +115,11 @@ public class TestParallelGCWithCDS {
                     out.shouldContain(HELLO);
                 } else {
                     String pattern = "((Too small maximum heap)" +
-                                       "|(GC triggered before VM initialization completed)" +
-                                       "|(java.lang.OutOfMemoryError: Java heap space))";
+                                     "|(GC triggered before VM initialization completed)" +
+                                     "|(java.lang.OutOfMemoryError: Java heap space)" +
+                                     "|(Initial heap size set to a larger value than the maximum heap size))";
                     out.shouldMatch(pattern);
+                    out.shouldNotHaveFatalError();
                 }
                 n++;
             }

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -42,6 +42,8 @@ public final class OutputAnalyzer {
 
     private static final String deprecatedmsg = ".* VM warning:.* deprecated.*";
 
+    private static final String FATAL_ERROR_PAT = "# A fatal error has been detected.*";
+
     private final OutputBuffer buffer;
     /**
      * Create an OutputAnalyzer, a utility class for verifying output and exit
@@ -847,6 +849,13 @@ public final class OutputAnalyzer {
 
     public void shouldContainMultiLinePattern(String... needles) {
         shouldContainMultiLinePattern(needles, true);
+    }
+
+    /**
+     * Assert that we did not crash with a hard VM error (generating an hs_err_pidXXX.log)
+     */
+    public void shouldNotHaveFatalError() {
+        shouldNotMatch(FATAL_ERROR_PAT);
     }
 
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316131](https://bugs.openjdk.org/browse/JDK-8316131) needs maintainer approval

### Issue
 * [JDK-8316131](https://bugs.openjdk.org/browse/JDK-8316131): runtime/cds/appcds/TestParallelGCWithCDS.java fails with JNI error (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/859/head:pull/859` \
`$ git checkout pull/859`

Update a local copy of the PR: \
`$ git checkout pull/859` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 859`

View PR using the GUI difftool: \
`$ git pr show -t 859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/859.diff">https://git.openjdk.org/jdk21u-dev/pull/859.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/859#issuecomment-2242251358)