### PR TITLE
8328303: 3 JDI tests timed out with UT enabled

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/referenceType/refType001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/referenceType/refType001.java
@@ -28,6 +28,8 @@ import com.sun.jdi.event.*;
 import com.sun.jdi.request.*;
 
 import java.io.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.Iterator;
 
 import nsk.share.*;
@@ -68,7 +70,8 @@ public class refType001 {
                 {"AnotherThread",   "Inter",                    "0"}
              };
 
-    static private volatile boolean testFailed, eventsReceived, threadsStarted;
+    static private volatile boolean testFailed;
+    static private CountDownLatch eventsReceivedLatch;
     static private int eventTimeout;
 
     public static void main (String args[]) {
@@ -79,9 +82,7 @@ public class refType001 {
         String command;
 
         testFailed = false;
-        eventsReceived = false;
-        threadsStarted = false;
-
+        eventsReceivedLatch = new CountDownLatch(1);
 
         argHandler = new ArgumentHandler(args);
         log = new Log(out, argHandler);
@@ -111,8 +112,10 @@ public class refType001 {
 
                 public void run() {
 
-                    // handle events until all threads started and all expected events received
-                    while (!(threadsStarted && eventsReceived)) {
+                    boolean isConnected = true;
+                    boolean allEventsReceived = false;
+                    // handle events until debuggee is disconnected
+                    while (isConnected) {
                         EventSet eventSet = null;
                         try {
                             eventSet = vm.eventQueue().remove(TIMEOUT_DELTA);
@@ -130,8 +133,10 @@ public class refType001 {
                             Event event = eventIterator.nextEvent();
 //                            log.display("\nEvent received:\n  " + event);
 
-                            // handle ClassPrepareEvent
-                            if (event instanceof ClassPrepareEvent) {
+                            if (event instanceof VMDeathEvent || event instanceof VMDisconnectEvent) {
+                                log.display("eventHandler got " + event);
+                                isConnected = false;
+                            } else  if (event instanceof ClassPrepareEvent) {
                                 ClassPrepareEvent castedEvent = (ClassPrepareEvent)event;
                                 log.display("\nClassPrepareEvent received:\n  " + event);
 
@@ -195,11 +200,20 @@ public class refType001 {
                                                    }
                                               }
 
-                                              // Check that all expected ClassPrepareEvent are received
-                                              eventsReceived = true;
-                                              for (int i = 0; i < checkedTypes.length; i++) {
-                                                   if (checkedTypes[i][2] == "0")
-                                                       eventsReceived = false;
+                                              // Check that all expected ClassPrepareEvent(s) are received.
+                                              if (!allEventsReceived) {
+                                                  allEventsReceived = true;
+                                                  for (int i = 0; i < checkedTypes.length; i++) {
+                                                      // checkedTypes[i][2] is "0" initially,
+                                                      // "1" after corresponding ClassPrepareEvent is received.
+                                                      if (checkedTypes[i][2] == "0") {
+                                                          allEventsReceived = false;
+                                                          break;
+                                                      }
+                                                  }
+                                                  if (allEventsReceived) {
+                                                      eventsReceivedLatch.countDown();
+                                                  }
                                               }
                                          }
                                     }
@@ -216,7 +230,9 @@ public class refType001 {
                         } // event handled
 
 //                        log.display("Resuming event set");
-                        eventSet.resume();
+                        if (isConnected) {
+                            eventSet.resume();
+                        }
 
                     } // event set handled
 
@@ -257,17 +273,12 @@ public class refType001 {
                 testFailed = true;
             }
 
-            // notify EventHandler that all threads started
-            threadsStarted = true;
-
             // wait for all expected events received or timeout exceeds
             try {
-                  eventHandler.join(eventTimeout);
-                  if (eventHandler.isAlive()) {
-                      log.complain("FAILURE 20: Timeout for waiting event was exceeded");
-                      eventHandler.interrupt();
-                      testFailed = true;
-                  }
+                if (!eventsReceivedLatch.await(eventTimeout, TimeUnit.MILLISECONDS)) {
+                    log.complain("FAILURE 20: Timeout waiting for all events was exceeded");
+                    testFailed = true;
+                }
             } catch (InterruptedException e) {
                   log.complain("TEST INCOMPLETE: InterruptedException caught while waiting for eventHandler's death");
                   testFailed = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
@@ -28,6 +28,8 @@ import com.sun.jdi.event.*;
 import com.sun.jdi.request.*;
 
 import java.io.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.Iterator;
 
 import nsk.share.*;
@@ -72,7 +74,8 @@ public class thread001 {
 
     static private int threadStatus;
 
-    static private volatile boolean testFailed, eventsReceived, threadsStarted;
+    static private volatile boolean testFailed;
+    static private CountDownLatch eventsReceivedLatch;
     static private int eventTimeout;
 
     public static void main (String args[]) {
@@ -83,8 +86,7 @@ public class thread001 {
         String command;
 
         testFailed = false;
-        eventsReceived = false;
-        threadsStarted = false;
+        eventsReceivedLatch = new CountDownLatch(1);
 
         argHandler = new ArgumentHandler(args);
         log = new Log(out, argHandler);
@@ -131,8 +133,10 @@ public class thread001 {
 
                 public void run() {
 
-                    // handle events until all threads started and all expected events received
-                    while (!(threadsStarted && eventsReceived)) {
+                    boolean isConnected = true;
+                    boolean allEventsReceived = false;
+                    // handle events until debuggee is disconnected
+                    while (isConnected) {
                         EventSet eventSet = null;
                         try {
                             eventSet = vm.eventQueue().remove(TIMEOUT_DELTA);
@@ -150,8 +154,10 @@ public class thread001 {
                             Event event = eventIterator.nextEvent();
 //                            log.display("\nEvent received:\n  " + event);
 
-                            // handle ClassPrepareEvent
-                            if (event instanceof ClassPrepareEvent) {
+                            if (event instanceof VMDeathEvent || event instanceof VMDisconnectEvent) {
+                                log.display("eventHandler got " + event);
+                                isConnected = false;
+                            } else  if (event instanceof ClassPrepareEvent) {
                                 ClassPrepareEvent castedEvent = (ClassPrepareEvent)event;
                                 log.display("\nClassPrepareEvent received:\n  " + event);
 
@@ -224,12 +230,20 @@ public class thread001 {
                                                }
                                           }
 
-                                          // Check that all expected ClassPrepareEvent are received
-                                          eventsReceived = true;
-                                          for (int i = 0; i < checkedThreads.length; i++) {
-                                               if (checkedThreads[i][2] == "0") {
-                                                    eventsReceived = false;
-                                               }
+                                          // Check that all expected ClassPrepareEvent(s) are received.
+                                          if (!allEventsReceived) {
+                                              allEventsReceived = true;
+                                              for (int i = 0; i < checkedThreads.length; i++) {
+                                                  // checkedTypes[i][2] is "0" initially,
+                                                  // "1" after corresponding ClassPrepareEvent is received.
+                                                  if (checkedThreads[i][2] == "0") {
+                                                      allEventsReceived = false;
+                                                      break;
+                                                   }
+                                              }
+                                              if (allEventsReceived) {
+                                                  eventsReceivedLatch.countDown();
+                                              }
                                           }
                                      }
                                  }
@@ -240,7 +254,9 @@ public class thread001 {
                         } // event handled
 
 //                        log.display("Resuming event set");
-                        eventSet.resume();
+                        if (isConnected) {
+                            eventSet.resume();
+                        }
 
                     } // event set handled
 
@@ -280,17 +296,12 @@ public class thread001 {
                 testFailed = true;
             }
 
-            // notify EventHandler that all threads started
-            threadsStarted = true;
-
             // wait for all expected events received or timeout exceeds
             try {
-                  eventHandler.join(eventTimeout);
-                  if (eventHandler.isAlive()) {
-                      log.complain("FAILURE 20: Timeout for waiting event was exceeded");
-                      eventHandler.interrupt();
-                      testFailed = true;
-                  }
+                if (!eventsReceivedLatch.await(eventTimeout, TimeUnit.MILLISECONDS)) {
+                    log.complain("FAILURE 20: Timeout waiting for all events was exceeded");
+                    testFailed = true;
+                }
             } catch (InterruptedException e) {
                   log.complain("TEST INCOMPLETE: InterruptedException caught while waiting for eventHandler's death");
                   testFailed = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadDeathRequests/thrdeathreq001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadDeathRequests/thrdeathreq001.java
@@ -168,8 +168,8 @@ public class thrdeathreq001 {
     }
 
     private int quitDebuggee() {
+        pipe.println(COMMAND_QUIT);
         if (elThread != null) {
-            elThread.isConnected = false;
             try {
                 if (elThread.isAlive())
                     elThread.join();
@@ -180,7 +180,6 @@ public class thrdeathreq001 {
             }
         }
 
-        pipe.println(COMMAND_QUIT);
         debuggee.waitFor();
         int debStat = debuggee.getStatus();
         if (debStat != (JCK_STATUS_BASE + PASSED)) {
@@ -195,30 +194,24 @@ public class thrdeathreq001 {
     }
 
     class EventListener extends Thread {
-        public volatile boolean isConnected = true;
 
         public void run() {
             try {
+                boolean isConnected = true;
                 do {
                     EventSet eventSet = vm.eventQueue().remove(1000);
                     if (eventSet != null) { // there is not a timeout
                         EventIterator it = eventSet.eventIterator();
                         while (it.hasNext()) {
                             Event event = it.nextEvent();
-                            if (event instanceof VMDeathEvent) {
-                                tot_res = FAILED;
+                            if (event instanceof VMDeathEvent || event instanceof VMDisconnectEvent) {
+                                log.display("EventListener: got " + event);
                                 isConnected = false;
-                                log.complain("TEST FAILED: unexpected VMDeathEvent");
-                            } else if (event instanceof VMDisconnectEvent) {
-                                tot_res = FAILED;
-                                isConnected = false;
-                                log.complain("TEST FAILED: unexpected VMDisconnectEvent");
-                            } else
+                            } else {
                                 log.display("EventListener: following JDI event occured: "
                                     + event.toString());
-                        }
-                        if (isConnected) {
-                            eventSet.resume();
+                                eventSet.resume();
+                            }
                         }
                     }
                 } while (isConnected);


### PR DESCRIPTION
I backport this to improve testing. Without this, 8326898 might cause problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328303](https://bugs.openjdk.org/browse/JDK-8328303) needs maintainer approval

### Issue
 * [JDK-8328303](https://bugs.openjdk.org/browse/JDK-8328303): 3 JDI tests timed out with UT enabled (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/967/head:pull/967` \
`$ git checkout pull/967`

Update a local copy of the PR: \
`$ git checkout pull/967` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 967`

View PR using the GUI difftool: \
`$ git pr show -t 967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/967.diff">https://git.openjdk.org/jdk21u-dev/pull/967.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/967#issuecomment-2346091366)