### PR TITLE
8311644: Server should not send bad_certificate alert when the client does not send any certificates

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/Alert.java
+++ b/src/java.base/share/classes/sun/security/ssl/Alert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,13 +123,13 @@ enum Alert {
         }
 
         if (cause instanceof IOException) {
-            return new SSLException(reason, cause);
+            return new SSLException("(" + description + ") " + reason, cause);
         } else if ((this == UNEXPECTED_MESSAGE)) {
-            return new SSLProtocolException(reason, cause);
+            return new SSLProtocolException("(" + description + ") " + reason, cause);
         } else if (handshakeOnly) {
-            return new SSLHandshakeException(reason, cause);
+            return new SSLHandshakeException("(" + description + ") " + reason, cause);
         } else {
-            return new SSLException(reason, cause);
+            return new SSLException("(" + description + ") " + reason, cause);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/CertificateMessage.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateMessage.java
@@ -381,7 +381,7 @@ final class CertificateMessage {
                 if (shc.sslConfig.clientAuthType !=
                         ClientAuthType.CLIENT_AUTH_REQUESTED) {
                     // unexpected or require client authentication
-                    throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
+                    throw shc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
                         "Empty client certificate chain");
                 } else {
                     return;
@@ -1154,7 +1154,7 @@ final class CertificateMessage {
                 shc.handshakeConsumers.remove(
                         SSLHandshake.CERTIFICATE_VERIFY.id);
                 if (shc.sslConfig.clientAuthType == CLIENT_AUTH_REQUIRED) {
-                    throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
+                    throw shc.conContext.fatal(Alert.CERTIFICATE_REQUIRED,
                         "Empty client certificate chain");
                 } else {
                     // optional client authentication
@@ -1178,7 +1178,7 @@ final class CertificateMessage {
                 T13CertificateMessage certificateMessage )throws IOException {
             if (certificateMessage.certEntries == null ||
                     certificateMessage.certEntries.isEmpty()) {
-                throw chc.conContext.fatal(Alert.BAD_CERTIFICATE,
+                throw chc.conContext.fatal(Alert.DECODE_ERROR,
                     "Empty server certificate chain");
             }
 

--- a/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
+++ b/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /javax/net/ssl/templates
+ * @bug 8311644
+ * @summary Verify CertificateMessage alerts are correct to the TLS specs
+ * @run main/othervm -Djdk.tls.client.protocols=TLSv1.2 CertMsgCheck handshake_failure
+ * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 CertMsgCheck certificate_required
+ *
+ */
+
+public class CertMsgCheck {
+
+    public static void main(String[] args) throws Exception {
+        // Start server
+        TLSBase.Server server = new TLSBase.ServerBuilder().setClientAuth(true).
+            build();
+
+        // Initial client session
+        TLSBase.Client client1 = new TLSBase.Client(true, false);
+        if (server.getSession(client1).getSessionContext() == null) {
+            for (Exception e : server.getExceptionList()) {
+                System.out.println("Looking at " + e.getClass() + " " +
+                    e.getMessage());
+                if (e.getMessage().contains(args[0])) {
+                    System.out.println("Found correct exception: " + args[0] +
+                    " in " + e.getMessage());
+                    return;
+                } else {
+                    System.out.println("No \"" + args[0] + "\" found.");
+                }
+            }
+
+            throw new Exception("Failed to find expected alert: " + args[0]);
+        }
+    }
+}

--- a/test/jdk/javax/net/ssl/SSLSession/CheckSessionContext.java
+++ b/test/jdk/javax/net/ssl/SSLSession/CheckSessionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,15 +36,11 @@
  */
 
 import javax.net.ssl.SSLSession;
+import java.util.HexFormat;
 
 public class CheckSessionContext {
 
-    static void toHex(byte[] id) {
-        for (byte b : id) {
-            System.out.printf("%02X ", b);
-        }
-        System.out.println();
-    }
+    static HexFormat hex = HexFormat.of();
 
     public static void main(String[] args) throws Exception {
         TLSBase.Server server = new TLSBase.Server();
@@ -52,20 +48,18 @@ public class CheckSessionContext {
         // Initial client session
         TLSBase.Client client1 = new TLSBase.Client();
         if (server.getSession(client1).getSessionContext() == null) {
-            throw new Exception("Context was null");
+            throw new Exception("Context was null.  Handshake failure.");
         } else {
             System.out.println("Context was found");
         }
         SSLSession ss = server.getSession(client1);
         System.out.println(ss);
         byte[] id = ss.getId();
-        System.out.print("id = ");
-        toHex(id);
+        System.out.println("id = " + hex.formatHex(id));
         System.out.println("ss.getSessionContext().getSession(id) = " + ss.getSessionContext().getSession(id));
         if (ss.getSessionContext().getSession(id) != null) {
             id = ss.getSessionContext().getSession(id).getId();
-            System.out.print("id = ");
-            toHex(id);
+            System.out.println("id = " + hex.formatHex(id));
         }
         server.close(client1);
         client1.close();

--- a/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
+++ b/test/jdk/sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
             throw new Exception("Legacy DH keys (< 1024) should be restricted");
         } catch (SSLHandshakeException she) {
             String expectedExMsg = "Received fatal alert: insufficient_security";
-            if (!expectedExMsg.equals(she.getMessage())) {
+            if (!she.getMessage().endsWith(expectedExMsg)) {
                 throw she;
             }
             System.out.println("Expected exception thrown in server");
@@ -77,7 +77,7 @@ public class LegacyDHEKeyExchange extends SSLSocketTemplate{
         } catch (SSLHandshakeException she) {
             String expectedExMsg = "DH ServerKeyExchange does not comply to" +
                     " algorithm constraints";
-            if (!expectedExMsg.equals(she.getMessage())) {
+            if (!she.getMessage().endsWith(expectedExMsg)) {
                 throw she;
             }
             System.out.println("Expected exception thrown in client");

--- a/test/jdk/sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS12.java
+++ b/test/jdk/sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS12.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (C) 2021, 2024 THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +123,7 @@ public class SigAlgosExtTestWithTLS12 extends SSLEngineTemplate {
                         "Expected SSLHandshakeException wasn't thrown");
             }
         } catch (SSLHandshakeException e) {
-            if (EXPECT_FAIL && e.getMessage().equals(
+            if (EXPECT_FAIL && e.getMessage().endsWith(
                     "No supported signature algorithm")) {
                 System.out.println("Expected SSLHandshakeException");
             } else {

--- a/test/jdk/sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS13.java
+++ b/test/jdk/sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS13.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -78,7 +79,7 @@ public class SigAlgosExtTestWithTLS13 extends SSLSocketTemplate {
                         "Expected SSLHandshakeException wasn't thrown");
             }
         } catch (SSLHandshakeException e) {
-            if (expectFail && e.getMessage().equals(
+            if (expectFail && e.getMessage().endsWith(
                     "No supported signature algorithm")) {
                 System.out.println("Expected SSLHandshakeException");
             } else {


### PR DESCRIPTION
Backport of [JDK-8311644](https://bugs.openjdk.org/browse/JDK-8311644)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - `CertMsgCheck.java`: Test results: passed: 1
  - `CheckSessionContext.java`: Test results: passed: 1
  - `LegacyDHEKeyExchange.java`: Test results: passed: 1
  - `SigAlgosExtTestWithTLS12.java`: Test results: passed: 1
  - `SigAlgosExtTestWithTLS13.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8311644](https://bugs.openjdk.org/browse/JDK-8311644) needs maintainer approval

### Issue
 * [JDK-8311644](https://bugs.openjdk.org/browse/JDK-8311644): Server should not send bad_certificate alert when the client does not send any certificates (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/932/head:pull/932` \
`$ git checkout pull/932`

Update a local copy of the PR: \
`$ git checkout pull/932` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 932`

View PR using the GUI difftool: \
`$ git pr show -t 932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/932.diff">https://git.openjdk.org/jdk21u-dev/pull/932.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/932#issuecomment-2294616617)