### PR TITLE
8335237: ubsan: vtableStubs.hpp  is_vtable_stub exclude from ubsan checks

### DIFF
--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #include "asm/macroAssembler.hpp"
 #include "code/vmreg.hpp"
 #include "memory/allStatic.hpp"
+#include "sanitizers/ub.hpp"
 
 // A VtableStub holds an individual code stub for a pair (vtable index, #args) for either itables or vtables
 // There's a one-to-one relationship between a VtableStub and such a pair.
@@ -173,6 +174,9 @@ class VtableStub {
  public:
   // Query
   bool is_itable_stub()                          { return !_is_vtable_stub; }
+  // We reinterpret arbitrary memory as VtableStub. This does not cause failures because the lookup/equality
+  // check will reject false objects. Disabling UBSan is a temporary workaround until JDK-8331725 is fixed.
+  ATTRIBUTE_NO_UBSAN
   bool is_vtable_stub()                          { return  _is_vtable_stub; }
   bool is_abstract_method_error(address epc)     { return epc == code_begin()+_ame_offset; }
   bool is_null_pointer_exception(address epc)    { return epc == code_begin()+_npe_offset; }


### PR DESCRIPTION
Backport of 8335237, diff in stride at headers but still recognized clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335237](https://bugs.openjdk.org/browse/JDK-8335237) needs maintainer approval

### Issue
 * [JDK-8335237](https://bugs.openjdk.org/browse/JDK-8335237): ubsan: vtableStubs.hpp  is_vtable_stub exclude from ubsan checks (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/899/head:pull/899` \
`$ git checkout pull/899`

Update a local copy of the PR: \
`$ git checkout pull/899` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 899`

View PR using the GUI difftool: \
`$ git pr show -t 899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/899.diff">https://git.openjdk.org/jdk21u-dev/pull/899.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/899#issuecomment-2272900083)