### PR TITLE
8333361: ubsan,test : libHeapMonitorTest.cpp:518:9: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp
@@ -515,7 +515,9 @@ static void event_storage_augment_storage(EventStorage* storage) {
   ObjectTrace** new_objects = reinterpret_cast<ObjectTrace**>(malloc(new_max * sizeof(*new_objects)));
 
   int current_count = storage->live_object_count;
-  memcpy(new_objects, storage->live_objects, current_count * sizeof(*new_objects));
+  if (storage->live_objects != nullptr) {
+    memcpy(new_objects, storage->live_objects, current_count * sizeof(*new_objects));
+  }
   free(storage->live_objects);
   storage->live_objects = new_objects;
   storage->live_object_size = new_max;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333361](https://bugs.openjdk.org/browse/JDK-8333361) needs maintainer approval

### Issue
 * [JDK-8333361](https://bugs.openjdk.org/browse/JDK-8333361): ubsan,test : libHeapMonitorTest.cpp:518:9: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/861/head:pull/861` \
`$ git checkout pull/861`

Update a local copy of the PR: \
`$ git checkout pull/861` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 861`

View PR using the GUI difftool: \
`$ git pr show -t 861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/861.diff">https://git.openjdk.org/jdk21u-dev/pull/861.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/861#issuecomment-2242650419)