### PR TITLE
8321206: Make Locale related system properties `StaticProperty`

### DIFF
--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -129,7 +129,23 @@ CDSHeapVerifier::CDSHeapVerifier() : _archived_objs(0), _problems(0)
   // This just points to an empty Map
   ADD_EXCL("jdk/internal/reflect/Reflection",            "methodFilterMap");       // E
   ADD_EXCL("jdk/internal/util/StaticProperty",           "FILE_ENCODING",          // C
-                                                 "JAVA_LOCALE_USE_OLD_ISO_CODES"); // C
+                                                 "JAVA_LOCALE_USE_OLD_ISO_CODES",  // C
+                                                 "USER_LANGUAGE",                  // C
+                                                 "USER_LANGUAGE_DISPLAY",          // C
+                                                 "USER_LANGUAGE_FORMAT",           // C
+                                                 "USER_SCRIPT",                    // C
+                                                 "USER_SCRIPT_DISPLAY",            // C
+                                                 "USER_SCRIPT_FORMAT",             // C
+                                                 "USER_COUNTRY",                   // C
+                                                 "USER_COUNTRY_DISPLAY",           // C
+                                                 "USER_COUNTRY_FORMAT",            // C
+                                                 "USER_VARIANT",                   // C
+                                                 "USER_VARIANT_DISPLAY",           // C
+                                                 "USER_VARIANT_FORMAT",            // C
+                                                 "USER_EXTENSIONS",                // C
+                                                 "USER_EXTENSIONS_DISPLAY",        // C
+                                                 "USER_EXTENSIONS_FORMAT",         // C
+                                                 "USER_REGION");                   // C
 
   // Integer for 0 and 1 are in java/lang/Integer$IntegerCache and are archived
   ADD_EXCL("sun/invoke/util/ValueConversions",           "ONE_INT",                // E

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.spi.LocaleNameProvider;
 import java.util.stream.Stream;
 
+import jdk.internal.util.StaticProperty;
 import jdk.internal.vm.annotation.Stable;
 
 import sun.security.action.GetPropertyAction;
@@ -1053,11 +1054,10 @@ public final class Locale implements Cloneable, Serializable {
 
     private static Locale initDefault() {
         String language, region, script, country, variant;
-        Properties props = GetPropertyAction.privilegedGetProperties();
-        language = props.getProperty("user.language", "en");
+        language = StaticProperty.USER_LANGUAGE;
         // for compatibility, check for old user.region property
-        region = props.getProperty("user.region");
-        if (region != null) {
+        region = StaticProperty.USER_REGION;
+        if (!region.isEmpty()) {
             // region can be of form country, country_variant, or _variant
             int i = region.indexOf('_');
             if (i >= 0) {
@@ -1069,30 +1069,24 @@ public final class Locale implements Cloneable, Serializable {
             }
             script = "";
         } else {
-            script = props.getProperty("user.script", "");
-            country = props.getProperty("user.country", "");
-            variant = props.getProperty("user.variant", "");
+            script = StaticProperty.USER_SCRIPT;
+            country = StaticProperty.USER_COUNTRY;
+            variant = StaticProperty.USER_VARIANT;
         }
 
         return getInstance(language, script, country, variant,
-                getDefaultExtensions(props.getProperty("user.extensions", ""))
+                getDefaultExtensions(StaticProperty.USER_EXTENSIONS)
                     .orElse(null));
     }
 
     private static Locale initDefault(Locale.Category category) {
-        Properties props = GetPropertyAction.privilegedGetProperties();
-
         Locale locale = Locale.defaultLocale;
         return getInstance(
-            props.getProperty(category.languageKey,
-                    locale.getLanguage()),
-            props.getProperty(category.scriptKey,
-                    locale.getScript()),
-            props.getProperty(category.countryKey,
-                    locale.getCountry()),
-            props.getProperty(category.variantKey,
-                    locale.getVariant()),
-            getDefaultExtensions(props.getProperty(category.extensionsKey, ""))
+            category == Category.DISPLAY ? StaticProperty.USER_LANGUAGE_DISPLAY : StaticProperty.USER_LANGUAGE_FORMAT,
+            category == Category.DISPLAY ? StaticProperty.USER_SCRIPT_DISPLAY : StaticProperty.USER_SCRIPT_FORMAT,
+            category == Category.DISPLAY ? StaticProperty.USER_COUNTRY_DISPLAY : StaticProperty.USER_COUNTRY_FORMAT,
+            category == Category.DISPLAY ? StaticProperty.USER_VARIANT_DISPLAY : StaticProperty.USER_VARIANT_FORMAT,
+            getDefaultExtensions(category == Category.DISPLAY ? StaticProperty.USER_EXTENSIONS_DISPLAY : StaticProperty.USER_EXTENSIONS_FORMAT)
                 .orElse(locale.getLocaleExtensions()));
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -57,6 +57,22 @@ public final class StaticProperty {
     private static final String OS_NAME;
     private static final String OS_ARCH;
     private static final String OS_VERSION;
+    public static final String USER_LANGUAGE;
+    public static final String USER_LANGUAGE_DISPLAY;
+    public static final String USER_LANGUAGE_FORMAT;
+    public static final String USER_SCRIPT;
+    public static final String USER_SCRIPT_DISPLAY;
+    public static final String USER_SCRIPT_FORMAT;
+    public static final String USER_COUNTRY;
+    public static final String USER_COUNTRY_DISPLAY;
+    public static final String USER_COUNTRY_FORMAT;
+    public static final String USER_VARIANT;
+    public static final String USER_VARIANT_DISPLAY;
+    public static final String USER_VARIANT_FORMAT;
+    public static final String USER_EXTENSIONS;
+    public static final String USER_EXTENSIONS_DISPLAY;
+    public static final String USER_EXTENSIONS_FORMAT;
+    public static final String USER_REGION;
 
     private StaticProperty() {}
 
@@ -79,6 +95,22 @@ public final class StaticProperty {
         OS_NAME = getProperty(props, "os.name");
         OS_ARCH = getProperty(props, "os.arch");
         OS_VERSION = getProperty(props, "os.version");
+        USER_LANGUAGE = getProperty(props, "user.language", "en");
+        USER_LANGUAGE_DISPLAY = getProperty(props, "user.language.display", USER_LANGUAGE);
+        USER_LANGUAGE_FORMAT = getProperty(props, "user.language.format", USER_LANGUAGE);
+        USER_SCRIPT = getProperty(props, "user.script", "");
+        USER_SCRIPT_DISPLAY = getProperty(props, "user.script.display", USER_SCRIPT);
+        USER_SCRIPT_FORMAT = getProperty(props, "user.script.format", USER_SCRIPT);
+        USER_COUNTRY = getProperty(props, "user.country", "");
+        USER_COUNTRY_DISPLAY = getProperty(props, "user.country.display", USER_COUNTRY);
+        USER_COUNTRY_FORMAT = getProperty(props, "user.country.format", USER_COUNTRY);
+        USER_VARIANT = getProperty(props, "user.variant", "");
+        USER_VARIANT_DISPLAY = getProperty(props, "user.variant.display", USER_VARIANT);
+        USER_VARIANT_FORMAT = getProperty(props, "user.variant.format", USER_VARIANT);
+        USER_EXTENSIONS = getProperty(props, "user.extensions", "");
+        USER_EXTENSIONS_DISPLAY = getProperty(props, "user.extensions.display", USER_EXTENSIONS);
+        USER_EXTENSIONS_FORMAT = getProperty(props, "user.extensions.format", USER_EXTENSIONS);
+        USER_REGION = getProperty(props, "user.region", "");
     }
 
     private static String getProperty(Properties props, String key) {


### PR DESCRIPTION
Clean backport of change to make Locale system properties static. Change passes all tier 1 tests locally on x86_64 linux.

From the original PR:
>Currently, Locale-related system properties, such as user.language or user.country, are initialized when the Locale class is loaded. Making them static properties is safer than relying on the Locale class loading timing, which could potentially be changed depending on the implementation.

This change also makes [JDK-8321940](https://bugs.openjdk.org/browse/JDK-8321940) clean, which will improve maintainability by reducing the number of manually curated `ADD_EXCL` entries in `cdsHeapVerifier.cpp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8321206](https://bugs.openjdk.org/browse/JDK-8321206) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321206](https://bugs.openjdk.org/browse/JDK-8321206): Make Locale related system properties `StaticProperty` (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/912/head:pull/912` \
`$ git checkout pull/912`

Update a local copy of the PR: \
`$ git checkout pull/912` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 912`

View PR using the GUI difftool: \
`$ git pr show -t 912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/912.diff">https://git.openjdk.org/jdk21u-dev/pull/912.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/912#issuecomment-2284808263)