### PR TITLE
8338101: remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3354,8 +3354,8 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
                                      os::attempt_reserve_memory_at(aligned_base, size);
   }
 
-  assert(aligned_base != nullptr, "Did not manage to re-map after %d attempts?", max_attempts);
-  assert(aligned_base != nullptr, "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
+  assert(aligned_base != nullptr,
+      "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
 
   return aligned_base;
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8338101](https://bugs.openjdk.org/browse/JDK-8338101) needs maintainer approval
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8338101: remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058`

### Issue
 * [JDK-8338101](https://bugs.openjdk.org/browse/JDK-8338101): remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/950/head:pull/950` \
`$ git checkout pull/950`

Update a local copy of the PR: \
`$ git checkout pull/950` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 950`

View PR using the GUI difftool: \
`$ git pr show -t 950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/950.diff">https://git.openjdk.org/jdk21u-dev/pull/950.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/950#issuecomment-2321305365)