### PR TITLE
Backport a36eaf03afd148581a9d9754f85a652cac84d655

### DIFF
--- a/test/jdk/java/awt/Frame/DefaultSizeTest.java
+++ b/test/jdk/java/awt/Frame/DefaultSizeTest.java
@@ -50,6 +50,7 @@ public class DefaultSizeTest {
                 .testTimeOut(5)
                 .rows(10)
                 .columns(45)
+                .screenCapture()
                 .build();
 
         EventQueue.invokeAndWait(() -> {


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

