### PR TITLE
8336926: jdk/internal/util/ReferencedKeyTest.java can fail with ConcurrentModificationException

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,8 +204,14 @@ public final class ReferencedKeyMap<K, V> implements Map<K, V> {
 
     @Override
     public V get(Object key) {
-        Objects.requireNonNull(key, "key must not be null");
         removeStaleReferences();
+        return getNoCheckStale(key);
+    }
+
+    // Internal get(key) without removing stale references that would modify the keyset.
+    // Use when iterating or streaming over the keys to avoid ConcurrentModificationException.
+    private V getNoCheckStale(Object key) {
+        Objects.requireNonNull(key, "key must not be null");
         return map.get(lookupKey(key));
     }
 
@@ -276,7 +282,7 @@ public final class ReferencedKeyMap<K, V> implements Map<K, V> {
     public Set<Entry<K, V>> entrySet() {
         removeStaleReferences();
         return filterKeySet()
-                .map(k -> new AbstractMap.SimpleEntry<>(k, get(k)))
+                .map(k -> new AbstractMap.SimpleEntry<>(k, getNoCheckStale(k)))
                 .collect(Collectors.toSet());
     }
 
@@ -320,7 +326,7 @@ public final class ReferencedKeyMap<K, V> implements Map<K, V> {
     public String toString() {
         removeStaleReferences();
         return filterKeySet()
-                .map(k -> k + "=" + get(k))
+                .map(k -> k + "=" + getNoCheckStale(k))
                 .collect(Collectors.joining(", ", "{", "}"));
     }
 


### PR DESCRIPTION
Clean backport to fix potential `CME` in `ReferencedKeyMap`.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `jdk/internal/util java/lang/invoke`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336926](https://bugs.openjdk.org/browse/JDK-8336926) needs maintainer approval

### Issue
 * [JDK-8336926](https://bugs.openjdk.org/browse/JDK-8336926): jdk/internal/util/ReferencedKeyTest.java can fail with ConcurrentModificationException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/916/head:pull/916` \
`$ git checkout pull/916`

Update a local copy of the PR: \
`$ git checkout pull/916` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 916`

View PR using the GUI difftool: \
`$ git pr show -t 916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/916.diff">https://git.openjdk.org/jdk21u-dev/pull/916.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/916#issuecomment-2285986323)