### PR TITLE
8339487: ProcessHandleImpl os_getChildren sysctl call - retry in case of ENOMEM and enhance exception message

### DIFF
--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -97,25 +97,35 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
         }
     }
 
-    // Get buffer size needed to read all processes
-    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0};
-    if (sysctl(mib, 4, NULL, &bufSize, NULL, 0) < 0) {
-        JNU_ThrowByNameWithLastError(env,
-            "java/lang/RuntimeException", "sysctl failed");
-        return -1;
-    }
+    int errsysctl;
+    int maxRetries = 100;
+    void *buffer = NULL;
+    do {
+        int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0};
+        if (buffer != NULL) free(buffer);
+        // Get buffer size needed to read all processes
+        if (sysctl(mib, 4, NULL, &bufSize, NULL, 0) < 0) {
+            JNU_ThrowByNameWithMessageAndLastError(env,
+                "java/lang/RuntimeException", "sysctl failed");
+            return -1;
+        }
 
-    // Allocate buffer big enough for all processes
-    void *buffer = malloc(bufSize);
-    if (buffer == NULL) {
-        JNU_ThrowOutOfMemoryError(env, "malloc failed");
-        return -1;
-    }
+        // Allocate buffer big enough for all processes; add a little
+        // bit of space to be able to hold a few more proc infos
+        // for processes started right after the first sysctl call
+        buffer = malloc(bufSize + 4 * sizeof(struct kinfo_proc));
+        if (buffer == NULL) {
+            JNU_ThrowOutOfMemoryError(env, "malloc failed");
+            return -1;
+        }
 
-    // Read process info for all processes
-    if (sysctl(mib, 4, buffer, &bufSize, NULL, 0) < 0) {
-        JNU_ThrowByNameWithLastError(env,
-            "java/lang/RuntimeException", "sysctl failed");
+        // Read process info for all processes
+        errsysctl = sysctl(mib, 4, buffer, &bufSize, NULL, 0);
+    } while (errsysctl < 0 && errno == ENOMEM && maxRetries-- > 0);
+
+    if (errsysctl < 0) {
+        JNU_ThrowByNameWithMessageAndLastError(env,
+            "java/lang/RuntimeException", "sysctl failed to get info about all processes");
         free(buffer);
         return -1;
     }

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
@@ -547,7 +547,7 @@ jint unix_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
      * position integer as a filename.
      */
     if ((dir = opendir("/proc")) == NULL) {
-        JNU_ThrowByNameWithLastError(env,
+        JNU_ThrowByNameWithMessageAndLastError(env,
             "java/lang/RuntimeException", "Unable to open /proc");
         return -1;
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339487](https://bugs.openjdk.org/browse/JDK-8339487) needs maintainer approval

### Issue
 * [JDK-8339487](https://bugs.openjdk.org/browse/JDK-8339487): ProcessHandleImpl os_getChildren sysctl call - retry in case of ENOMEM and enhance exception message (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1010/head:pull/1010` \
`$ git checkout pull/1010`

Update a local copy of the PR: \
`$ git checkout pull/1010` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1010`

View PR using the GUI difftool: \
`$ git pr show -t 1010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1010.diff">https://git.openjdk.org/jdk21u-dev/pull/1010.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1010#issuecomment-2374060721)