### PR TITLE
8335904: Fix invalid comment in ShenandoahLock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -44,7 +44,7 @@ void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
 template<bool ALLOW_BLOCK>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
   assert(!ALLOW_BLOCK || java_thread != nullptr, "Must have a Java thread when allowing block.");
-  // Spin this much on multi-processor, do not spin on multi-processor.
+  // Spin this much, but only on multi-processor systems.
   int ctr = os::is_MP() ? 0xFF : 0;
   // Apply TTAS to avoid more expensive CAS calls if the lock is still held by other thread.
   while (Atomic::load(&_state) == locked ||


### PR DESCRIPTION
Trivial change to fix the wrong comment introduced by https://bugs.openjdk.org/browse/JDK-8331411, JDK-8331411 has been backported to jdk21.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8335904](https://bugs.openjdk.org/browse/JDK-8335904) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335904](https://bugs.openjdk.org/browse/JDK-8335904): Fix invalid comment in ShenandoahLock (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/882/head:pull/882` \
`$ git checkout pull/882`

Update a local copy of the PR: \
`$ git checkout pull/882` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 882`

View PR using the GUI difftool: \
`$ git pr show -t 882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/882.diff">https://git.openjdk.org/jdk21u-dev/pull/882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/882#issuecomment-2259156938)