### PR TITLE
8330981: ZGC: Should not dedup strings in the finalizer graph

### DIFF
--- a/src/hotspot/share/gc/x/xMark.cpp
+++ b/src/hotspot/share/gc/x/xMark.cpp
@@ -367,8 +367,10 @@ void XMark::mark_and_follow(XMarkContext* context, XMarkStackEntry entry) {
       const oop obj = XOop::from_address(addr);
       follow_object(obj, finalizable);
 
-      // Try deduplicate
-      try_deduplicate(context, obj);
+      if (!finalizable) {
+        // Try deduplicate
+        try_deduplicate(context, obj);
+      }
     }
   }
 }

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -457,8 +457,10 @@ void ZMark::mark_and_follow(ZMarkContext* context, ZMarkStackEntry entry) {
       const oop obj = to_oop(addr);
       follow_object(obj, finalizable);
 
-      // Try deduplicate
-      try_deduplicate(context, obj);
+      if (!finalizable) {
+        // Try deduplicate
+        try_deduplicate(context, obj);
+      }
     }
   }
 }


### PR DESCRIPTION
Clean backport to fix a ZGC corner case.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseZGC`
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseZGC -XX:+ZGenerational`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8330981](https://bugs.openjdk.org/browse/JDK-8330981) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330981](https://bugs.openjdk.org/browse/JDK-8330981): ZGC: Should not dedup strings in the finalizer graph (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/917/head:pull/917` \
`$ git checkout pull/917`

Update a local copy of the PR: \
`$ git checkout pull/917` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 917`

View PR using the GUI difftool: \
`$ git pr show -t 917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/917.diff">https://git.openjdk.org/jdk21u-dev/pull/917.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/917#issuecomment-2286248587)