### PR TITLE
8322881: java/nio/file/Files/CopyMoveVariations.java fails with AccessDeniedException due to permissions of files in /tmp

### DIFF
--- a/test/jdk/java/nio/file/Files/CopyMoveVariations.java
+++ b/test/jdk/java/nio/file/Files/CopyMoveVariations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,17 +70,17 @@ public class CopyMoveVariations {
     private static final boolean SUPPORTS_POSIX_PERMISSIONS;
 
     static {
-        Path tmp = null;
+        Path currentDir = null;
         try {
-            tmp = Files.createTempFile("this", "that");
+            currentDir = Files.createTempFile(Path.of("."), "this", "that");
             SUPPORTS_POSIX_PERMISSIONS =
-                Files.getFileStore(tmp).supportsFileAttributeView("posix");
+                Files.getFileStore(currentDir).supportsFileAttributeView("posix");
         } catch (IOException cause) {
             throw new UncheckedIOException(cause);
         } finally {
-            if (tmp != null) {
+            if (currentDir != null) {
                 try {
-                    Files.delete(tmp);
+                    Files.delete(currentDir);
                 } catch (IOException ignore)  {
                 }
             }
@@ -142,14 +142,15 @@ public class CopyMoveVariations {
         Path source = null;
         Path target = null;
         Path linkTarget = null;
+        Path currentDir = Path.of(".");
         try {
             switch (type) {
                 case FILE ->
-                    source = Files.createTempFile("file", "dat");
+                    source = Files.createTempFile(currentDir, "file", "dat");
                 case DIR ->
-                    source = Files.createTempDirectory("dir");
+                    source = Files.createTempDirectory(currentDir, "dir");
                 case LINK -> {
-                    linkTarget = Files.createTempFile("link", "target");
+                    linkTarget = Files.createTempFile(currentDir, "link", "target");
                     Path link = Path.of("link");
                     source = Files.createSymbolicLink(link, linkTarget);
                 }
@@ -163,7 +164,7 @@ public class CopyMoveVariations {
                 Files.setPosixFilePermissions(source, perms);
 
             if (targetExists)
-                target = Files.createTempFile("file", "target");
+                target = Files.createTempFile(currentDir, "file", "target");
             else
                 target = Path.of("target");
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [bf13a4e2](https://github.com/openjdk/jdk/commit/bf13a4e2819fa5bcb3e4f2281121d4e0b5535403) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by sunyaqi on 26 Feb 2024 and was reviewed by Brian Burkhalter.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322881](https://bugs.openjdk.org/browse/JDK-8322881) needs maintainer approval

### Issue
 * [JDK-8322881](https://bugs.openjdk.org/browse/JDK-8322881): java/nio/file/Files/CopyMoveVariations.java fails with AccessDeniedException due to permissions of files in /tmp (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/921/head:pull/921` \
`$ git checkout pull/921`

Update a local copy of the PR: \
`$ git checkout pull/921` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 921`

View PR using the GUI difftool: \
`$ git pr show -t 921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/921.diff">https://git.openjdk.org/jdk21u-dev/pull/921.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/921#issuecomment-2289225384)