### PR TITLE
8337038: Test java/nio/file/attribute/BasicFileAttributeView/CreationTime.java shoud set as /native

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -27,7 +27,7 @@
  *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
- * @run main CreationTime
+ * @run main/native CreationTime
  */
 
 /* @test id=cwd
@@ -36,7 +36,7 @@
  *     scratch directory maybe at diff disk partition to /tmp on linux.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
- * @run main CreationTime .
+ * @run main/native CreationTime .
  */
 
 import java.nio.file.Path;


### PR DESCRIPTION
Hi all,
Test `test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java` invoke `CreationTimeHelper` in [CreationTime.java](https://github.com/openjdk/jdk21u-dev/blob/master/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java#L109), and `CreationTimeHelper` invoke native function. So test `test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java` should set as `/native`.
In the [PR](https://github.com/openjdk/jdk21u/pull/282) of backport [JDK-8316304](https://bugs.openjdk.org/browse/JDK-8316304) to jdk21u-dev, this test has been rewritten to use JNI instead so as to avoid using `Linker API`, thus this is specific to jdk21u-dev and jdk17u-dev.
Trivial fix, the change has been verified, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337038](https://bugs.openjdk.org/browse/JDK-8337038) needs maintainer approval

### Issue
 * [JDK-8337038](https://bugs.openjdk.org/browse/JDK-8337038): Test java/nio/file/attribute/BasicFileAttributeView/CreationTime.java shoud set as /native (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/869/head:pull/869` \
`$ git checkout pull/869`

Update a local copy of the PR: \
`$ git checkout pull/869` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 869`

View PR using the GUI difftool: \
`$ git pr show -t 869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/869.diff">https://git.openjdk.org/jdk21u-dev/pull/869.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/869#issuecomment-2247392370)