### PR TITLE
8315965: Open source various AWT applet tests

### DIFF
--- a/test/jdk/java/awt/ScrollPane/ScrollPaneTest.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.ScrollPane;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+
+/*
+ * @test
+ * @bug 4124460
+ * @key headful
+ * @summary Test for initializing a Motif peer component causes a crash.
+*/
+
+public class ScrollPaneTest {
+    private static volatile Point p1 = null;
+    private static volatile Point p2 = null;
+    private static Robot robot = null;
+
+    private static Point getClickPoint(Component component) {
+        Point locationOnScreen = component.getLocationOnScreen();
+        Dimension size = component.getSize();
+        locationOnScreen.x += size.width / 2;
+        locationOnScreen.y += size.height / 2;
+        return locationOnScreen;
+    }
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(100);
+
+        try {
+            doTest();
+        } finally {
+            ScrollPaneTester.disposeAll();
+        }
+    }
+
+    private static void doTest() throws Exception {
+        EventQueue.invokeAndWait(ScrollPaneTester::initAndShowGui);
+
+        robot.waitForIdle();
+        robot.delay(1000);
+
+        EventQueue.invokeAndWait(() -> {
+            p1 = getClickPoint(ScrollPaneTester.st1.buttonRight);
+            p2 = getClickPoint(ScrollPaneTester.st1.buttonSwap);
+        });
+
+        robot.mouseMove(p1.x, p1.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        robot.mouseMove(p2.x, p2.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        robot.delay(1000);
+
+        EventQueue.invokeAndWait(() -> {
+            p1 = getClickPoint(ScrollPaneTester.st2.buttonRight);
+            p2 = getClickPoint(ScrollPaneTester.st2.buttonSwap);
+        });
+
+        robot.mouseMove(p1.x, p1.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        robot.mouseMove(p2.x, p2.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+    }
+}
+
+class ScrollPaneTester implements ActionListener {
+    static ScrollPaneTester st1, st2;
+    final Button buttonLeft, buttonRight, buttonQuit, buttonSwap;
+    protected ScrollPane sp;
+    protected Frame f;
+
+    public static void initAndShowGui() {
+        ScrollPaneTester.st1 = new ScrollPaneTester(true);
+        ScrollPaneTester.st2 = new ScrollPaneTester(false);
+    }
+
+    public ScrollPaneTester(boolean large) {
+        sp = new ScrollPane(ScrollPane.SCROLLBARS_NEVER);
+
+        Panel p = new Panel();
+
+        if (large) {
+            p.setLayout(new GridLayout(10, 10));
+            for (int i = 0; i < 10; i++)
+                for (int j = 0; j < 10; j++) {
+                    TextField tf = new TextField("I am " + i + j);
+                    tf.setSize(100, 20);
+                    p.add(tf);
+                }
+        } else {
+            TextField tf = new TextField("Smallness:");
+            tf.setSize(150, 50);
+            p.add(tf);
+        }
+
+        sp.add(p);
+
+        // Button panel
+        buttonLeft = new Button("Left");
+        buttonLeft.addActionListener(this);
+        buttonQuit = new Button("Quit");
+        buttonQuit.addActionListener(this);
+        buttonSwap = new Button("Swap");
+        buttonSwap.addActionListener(this);
+        buttonRight = new Button("Right");
+        buttonRight.addActionListener(this);
+
+        Panel bp = new Panel();
+        bp.add(buttonLeft);
+        bp.add(buttonSwap);
+        bp.add(buttonQuit);
+        bp.add(buttonRight);
+
+        // Window w/ button panel and scrollpane
+        f = new Frame("ScrollPane Test " + (large ? "large" : "small"));
+        f.setLayout(new BorderLayout());
+        f.add("South", bp);
+        f.add("Center", sp);
+
+        if (large) {
+            f.setSize(300, 200);
+            f.setLocation(100, 100);
+        } else {
+            f.setSize(200, 100);
+            f.setLocation(500, 100);
+        }
+
+        f.setVisible(true);
+    }
+
+    public static void disposeAll() {
+        ScrollPaneTester.st1.f.dispose();
+        ScrollPaneTester.st2.f.dispose();
+    }
+
+    public static void
+    swapPanels() {
+        ScrollPane sss = st1.sp;
+
+        st1.f.add("Center", st2.sp);
+        st1.sp = st2.sp;
+
+        st2.f.add("Center", sss);
+        st2.sp = sss;
+    }
+
+    public void
+    actionPerformed(ActionEvent ev) {
+        Object s = ev.getSource();
+
+        if (s == buttonLeft) {
+            scroll(true);
+        } else if (s == buttonRight) {
+            scroll(false);
+        } else if (s == buttonSwap) {
+            swapPanels();
+        } else if (s == buttonQuit) {
+            disposeAll();
+        }
+    }
+
+    private void
+    scroll(boolean scroll_left) {
+        Point p = sp.getScrollPosition();
+
+        if (scroll_left)
+            p.x = Math.max(0, p.x - 20);
+        else {
+            int cwidth = sp.getComponent(0).getSize().width;
+            p.x = Math.min(p.x + 20, cwidth);
+        }
+
+        sp.setScrollPosition(p);
+    }
+}

--- a/test/jdk/java/awt/TextArea/Length.java
+++ b/test/jdk/java/awt/TextArea/Length.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 4120876
+ * @key headful
+ * @summary Ensure that getText can handle strings of various lengths,
+ *          in particular strings longer than 255 characters
+ */
+
+public class Length {
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            TextArea ta = new TextArea();
+            StringBuffer sb = new StringBuffer("x");
+
+            for (int i = 0; i < 14; i++) {
+                String s = sb.toString();
+                check(ta, s.substring(1));
+                check(ta, s);
+                check(ta, s + "y");
+                sb.append(s);
+            }
+        });
+    }
+
+    static void check(TextArea ta, String s) {
+        ta.setText(s);
+        String s2 = ta.getText();
+        System.err.println(s.length() + " " + s2.length());
+        if (s.length() != s2.length()) {
+            throw new RuntimeException("Expected " + s.length() +
+                                       "chars, got " + s2.length());
+        }
+    }
+}

