### PR TITLE
8333622: ubsan: relocInfo_x86.cpp:101:56: runtime error: pointer index expression with base (-1) overflowed

### DIFF
--- a/src/hotspot/cpu/x86/relocInfo_x86.cpp
+++ b/src/hotspot/cpu/x86/relocInfo_x86.cpp
@@ -97,7 +97,11 @@ address Relocation::pd_call_destination(address orig_addr) {
   if (ni->is_call()) {
     return nativeCall_at(addr())->destination() + adj;
   } else if (ni->is_jump()) {
-    return nativeJump_at(addr())->jump_destination() + adj;
+    address dest = nativeJump_at(addr())->jump_destination();
+    if (dest == (address) -1) {
+      return addr(); // jump to self
+    }
+    return dest + adj;
   } else if (ni->is_cond_jump()) {
     return nativeGeneralJump_at(addr())->jump_destination() + adj;
   } else if (ni->is_mov_literal64()) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333622](https://bugs.openjdk.org/browse/JDK-8333622) needs maintainer approval

### Issue
 * [JDK-8333622](https://bugs.openjdk.org/browse/JDK-8333622): ubsan: relocInfo_x86.cpp:101:56: runtime error: pointer index expression with base (-1) overflowed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/894/head:pull/894` \
`$ git checkout pull/894`

Update a local copy of the PR: \
`$ git checkout pull/894` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 894`

View PR using the GUI difftool: \
`$ git pr show -t 894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/894.diff">https://git.openjdk.org/jdk21u-dev/pull/894.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/894#issuecomment-2268331819)