### PR TITLE
8333867: SHA3 performance can be improved

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -7428,7 +7428,7 @@ bool LibraryCallKit::inline_digestBase_implCompress(vmIntrinsics::ID id) {
     break;
   case vmIntrinsics::_sha3_implCompress:
     assert(UseSHA3Intrinsics, "need SHA3 instruction support");
-    state = get_state_from_digest_object(digestBase_obj, T_BYTE);
+    state = get_state_from_digest_object(digestBase_obj, T_LONG);
     stubAddr = StubRoutines::sha3_implCompress();
     stubName = "sha3_implCompress";
     block_size = get_block_size_from_digest_object(digestBase_obj);
@@ -7528,7 +7528,7 @@ bool LibraryCallKit::inline_digestBase_implCompressMB(int predicate) {
       klass_digestBase_name = "sun/security/provider/SHA3";
       stub_name = "sha3_implCompressMB";
       stub_addr = StubRoutines::sha3_implCompressMB();
-      elem_type = T_BYTE;
+      elem_type = T_LONG;
     }
     break;
   default:

--- a/src/java.base/share/classes/sun/security/provider/DigestBase.java
+++ b/src/java.base/share/classes/sun/security/provider/DigestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ abstract class DigestBase extends MessageDigestSpi implements Cloneable {
     private final int digestLength;
 
     // size of the input to the compression function in bytes
-    private final int blockSize;
+    protected final int blockSize;
     // buffer to store partial blocks, blockSize bytes large
     // Subclasses should not access this array directly except possibly in their
     // implDigest() method. See MD5.java as an example.


### PR DESCRIPTION
This is a clean backport of multi-platform SHA3 performance improvement. MessageDigests benchmarks show same speedup as for the original change (C2 generated code variant, -XX:-UseSHA3Intrinsics).

Testing: test/jdk/sun/security, tier1, tier2 (linux-aarch64, linux-amd64).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8333867](https://bugs.openjdk.org/browse/JDK-8333867) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333867](https://bugs.openjdk.org/browse/JDK-8333867): SHA3 performance can be improved (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1000/head:pull/1000` \
`$ git checkout pull/1000`

Update a local copy of the PR: \
`$ git checkout pull/1000` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1000`

View PR using the GUI difftool: \
`$ git pr show -t 1000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1000.diff">https://git.openjdk.org/jdk21u-dev/pull/1000.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1000#issuecomment-2368049408)
</details>
