### PR TITLE
8320682: [AArch64] C1 compilation fails with "Field too big for insn"

### DIFF
--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -275,9 +275,11 @@
   develop(bool, InstallMethods, true,                                       \
           "Install methods at the end of successful compilations")          \
                                                                             \
+  /* The compiler assumes, in many places, that methods are at most 1MB. */ \
+  /* Therefore, we restrict this flag to at most 1MB.                    */ \
   develop(intx, NMethodSizeLimit, (64*K)*wordSize,                          \
           "Maximum size of a compiled method.")                             \
-          range(0, max_jint)                                                \
+          range(0, 1*M)                                                     \
                                                                             \
   develop(bool, TraceFPUStack, false,                                       \
           "Trace emulation of the FPU stack (intel only)")                  \

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8316653
+ * @requires vm.debug
+ * @summary Test flag with max value.
+ *
+ * @run main/othervm -XX:NMethodSizeLimit=1M
+ *                   compiler.arguments.TestC1Globals
+ */
+
+/**
+ * @test
+ * @bug 8318817
+ * @requires vm.debug
+ * @requires os.family == "linux"
+ * @summary Test flag with max value combined with transparent huge pages on
+ *          Linux.
+ *
+ * @run main/othervm -XX:NMethodSizeLimit=1M
+ *                   -XX:+UseTransparentHugePages
+ *                   compiler.arguments.TestC1Globals
+ */
+
+/**
+ * @test
+ * @bug 8320682
+ * @requires vm.debug
+ * @summary Test flag with max value and specific compilation.
+ *
+ * @run main/othervm -XX:NMethodSizeLimit=1M
+ *                   -XX:CompileOnly=java.util.HashMap::putMapEntries
+ *                   -Xcomp
+ *                   compiler.arguments.TestC1Globals
+ *
+ */
+
+package compiler.arguments;
+
+public class TestC1Globals {
+
+    public static void main(String args[]) {
+        System.out.println("Passed");
+    }
+}


### PR DESCRIPTION
Hi all,

This is a backport of [JDK-8320682](https://github.com/openjdk/jdk/pull/16951) change to fix C1 internal error caused by adr limit being broken by too large NMethodSizeLimit option value.

The backported patch includes a change to the TestC1Globals.java that does not yet exist in the jdk21u codebase. In the mainline the test has four updates:
 - [1] https://github.com/openjdk/jdk/commit/7df73a23
 - [2] https://github.com/openjdk/jdk/commit/c36ec2ca
 - [3] https://github.com/openjdk/jdk/commit/69014cd5 (this change)
 - [4] https://github.com/openjdk/jdk/commit/27d5f5c2

With this change I simply copy version [3] of TestC1Globals.java corresponding to this change in jdk-23. Why not backport [1]+[2]+[3] to have a clean incremental patch?
- I do not think [1] fits the backporting rules (not a crash fix, and not very important)
- change [3] is stronger than change [2] (once NMethodSizeLimit is limited, no need to gracefully handle large values)

Testing: jtreg tier1-3.
Without the patch `$ fastdebug/bin/java -XX:NMethodSizeLimit=4M` causes the `guarantee(chk == -1 || chk == 0) failed: Field too big for insn`. With the change the 4M value becomes invalid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320682](https://bugs.openjdk.org/browse/JDK-8320682) needs maintainer approval

### Issue
 * [JDK-8320682](https://bugs.openjdk.org/browse/JDK-8320682): [AArch64] C1 compilation fails with "Field too big for insn" (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/956/head:pull/956` \
`$ git checkout pull/956`

Update a local copy of the PR: \
`$ git checkout pull/956` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 956`

View PR using the GUI difftool: \
`$ git pr show -t 956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/956.diff">https://git.openjdk.org/jdk21u-dev/pull/956.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/956#issuecomment-2332280167)