### PR TITLE
8333178: ubsan: jvmti_tools.cpp:149:16: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
@@ -146,7 +146,9 @@ static int add_option(const char opt[], int opt_len, const char val[], int val_l
     } else {
         strncpy(name, opt, opt_len);
         name[opt_len] = '\0';
-        strncpy(value, val, val_len);
+        if (val != nullptr) {
+            strncpy(value, val, val_len);
+        }
         value[val_len] = '\0';
 
         if (!check_option(dashed_opt, name, value)) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333178](https://bugs.openjdk.org/browse/JDK-8333178) needs maintainer approval

### Issue
 * [JDK-8333178](https://bugs.openjdk.org/browse/JDK-8333178): ubsan: jvmti_tools.cpp:149:16: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/884/head:pull/884` \
`$ git checkout pull/884`

Update a local copy of the PR: \
`$ git checkout pull/884` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 884`

View PR using the GUI difftool: \
`$ git pr show -t 884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/884.diff">https://git.openjdk.org/jdk21u-dev/pull/884.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/884#issuecomment-2260647670)