### PR TITLE
8317575: AArch64: C2_MacroAssembler::fast_lock uses rscratch1 for cmpxchg result

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -117,7 +117,7 @@ void C2_MacroAssembler::fast_lock(Register objectReg, Register boxReg, Register 
   // Try to CAS m->owner from NULL to current thread.
   add(tmp, disp_hdr, (in_bytes(ObjectMonitor::owner_offset())-markWord::monitor_value));
   cmpxchg(tmp, zr, rthread, Assembler::xword, /*acquire*/ true,
-          /*release*/ true, /*weak*/ false, rscratch1); // Sets flags for result
+          /*release*/ true, /*weak*/ false, tmp3Reg); // Sets flags for result
 
   if (LockingMode != LM_LIGHTWEIGHT) {
     // Store a non-null value into the box to avoid looking like a re-entrant
@@ -129,7 +129,7 @@ void C2_MacroAssembler::fast_lock(Register objectReg, Register boxReg, Register 
   }
   br(Assembler::EQ, cont); // CAS success means locking succeeded
 
-  cmp(rscratch1, rthread);
+  cmp(tmp3Reg, rthread);
   br(Assembler::NE, cont); // Check for recursive locking
 
   // Recursive lock case


### PR DESCRIPTION
This is a clean backport to avoid a potentially rscratch1 register clobbering in C2_MacroAssembler::fast_lock.

Testing: jtreg tier1-3 on linux-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317575](https://bugs.openjdk.org/browse/JDK-8317575) needs maintainer approval

### Issue
 * [JDK-8317575](https://bugs.openjdk.org/browse/JDK-8317575): AArch64: C2_MacroAssembler::fast_lock uses rscratch1 for cmpxchg result (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/941/head:pull/941` \
`$ git checkout pull/941`

Update a local copy of the PR: \
`$ git checkout pull/941` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 941`

View PR using the GUI difftool: \
`$ git pr show -t 941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/941.diff">https://git.openjdk.org/jdk21u-dev/pull/941.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/941#issuecomment-2303087122)