### PR TITLE
8339644: Improve parsing of Day/Month in tzdata rules

### DIFF
--- a/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesProvider.java
+++ b/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,33 +364,35 @@ class TzdbZoneRulesProvider {
         }
 
         Month parseMonth(String mon) {
-            switch (mon) {
-            case "Jan": return Month.JANUARY;
-            case "Feb": return Month.FEBRUARY;
-            case "Mar": return Month.MARCH;
-            case "Apr": return Month.APRIL;
-            case "May": return Month.MAY;
-            case "Jun": return Month.JUNE;
-            case "Jul": return Month.JULY;
-            case "Aug": return Month.AUGUST;
-            case "Sep": return Month.SEPTEMBER;
-            case "Oct": return Month.OCTOBER;
-            case "Nov": return Month.NOVEMBER;
-            case "Dec": return Month.DECEMBER;
-            }
+            int len = mon.length();
+
+            if (mon.regionMatches(true, 0, "January", 0, len)) return Month.JANUARY;
+            if (mon.regionMatches(true, 0, "February", 0, len)) return Month.FEBRUARY;
+            if (mon.regionMatches(true, 0, "March", 0, len)) return Month.MARCH;
+            if (mon.regionMatches(true, 0, "April", 0, len)) return Month.APRIL;
+            if (mon.regionMatches(true, 0, "May", 0, len)) return Month.MAY;
+            if (mon.regionMatches(true, 0, "June", 0, len)) return Month.JUNE;
+            if (mon.regionMatches(true, 0, "July", 0, len)) return Month.JULY;
+            if (mon.regionMatches(true, 0, "August", 0, len)) return Month.AUGUST;
+            if (mon.regionMatches(true, 0, "September", 0, len)) return Month.SEPTEMBER;
+            if (mon.regionMatches(true, 0, "October", 0, len)) return Month.OCTOBER;
+            if (mon.regionMatches(true, 0, "November", 0, len)) return Month.NOVEMBER;
+            if (mon.regionMatches(true, 0, "December", 0, len)) return Month.DECEMBER;
+
             throw new IllegalArgumentException("Unknown month: " + mon);
         }
 
         DayOfWeek parseDayOfWeek(String dow) {
-            switch (dow) {
-            case "Mon": return DayOfWeek.MONDAY;
-            case "Tue": return DayOfWeek.TUESDAY;
-            case "Wed": return DayOfWeek.WEDNESDAY;
-            case "Thu": return DayOfWeek.THURSDAY;
-            case "Fri": return DayOfWeek.FRIDAY;
-            case "Sat": return DayOfWeek.SATURDAY;
-            case "Sun": return DayOfWeek.SUNDAY;
-            }
+            int len = dow.length();
+
+            if (dow.regionMatches(true, 0, "Monday", 0, len)) return DayOfWeek.MONDAY;
+            if (dow.regionMatches(true, 0, "Tuesday", 0, len)) return DayOfWeek.TUESDAY;
+            if (dow.regionMatches(true, 0, "Wednesday", 0, len)) return DayOfWeek.WEDNESDAY;
+            if (dow.regionMatches(true, 0, "Thursday", 0, len)) return DayOfWeek.THURSDAY;
+            if (dow.regionMatches(true, 0, "Friday", 0, len)) return DayOfWeek.FRIDAY;
+            if (dow.regionMatches(true, 0, "Saturday", 0, len)) return DayOfWeek.SATURDAY;
+            if (dow.regionMatches(true, 0, "Sunday", 0, len)) return DayOfWeek.SUNDAY;
+
             throw new IllegalArgumentException("Unknown day-of-week: " + dow);
         }
 

