### PR TITLE
8325542: CTW: Runner can produce negative StressSeed

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.Random;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -266,7 +267,7 @@ public class CtwRunner {
     private String[] cmd(long classStart, long classStop) {
         String phase = phaseName(classStart);
         Path file = Paths.get(phase + ".cmd");
-        var rng = Utils.getRandomInstance();
+        Random rng = Utils.getRandomInstance();
 
         ArrayList<String> Args = new ArrayList<String>(Arrays.asList(
                 "-Xbatch",
@@ -302,7 +303,7 @@ public class CtwRunner {
                 "-XX:+StressIGVN",
                 "-XX:+StressCCP",
                 // StressSeed is uint
-                "-XX:StressSeed=" + Math.abs(rng.nextInt())));
+                "-XX:StressSeed=" + rng.nextInt(Integer.MAX_VALUE)));
 
         for (String arg : CTW_EXTRA_ARGS.split(",")) {
             Args.add(arg);


### PR DESCRIPTION
Backporting to streamline tests and parity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8325542](https://bugs.openjdk.org/browse/JDK-8325542) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325542](https://bugs.openjdk.org/browse/JDK-8325542): CTW: Runner can produce negative StressSeed (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/860/head:pull/860` \
`$ git checkout pull/860`

Update a local copy of the PR: \
`$ git checkout pull/860` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 860`

View PR using the GUI difftool: \
`$ git pr show -t 860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/860.diff">https://git.openjdk.org/jdk21u-dev/pull/860.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/860#issuecomment-2242623571)