### PR TITLE
8321299: runtime/logging/ClassLoadUnloadTest.java doesn't reliably trigger class unloading

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,10 +70,13 @@ public class ClassLoadUnloadTest {
 
     // Use the same command-line heap size setting as ../ClassUnload/UnloadTest.java
     static OutputAnalyzer exec(String... args) throws Exception {
+        String classPath = System.getProperty("test.class.path", ".");
+
+        // Sub-process does not get all the properties automatically, so the test class path needs to be passed explicitly
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m", "-Xbootclasspath/a:.", "-XX:+UnlockDiagnosticVMOptions",
-                           "-XX:+WhiteBoxAPI", "-XX:+ClassUnloading", ClassUnloadTestMain.class.getName());
+                           "-XX:+WhiteBoxAPI", "-XX:+ClassUnloading", "-Dtest.class.path=" + classPath, ClassUnloadTestMain.class.getName());
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(argsList);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
@@ -86,7 +89,7 @@ public class ClassLoadUnloadTest {
 
         //  -Xlog:class+unload=info
         output = exec("-Xlog:class+unload=info");
-        checkFor(output, "[class,unload]", "unloading class");
+        checkFor(output, "[class,unload]", "unloading class test.Empty");
 
         //  -Xlog:class+unload=off
         output = exec("-Xlog:class+unload=off");


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321299](https://bugs.openjdk.org/browse/JDK-8321299) needs maintainer approval

### Issue
 * [JDK-8321299](https://bugs.openjdk.org/browse/JDK-8321299): runtime/logging/ClassLoadUnloadTest.java doesn't reliably trigger class unloading (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1045/head:pull/1045` \
`$ git checkout pull/1045`

Update a local copy of the PR: \
`$ git checkout pull/1045` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1045`

View PR using the GUI difftool: \
`$ git pr show -t 1045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1045.diff">https://git.openjdk.org/jdk21u-dev/pull/1045.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1045#issuecomment-2407188328)