### PR TITLE
8326332: Unclosed inline tags cause misalignment in summary tables

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -1134,6 +1135,23 @@ public class HtmlDocletWriter {
         }
     }
 
+    // helper methods because jdk21 functionality is not allowed
+    Name getLastHelper(List<Name> l) {
+        if (l.isEmpty()) {
+            throw new NoSuchElementException();
+        } else {
+            return l.get(l.size() - 1);
+        }
+    }
+
+    Name removeLastHelper(List<Name> l) {
+        if (l.isEmpty()) {
+            throw new NoSuchElementException();
+        } else {
+            return l.remove(l.size() - 1);
+        }
+    }
+
     boolean ignoreNonInlineTag(DocTree dtree, List<Name> openTags) {
         Name name = null;
         Kind kind = dtree.getKind();
@@ -1153,8 +1171,8 @@ public class HtmlDocletWriter {
                 if (kind == START_ELEMENT && htmlTag.endKind == HtmlTag.EndKind.REQUIRED) {
                     openTags.add(name);
                 } else if (kind == Kind.END_ELEMENT && !openTags.isEmpty()
-                        && openTags.getLast().equals(name)) {
-                    openTags.removeLast();
+                        && getLastHelper(openTags).equals(name)) {
+                    removeLastHelper(openTags);
                 }
             }
         }
@@ -1498,7 +1516,7 @@ public class HtmlDocletWriter {
         }
         // Close any open inline tags
         while (!openTags.isEmpty()) {
-            result.add(RawHtml.endElement(openTags.removeLast()));
+            result.add(RawHtml.endElement(removeLastHelper(openTags)));
         }
         return result;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -117,6 +117,7 @@ import static com.sun.source.doctree.DocTree.Kind.COMMENT;
 import static com.sun.source.doctree.DocTree.Kind.LINK;
 import static com.sun.source.doctree.DocTree.Kind.LINK_PLAIN;
 import static com.sun.source.doctree.DocTree.Kind.SEE;
+import static com.sun.source.doctree.DocTree.Kind.START_ELEMENT;
 import static com.sun.source.doctree.DocTree.Kind.TEXT;
 
 
@@ -1133,21 +1134,28 @@ public class HtmlDocletWriter {
         }
     }
 
