### PR TITLE
8325022: Incorrect error message on client authentication

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertificateMessage.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateMessage.java
@@ -382,7 +382,7 @@ final class CertificateMessage {
                         ClientAuthType.CLIENT_AUTH_REQUESTED) {
                     // unexpected or require client authentication
                     throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                        "Empty server certificate chain");
+                        "Empty client certificate chain");
                 } else {
                     return;
                 }
@@ -399,7 +399,7 @@ final class CertificateMessage {
                 }
             } catch (CertificateException ce) {
                 throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                    "Failed to parse server certificates", ce);
+                    "Failed to parse client certificates", ce);
             }
 
             checkClientCerts(shc, x509Certs);
@@ -1216,7 +1216,7 @@ final class CertificateMessage {
                 }
             } catch (CertificateException ce) {
                 throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                    "Failed to parse server certificates", ce);
+                    "Failed to parse client certificates", ce);
             }
 
             // find out the types of client authentication used


### PR DESCRIPTION
Backport of [JDK-8325022](https://bugs.openjdk.org/browse/JDK-8325022)

Testing
- Local: 
  - Build passed on `MacOS 14.6.1` on Apple M1 Max
  - No applicable test case
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies Passed on `2024-08-14,15` (No side effect found)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325022](https://bugs.openjdk.org/browse/JDK-8325022) needs maintainer approval

### Issue
 * [JDK-8325022](https://bugs.openjdk.org/browse/JDK-8325022): Incorrect error message on client authentication (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/905/head:pull/905` \
`$ git checkout pull/905`

Update a local copy of the PR: \
`$ git checkout pull/905` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 905`

View PR using the GUI difftool: \
`$ git pr show -t 905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/905.diff">https://git.openjdk.org/jdk21u-dev/pull/905.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/905#issuecomment-2276953910)