--- a/test/jdk/java/awt/Window/WindowOwner.java
+++ b/test/jdk/java/awt/Window/WindowOwner.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.Window;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * @test
+ * @key headful
+ * @summary automated test for window-ownership on Windows, Frames, and Dialogs
+ */
+
+public class WindowOwner extends Panel {
+
+    Label status = null;
+    static List<Window> windowsToDispose = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        WindowOwner windowOwner = new WindowOwner();
+        try {
+            EventQueue.invokeAndWait(windowOwner::init);
+            Thread.sleep(2000);
+        } finally {
+            EventQueue.invokeAndWait(
+                    () -> windowsToDispose.forEach(Window::dispose)
+            );
+        }
+    }
+
+    public void init() {
+        status = new Label();
+        add(status);
+
+        statusMessage("Testing Window Ownership...");
+
+        // Test Frame as owner
+        Frame frame0 = new Frame("WindowOwner Test");
+        windowsToDispose.add(frame0);
+        frame0.add("Center", new Label("Frame Level0"));
+
+        Dialog dialog1 = new Dialog(frame0, "WindowOwner Test");
+        windowsToDispose.add(dialog1);
+        dialog1.add("Center", new Label("Dialog Level1"));
+        verifyOwner(dialog1, frame0);
+
+        Window window1 = new Window(frame0);
+        windowsToDispose.add(window1);
+        window1.add("Center", new Label("Window Level1"));
+        window1.setBounds(10, 10, 140, 70);
+        verifyOwner(window1, frame0);
+
+        verifyOwnee(frame0, dialog1);
+        verifyOwnee(frame0, window1);
+
+        // Test Dialog as owner
+        Dialog dialog2 = new Dialog(dialog1, "WindowOwner Test");
+        windowsToDispose.add(dialog2);
+        dialog2.add("Center", new Label("Dialog Level2"));
+        verifyOwner(dialog2, dialog1);
+
+        Window window2 = new Window(dialog1);
+        windowsToDispose.add(window2);
+        window2.add("Center", new Label("Window Level2"));
+        window2.setBounds(110, 110, 140, 70);
+        verifyOwner(window2, dialog1);
+
+        verifyOwnee(dialog1, window2);
+        verifyOwnee(dialog1, dialog2);
+
+        // Test Window as owner
+        Window window3 = new Window(window2);
+        windowsToDispose.add(window3);
+        window3.add("Center", new Label("Window Level3"));
+        window3.setBounds(210, 210, 140, 70);
+        verifyOwner(window3, window2);
+        verifyOwnee(window2, window3);
+
+        // Ensure native peers handle ownership without errors
+        frame0.pack();
+        frame0.setVisible(true);
+
+        dialog1.pack();
+        dialog1.setVisible(true);
+
+        window1.setLocation(50, 50);
+        window1.setVisible(true);
+
+        dialog2.pack();
+        dialog2.setVisible(true);
+
+        window2.setLocation(100, 100);
+        window2.setVisible(true);
+
+        window3.setLocation(150, 150);
+        window3.setVisible(true);
+
+        statusMessage("Window Ownership test completed successfully.");
+    }
+
+  public void statusMessage(String msg) {
+      status.setText(msg);
+      status.invalidate();
+      validate();
+  }
+
+  public static void verifyOwner(Window ownee, Window owner) {
+      if (ownee.getOwner() != owner) {
+          throw new RuntimeException("Window owner not valid for "
+                  + ownee.getName());
+      }
+  }
+
+  public static void verifyOwnee(Window owner, Window ownee) {
+      Window[] ownedWins = owner.getOwnedWindows();
+      if (!windowInList(ownedWins, ownee)) {
+          throw new RuntimeException("Ownee " + ownee.getName()
+                  + " not found in owner list for " + owner.getName());
+      }
+  }
+
+  public static boolean windowInList(Window[] windows, Window target) {
+      for (Window window : windows) {
+          if (window == target) {
+              return true;
+          }
+      }
+      return false;
+  }
+}

