### PR TITLE
8324861: Exceptions::wrap_dynamic_exception() doesn't have ResourceMark

### DIFF
--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -438,6 +438,7 @@ void Exceptions::wrap_dynamic_exception(bool is_indy, JavaThread* THREAD) {
       // Pass through an Error, including BootstrapMethodError, any other form
       // of linkage error, or say OutOfMemoryError
       if (ls != nullptr) {
+        ResourceMark rm(THREAD);
         ls->print_cr("bootstrap method invocation wraps BSME around " PTR_FORMAT, p2i(exception));
         exception->print_on(ls);
       }
@@ -446,6 +447,7 @@ void Exceptions::wrap_dynamic_exception(bool is_indy, JavaThread* THREAD) {
 
     // Otherwise wrap the exception in a BootstrapMethodError
     if (ls != nullptr) {
+      ResourceMark rm(THREAD);
       ls->print_cr("%s throws BSME for " PTR_FORMAT, is_indy ? "invokedynamic" : "dynamic constant", p2i(exception));
       exception->print_on(ls);
     }


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324861](https://bugs.openjdk.org/browse/JDK-8324861) needs maintainer approval

### Issue
 * [JDK-8324861](https://bugs.openjdk.org/browse/JDK-8324861): Exceptions::wrap_dynamic_exception() doesn't have ResourceMark (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/992/head:pull/992` \
`$ git checkout pull/992`

Update a local copy of the PR: \
`$ git checkout pull/992` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 992`

View PR using the GUI difftool: \
`$ git pr show -t 992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/992.diff">https://git.openjdk.org/jdk21u-dev/pull/992.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/992#issuecomment-2363025502)