### PR TITLE
8338402: GHA: some of bundles may not get removed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -370,7 +370,7 @@ jobs:
               -H 'Accept: application/vnd.github+json' \
               -H 'Authorization: Bearer ${{ github.token }}' \
               -H 'X-GitHub-Api-Version: 2022-11-28' \
-              '${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts')"
+              '${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100')"
           BUNDLE_ARTIFACT_IDS="$(echo "$ALL_ARTIFACT_IDS" | jq -r -c '.artifacts | map(select(.name|startswith("bundles-"))) | .[].id')"
           for id in $BUNDLE_ARTIFACT_IDS; do
             echo "Removing $id"


### PR DESCRIPTION
Backport fixing problem, where some bundles may not get removed in GHA.

GHA testing: OK (no leftover bundles)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8338402](https://bugs.openjdk.org/browse/JDK-8338402) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338402](https://bugs.openjdk.org/browse/JDK-8338402): GHA: some of bundles may not get removed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/952/head:pull/952` \
`$ git checkout pull/952`

Update a local copy of the PR: \
`$ git checkout pull/952` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 952`

View PR using the GUI difftool: \
`$ git pr show -t 952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/952.diff">https://git.openjdk.org/jdk21u-dev/pull/952.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/952#issuecomment-2325051742)