### PR TITLE
8340632: ProblemList java/nio/channels/DatagramChannel/ for Macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -536,8 +536,8 @@ javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java 
 
 # jdk_net
 
-java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
-java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64
+java/net/DatagramSocket/DatagramSocketExample.java              8144003,8308807 macosx-all,aix-ppc64
+java/net/DatagramSocket/DatagramSocketMulticasting.java         8144003,8308807 macosx-all,aix-ppc64
 
 java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
 java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
@@ -561,9 +561,12 @@ java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc6
 
 java/nio/channels/Channels/SocketChannelStreams.java            8317838 aix-ppc64
 
-java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8144003,8308807 macosx-all,aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
+java/nio/channels/DatagramChannel/BasicMulticastTests.java      8144003 macosx-all
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java 8144003 macosx-all
+java/nio/channels/DatagramChannel/Promiscuous.java              8144003 macosx-all
 java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
 
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64


### PR DESCRIPTION
I want to have this change in open jdk21u-dev because we see these tests failing regularly.

As the original change was made in 21.0.6-oracle no commit is available to base this on.
But the change is simple enough to implement based on the description.

I'm not sure about the order of bugIDs in ProblemLists, I sorted them numerical, i.e. prepended before 8308807.

Will backport to 17

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340632](https://bugs.openjdk.org/browse/JDK-8340632) needs maintainer approval

### Issue
 * [JDK-8340632](https://bugs.openjdk.org/browse/JDK-8340632): ProblemList java/nio/channels/DatagramChannel/ for Macos (**Sub-task** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1041/head:pull/1041` \
`$ git checkout pull/1041`

Update a local copy of the PR: \
`$ git checkout pull/1041` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1041`

View PR using the GUI difftool: \
`$ git pr show -t 1041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1041.diff">https://git.openjdk.org/jdk21u-dev/pull/1041.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1041#issuecomment-2402086890)