### PR TITLE
8340230: Tests crash: assert(is_in_encoding_range || k->is_interface() || k->is_abstract()) failed: sanity

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3303,8 +3303,8 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
       bool is_oop   = t->isa_oopptr() != nullptr;
       bool is_klass = t->isa_klassptr() != nullptr;
 
-      if ((is_oop   && Matcher::const_oop_prefer_decode()  ) ||
-          (is_klass && Matcher::const_klass_prefer_decode())) {
+      if ((is_oop   && UseCompressedOops          && Matcher::const_oop_prefer_decode()  ) ||
+          (is_klass && UseCompressedClassPointers && Matcher::const_klass_prefer_decode())) {
         Node* nn = nullptr;
 
         int op = is_oop ? Op_ConN : Op_ConNKlass;


### PR DESCRIPTION
Clean backport of [JDK-8340230](https://bugs.openjdk.org/browse/JDK-8340230) from jdk23u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8340230](https://bugs.openjdk.org/browse/JDK-8340230) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340230](https://bugs.openjdk.org/browse/JDK-8340230): Tests crash: assert(is_in_encoding_range || k-&gt;is_interface() || k-&gt;is_abstract()) failed: sanity (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1001/head:pull/1001` \
`$ git checkout pull/1001`

Update a local copy of the PR: \
`$ git checkout pull/1001` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1001`

View PR using the GUI difftool: \
`$ git pr show -t 1001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1001.diff">https://git.openjdk.org/jdk21u-dev/pull/1001.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1001#issuecomment-2368139644)