### PR TITLE
8336499: Failure when creating non-CRT RSA private keys in SunPKCS11

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -580,47 +580,73 @@ abstract class P11Key implements Key, Length {
         static P11RSAPrivateKeyInternal of(Session session, long keyID,
                 String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
                 boolean keySensitive) {
-            if (keySensitive) {
-                return new P11RSAPrivateKeyInternal(session, keyID, algorithm,
-                        keyLength, attrs);
-            } else {
-                CK_ATTRIBUTE[] rsaAttrs = new CK_ATTRIBUTE[] {
-                        new CK_ATTRIBUTE(CKA_MODULUS),
-                        new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-                        new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
-                        new CK_ATTRIBUTE(CKA_PRIME_1),
-                        new CK_ATTRIBUTE(CKA_PRIME_2),
-                        new CK_ATTRIBUTE(CKA_EXPONENT_1),
-                        new CK_ATTRIBUTE(CKA_EXPONENT_2),
-                        new CK_ATTRIBUTE(CKA_COEFFICIENT),
-                };
-                boolean isCRT = true;
-                Session tempSession = null;
-                try {
-                    tempSession = session.token.getOpSession();
-                    session.token.p11.C_GetAttributeValue(tempSession.id(),
-                            keyID, rsaAttrs);
-                    for (CK_ATTRIBUTE attr : rsaAttrs) {
-                        isCRT &= (attr.pValue instanceof byte[]);
-                        if (!isCRT) break;
-                    }
-                } catch (PKCS11Exception e) {
-                    // ignore, assume not available
-                    isCRT = false;
-                } finally {
-                    session.token.releaseSession(tempSession);
-                }
-                BigInteger n = rsaAttrs[0].getBigInteger();
-                BigInteger d = rsaAttrs[1].getBigInteger();
-                if (isCRT) {
-                    return new P11RSAPrivateKey(session, keyID, algorithm,
-                           keyLength, attrs, n, d,
-                           Arrays.copyOfRange(rsaAttrs, 2, rsaAttrs.length));
-                } else {
-                    return new P11RSAPrivateNonCRTKey(session, keyID,
-                           algorithm, keyLength, attrs, n, d);
+            P11RSAPrivateKeyInternal p11Key = null;
+            if (!keySensitive) {
+                // Key is not sensitive: try to interpret as CRT or non-CRT.
+                p11Key = asCRT(session, keyID, algorithm, keyLength, attrs);
+                if (p11Key == null) {
+                    p11Key = asNonCRT(session, keyID, algorithm, keyLength,
+                            attrs);
                 }
             }
+            if (p11Key == null) {
+                // Key is sensitive or there was a failure while querying its
+                // attributes: handle as opaque.
+                p11Key = new P11RSAPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            }
+            return p11Key;
+        }
+
+        private static CK_ATTRIBUTE[] tryFetchAttributes(Session session,
+                long keyID, long... attrTypes) {
+            int i = 0;
+            CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[attrTypes.length];
+            for (long attrType : attrTypes) {
+                attrs[i++] = new CK_ATTRIBUTE(attrType);
+            }
+            try {
+                session.token.p11.C_GetAttributeValue(session.id(), keyID,
+                        attrs);
+                for (CK_ATTRIBUTE attr : attrs) {
+                    if (!(attr.pValue instanceof byte[])) {
+                        return null;
+                    }
+                }
+                return attrs;
+            } catch (PKCS11Exception ignored) {
+                // ignore, assume not available
+                return null;
+            }
+        }
+
+        private static P11RSAPrivateKeyInternal asCRT(Session session,
+                long keyID, String algorithm, int keyLength,
+                CK_ATTRIBUTE[] attrs) {
+            CK_ATTRIBUTE[] rsaCRTAttrs = tryFetchAttributes(session, keyID,
+                    CKA_MODULUS, CKA_PRIVATE_EXPONENT, CKA_PUBLIC_EXPONENT,
+                    CKA_PRIME_1, CKA_PRIME_2, CKA_EXPONENT_1, CKA_EXPONENT_2,
+                    CKA_COEFFICIENT);
+            if (rsaCRTAttrs == null) {
+                return null;
+            }
+            return new P11RSAPrivateKey(session, keyID, algorithm, keyLength,
+                    attrs, rsaCRTAttrs[0].getBigInteger(),
+                    rsaCRTAttrs[1].getBigInteger(),
+                    Arrays.copyOfRange(rsaCRTAttrs, 2, rsaCRTAttrs.length));
+        }
+
+        private static P11RSAPrivateKeyInternal asNonCRT(Session session,
+                long keyID, String algorithm, int keyLength,
+                CK_ATTRIBUTE[] attrs) {
+            CK_ATTRIBUTE[] rsaNonCRTAttrs = tryFetchAttributes(session, keyID,
+                    CKA_MODULUS, CKA_PRIVATE_EXPONENT);
+            if (rsaNonCRTAttrs == null) {
+                return null;
+            }
+            return new P11RSAPrivateNonCRTKey(session, keyID, algorithm,
+                    keyLength, attrs, rsaNonCRTAttrs[0].getBigInteger(),
+                    rsaNonCRTAttrs[1].getBigInteger());
         }
 
         protected transient BigInteger n;


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [3251eea](https://github.com/openjdk/jdk/commit/3251eea1f4289a0505052be204407c02ca38b0ad) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
Tier1 testing is successful.
Thanks!

JBS Issue: [JDK-8336499](https://bugs.openjdk.org/browse/JDK-8336499)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8336499](https://bugs.openjdk.org/browse/JDK-8336499) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336499](https://bugs.openjdk.org/browse/JDK-8336499): Failure when creating non-CRT RSA private keys in SunPKCS11 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1021/head:pull/1021` \
`$ git checkout pull/1021`

Update a local copy of the PR: \
`$ git checkout pull/1021` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1021`

View PR using the GUI difftool: \
`$ git pr show -t 1021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1021.diff">https://git.openjdk.org/jdk21u-dev/pull/1021.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1021#issuecomment-2429965663)
</details>
