### PR TITLE
8320586: update manual test/jdk/TEST.groups

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -592,7 +592,9 @@ jdk_nio_networkchannel = \
 
 jdk_core_manual = \
     :jdk_core_manual_no_input \
-    :jdk_core_manual_no_input_security
+    :jdk_security_manual_no_input \
+    :jdk_core_manual_interactive \
+    :jdk_security_manual_interactive
 
 jdk_core_manual_no_input = \
     java/net/HugeDataTransferTest.java \
@@ -610,7 +612,7 @@ jdk_core_manual_no_input = \
     com/sun/net/httpserver/simpleserver/CommandLinePortNotSpecifiedTest.java \
     com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePortNotSpecifiedTest.java
 
-jdk_core_manual_no_input_security = \
+jdk_security_manual_no_input = \
     :jdk_security_infra \
     com/sun/crypto/provider/Cipher/DES/PerformanceTest.java \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementByte4.java \
@@ -637,13 +639,14 @@ jdk_core_manual_no_input_security = \
 jdk_core_manual_interactive = \
     com/sun/jndi/dns/Test6991580.java \
     java/util/TimeZone/DefaultTimeZoneTest.java \
-    sun/security/tools/keytool/i18n.java \
     java/nio/MappedByteBuffer/PmemTest.java \
     java/rmi/registry/nonLocalRegistry/NonLocalRegistryTest.java \
-    java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java \
+    java/rmi/registry/nonLocalRegistry/NonLocalSkeletonTest.java
+
+jdk_security_manual_interactive = \
+    sun/security/tools/keytool/i18n.java \
     java/security/Policy/Root/Root.java \
     sun/security/krb5/config/native/TestDynamicStore.java
-
 
 # Test sets for running inside container environment
 jdk_containers_extended = \


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320586](https://bugs.openjdk.org/browse/JDK-8320586) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8320586: update manual test/jdk/TEST.groups`

### Issue
 * [JDK-8320586](https://bugs.openjdk.org/browse/JDK-8320586): update manual test/jdk/TEST.groups (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/985/head:pull/985` \
`$ git checkout pull/985`

Update a local copy of the PR: \
`$ git checkout pull/985` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 985`

View PR using the GUI difftool: \
`$ git pr show -t 985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/985.diff">https://git.openjdk.org/jdk21u-dev/pull/985.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/985#issuecomment-2357650941)