### PR TITLE
8326898: NSK tests should listen on loopback addresses only

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach004/attach004t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach004/attach004t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ public class attach004t {
         SocketIOPipe pipe = null;
         try {
             int portNumber = readPortNumber(log);
-            pipe = SocketIOPipe.createClientIOPipe(log, "localhost", portNumber, 0);
+            pipe = SocketIOPipe.createClientIOPipe(log, portNumber, 0);
             log.display("Send message to debugger: " + attach004.messageOK);
             pipe.println(attach004.messageOK);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/DummyTargetApplication.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/DummyTargetApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class DummyTargetApplication {
     }
 
     public void runTargetApplication() {
-        pipe = SocketIOPipe.createClientIOPipe(log, "localhost", argParser.getPort(), 0);
+        pipe = SocketIOPipe.createClientIOPipe(log, argParser.getPort(), 0);
         log.display("Sending signal '" + AODTestRunner.SIGNAL_READY_FOR_ATTACH + "'");
         pipe.println(AODTestRunner.SIGNAL_READY_FOR_ATTACH);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/TargetApplicationWaitingAgents.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/TargetApplicationWaitingAgents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -341,7 +341,7 @@ public class TargetApplicationWaitingAgents {
                 /*
                  * When target application initialized send signal to AODTestRunner
                  */
-                pipe = SocketIOPipe.createClientIOPipe(log, "localhost", argParser.getPort(), 0);
+                pipe = SocketIOPipe.createClientIOPipe(log, argParser.getPort(), 0);
                 log.display("Sending signal '" + AODTestRunner.SIGNAL_READY_FOR_ATTACH + "'");
                 pipe.println(AODTestRunner.SIGNAL_READY_FOR_ATTACH);
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,12 +108,12 @@ public class DebugeeArgumentHandler extends ArgumentParser {
     /**
      * Return name of the host where test executes, specified by
      * <code>-test.host</code> command line option or
-     * "<i>localhost</i>" string by default.
+     * empty string (represents an address of the loopback interface) by default.
      *
      * @see #setRawArguments(String[])
      */
     public String getTestHost() {
-        return options.getProperty("test.host", "localhost");
+        return options.getProperty("test.host", "");
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,7 +180,7 @@ public class DebugeeBinder extends Log.Logger implements Finalizable {
             try {
                 pipeServerSocket = new ServerSocket();
                 pipeServerSocket.setReuseAddress(false);
-                pipeServerSocket.bind(null);
+                pipeServerSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 
             } catch (IOException e) {
                 e.printStackTrace(getOutStream());

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketIOPipe.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketIOPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package nsk.share.jpda;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import nsk.share.*;
@@ -35,13 +36,13 @@ import nsk.share.*;
  *
  * Server and client objects should be created using special static methods provided by this class,
  * for example 'createServerIOPipe(Log log, int port, long timeout)' for server SocketIOPipe
- * and 'createClientIOPipe(Log log, String host, int port, long timeout)' for client SocketIOPipe.
+ * and 'createClientIOPipe(Log log, int port, long timeout)' for client SocketIOPipe.
  *
  * When SocketIOPipe is created it can be used to send and receive strings using methods 'readln()' and 'println(String s)'.
  * TCP/IP connection is established at the first attempt to read or write data.
  *
- * For example, if client process should send string 'OK' to the server process which is run
- * at the host 'SERVER_HOST' following code can be written:
+ * For example, if client process should send string 'OK' to the server process,
+ * the following code can be written:
  *
  * Server side:
  *
@@ -53,8 +54,8 @@ import nsk.share.*;
  *
  * Client side:
  *
- *  // initialize SocketIOPipe with given values of server host name and port
- *  SocketIOPipe pipe = SocketIOPipe.createClientIOPipe(log, 'SERVER_HOST', port, timeoutValue);
+ *  // initialize SocketIOPipe with given port
+ *  SocketIOPipe pipe = SocketIOPipe.createClientIOPipe(log, port, timeoutValue);
  *
  *  String command = "OK";
  *  // SocketIOPipe tries to create socket and send command to the server
@@ -123,7 +124,7 @@ public class SocketIOPipe extends Log.Logger implements Finalizable {
               // then we should retry the bind() a few times.
               ss.setReuseAddress(false);
             }
-            ss.bind(new InetSocketAddress(port));
+            ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), port));
             pipe.setServerSocket(ss);
         } catch (IOException e) {
             e.printStackTrace(log.getOutStream());
@@ -143,8 +144,9 @@ public class SocketIOPipe extends Log.Logger implements Finalizable {
     /**
      *  Create attaching SocketIOPipe using given port and timeout
      */
-    public static SocketIOPipe createClientIOPipe(Log log, String host, int port, long timeout) {
-        return new SocketIOPipe(log, DEFAULT_PIPE_LOG_PREFIX, host, port, timeout, false);
+    public static SocketIOPipe createClientIOPipe(Log log, int port, long timeout) {
+        // use null for host to connect to loopback address
+        return new SocketIOPipe(log, DEFAULT_PIPE_LOG_PREFIX, null, port, timeout, false);
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8326898](https://bugs.openjdk.org/browse/JDK-8326898) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326898](https://bugs.openjdk.org/browse/JDK-8326898): NSK tests should listen on loopback addresses only (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/968/head:pull/968` \
`$ git checkout pull/968`

Update a local copy of the PR: \
`$ git checkout pull/968` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 968`

View PR using the GUI difftool: \
`$ git pr show -t 968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/968.diff">https://git.openjdk.org/jdk21u-dev/pull/968.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/968#issuecomment-2346121945)