### PR TITLE
8342063: [21u][aix] Backport introduced redundant line in ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -569,7 +569,6 @@ java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java 8144003 macosx-
 java/nio/channels/DatagramChannel/Promiscuous.java              8144003 macosx-all
 java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
 
-java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
 java/nio/file/Files/probeContentType/Basic.java                 8320943 windows-all
 
 ############################################################################


### PR DESCRIPTION
Just removed the line that exists twice.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342063](https://bugs.openjdk.org/browse/JDK-8342063) needs maintainer approval

### Issue
 * [JDK-8342063](https://bugs.openjdk.org/browse/JDK-8342063): [21u][aix] Backport introduced redundant line in ProblemList (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1050/head:pull/1050` \
`$ git checkout pull/1050`

Update a local copy of the PR: \
`$ git checkout pull/1050` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1050`

View PR using the GUI difftool: \
`$ git pr show -t 1050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1050.diff">https://git.openjdk.org/jdk21u-dev/pull/1050.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1050#issuecomment-2411398971)