### PR TITLE
8296972: [macos13] java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java: getExtendedState() != 6 as expected.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -119,7 +119,6 @@ java/awt/Focus/FocusOwnerFrameOnClick/FocusOwnerFrameOnClick.java 8081489 generi
 java/awt/Focus/IconifiedFrameFocusChangeTest/IconifiedFrameFocusChangeTest.java 6849364 generic-all
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java 6848406 generic-all
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java 6848407 generic-all
-java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java 8296972 macosx-all
 java/awt/Frame/MaximizedUndecorated/MaximizedUndecorated.java 8022302 generic-all
 java/awt/Frame/RestoreToOppositeScreen/RestoreToOppositeScreen.java 8286840 linux-all
 java/awt/FileDialog/FileDialogIconTest/FileDialogIconTest.java 8160558 windows-all

--- a/test/jdk/java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java
+++ b/test/jdk/java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java
@@ -45,7 +45,7 @@ import java.awt.event.WindowStateListener;
 
 public class MaximizedToIconified
 {
-    static volatile int lastFrameState = Frame.NORMAL;
+    static volatile int lastFrameState;
     static volatile boolean failed = false;
     static volatile Toolkit myKit;
     private static Robot robot;
@@ -76,6 +76,8 @@ public class MaximizedToIconified
         Frame frame = new Frame("test");
         frame.setSize(200, 200);
         frame.setVisible(true);
+
+        lastFrameState = Frame.NORMAL;
 
         robot.waitForIdle();
 
@@ -114,7 +116,12 @@ public class MaximizedToIconified
         //    because Toolkit.isFrameStateSupported() method reports these states
         //    as not supported. And such states will simply be skipped.
         examineStates(new int[] {Frame.MAXIMIZED_BOTH, Frame.ICONIFIED, Frame.NORMAL});
+        System.out.println("------");
         examineStates(new int[] {Frame.ICONIFIED, Frame.MAXIMIZED_BOTH, Frame.NORMAL});
+        System.out.println("------");
+        examineStates(new int[] {Frame.NORMAL, Frame.MAXIMIZED_BOTH, Frame.ICONIFIED});
+        System.out.println("------");
+        examineStates(new int[] {Frame.NORMAL, Frame.ICONIFIED, Frame.MAXIMIZED_BOTH});
 
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296972](https://bugs.openjdk.org/browse/JDK-8296972) needs maintainer approval

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8296972: [macos13] java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java: getExtendedState() != 6 as expected.`

### Issue
 * [JDK-8296972](https://bugs.openjdk.org/browse/JDK-8296972): [macos13] java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java: getExtendedState() != 6 as expected. (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/965/head:pull/965` \
`$ git checkout pull/965`

Update a local copy of the PR: \
`$ git checkout pull/965` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 965`

View PR using the GUI difftool: \
`$ git pr show -t 965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/965.diff">https://git.openjdk.org/jdk21u-dev/pull/965.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/965#issuecomment-2345470649)