### PR TITLE
8328665: serviceability/jvmti/vthread/PopFrameTest failed with a timeout

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/PopFrameTest/libPopFrameTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/PopFrameTest/libPopFrameTest.cpp
@@ -49,11 +49,13 @@ Breakpoint(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
   {
     RawMonitorLocker rml(jvmti, jni, monitor);
     bp_sync_reached = true;
-    rml.wait(0);
+    while (bp_sync_reached) { // guard against spurious wakeups
+      rml.wait(0);
+    }
   }
   LOG("Breakpoint: In method TestTask.B(): after sync section\n");
 
-  if (do_pop_frame != 0) {
+  if (do_pop_frame) {
     err = jvmti->PopFrame(thread);
     LOG("Breakpoint: PopFrame returned code: %s (%d)\n", TranslateError(err), err);
     check_jvmti_status(jni, err, "Breakpoint: Failed in PopFrame");
@@ -152,13 +154,15 @@ Java_PopFrameTest_popFrame(JNIEnv *jni, jclass cls, jthread thread) {
 
 JNIEXPORT void JNICALL
 Java_PopFrameTest_ensureAtBreakpoint(JNIEnv *jni, jclass cls) {
-  bool need_stop = false;
-
   LOG("Main: ensureAtBreakpoint\n");
-  while (!need_stop) {
-    RawMonitorLocker rml(jvmti, jni, monitor);
-    need_stop = bp_sync_reached;
-    sleep_ms(1); // 1 millisecond
+  RawMonitorLocker rml(jvmti, jni, monitor);
+  int attempts = 0;
+  while (!bp_sync_reached) {
+    if (++attempts > 100) {
+      fatal(jni, "Main: ensureAtBreakpoint: waited 20 sec");
+    }
+    LOG("Main: ensureAtBreakpoint: waiting 200 millis\n");
+    rml.wait(200); // 200 milliseconds
   }
 }
 
@@ -166,6 +170,9 @@ JNIEXPORT void JNICALL
 Java_PopFrameTest_notifyAtBreakpoint(JNIEnv *jni, jclass cls) {
   LOG("Main: notifyAtBreakpoint\n");
   RawMonitorLocker rml(jvmti, jni, monitor);
+  if (!bp_sync_reached) { // better diagnosability
+    fatal(jni, "Main: notifyAtBreakpoint: expected: bp_sync_reached==true");
+  }
   bp_sync_reached = false;
   rml.notify_all();
 }


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328665](https://bugs.openjdk.org/browse/JDK-8328665) needs maintainer approval

### Issue
 * [JDK-8328665](https://bugs.openjdk.org/browse/JDK-8328665): serviceability/jvmti/vthread/PopFrameTest failed with a timeout (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/963/head:pull/963` \
`$ git checkout pull/963`

Update a local copy of the PR: \
`$ git checkout pull/963` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 963`

View PR using the GUI difftool: \
`$ git pr show -t 963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/963.diff">https://git.openjdk.org/jdk21u-dev/pull/963.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/963#issuecomment-2340715281)