### PR TITLE
8337067: Test runtime/classFileParserBug/Bad_NCDFE_Msg.java won't compile

### DIFF
--- a/test/hotspot/jtreg/runtime/classFileParserBug/Bad_NCDFE_Msg.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/Bad_NCDFE_Msg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  *          java.management
  * @compile C.java
  * @run driver Bad_NCDFE_Msg
+ */
 
 import java.io.File;
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337067](https://bugs.openjdk.org/browse/JDK-8337067) needs maintainer approval

### Issue
 * [JDK-8337067](https://bugs.openjdk.org/browse/JDK-8337067): Test runtime/classFileParserBug/Bad_NCDFE_Msg.java won't compile (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1046/head:pull/1046` \
`$ git checkout pull/1046`

Update a local copy of the PR: \
`$ git checkout pull/1046` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1046`

View PR using the GUI difftool: \
`$ git pr show -t 1046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1046.diff">https://git.openjdk.org/jdk21u-dev/pull/1046.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1046#issuecomment-2407233017)