### PR TITLE
8340418: GHA: MacOS AArch64 bundles can be removed prematurely

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -349,6 +349,7 @@ jobs:
       - build-windows-aarch64
       - test-linux-x64
       - test-macos-x64
+      - test-macos-aarch64
       - test-windows-x64
 
     steps:


### PR DESCRIPTION
Clean backport to improve GHA reliability. Follows [JDK-8325194](https://bugs.openjdk.org/browse/JDK-8325194).

Additional testing: 
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340418](https://bugs.openjdk.org/browse/JDK-8340418) needs maintainer approval

### Issue
 * [JDK-8340418](https://bugs.openjdk.org/browse/JDK-8340418): GHA: MacOS AArch64 bundles can be removed prematurely (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1003/head:pull/1003` \
`$ git checkout pull/1003`

Update a local copy of the PR: \
`$ git checkout pull/1003` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1003`

View PR using the GUI difftool: \
`$ git pr show -t 1003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1003.diff">https://git.openjdk.org/jdk21u-dev/pull/1003.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1003#issuecomment-2368444836)