### PR TITLE
8334475: UnsafeIntrinsicsTest.java#ZGenerationalDebug assert(!assert_on_failure) failed: Has low-order bits set

### DIFF
--- a/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.hpp
@@ -26,7 +26,26 @@
 #ifndef OS_CPU_WINDOWS_AARCH64_COPY_WINDOWS_AARCH64_HPP
 #define OS_CPU_WINDOWS_AARCH64_COPY_WINDOWS_AARCH64_HPP
 
+#include "runtime/atomic.hpp"
+
 #include <string.h>
+
+template <typename T>
+static void pd_conjoint_atomic_helper(const T* from, T* to, size_t count) {
+  if (from > to) {
+    while (count-- > 0) {
+      // Copy forwards
+      Atomic::store(to++, Atomic::load(from++));
+    }
+  } else {
+    from += count - 1;
+    to   += count - 1;
+    while (count-- > 0) {
+      // Copy backwards
+      Atomic::store(to--, Atomic::load(from--));
+    }
+  }
+}
 
 static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
   (void)memmove(to, from, count * HeapWordSize);
@@ -71,55 +90,19 @@ static void pd_conjoint_bytes_atomic(const void* from, void* to, size_t count) {
 }
 
 static void pd_conjoint_jshorts_atomic(const jshort* from, jshort* to, size_t count) {
-  if (from > to) {
-    while (count-- > 0) {
-      // Copy forwards
-      *to++ = *from++;
-    }
-  } else {
-    from += count - 1;
-    to   += count - 1;
-    while (count-- > 0) {
-      // Copy backwards
-      *to-- = *from--;
-    }
-  }
+  pd_conjoint_atomic_helper(from, to, count);
 }
 
 static void pd_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
-  if (from > to) {
-    while (count-- > 0) {
-      // Copy forwards
-      *to++ = *from++;
-    }
-  } else {
-    from += count - 1;
-    to   += count - 1;
-    while (count-- > 0) {
-      // Copy backwards
-      *to-- = *from--;
-    }
-  }
+  pd_conjoint_atomic_helper(from, to, count);
 }
 
 static void pd_conjoint_jlongs_atomic(const jlong* from, jlong* to, size_t count) {
-  pd_conjoint_oops_atomic((const oop*)from, (oop*)to, count);
+  pd_conjoint_atomic_helper(from, to, count);
 }
 
 static void pd_conjoint_oops_atomic(const oop* from, oop* to, size_t count) {
- if (from > to) {
-    while (count-- > 0) {
-      // Copy forwards
-      *to++ = *from++;
-    }
-  } else {
-    from += count - 1;
-    to   += count - 1;
-    while (count-- > 0) {
-      // Copy backwards
-      *to-- = *from--;
-    }
-  }
+ pd_conjoint_atomic_helper(from, to, count);
 }
 
 static void pd_arrayof_conjoint_bytes(const HeapWord* from, HeapWord* to, size_t count) {


### PR DESCRIPTION
Backport https://github.com/openjdk/jdk23u/commit/7f189a59d9ad803aee72565bc46a817d3f46f2e5 to jdk21u. UnsafeIntrinsicsTest.java#ZGenerationalDebug test now passes on Windows AArch64 with this change. All tier1 tests also passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8334475](https://bugs.openjdk.org/browse/JDK-8334475) needs maintainer approval

### Issue
 * [JDK-8334475](https://bugs.openjdk.org/browse/JDK-8334475): UnsafeIntrinsicsTest.java#ZGenerationalDebug assert(!assert_on_failure) failed: Has low-order bits set (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1032/head:pull/1032` \
`$ git checkout pull/1032`

Update a local copy of the PR: \
`$ git checkout pull/1032` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1032`

View PR using the GUI difftool: \
`$ git pr show -t 1032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1032.diff">https://git.openjdk.org/jdk21u-dev/pull/1032.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1032#issuecomment-2397463903)
</details>
