### PR TITLE
8330520: linux clang build fails in os_linux.cpp with static_assert with no message is a C++17 extension

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2836,7 +2836,17 @@ void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
   #define MADV_POPULATE_WRITE MADV_POPULATE_WRITE_value
 #else
   // Sanity-check our assumed default value if we build with a new enough libc.
-  static_assert(MADV_POPULATE_WRITE == MADV_POPULATE_WRITE_value);
+  STATIC_ASSERT(MADV_POPULATE_WRITE == MADV_POPULATE_WRITE_value);
+#endif
+
+// Note that the value for MAP_FIXED_NOREPLACE differs between architectures, but all architectures
+// supported by OpenJDK share the same flag value.
+#define MAP_FIXED_NOREPLACE_value 0x100000
+#ifndef MAP_FIXED_NOREPLACE
+  #define MAP_FIXED_NOREPLACE MAP_FIXED_NOREPLACE_value
+#else
+  // Sanity-check our assumed default value if we build with a new enough libc.
+  STATIC_ASSERT(MAP_FIXED_NOREPLACE == MAP_FIXED_NOREPLACE_value);
 #endif
 
 int os::Linux::commit_memory_impl(char* addr, size_t size,


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4b55fe57](https://github.com/openjdk/jdk/commit/4b55fe577701317e6570f045ed9fe28aa97fc7ea) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 18 Apr 2024 and was reviewed by Stefan Karlsson and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330520](https://bugs.openjdk.org/browse/JDK-8330520) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8330520: linux clang build fails in os_linux.cpp with static_assert with no message is a C++17 extension`

### Issue
 * [JDK-8330520](https://bugs.openjdk.org/browse/JDK-8330520): linux clang build fails in os_linux.cpp with static_assert with no message is a C++17 extension (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/876/head:pull/876` \
`$ git checkout pull/876`

Update a local copy of the PR: \
`$ git checkout pull/876` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 876`

View PR using the GUI difftool: \
`$ git pr show -t 876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/876.diff">https://git.openjdk.org/jdk21u-dev/pull/876.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/876#issuecomment-2257561737)