### PR TITLE
8339648: ZGC: Division by zero in rule_major_allocation_rate

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -488,7 +488,8 @@ static bool rule_major_allocation_rate(const ZDirectorStats& stats) {
 
   // Calculate the GC cost for each reclaimed byte
   const double current_young_gc_time_per_bytes_freed = double(young_gc_time) / double(reclaimed_per_young_gc);
-  const double current_old_gc_time_per_bytes_freed = double(old_gc_time) / double(reclaimed_per_old_gc);
+  const double current_old_gc_time_per_bytes_freed = reclaimed_per_old_gc == 0 ? std::numeric_limits<double>::infinity()
+                                                                               : (double(old_gc_time) / double(reclaimed_per_old_gc));
 
   // Calculate extra time per young collection inflicted by *not* doing an
   // old collection that frees up memory in the old generation.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339648](https://bugs.openjdk.org/browse/JDK-8339648) needs maintainer approval

### Issue
 * [JDK-8339648](https://bugs.openjdk.org/browse/JDK-8339648): ZGC: Division by zero in rule_major_allocation_rate (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1022/head:pull/1022` \
`$ git checkout pull/1022`

Update a local copy of the PR: \
`$ git checkout pull/1022` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1022`

View PR using the GUI difftool: \
`$ git pr show -t 1022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1022.diff">https://git.openjdk.org/jdk21u-dev/pull/1022.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1022#issuecomment-2393636151)