### PR TITLE
8337966: (fs) Files.readAttributes fails with Operation not permitted…

### DIFF
--- a/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
@@ -71,6 +71,8 @@ Java_sun_nio_ch_FileDispatcherImpl_transferFrom0(JNIEnv *env, jobject this,
         if (errno == EINTR) {
             return IOS_INTERRUPTED;
         }
+        if (errno == EPERM)
+            return IOS_UNSUPPORTED;
         JNU_ThrowIOExceptionWithLastError(env, "Transfer failed");
         return IOS_THROWN;
     }
@@ -103,6 +105,7 @@ Java_sun_nio_ch_FileDispatcherImpl_transferTo0(JNIEnv *env, jobject this,
                 case EINVAL:
                 case ENOSYS:
                 case EXDEV:
+                case EPERM:
                     // ignore and try sendfile()
                     break;
                 default:

--- a/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
+++ b/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
@@ -199,6 +199,7 @@ Java_sun_nio_fs_LinuxNativeDispatcher_directCopy0
                     case EINVAL:
                     case ENOSYS:
                     case EXDEV:
+                    case EPERM:
                         // ignore and try sendfile()
                         break;
                     default:

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -687,7 +687,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_stat0(JNIEnv* env, jclass this,
         if (err == 0) {
             copy_statx_attributes(env, &statx_buf, attrs);
             return 0;
-        } else {
+        } else if (errno != ENOSYS && errno != EPERM) {
             return errno;
         }
     }
@@ -718,11 +718,11 @@ Java_sun_nio_fs_UnixNativeDispatcher_lstat0(JNIEnv* env, jclass this,
         RESTARTABLE(statx_wrapper(AT_FDCWD, path, flags, mask, &statx_buf), err);
         if (err == 0) {
             copy_statx_attributes(env, &statx_buf, attrs);
-        } else {
+            return;
+        } else if (errno != ENOSYS && errno != EPERM) {
             throwUnixException(env, errno);
+            return;
         }
-        // statx was available, so return now
-        return;
     }
 #endif
     RESTARTABLE(lstat64(path, &buf), err);
@@ -750,11 +750,11 @@ Java_sun_nio_fs_UnixNativeDispatcher_fstat0(JNIEnv* env, jclass this, jint fd,
         RESTARTABLE(statx_wrapper((int)fd, "", flags, mask, &statx_buf), err);
         if (err == 0) {
             copy_statx_attributes(env, &statx_buf, attrs);
-        } else {
+            return;
+        } else if (errno != ENOSYS && errno != EPERM) {
             throwUnixException(env, errno);
+            return;
         }
-        // statx was available, so return now
-        return;
     }
 #endif
     RESTARTABLE(fstat64((int)fd, &buf), err);
@@ -785,11 +785,11 @@ Java_sun_nio_fs_UnixNativeDispatcher_fstatat0(JNIEnv* env, jclass this, jint dfd
         RESTARTABLE(statx_wrapper((int)dfd, path, flags, mask, &statx_buf), err);
         if (err == 0) {
             copy_statx_attributes(env, &statx_buf, attrs);
-        } else {
+            return;
+        } else if (errno != ENOSYS && errno != EPERM) {
             throwUnixException(env, errno);
+            return;
         }
-        // statx was available, so return now
-        return;
     }
 #endif
 


### PR DESCRIPTION
… on older docker releases

Please review the fix for regression on the old Docker versions (before v18.04).

[JDK-8316304](https://bugs.openjdk.org/browse/JDK-8316304) was backported to JDK21, requiring statx syscall support.
In the old Docker versions, the default seccomp profile does not allow statx syscall and fails with EPERM error code.
Suggest fixing this issue by fallback to alternative implementation at runtime if syscall is not allowed.

The same issue with copy_file_range syscall.

The fix was initially submitted against upstream jdk ( https://github.com/openjdk/jdk/pull/20484 ) but after discussion submitted to JDK21
