### PR TITLE
8309067: gtest/AsyncLogGtest.java fails again in stderrOutput_vm

### DIFF
--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -74,6 +74,7 @@ LOG_LEVEL_LIST
   // Emit all logs between constructor and destructor of BufferUpdater.
   void test_asynclog_drop_messages() {
     const size_t sz = 2000;
+
     // shrink async buffer.
     AsyncLogWriter::BufferUpdater saver(1024);
     test_asynclog_ls(); // roughly 200 bytes.

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -79,6 +79,7 @@ LOG_LEVEL_LIST
     AsyncLogWriter::BufferUpdater saver(1024);
     test_asynclog_ls(); // roughly 200 bytes.
     LogMessage(logging) lm;
+
     // write more messages than its capacity in burst
     for (size_t i = 0; i < sz; ++i) {
       lm.debug("a lot of log...");


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.
add added codes are clean, except line different.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309067](https://bugs.openjdk.org/browse/JDK-8309067) needs maintainer approval

### Issue
 * [JDK-8309067](https://bugs.openjdk.org/browse/JDK-8309067): gtest/AsyncLogGtest.java fails again in stderrOutput_vm (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/923/head:pull/923` \
`$ git checkout pull/923`

Update a local copy of the PR: \
`$ git checkout pull/923` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 923`

View PR using the GUI difftool: \
`$ git pr show -t 923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/923.diff">https://git.openjdk.org/jdk21u-dev/pull/923.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/923#issuecomment-2290752672)