### PR TITLE
8333108: Update vmTestbase/nsk/share/DebugeeProcess.java to don't use finalization

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001.java
@@ -107,6 +107,11 @@ public class tc04x001 {
             e.printStackTrace();
         } finally {
             debugee.resume();
+            int code = debugee.waitFor();
+            if (code != Consts.JCK_STATUS_BASE) {
+                log.complain("Debugee FAILED with exit code: " + code);
+                exitStatus = Consts.TEST_FAILED;
+            }
         }
         display("Test finished. exitStatus = " + exitStatus);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VMDeathEvent/_itself_/vmdeath003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VMDeathEvent/_itself_/vmdeath003.java
@@ -278,7 +278,12 @@ public class vmdeath003 extends JDIBase {
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
         log1("    TESTING ENDS");
-        return;
+        int code = debuggee.waitFor();
+        if (code != Consts.JCK_STATUS_BASE) {
+            log2("Debugee FAILED with exit code: " + code);
+            testExitCode = Consts.TEST_FAILED;
+        }
+
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/exit/exit001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/exit/exit001.java
@@ -171,6 +171,12 @@ public class exit001 {
             logHandler.complain("TEST FAILED");
         }
 
+        int code = debuggee.waitFor();
+        if (code != 0) {
+            log2("Debugee FAILED with exit code: " + code);
+            testExitCode = Consts.TEST_FAILED;
+        }
+
         return testExitCode;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -128,8 +128,6 @@ public class Binder extends DebugeeBinder {
      */
     public Debugee makeLocalDebugee(Process process) {
         LocalLaunchedDebugee debugee = new LocalLaunchedDebugee(process, this);
-
-        debugee.registerCleanup();
         return debugee;
     }
 
@@ -939,9 +937,6 @@ public class Binder extends DebugeeBinder {
         }
 
         RemoteLaunchedDebugee debugee = new RemoteLaunchedDebugee(this);
-
-        debugee.registerCleanup();
-
         return debugee;
     }
 
@@ -952,9 +947,6 @@ public class Binder extends DebugeeBinder {
     protected ManualLaunchedDebugee startManualDebugee(String cmd) {
         ManualLaunchedDebugee debugee = new ManualLaunchedDebugee(this);
         debugee.launchDebugee(cmd);
-
-        debugee.registerCleanup();
-
         return debugee;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/Binder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,8 +105,6 @@ final public class Binder extends DebugeeBinder {
             debugee = launchDebugee(classToExecute);
             debugee.redirectOutput(log);
         }
-
-        debugee.registerCleanup();
 
         Transport transport = debugee.connect();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ import java.util.function.Consumer;
  * @see nsk.share.jdi.Debugee
  * @see nsk.share.jdwp.Debugee
  */
-abstract public class DebugeeProcess extends FinalizableObject {
+abstract public class DebugeeProcess {
 
     /** Default prefix for log messages. */
     public static final String LOG_PREFIX = "binder> ";
@@ -84,9 +84,6 @@ abstract public class DebugeeProcess extends FinalizableObject {
     protected DebugeeProcess (DebugeeBinder binder) {
         this.binder = binder;
         this.log = binder.getLog();
-
-        // Register the cleanup() method to be called when this instance becomes unreachable.
-        registerCleanup();
     }
 
     /**
@@ -430,7 +427,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
     /**
      * Kill the debugee VM if it is not terminated yet.
      *
-     * @throws Throwable if any throwable exception is thrown during finalization
+     * @throws Throwable if any throwable exception is thrown during shutdown
      */
     public void close() {
         if (checkTermination) {
@@ -458,12 +455,4 @@ abstract public class DebugeeProcess extends FinalizableObject {
         log.complain(prefix + message);
     }
 
-    /**
-     * Finalize debuggee VM wrapper by invoking <code>close()</code>.
-     *
-     * @throws Throwable if any throwable exception is thrown during finalization
-     */
-    public void cleanup() {
-        close();
-    }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333108](https://bugs.openjdk.org/browse/JDK-8333108) needs maintainer approval

### Issue
 * [JDK-8333108](https://bugs.openjdk.org/browse/JDK-8333108): Update vmTestbase/nsk/share/DebugeeProcess.java to don't use finalization (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/971/head:pull/971` \
`$ git checkout pull/971`

Update a local copy of the PR: \
`$ git checkout pull/971` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 971`

View PR using the GUI difftool: \
`$ git pr show -t 971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/971.diff">https://git.openjdk.org/jdk21u-dev/pull/971.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/971#issuecomment-2346262768)