--- a/test/jdk/java/awt/font/Rotate/RotateTest3.java
+++ b/test/jdk/java/awt/font/Rotate/RotateTest3.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4240228
+ * @summary This test is designed to test for a crashing bug in the zh
+ *          locale on Solaris. Rotated text should be displayed, but
+ *          anything other than a crash passes the specific test.
+ *          For example, the missing glyph empty box may be displayed
+ *          in some locales, or no text at all.
+ */
+
+public class RotateTest3 extends Panel {
+    static JFrame frame;
+
+    protected Java2DView java2DView;
+
+    public RotateTest3(){
+        this.setLayout(new GridLayout(1, 1));
+        this.setSize(300, 300);
+        this.java2DView = new Java2DView();
+        this.add(this.java2DView);
+    }
+
+    public static void main(String[] s) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(RotateTest3::initAndShowGui);
+            Thread.sleep(1000);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void initAndShowGui() {
+        RotateTest3 panel = new RotateTest3();
+
+        frame = new JFrame("RotateTest3");
+        frame.addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                frame.dispose();
+            }
+        });
+        frame.getContentPane().setLayout(new GridLayout(1, 1));
+        frame.getContentPane().add("Center", panel);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    static public class Java2DView extends Component {
+
+        public void paint(Graphics g){
+            Graphics2D g2d = (Graphics2D) g;
+            Dimension d = this.getSize();
+            g.setColor(this.getBackground());
+            g.fillRect(0, 0, d.width, d.height);
+            g2d.setPaint(Color.black);
+
+            g2d.translate(150,150);
+            g2d.rotate(-Math.PI / 3);
+
+            String testString =
+             "\u4e00\u4e8c\u4e09\u56db\u4e94\u516d\u4e03\u516b\u4e5d\u5341";
+            g2d.drawString(testString, 0, 0);
+        }
+
+        public Dimension getMinimumSize(){
+            return new Dimension(300, 300);
+        }
+
+        public Dimension getPreferredSize(){
+            return new Dimension(300, 300);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315965](https://bugs.openjdk.org/browse/JDK-8315965) needs maintainer approval

### Issue
 * [JDK-8315965](https://bugs.openjdk.org/browse/JDK-8315965): Open source various AWT applet tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/908/head:pull/908` \
`$ git checkout pull/908`

Update a local copy of the PR: \
`$ git checkout pull/908` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 908`

View PR using the GUI difftool: \
`$ git pr show -t 908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/908.diff">https://git.openjdk.org/jdk21u-dev/pull/908.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/908#issuecomment-2277486556)