### PR TITLE
8333149: ubsan : memset on nullptr target detected in jvmtiEnvBase.cpp get_object_monitor_usage

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1515,8 +1515,12 @@ JvmtiEnvBase::get_object_monitor_usage(JavaThread* calling_thread, jobject objec
 
     // Number of waiters may actually be less than the waiter count.
     // So null out memory so that unused memory will be null.
-    memset(ret.waiters, 0, ret.waiter_count * sizeof(jthread *));
-    memset(ret.notify_waiters, 0, ret.notify_waiter_count * sizeof(jthread *));
+    if (ret.waiters != nullptr) {
+      memset(ret.waiters, 0, ret.waiter_count * sizeof(jthread *));
+    }
+    if (ret.notify_waiters != nullptr) {
+      memset(ret.notify_waiters, 0, ret.notify_waiter_count * sizeof(jthread *));
+    }
 
     if (ret.waiter_count > 0) {
       // we have contending and/or waiting threads


### PR DESCRIPTION
Backport of 8333149, diff in stride

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333149](https://bugs.openjdk.org/browse/JDK-8333149) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8333149: ubsan : memset on nullptr target detected in jvmtiEnvBase.cpp get_object_monitor_usage`

### Issue
 * [JDK-8333149](https://bugs.openjdk.org/browse/JDK-8333149): ubsan : memset on nullptr target detected in jvmtiEnvBase.cpp get_object_monitor_usage (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/928/head:pull/928` \
`$ git checkout pull/928`

Update a local copy of the PR: \
`$ git checkout pull/928` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 928`

View PR using the GUI difftool: \
`$ git pr show -t 928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/928.diff">https://git.openjdk.org/jdk21u-dev/pull/928.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/928#issuecomment-2293223997)