### PR TITLE
8328723: IP Address error when client enables HTTPS endpoint check on server socket

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -428,8 +428,17 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
         }
 
         if (!identifiable) {
-            checkIdentity(peerHost,
-                    trustedChain[0], algorithm, chainsToPublicCA);
+            try {
+                checkIdentity(peerHost,
+                        trustedChain[0], algorithm, chainsToPublicCA);
+            } catch(CertificateException ce) {
+                if (checkClientTrusted && "HTTPS".equalsIgnoreCase(algorithm)) {
+                    throw new CertificateException("Endpoint Identification Algorithm " +
+                            "HTTPS is not supported on the server side");
+                } else {
+                    throw ce;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8328723](https://bugs.openjdk.org/browse/JDK-8328723) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328723](https://bugs.openjdk.org/browse/JDK-8328723): IP Address error when client enables HTTPS endpoint check on server socket (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/959/head:pull/959` \
`$ git checkout pull/959`

Update a local copy of the PR: \
`$ git checkout pull/959` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 959`

View PR using the GUI difftool: \
`$ git pr show -t 959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/959.diff">https://git.openjdk.org/jdk21u-dev/pull/959.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/959#issuecomment-2337167876)