### PR TITLE
8334166: Enable binary check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -5,7 +5,7 @@ version=21.0.5
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
-warning=binary
+warning=issuestitle,binary
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -5,6 +5,7 @@ version=21.0.5
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
+warning=binary
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)


### PR DESCRIPTION
Backport of 8334166; previous warning setting missing so not clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8332008](https://bugs.openjdk.org/browse/JDK-8332008) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8334166](https://bugs.openjdk.org/browse/JDK-8334166) needs maintainer approval

### Issues
 * [JDK-8334166](https://bugs.openjdk.org/browse/JDK-8334166): Enable binary check (**Bug** - P4 - Approved)
 * [JDK-8332008](https://bugs.openjdk.org/browse/JDK-8332008): Enable issuestitle check (**Enhancement** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/906/head:pull/906` \
`$ git checkout pull/906`

Update a local copy of the PR: \
`$ git checkout pull/906` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 906`

View PR using the GUI difftool: \
`$ git pr show -t 906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/906.diff">https://git.openjdk.org/jdk21u-dev/pull/906.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/906#issuecomment-2277309610)