### PR TITLE
8325037: x86: enable and fix hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,13 +44,12 @@ public class TestRoundVectFloat {
 
   public static void main(String args[]) {
       TestFramework.runWithFlags("-XX:-TieredCompilation",
-                                 "-XX:UseAVX=1",
                                  "-XX:CompileThresholdScaling=0.3");
       System.out.println("PASSED");
   }
 
   @Test
-  @IR(applyIf = {"UseAVX", " > 1"}, counts = {"RoundVF" , " > 0 "})
+  @IR(applyIf = {"UseAVX", " > 1"}, counts = {IRNode.ROUND_VF , " > 0 "})
   public void test_round_float(int[] iout, float[] finp) {
       for (int i = 0; i < finp.length; i+=1) {
           iout[i] = Math.round(finp[i]);


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325037](https://bugs.openjdk.org/browse/JDK-8325037) needs maintainer approval

### Issue
 * [JDK-8325037](https://bugs.openjdk.org/browse/JDK-8325037): x86: enable and fix hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/878/head:pull/878` \
`$ git checkout pull/878`

Update a local copy of the PR: \
`$ git checkout pull/878` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 878`

View PR using the GUI difftool: \
`$ git pr show -t 878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/878.diff">https://git.openjdk.org/jdk21u-dev/pull/878.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/878#issuecomment-2257882686)