### PR TITLE
8317738: CodeCacheFullCountTest failed with "VirtualMachineError: Out of space in CodeCache for method handle intrinsic"

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -67,7 +67,7 @@ public class CodeCacheFullCountTest {
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         // Ignore adapter creation failures
-        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache for adapters")) {
+        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache")) {
             oa.reportDiagnosticSummary();
             throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
         }


### PR DESCRIPTION
Backport of [JDK-8317738](https://bugs.openjdk.org/browse/JDK-8317738)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - `CodeCacheFullCountTest.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies Passed on `2024-08-15`
  - Automated jtreg test: `jtreg_hotspot_tier1`, Started at `2024-08-15 02:12:39+01:00`
  - compiler/codecache/CodeCacheFullCountTest.java: `SUCCESSFUL` GitHub 📊 - [02:13:19.170 -> 6,082 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317738](https://bugs.openjdk.org/browse/JDK-8317738) needs maintainer approval

### Issue
 * [JDK-8317738](https://bugs.openjdk.org/browse/JDK-8317738): CodeCacheFullCountTest failed with "VirtualMachineError: Out of space in CodeCache for method handle intrinsic" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/904/head:pull/904` \
`$ git checkout pull/904`

Update a local copy of the PR: \
`$ git checkout pull/904` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 904`

View PR using the GUI difftool: \
`$ git pr show -t 904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/904.diff">https://git.openjdk.org/jdk21u-dev/pull/904.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/904#issuecomment-2276733984)