### PR TITLE
8338924: C1: assert(0 <= i && i < _len) failed: illegal index 5 for length 5

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1388,6 +1388,11 @@ void GraphBuilder::jsr(int dest) {
   // If the bytecodes are strange (jumping out of a jsr block) then we
   // might end up trying to re-parse a block containing a jsr which
   // has already been activated. Watch for this case and bail out.
+  if (next_bci() >= method()->code_size()) {
+    // This can happen if the subroutine does not terminate with a ret,
+    // effectively turning the jsr into a goto.
+    BAILOUT("too-complicated jsr/ret structure");
+  }
   for (ScopeData* cur_scope_data = scope_data();
        cur_scope_data != nullptr && cur_scope_data->parsing_jsr() && cur_scope_data->scope() == scope();
        cur_scope_data = cur_scope_data->parent()) {
@@ -3716,6 +3721,9 @@ bool GraphBuilder::try_inline_intrinsics(ciMethod* callee, bool ignore_return) {
 bool GraphBuilder::try_inline_jsr(int jsr_dest_bci) {
   // Introduce a new callee continuation point - all Ret instructions
   // will be replaced with Gotos to this point.
+  if (next_bci() >= method()->code_size()) {
+    return false;
+  }
   BlockBegin* cont = block_at(next_bci());
   assert(cont != nullptr, "continuation must exist (BlockListBuilder starts a new block after a jsr");
 

--- a/src/hotspot/share/compiler/methodLiveness.cpp
+++ b/src/hotspot/share/compiler/methodLiveness.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,6 +222,9 @@ void MethodLiveness::init_basic_blocks() {
           dest = _block_map->at(bytes.get_dest());
           assert(dest != nullptr, "branch destination must start a block.");
           dest->add_normal_predecessor(current_block);
+          if (bci + Bytecodes::length_for(code) >= method_len) {
+            break;
+          }
           BasicBlock *jsrExit = _block_map->at(current_block->limit_bci());
           assert(jsrExit != nullptr, "jsr return bci must start a block.");
           jsr_exit_list->append(jsrExit);
@@ -232,6 +235,9 @@ void MethodLiveness::init_basic_blocks() {
           dest = _block_map->at(bytes.get_far_dest());
           assert(dest != nullptr, "branch destination must start a block.");
           dest->add_normal_predecessor(current_block);
+          if (bci + Bytecodes::length_for(code) >= method_len) {
+            break;
+          }
           BasicBlock *jsrExit = _block_map->at(current_block->limit_bci());
           assert(jsrExit != nullptr, "jsr return bci must start a block.");
           jsr_exit_list->append(jsrExit);

--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -436,12 +436,12 @@ void GenerateOopMap::mark_bbheaders_and_count_gc_points() {
      /* We will also mark successors of jsr's as basic block headers. */
     switch (bytecode) {
       case Bytecodes::_jsr:
-        assert(!fellThrough, "should not happen");
-        bb_mark_fct(this, bci + Bytecodes::length_for(bytecode), nullptr);
-        break;
       case Bytecodes::_jsr_w:
         assert(!fellThrough, "should not happen");
-        bb_mark_fct(this, bci + Bytecodes::length_for(bytecode), nullptr);
+        // If this is the last bytecode, there is no successor to mark
+        if (bci + Bytecodes::length_for(bytecode) < method()->code_size()) {
+          bb_mark_fct(this, bci + Bytecodes::length_for(bytecode), nullptr);
+        }
         break;
       default:
         break;
@@ -502,7 +502,10 @@ void GenerateOopMap::mark_reachable_code() {
           case Bytecodes::_jsr:
           case Bytecodes::_jsr_w:
             assert(!fell_through, "should not happen");
-            reachable_basicblock(this, bci + Bytecodes::length_for(bytecode), &change);
+            // If this is the last bytecode, there is no successor to mark
+            if (bci + Bytecodes::length_for(bytecode) < method()->code_size()) {
+              reachable_basicblock(this, bci + Bytecodes::length_for(bytecode), &change);
+            }
             break;
           default:
             break;
@@ -586,9 +589,6 @@ bool GenerateOopMap::jump_targets_do(BytecodeStream *bcs, jmpFct_t jmpFct, int *
     case Bytecodes::_jsr:
       assert(bcs->is_wide()==false, "sanity check");
       (*jmpFct)(this, bcs->dest(), data);
-
-
-
       break;
     case Bytecodes::_jsr_w:
       (*jmpFct)(this, bcs->dest_w(), data);

--- a/test/hotspot/jtreg/runtime/interpreter/LastJsr.jasm
+++ b/test/hotspot/jtreg/runtime/interpreter/LastJsr.jasm
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+super public class LastJsr
+{
+    public static Method test:"()V"
+    stack 100 locals 100
+    {
+        return;
+    LABEL:
+        nop;
+        jsr LABEL; // bci=2. Compute bci + length(jsr) -> bci = 5 accessed, out of bounds.
+    }
+}

--- a/test/hotspot/jtreg/runtime/interpreter/LastJsrReachable.jasm
+++ b/test/hotspot/jtreg/runtime/interpreter/LastJsrReachable.jasm
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+super public class LastJsrReachable
+{
+    public static Method test:"()V"
+    stack 100 locals 100
+    {
+        goto LB2;
+    LABEL:
+        return;
+    LB2:
+        nop;
+        jsr LABEL;
+    }
+}

--- a/test/hotspot/jtreg/runtime/interpreter/LastJsrTest.java
+++ b/test/hotspot/jtreg/runtime/interpreter/LastJsrTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8335664 8338924
+ * @summary Ensure a program that ends with a JSR does not crash
+ * @library /test/lib
+ * @compile LastJsr.jasm
+ * @compile LastJsrReachable.jasm
+ * @run main/othervm -Xbatch LastJsrTest
+ */
+
+public class LastJsrTest {
+    public static void main(String[] args) {
+        for (int i = 0; i < 1000; ++i) {
+            LastJsr.test();
+            LastJsrReachable.test();
+        }
+        System.out.println("PASSED");
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8338924](https://bugs.openjdk.org/browse/JDK-8338924) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8335664](https://bugs.openjdk.org/browse/JDK-8335664) needs maintainer approval

### Issues
 * [JDK-8338924](https://bugs.openjdk.org/browse/JDK-8338924): C1: assert(0 &lt;= i &amp;&amp; i &lt; _len) failed: illegal index 5 for length 5 (**Bug** - P4 - Approved)
 * [JDK-8335664](https://bugs.openjdk.org/browse/JDK-8335664): Parsing jsr broken: assert(bci&gt;= 0 &amp;&amp; bci &lt; c-&gt;method()-&gt;code_size()) failed: index out of bounds (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1012/head:pull/1012` \
`$ git checkout pull/1012`

Update a local copy of the PR: \
`$ git checkout pull/1012` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1012`

View PR using the GUI difftool: \
`$ git pr show -t 1012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1012.diff">https://git.openjdk.org/jdk21u-dev/pull/1012.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1012#issuecomment-2376233609)