### PR TITLE
8321550: Update several runtime/cds tests to use vm flags or mark as flagless

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -49,10 +49,10 @@ public class TestCDSVMCrash {
             }
         }
         // else this is the main test
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
-                                                                             "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
-                                                                             "-Xshare:on", TestCDSVMCrash.class.getName(),
-                                                                             "throwOOME");
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
+                                                                      "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
+                                                                      "-Xshare:on", TestCDSVMCrash.class.getName(),
+                                                                      "throwOOME");
         // executeAndLog should throw an exception in the VM crashed
         try {
             CDSTestUtils.executeAndLog(pb, "cds_vm_crash");

--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -25,6 +25,7 @@
  * @test TestCDSVMCrash
  * @summary Verify that an exception is thrown when the VM crashes during executeAndLog
  * @requires vm.cds
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestCDSVMCrash
@@ -37,19 +38,21 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TestCDSVMCrash {
 
+    static Object[] oa;
+
     public static void main(String[] args) throws Exception {
         if (args.length == 1) {
             // This should guarantee to throw:
             // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
             try {
-                Object[] oa = new Object[Integer.MAX_VALUE];
+                oa = new Object[Integer.MAX_VALUE];
                 throw new Error("OOME not triggered");
             } catch (OutOfMemoryError err) {
                 throw new Error("OOME didn't abort JVM!");
             }
         }
         // else this is the main test
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
                                                                       "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
                                                                       "-Xshare:on", TestCDSVMCrash.class.getName(),
                                                                       "throwOOME");

--- a/test/hotspot/jtreg/runtime/cds/appcds/FillerObjectLoadTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/FillerObjectLoadTest.java
@@ -27,6 +27,7 @@
  * @summary VM crash caused by unloaded FillerObject_klass
  * @library /test/lib
  * @requires vm.cds
+ * @requires vm.flagless
  * @run driver FillerObjectLoadTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
@@ -29,6 +29,7 @@
  * @bug 8279009 8275084
  * @requires vm.cds
  * @requires vm.cds.custom.loaders
+ * @requires vm.flagless
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile test-classes/Hello.java ClassSpecializerTestApp.java ClassListWithCustomClassNoSource.java
  * @run main/othervm TestDumpClassListSource

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
@@ -26,6 +26,7 @@
  * @bug 8313638
  * @summary Testing resolved references array to ensure elements are non-null
  * @requires vm.cds.write.archived.java.heap
+ * @requires vm.flagless
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox ResolvedReferencesWb ResolvedReferencesTestApp
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -42,14 +43,14 @@ public class ResolvedReferencesNotNullTest {
         String appJar = TestCommon.getTestJar(SharedStringsUtils.TEST_JAR_NAME_FULL);
         String whiteboxParam = SharedStringsUtils.getWbParam();
 
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-cp",
-                                                                      appJar,
-                                                                      whiteboxParam,
-                                                                      "-XX:+UnlockDiagnosticVMOptions",
-                                                                      "-XX:+WhiteBoxAPI",
-                                                                      "ResolvedReferencesWb",
-                                                                      "false" // ResolvedReferencesTestApp is not archived
-                                                                      );
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-cp",
+                                                                             appJar,
+                                                                             whiteboxParam,
+                                                                             "-XX:+UnlockDiagnosticVMOptions",
+                                                                             "-XX:+WhiteBoxAPI",
+                                                                             "ResolvedReferencesWb",
+                                                                             "false" // ResolvedReferencesTestApp is not archived
+                                                                             );
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
@@ -42,14 +42,14 @@ public class ResolvedReferencesNotNullTest {
         String appJar = TestCommon.getTestJar(SharedStringsUtils.TEST_JAR_NAME_FULL);
         String whiteboxParam = SharedStringsUtils.getWbParam();
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-cp",
-                                                                             appJar,
-                                                                             whiteboxParam,
-                                                                             "-XX:+UnlockDiagnosticVMOptions",
-                                                                             "-XX:+WhiteBoxAPI",
-                                                                             "ResolvedReferencesWb",
-                                                                             "false" // ResolvedReferencesTestApp is not archived
-                                                                             );
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-cp",
+                                                                      appJar,
+                                                                      whiteboxParam,
+                                                                      "-XX:+UnlockDiagnosticVMOptions",
+                                                                      "-XX:+WhiteBoxAPI",
+                                                                      "ResolvedReferencesWb",
+                                                                      "false" // ResolvedReferencesTestApp is not archived
+                                                                      );
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
 


### PR DESCRIPTION
I include two follow ups. All three are clean backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329533](https://bugs.openjdk.org/browse/JDK-8329533) needs maintainer approval
- [x] [JDK-8321550](https://bugs.openjdk.org/browse/JDK-8321550) needs maintainer approval
- [x] [JDK-8329353](https://bugs.openjdk.org/browse/JDK-8329353) needs maintainer approval

### Issues
 * [JDK-8321550](https://bugs.openjdk.org/browse/JDK-8321550): Update several runtime/cds tests to use vm flags or mark as flagless (**Enhancement** - P4 - Approved)
 * [JDK-8329533](https://bugs.openjdk.org/browse/JDK-8329533): TestCDSVMCrash fails on libgraal (**Bug** - P4 - Approved)
 * [JDK-8329353](https://bugs.openjdk.org/browse/JDK-8329353): ResolvedReferencesNotNullTest.java failed with Incorrect resolved references array, quxString should not be archived (**Bug** - P2 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/969/head:pull/969` \
`$ git checkout pull/969`

Update a local copy of the PR: \
`$ git checkout pull/969` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 969`

View PR using the GUI difftool: \
`$ git pr show -t 969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/969.diff">https://git.openjdk.org/jdk21u-dev/pull/969.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/969#issuecomment-2346155626)