### PR TITLE
8337320: Update ProblemList.txt with tests known to fail on XWayland

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -481,7 +481,6 @@ java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
 
 java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8332158 linux-x64
 java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java 8280991 linux-x64
-java/awt/FullScreen/SetFullScreenTest.java 8332155 linux-x64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -477,6 +477,12 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 # This test fails on macOS 14
 java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
 
+# Wayland related
+
+java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8332158 linux-x64
+java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java 8280991 linux-x64
+java/awt/FullScreen/SetFullScreenTest.java 8332155 linux-x64
+
 ############################################################################
 
 # jdk_lang


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.
Not clean, this file java/awt/FullScreen/SetFullScreenTest.java does not exist in jdk21

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337320](https://bugs.openjdk.org/browse/JDK-8337320) needs maintainer approval

### Issue
 * [JDK-8337320](https://bugs.openjdk.org/browse/JDK-8337320): Update ProblemList.txt with tests known to fail on XWayland (**Bug** - P3 - Approved)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/961/head:pull/961` \
`$ git checkout pull/961`

Update a local copy of the PR: \
`$ git checkout pull/961` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 961`

View PR using the GUI difftool: \
`$ git pr show -t 961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/961.diff">https://git.openjdk.org/jdk21u-dev/pull/961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/961#issuecomment-2337169165)