### PR TITLE
8340923: The class LogSelection copies uninitialized memory

### DIFF
--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -33,11 +33,11 @@
 
 const LogSelection LogSelection::Invalid;
 
-LogSelection::LogSelection() : _ntags(0), _wildcard(false), _level(LogLevel::Invalid), _tag_sets_selected(0) {
+LogSelection::LogSelection() : _ntags(0), _tags(), _wildcard(false), _level(LogLevel::Invalid), _tag_sets_selected(0) {
 }
 
 LogSelection::LogSelection(const LogTagType tags[LogTag::MaxTags], bool wildcard, LogLevelType level)
-    : _ntags(0), _wildcard(wildcard), _level(level), _tag_sets_selected(0) {
+  : _ntags(0), _tags(), _wildcard(wildcard), _level(level), _tag_sets_selected(0) {
   while (_ntags < LogTag::MaxTags && tags[_ntags] != LogTag::__NO_TAG) {
     _tags[_ntags] = tags[_ntags];
     _ntags++;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340923](https://bugs.openjdk.org/browse/JDK-8340923) needs maintainer approval

### Issue
 * [JDK-8340923](https://bugs.openjdk.org/browse/JDK-8340923): The class LogSelection copies uninitialized memory (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1023/head:pull/1023` \
`$ git checkout pull/1023`

Update a local copy of the PR: \
`$ git checkout pull/1023` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1023`

View PR using the GUI difftool: \
`$ git pr show -t 1023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1023.diff">https://git.openjdk.org/jdk21u-dev/pull/1023.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1023#issuecomment-2393715714)