### PR TITLE
8334078: RISC-V: TestIntVect.java fails after JDK-8332153 when running without RVV

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -131,7 +131,10 @@ void VM_Version::setup_cpu_available_features() {
       if (_feature_list[i]->feature_string()) {
         const char* tmp = _feature_list[i]->pretty();
         if (strlen(tmp) == 1) {
-          strcat(buf, " ");
+          // Feature string is expected to be in multi-character form
+          // like rvc, rvv, etc so that it will be easier to specify
+          // target feature string in tests.
+          strcat(buf, " rv");
           strcat(buf, tmp);
         } else {
           // Feature string is expected to be lower case.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -78,7 +78,9 @@ public class IREncodingPrinter {
         // AArch64
         "sha3",
         "asimd",
-        "sve"
+        "sve",
+        // Riscv64
+        "rvv"
     ));
 
     public IREncodingPrinter() {


### PR DESCRIPTION
Hi, at [JDK-8334078](https://bugs.openjdk.org/browse/JDK-8334078), modified the matching logic for the linux-riscv64 rvv test, here i would like to backport this to jdk21u-dev, to simplify the subsequent functionality and testing of the backport to jdk21u-dev. This is a risc-v specific change, risk is low.

### Testing
- [x] Run tier1 tests on SOPHON SG2042 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334078](https://bugs.openjdk.org/browse/JDK-8334078) needs maintainer approval

### Issue
 * [JDK-8334078](https://bugs.openjdk.org/browse/JDK-8334078): RISC-V: TestIntVect.java fails after JDK-8332153 when running without RVV (**Bug** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/937/head:pull/937` \
`$ git checkout pull/937`

Update a local copy of the PR: \
`$ git checkout pull/937` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 937`

View PR using the GUI difftool: \
`$ git pr show -t 937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/937.diff">https://git.openjdk.org/jdk21u-dev/pull/937.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/937#issuecomment-2299145651)