### PR TITLE
8296787: Unify debug printing format of X.509 cert serial numbers

### DIFF
--- a/src/java.base/share/classes/java/security/cert/X509CertSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CertSelector.java
@@ -1929,10 +1929,10 @@ public class X509CertSelector implements CertSelector {
         }
 
         if (debug != null) {
-            debug.println("X509CertSelector.match(SN: "
-                + (xcert.getSerialNumber()).toString(16) + "\n  Issuer: "
-                + xcert.getIssuerX500Principal() + "\n  Subject: " + xcert.getSubjectX500Principal()
-                + ")");
+            debug.println("X509CertSelector.match(Serial number: "
+                + Debug.toString(xcert.getSerialNumber())
+                + "\n  Issuer: " + xcert.getIssuerX500Principal() + "\n  Subject: "
+                + xcert.getSubjectX500Principal() + ")");
         }
 
         /* match on X509Certificate */

--- a/src/java.base/share/classes/sun/security/jca/JCAUtil.java
+++ b/src/java.base/share/classes/sun/security/jca/JCAUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.security.cert.X509Certificate;
 import jdk.internal.event.EventHelper;
 import jdk.internal.event.X509CertificateEvent;
 import sun.security.util.KeyUtil;
+import sun.security.util.Debug;
 
 /**
  * Collection of static utility methods used by the security framework.
@@ -104,7 +105,7 @@ public final class JCAUtil {
                 (cert instanceof X509Certificate x509)) {
             PublicKey pKey = x509.getPublicKey();
             String algId = x509.getSigAlgName();
-            String serNum = x509.getSerialNumber().toString(16);
+            String serNum = Debug.toString(x509.getSerialNumber());
             String subject = x509.getSubjectX500Principal().toString();
             String issuer = x509.getIssuerX500Principal().toString();
             String keyType = pKey.getAlgorithm();

--- a/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
@@ -678,14 +678,15 @@ public class SignerInfo implements DerEncoder {
             md.digest(encryptedDigest))) {
 
             throw new SignatureException("Signature timestamp (#" +
-                token.getSerialNumber() + ") generated on " + token.getDate() +
-                " is inapplicable");
+                Debug.toString(token.getSerialNumber()) +
+                ") generated on " + token.getDate() + " is inapplicable");
         }
 
         if (debug != null) {
             debug.println();
             debug.println("Detected signature timestamp (#" +
-                token.getSerialNumber() + ") generated on " + token.getDate());
+                Debug.toString(token.getSerialNumber()) +
+                ") generated on " + token.getDate());
             debug.println();
         }
     }

--- a/src/java.base/share/classes/sun/security/provider/certpath/BasicChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/BasicChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,7 +244,7 @@ class BasicChecker extends PKIXCertPathChecker {
             debug.println("BasicChecker.updateState issuer: " +
                 currCert.getIssuerX500Principal().toString() + "; subject: " +
                 currCert.getSubjectX500Principal() + "; serial#: " +
-                currCert.getSerialNumber().toString());
+                Debug.toString(currCert.getSerialNumber()));
         }
         if (PKIX.isDSAPublicKeyWithoutParams(cKey)) {
             // cKey needs to inherit DSA parameters from prev key

--- a/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
@@ -429,8 +429,7 @@ abstract class Builder {
                 if (debug != null) {
                     debug.println("Builder.addMatchingCerts: " +
                         "adding target cert" +
-                        "\n  SN: " + Debug.toHexString(
-                                            targetCert.getSerialNumber()) +
+                        "\n  SN: " + Debug.toString(targetCert.getSerialNumber()) +
                         "\n  Subject: " + targetCert.getSubjectX500Principal() +
                         "\n  Issuer: " + targetCert.getIssuerX500Principal());
                 }

--- a/src/java.base/share/classes/sun/security/provider/certpath/CertId.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/CertId.java
@@ -108,7 +108,7 @@ public class CertId implements DerEncoder {
                 encoder.encodeBuffer(issuerNameHash));
             System.out.println("issuerKeyHash is " +
                 encoder.encodeBuffer(issuerKeyHash));
-            System.out.println("SerialNumber is " + serialNumber.getNumber());
+            System.out.println("SerialNumber is " + Debug.toString(serialNumber.getNumber()));
         }
     }
 

--- a/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -314,7 +314,7 @@ public class DistributionPointFetcher {
         if (debug != null) {
             debug.println("DistributionPointFetcher.verifyCRL: " +
                 "checking revocation status for" +
-                "\n  SN: " + Debug.toHexString(certImpl.getSerialNumber()) +
+                "\n  SN: " + Debug.toString(certImpl.getSerialNumber()) +
                 "\n  Subject: " + certImpl.getSubjectX500Principal() +
                 "\n  Issuer: " + certImpl.getIssuerX500Principal());
         }

--- a/src/java.base/share/classes/sun/security/provider/certpath/ForwardBuilder.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/ForwardBuilder.java
@@ -284,7 +284,7 @@ final class ForwardBuilder extends Builder {
                     debug.println("ForwardBuilder.getMatchingCACerts: " +
                         "found matching trust anchor." +
                         "\n  SN: " +
-                            Debug.toHexString(trustedCert.getSerialNumber()) +
+                            Debug.toString(trustedCert.getSerialNumber()) +
                         "\n  Subject: " +
                             trustedCert.getSubjectX500Principal() +
                         "\n  Issuer: " +
@@ -698,7 +698,7 @@ final class ForwardBuilder extends Builder {
     {
         if (debug != null) {
             debug.println("ForwardBuilder.verifyCert(SN: "
-                + Debug.toHexString(cert.getSerialNumber())
+                + Debug.toString(cert.getSerialNumber())
                 + "\n  Issuer: " + cert.getIssuerX500Principal() + ")"
                 + "\n  Subject: " + cert.getSubjectX500Principal() + ")");
         }

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -405,7 +405,8 @@ public final class OCSPResponse {
             }
             if (debug != null) {
                 debug.println("Status of certificate (with serial number " +
-                    certId.getSerialNumber() + ") is: " + sr.getCertStatus());
+                    Debug.toString(certId.getSerialNumber()) +
+                    ") is: " + sr.getCertStatus());
             }
         }
 

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,7 +351,7 @@ class RevocationChecker extends PKIXRevocationChecker {
     {
         if (debug != null) {
             debug.println("RevocationChecker.check: checking cert" +
-                "\n  SN: " + Debug.toHexString(xcert.getSerialNumber()) +
+                "\n  SN: " + Debug.toString(xcert.getSerialNumber()) +
                 "\n  Subject: " + xcert.getSubjectX500Principal() +
                 "\n  Issuer: " + xcert.getIssuerX500Principal());
         }
@@ -642,7 +642,7 @@ class RevocationChecker extends PKIXRevocationChecker {
             debug.println("RevocationChecker.checkApprovedCRLs() " +
                           "starting the final sweep...");
             debug.println("RevocationChecker.checkApprovedCRLs()" +
-                          " cert SN: " + sn.toString());
+                          " cert SN: " + Debug.toString(sn));
         }
 
         CRLReason reasonCode = CRLReason.UNSPECIFIED;

--- a/src/java.base/share/classes/sun/security/provider/certpath/Vertex.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/Vertex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,7 @@ final class Vertex {
         sb.append("Subject:    ").append
                 (x509Cert.getSubjectX500Principal()).append("\n");
         sb.append("SerialNum:  ").append
-                (x509Cert.getSerialNumber().toString(16)).append("\n");
+                (Debug.toString(x509Cert.getSerialNumber())).append("\n");
         sb.append("Expires:    ").append
                 (x509Cert.getNotAfter().toString()).append("\n");
         boolean[] iUID = x509Cert.getIssuerUniqueID();

--- a/src/java.base/share/classes/sun/security/ssl/SSLLogger.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import java.util.*;
 
 import sun.security.action.GetPropertyAction;
 import sun.security.util.HexDumpEncoder;
+import sun.security.util.Debug;
 import sun.security.x509.*;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -485,8 +486,7 @@ public final class SSLLogger {
                 if (certExts == null) {
                     Object[] certFields = {
                         x509.getVersion(),
-                        Utilities.toHexString(
-                                x509.getSerialNumber().toByteArray()),
+                        Debug.toString(x509.getSerialNumber()),
                         x509.getSigAlgName(),
                         x509.getIssuerX500Principal().toString(),
                         dateTimeFormat.format(x509.getNotBefore().toInstant()),
@@ -510,8 +510,7 @@ public final class SSLLogger {
                     }
                     Object[] certFields = {
                         x509.getVersion(),
-                        Utilities.toHexString(
-                                x509.getSerialNumber().toByteArray()),
+                        Debug.toString(x509.getSerialNumber()),
                         x509.getSigAlgName(),
                         x509.getIssuerX500Principal().toString(),
                         dateTimeFormat.format(x509.getNotBefore().toInstant()),

--- a/src/java.base/share/classes/sun/security/ssl/StatusResponseManager.java
+++ b/src/java.base/share/classes/sun/security/ssl/StatusResponseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import sun.security.provider.certpath.OCSPResponse;
 import sun.security.provider.certpath.ResponderId;
 import sun.security.ssl.X509Authentication.X509Possession;
 import sun.security.util.Cache;
+import sun.security.util.Debug;
 import sun.security.x509.PKIXExtensions;
 import sun.security.x509.SerialNumber;
 import static sun.security.ssl.CertStatusExtension.*;
@@ -403,8 +404,8 @@ final class StatusResponseManager {
 
         if (SSLLogger.isOn && SSLLogger.isOn("respmgr")) {
             SSLLogger.fine(
-                    "Check cache for SN" + cid.getSerialNumber() + ": " +
-                    (respEntry != null ? "HIT" : "MISS"));
+                    "Check cache for SN" + Debug.toString(cid.getSerialNumber())
+                        + ": " + (respEntry != null ? "HIT" : "MISS"));
         }
         return respEntry;
     }
@@ -499,7 +500,7 @@ final class StatusResponseManager {
         public String toString() {
             return "StatusInfo:" + "\n\tCert: " +
                    this.cert.getSubjectX500Principal() +
-                   "\n\tSerial: " + this.cert.getSerialNumber() +
+                   "\n\tSerial: " + Debug.toString(this.cert.getSerialNumber()) +
                    "\n\tResponder: " + this.responder +
                    "\n\tResponse data: " +
                    (this.responseData != null ?
@@ -545,7 +546,7 @@ final class StatusResponseManager {
                 } else {
                     throw new IOException(
                             "Unable to find SingleResponse for SN " +
-                            cid.getSerialNumber());
+                            Debug.toString(cid.getSerialNumber()));
                 }
             } else {
                 nextUpdate = null;
@@ -596,7 +597,7 @@ final class StatusResponseManager {
             if (SSLLogger.isOn && SSLLogger.isOn("respmgr")) {
                 SSLLogger.fine(
                     "Starting fetch for SN " +
-                    statInfo.cid.getSerialNumber());
+                    Debug.toString(statInfo.cid.getSerialNumber()));
             }
             try {
                 ResponseCacheEntry cacheEntry;
@@ -681,7 +682,7 @@ final class StatusResponseManager {
                 if (SSLLogger.isOn && SSLLogger.isOn("respmgr")) {
                     SSLLogger.fine(
                         "Added response for SN " +
-                        certId.getSerialNumber() +
+                        Debug.toString(certId.getSerialNumber()) +
                         " to cache");
                 }
             }

--- a/src/java.base/share/classes/sun/security/util/Debug.java
+++ b/src/java.base/share/classes/sun/security/util/Debug.java
@@ -405,6 +405,10 @@ public class Debug {
         return HexFormat.ofDelimiter(":").formatHex(b);
     }
 
+    public static String toString(BigInteger b) {
+        return toString(b.toByteArray());
+    }
+
     // Holder class to break cyclic dependency seen during build
     private static class FormatHolder {
         private static final String PATTERN = "yyyy-MM-dd kk:mm:ss.SSS";

--- a/src/java.base/share/classes/sun/security/x509/SerialNumber.java
+++ b/src/java.base/share/classes/sun/security/x509/SerialNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package sun.security.x509;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.util.HexFormat;
 
 import sun.security.util.*;
 
@@ -101,7 +102,7 @@ public class SerialNumber {
      * Return the SerialNumber as user readable string.
      */
     public String toString() {
-        return "SerialNumber: [" + Debug.toHexString(serialNum) + ']';
+        return "SerialNumber: " + Debug.toString(serialNum);
     }
 
     /**

--- a/test/jdk/java/security/cert/X509CertSelectorTest.java
+++ b/test/jdk/java/security/cert/X509CertSelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,10 +60,11 @@ import sun.security.x509.PolicyInformation;
 import sun.security.x509.PrivateKeyUsageExtension;
 import sun.security.x509.SubjectAlternativeNameExtension;
 import sun.security.x509.X500Name;
+import sun.security.util.Debug;
 
 /*
  * @test
- * @bug 8074931
+ * @bug 8074931 8296787
  * @summary This class tests the X509CertSelector. The tests check particular criteria
  *          by setting them to a value that should match our test certificate and
  *          ensuring that they do match, then setting them to a value that should not
@@ -191,6 +192,14 @@ public class X509CertSelectorTest {
         // good match
         selector.setSerialNumber(cert.getSerialNumber());
         checkMatch(selector, cert, true);
+
+        // check serial number format
+        String serialNum = Debug.toString(selector.getSerialNumber());
+        String expected = "38:df:82:b8";
+        if (!serialNum.equals(expected)) {
+            throw new RuntimeException("Serial number toString format is incorrect. Got: "
+                + serialNum + " Expected: " + expected);
+        }
     }
 
     // Tests matching on the issuer name contained in the certificate.

--- a/test/lib/jdk/test/lib/security/TestCertificate.java
+++ b/test/lib/jdk/test/lib/security/TestCertificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public enum TestCertificate {
     // Subject: CN=SSLCertificate, O=SomeCompany
     // Issuer: CN=Intermediate CA Cert, O=SomeCompany
     // Validity: Tue Aug 30 14:37:19 PDT 2016 to Wed Aug 30 14:37:19 PDT 2017
-    ONE("1000",
+    ONE("10:00",
         "CN=SSLCertificate, O=SomeCompany",
         "CN=Intermediate CA Cert, O=SomeCompany",
         -1063259762,

--- a/test/lib/jdk/test/lib/security/TestTLSHandshake.java
+++ b/test/lib/jdk/test/lib/security/TestTLSHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@ public final class TestTLSHandshake extends SSLSocketTest {
         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384";
     public static final long CERT_ID = Integer.toUnsignedLong(-1057291798);
     public static final long ANCHOR_CERT_ID = Integer.toUnsignedLong(1688661792);
-    public static final String CERT_SERIAL = "edbec8f705af2514";
-    public static final String ANCHOR_CERT_SERIAL = "8e191778b2f331be";
+    public static final String CERT_SERIAL = "00:ed:be:c8:f7:05:af:25:14";
+    public static final String ANCHOR_CERT_SERIAL = "8e:19:17:78:b2:f3:31:be";
 
     public String protocolVersion;
     public String peerHost;


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

Trivial resolve in Debug.java, probably recognized clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296787](https://bugs.openjdk.org/browse/JDK-8296787) needs maintainer approval

### Issue
 * [JDK-8296787](https://bugs.openjdk.org/browse/JDK-8296787): Unify debug printing format of X.509 cert serial numbers (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/966/head:pull/966` \
`$ git checkout pull/966`

Update a local copy of the PR: \
`$ git checkout pull/966` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 966`

View PR using the GUI difftool: \
`$ git pr show -t 966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/966.diff">https://git.openjdk.org/jdk21u-dev/pull/966.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/966#issuecomment-2345838877)