### PR TITLE
8320665: update jdk_core at open/test/jdk/TEST.groups

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -652,3 +652,7 @@ jdk_containers_extended = \
     :jdk_io \
     :jdk_nio \
     :jdk_svc
+
+jdk_core_no_security = \
+   :jdk_core \
+   -:jdk_security


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320665](https://bugs.openjdk.org/browse/JDK-8320665) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8320665: update jdk_core at open/test/jdk/TEST.groups`

### Issue
 * [JDK-8320665](https://bugs.openjdk.org/browse/JDK-8320665): update jdk_core at open/test/jdk/TEST.groups (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1005/head:pull/1005` \
`$ git checkout pull/1005`

Update a local copy of the PR: \
`$ git checkout pull/1005` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1005`

View PR using the GUI difftool: \
`$ git pr show -t 1005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1005.diff">https://git.openjdk.org/jdk21u-dev/pull/1005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1005#issuecomment-2370395577)