### PR TITLE
8333728: ubsan: shenandoahFreeSet.cpp:1347:24: runtime error: division by zero

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -614,7 +614,6 @@ void ShenandoahFreeSet::print_on(outputStream* out) const {
 double ShenandoahFreeSet::internal_fragmentation() {
   double squared = 0;
   double linear = 0;
-  int count = 0;
 
   for (size_t index = _mutator_leftmost; index <= _mutator_rightmost; index++) {
     if (is_mutator_free(index)) {
@@ -622,11 +621,10 @@ double ShenandoahFreeSet::internal_fragmentation() {
       size_t used = r->used();
       squared += used * used;
       linear += used;
-      count++;
     }
   }
 
-  if (count > 0) {
+  if (linear > 0) {
     double s = squared / (ShenandoahHeapRegion::region_size_bytes() * linear);
     return 1 - s;
   } else {


### PR DESCRIPTION
Backport of 8333728; loop coding is a little different / diffs in the strides

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8333728](https://bugs.openjdk.org/browse/JDK-8333728) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333728](https://bugs.openjdk.org/browse/JDK-8333728): ubsan: shenandoahFreeSet.cpp:1347:24: runtime error: division by zero (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1030/head:pull/1030` \
`$ git checkout pull/1030`

Update a local copy of the PR: \
`$ git checkout pull/1030` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1030`

View PR using the GUI difftool: \
`$ git pr show -t 1030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1030.diff">https://git.openjdk.org/jdk21u-dev/pull/1030.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1030#issuecomment-2396763377)