### PR TITLE
8339248: RISC-V: Remove li64 macro assembler routine and related code

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -706,7 +706,6 @@ public:
 
   void li16u(Register Rd, uint16_t imm);
   void li32(Register Rd, int32_t imm);
-  void li64(Register Rd, int64_t imm);
   void li  (Register Rd, int64_t imm);  // optimized load immediate
 
   // mv

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -109,18 +109,6 @@ bool NativeInstruction::is_li32_at(address instr) {
          check_li32_data_dependency(instr);
 }
 
-bool NativeInstruction::is_li64_at(address instr) {
-  return is_lui_at(instr) && // lui
-         is_addi_at(instr + instruction_size) && // addi
-         is_slli_shift_at(instr + instruction_size * 2, 12) &&  // Slli Rd, Rs, 12
-         is_addi_at(instr + instruction_size * 3) && // addi
-         is_slli_shift_at(instr + instruction_size * 4, 12) &&  // Slli Rd, Rs, 12
-         is_addi_at(instr + instruction_size * 5) && // addi
-         is_slli_shift_at(instr + instruction_size * 6, 8) &&   // Slli Rd, Rs, 8
-         is_addi_at(instr + instruction_size * 7) && // addi
-         check_li64_data_dependency(instr);
-}
-
 void NativeCall::verify() {
   assert(NativeCall::is_call_at((address)this), "unexpected code at call site");
 }

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -127,40 +127,6 @@ class NativeInstruction {
            extract_rs1(last_instr) == extract_rd(slli2);
   }
 
-  // the instruction sequence of li64 is as below:
-  //     lui
-  //     addi
-  //     slli
-  //     addi
-  //     slli
-  //     addi
-  //     slli
-  //     addi
-  static bool check_li64_data_dependency(address instr) {
-    address lui = instr;
-    address addi1 = lui + instruction_size;
-    address slli1 = addi1 + instruction_size;
-    address addi2 = slli1 + instruction_size;
-    address slli2 = addi2 + instruction_size;
-    address addi3 = slli2 + instruction_size;
-    address slli3 = addi3 + instruction_size;
-    address addi4 = slli3 + instruction_size;
-    return extract_rs1(addi1) == extract_rd(lui) &&
-           extract_rs1(addi1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(slli2) &&
-           extract_rs1(addi3) == extract_rd(slli2) &&
-           extract_rs1(addi3) == extract_rd(addi3) &&
-           extract_rs1(slli3) == extract_rd(addi3) &&
-           extract_rs1(slli3) == extract_rd(slli3) &&
-           extract_rs1(addi4) == extract_rd(slli3) &&
-           extract_rs1(addi4) == extract_rd(addi4);
-  }
-
   // the instruction sequence of li16u is as below:
   //     lui
   //     srli
@@ -207,7 +173,6 @@ class NativeInstruction {
   static bool is_movptr_at(address instr);
   static bool is_li16u_at(address instr);
   static bool is_li32_at(address instr);
-  static bool is_li64_at(address instr);
   static bool is_pc_relative_at(address branch);
   static bool is_load_pc_relative_at(address branch);
 


### PR DESCRIPTION
Hi, The same issue also exists in jdk21u-dev. So I would like to backport [JDK-8339248](https://bugs.openjdk.org/browse/JDK-8339248) to jdk21u-dev. with this patch ,it will save us some unnecessary runtime checks. RISC-V specific change, risk is low.

### Testing
- [x] Run hotspot:tier1 tests on SOPHON SG2042 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339248](https://bugs.openjdk.org/browse/JDK-8339248) needs maintainer approval

### Issue
 * [JDK-8339248](https://bugs.openjdk.org/browse/JDK-8339248): RISC-V: Remove li64 macro assembler routine and related code (**Enhancement** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/953/head:pull/953` \
`$ git checkout pull/953`

Update a local copy of the PR: \
`$ git checkout pull/953` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 953`

View PR using the GUI difftool: \
`$ git pr show -t 953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/953.diff">https://git.openjdk.org/jdk21u-dev/pull/953.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/953#issuecomment-2326119956)