### PR TITLE
8340383: VM issues warning failure to find kernel32.dll on Windows nanoserver

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4051,6 +4051,39 @@ int    os::win32::_build_minor               = 0;
 bool   os::win32::_processor_group_warning_displayed = false;
 bool   os::win32::_job_object_processor_group_warning_displayed = false;
 
+void getWindowsInstallationType(char* buffer, int bufferSize) {
+  HKEY hKey;
+  const char* subKey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
+  const char* valueName = "InstallationType";
+
+  DWORD valueLength = bufferSize;
+
+  // Initialize buffer with empty string
+  buffer[0] = '\0';
+
+  // Open the registry key
+  if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, subKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
+    // Return empty buffer if key cannot be opened
+    return;
+  }
+
+  // Query the value
+  if (RegQueryValueExA(hKey, valueName, NULL, NULL, (LPBYTE)buffer, &valueLength) != ERROR_SUCCESS) {
+    RegCloseKey(hKey);
+    buffer[0] = '\0';
+    return;
+  }
+
+  RegCloseKey(hKey);
+}
+
+bool isNanoServer() {
+  const int BUFFER_SIZE = 256;
+  char installationType[BUFFER_SIZE];
+  getWindowsInstallationType(installationType, BUFFER_SIZE);
+  return (strcmp(installationType, "Nano Server") == 0);
+}
+
 void os::win32::initialize_windows_version() {
   assert(_major_version == 0, "windows version already initialized.");
 
@@ -4068,7 +4101,13 @@ void os::win32::initialize_windows_version() {
     warning("Attempt to determine system directory failed: %s", buf_len != 0 ? error_msg_buffer : "<unknown error>");
     return;
   }
-  strncat(kernel32_path, "\\kernel32.dll", MAX_PATH - ret);
+
+  if (isNanoServer()) {
+    // On Windows Nanoserver the kernel32.dll is located in the forwarders subdirectory
+    strncat(kernel32_path, "\\forwarders\\kernel32.dll", MAX_PATH - ret);
+  } else {
+    strncat(kernel32_path, "\\kernel32.dll", MAX_PATH - ret);
+  }
 
   DWORD version_size = GetFileVersionInfoSize(kernel32_path, nullptr);
   if (version_size == 0) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3c97d243](https://github.com/openjdk/jdk/commit/3c97d2437d34d2db47f3607fbb95ac3b8e2ec60b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by George Adams on 24 Sep 2024 and was reviewed by David Holmes and Julian Waters.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340383](https://bugs.openjdk.org/browse/JDK-8340383) needs maintainer approval

### Issue
 * [JDK-8340383](https://bugs.openjdk.org/browse/JDK-8340383): VM issues warning failure to find kernel32.dll on Windows nanoserver (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1014/head:pull/1014` \
`$ git checkout pull/1014`

Update a local copy of the PR: \
`$ git checkout pull/1014` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1014`

View PR using the GUI difftool: \
`$ git pr show -t 1014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1014.diff">https://git.openjdk.org/jdk21u-dev/pull/1014.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1014#issuecomment-2379579288)