-    boolean ignoreNonInlineTag(DocTree dtree) {
+    boolean ignoreNonInlineTag(DocTree dtree, List<Name> openTags) {
         Name name = null;
-        if (dtree.getKind() == Kind.START_ELEMENT) {
-            StartElementTree setree = (StartElementTree)dtree;
-            name = setree.getName();
-        } else if (dtree.getKind() == Kind.END_ELEMENT) {
-            EndElementTree eetree = (EndElementTree)dtree;
-            name = eetree.getName();
+        Kind kind = dtree.getKind();
+        if (kind == Kind.START_ELEMENT) {
+            name = ((StartElementTree)dtree).getName();
+        } else if (kind == Kind.END_ELEMENT) {
+            name = ((EndElementTree)dtree).getName();
         }
 
         if (name != null) {
             HtmlTag htmlTag = HtmlTag.get(name);
-            if (htmlTag != null &&
-                    htmlTag.blockType != jdk.javadoc.internal.doclint.HtmlTag.BlockType.INLINE) {
-                return true;
+            if (htmlTag != null) {
+                if (htmlTag.blockType != HtmlTag.BlockType.INLINE) {
+                    return true;
+                }
+                // Keep track of open inline tags that need to be closed, see 8326332
+                if (kind == START_ELEMENT && htmlTag.endKind == HtmlTag.EndKind.REQUIRED) {
+                    openTags.add(name);
+                } else if (kind == Kind.END_ELEMENT && !openTags.isEmpty()
+                        && openTags.getLast().equals(name)) {
+                    openTags.removeLast();
+                }
             }
         }
         return false;
@@ -1219,6 +1227,7 @@ public class HtmlDocletWriter {
         CommentHelper ch = utils.getCommentHelper(element);
         configuration.tagletManager.checkTags(element, trees);
         commentRemoved = false;
+        List<Name> openTags = new ArrayList<>();
 
         for (ListIterator<? extends DocTree> iterator = trees.listIterator(); iterator.hasNext();) {
             boolean isFirstNode = !iterator.hasPrevious();
@@ -1227,14 +1236,16 @@ public class HtmlDocletWriter {
 
             if (context.isFirstSentence) {
                 // Ignore block tags
-                if (ignoreNonInlineTag(tag))
+                if (ignoreNonInlineTag(tag, openTags)) {
                     continue;
+                }
 
                 // Ignore any trailing whitespace OR whitespace after removed html comment
                 if ((isLastNode || commentRemoved)
                         && tag.getKind() == TEXT
-                        && ((tag instanceof TextTree tt) && tt.getBody().isBlank()))
+                        && ((tag instanceof TextTree tt) && tt.getBody().isBlank())) {
                     continue;
+                }
 
                 // Ignore any leading html comments
                 if ((isFirstNode || commentRemoved) && tag.getKind() == COMMENT) {
@@ -1484,6 +1495,10 @@ public class HtmlDocletWriter {
 
             if (allDone)
                 break;
+        }
+        // Close any open inline tags
+        while (!openTags.isEmpty()) {
+            result.add(RawHtml.endElement(openTags.removeLast()));
         }
         return result;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -1137,19 +1136,11 @@ public class HtmlDocletWriter {
 
     // helper methods because jdk21 functionality is not allowed
     Name getLastHelper(List<Name> l) {
-        if (l.isEmpty()) {
-            throw new NoSuchElementException();
-        } else {
-            return l.get(l.size() - 1);
-        }
+        return l.get(l.size() - 1);
     }
 
     Name removeLastHelper(List<Name> l) {
-        if (l.isEmpty()) {
-            throw new NoSuchElementException();
-        } else {
-            return l.remove(l.size() - 1);
-        }
+        return l.remove(l.size() - 1);
     }
 
     boolean ignoreNonInlineTag(DocTree dtree, List<Name> openTags) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1135,11 +1135,11 @@ public class HtmlDocletWriter {
     }
 
     // helper methods because jdk21 functionality is not allowed
-    Name getLastHelper(List<Name> l) {
+    private static Name getLastHelper(List<Name> l) {
         return l.get(l.size() - 1);
     }
 
-    Name removeLastHelper(List<Name> l) {
+    private static Name removeLastHelper(List<Name> l) {
         return l.remove(l.size() - 1);
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testBreakIterator/TestBreakIterator.java
+++ b/test/langtools/jdk/javadoc/doclet/testBreakIterator/TestBreakIterator.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4165985
+ * @bug 4165985 8326332
  * @summary Determine the end of the first sentence using BreakIterator.
  * If the first sentence of "method" is parsed correctly, the test passes.
  * Correct Answer: "This is a class (i.e. it is indeed a class)."
@@ -76,5 +76,10 @@ public class TestBreakIterator extends JavadocTester {
                 """
                     <div class="block">A constant indicating that the keyLocation is indeterminate
                      or not relevant.</div>""");
+
+        checkOutput("pkg/BreakIteratorTest.html", true,
+                """
+                    <div class="block">Inline tags <i><a href="../index-all.html">extending
+                     beyond the first sentence.</a></i></div>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testBreakIterator/pkg/BreakIteratorTest.java
+++ b/test/langtools/jdk/javadoc/doclet/testBreakIterator/pkg/BreakIteratorTest.java
@@ -56,4 +56,9 @@ public class BreakIteratorTest {
      */
     public void fe(){}
 
+    /**
+     * Inline tags <i><a href="{@docRoot}/index-all.html">extending
+     * beyond the first sentence. Tags are closed here.</a></i>
+     */
+    public void meh(){}
 }


### PR DESCRIPTION
Backport of 8326332

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326332](https://bugs.openjdk.org/browse/JDK-8326332) needs maintainer approval

### Issue
 * [JDK-8326332](https://bugs.openjdk.org/browse/JDK-8326332): Unclosed inline tags cause misalignment in summary tables (**Bug** - P3 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/866/head:pull/866` \
`$ git checkout pull/866`

Update a local copy of the PR: \
`$ git checkout pull/866` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 866`

View PR using the GUI difftool: \
`$ git pr show -t 866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/866.diff">https://git.openjdk.org/jdk21u-dev/pull/866.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/866#issuecomment-2245084057)