--- a/test/jdk/sun/util/calendar/zi/Month.java
+++ b/test/jdk/sun/util/calendar/zi/Month.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,11 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Month enum handles month related manipulation.
@@ -47,15 +42,6 @@ enum Month {
 
     private final String abbr;
 
-    private static final Map<String,Month> abbreviations
-                                = new HashMap<String,Month>(12);
-
-    static {
-        for (Month m : Month.values()) {
-            abbreviations.put(m.abbr, m);
-        }
-    }
-
     private Month(String abbr) {
         this.abbr = abbr;
     }
@@ -70,11 +56,22 @@ enum Month {
      * @return the Month value
      */
     static Month parse(String name) {
-        Month m = abbreviations.get(name);
-        if (m != null) {
-            return m;
-        }
-        return null;
+        int len = name.length();
+
+        if (name.regionMatches(true, 0, "January", 0, len)) return Month.JANUARY;
+        if (name.regionMatches(true, 0, "February", 0, len)) return Month.FEBRUARY;
+        if (name.regionMatches(true, 0, "March", 0, len)) return Month.MARCH;
+        if (name.regionMatches(true, 0, "April", 0, len)) return Month.APRIL;
+        if (name.regionMatches(true, 0, "May", 0, len)) return Month.MAY;
+        if (name.regionMatches(true, 0, "June", 0, len)) return Month.JUNE;
+        if (name.regionMatches(true, 0, "July", 0, len)) return Month.JULY;
+        if (name.regionMatches(true, 0, "August", 0, len)) return Month.AUGUST;
+        if (name.regionMatches(true, 0, "September", 0, len)) return Month.SEPTEMBER;
+        if (name.regionMatches(true, 0, "October", 0, len)) return Month.OCTOBER;
+        if (name.regionMatches(true, 0, "November", 0, len)) return Month.NOVEMBER;
+        if (name.regionMatches(true, 0, "December", 0, len)) return Month.DECEMBER;
+
+        throw new IllegalArgumentException("Unknown month: " + name);
     }
 
     /**

--- a/test/jdk/sun/util/calendar/zi/RuleDay.java
+++ b/test/jdk/sun/util/calendar/zi/RuleDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,6 @@
  * questions.
  */
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * RuleDay class represents the value of the "ON" field.  The day of
  * week values start from 1 following the {@link java.util.Calendar}
@@ -34,13 +29,6 @@ import java.util.Map;
  * @since 1.4
  */
 class RuleDay {
-    private static final Map<String,DayOfWeek> abbreviations = new HashMap<String,DayOfWeek>(7);
-    static {
-        for (DayOfWeek day : DayOfWeek.values()) {
-            abbreviations.put(day.getAbbr(), day);
-        }
-    }
-
     private String dayName = null;
     private DayOfWeek dow;
     private boolean lastOne = false;
@@ -166,13 +154,23 @@ class RuleDay {
         return sign + toString(d);
     }
 
-    private static DayOfWeek getDOW(String abbr) {
-        return abbreviations.get(abbr);
+    private static DayOfWeek getDOW(String name) {
+        int len = name.length();
+
+        if (name.regionMatches(true, 0, "Monday", 0, len)) return DayOfWeek.MONDAY;
+        if (name.regionMatches(true, 0, "Tuesday", 0, len)) return DayOfWeek.TUESDAY;
+        if (name.regionMatches(true, 0, "Wednesday", 0, len)) return DayOfWeek.WEDNESDAY;
+        if (name.regionMatches(true, 0, "Thursday", 0, len)) return DayOfWeek.THURSDAY;
+        if (name.regionMatches(true, 0, "Friday", 0, len)) return DayOfWeek.FRIDAY;
+        if (name.regionMatches(true, 0, "Saturday", 0, len)) return DayOfWeek.SATURDAY;
+        if (name.regionMatches(true, 0, "Sunday", 0, len)) return DayOfWeek.SUNDAY;
+
+        throw new IllegalArgumentException("Unknown day-of-week: " + name);
     }
 
     /**
      * Converts the specified day of week value to the day-of-week
-     * name defined in {@link java.util.Calenda}.
+     * name defined in {@link java.util.Calendar}.
      * @param dow 1-based day of week value
      * @return the Calendar day of week name with "Calendar." prefix.
      * @throws IllegalArgumentException if the specified dow value is out of range.


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339644](https://bugs.openjdk.org/browse/JDK-8339644) needs maintainer approval

### Issue
 * [JDK-8339644](https://bugs.openjdk.org/browse/JDK-8339644): Improve parsing of Day/Month in tzdata rules (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/979/head:pull/979` \
`$ git checkout pull/979`

Update a local copy of the PR: \
`$ git checkout pull/979` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 979`

View PR using the GUI difftool: \
`$ git pr show -t 979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/979.diff">https://git.openjdk.org/jdk21u-dev/pull/979.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/979#issuecomment-2352088815)