### PR TITLE
Backport 6cda4c59851d7a9bbe8bd39c93a8923b039a7184

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -82,7 +82,7 @@ public abstract class PKCS11Test {
 
     // Version of the NSS artifact. This coincides with the version of
     // the NSS version
-    private static final String NSS_BUNDLE_VERSION = "3.91";
+    private static final String NSS_BUNDLE_VERSION = "3.96";
     private static final String NSSLIB = "jpg.tests.jdk.nsslib";
 
     static double nss_version = -1;


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.