### PR TITLE
8335134: Test com/sun/jdi/BreakpointOnClassPrepare.java timeout

### DIFF
--- a/test/jdk/com/sun/jdi/BreakpointOnClassPrepare.java
+++ b/test/jdk/com/sun/jdi/BreakpointOnClassPrepare.java
@@ -104,7 +104,15 @@ public class BreakpointOnClassPrepare extends TestScaffold {
 
     public void breakpointReached(BreakpointEvent event) {
         bkptCount++;
-        System.out.println("Got BreakpointEvent: " + bkptCount + " for thread " + event.thread());
+        String threadInfo;
+        try {
+            threadInfo = event.thread().toString();
+        } catch (ObjectCollectedException e) {
+            // It's possible the Thread already terminated and was collected
+            // if the SUSPEND_NONE policy was used.
+            threadInfo = "(thread collected)";
+        }
+        System.out.println("Got BreakpointEvent: " + bkptCount + " for thread " + threadInfo);
     }
 
     public void vmDisconnected(VMDisconnectEvent event) {


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335134](https://bugs.openjdk.org/browse/JDK-8335134) needs maintainer approval

### Issue
 * [JDK-8335134](https://bugs.openjdk.org/browse/JDK-8335134): Test com/sun/jdi/BreakpointOnClassPrepare.java timeout (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/877/head:pull/877` \
`$ git checkout pull/877`

Update a local copy of the PR: \
`$ git checkout pull/877` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 877`

View PR using the GUI difftool: \
`$ git pr show -t 877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/877.diff">https://git.openjdk.org/jdk21u-dev/pull/877.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/877#issuecomment-2257867608)