### PR TITLE
8195675: Call to insertText with single character from custom Input Method ignored

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -38,6 +38,9 @@
 // keyboard layout
 static NSString *kbdLayout;
 
+// Constant for keyman layouts
+#define KEYMAN_LAYOUT "keyman"
+
 @interface AWTView()
 @property (retain) CDropTarget *_dropTarget;
 @property (retain) CDragSource *_dragSource;
@@ -259,7 +262,7 @@ static BOOL shouldUsePressAndHold() {
 
 - (void) keyDown: (NSEvent *)event {
     fProcessingKeystroke = YES;
-    fKeyEventsNeeded = YES;
+    fKeyEventsNeeded = ![(NSString *)kbdLayout containsString:@KEYMAN_LAYOUT];
 
     // Allow TSM to look at the event and potentially send back NSTextInputClient messages.
     [self interpretKeyEvents:[NSArray arrayWithObject:event]];
@@ -965,7 +968,7 @@ static jclass jc_CInputMethod = NULL;
 
     if ((utf16Length > 2) ||
         ((utf8Length > 1) && [self isCodePointInUnicodeBlockNeedingIMEvent:codePoint]) ||
-        ((codePoint == 0x5c) && ([(NSString *)kbdLayout containsString:@"Kotoeri"]))) {
+        [(NSString *)kbdLayout containsString:@KEYMAN_LAYOUT]) {
 #ifdef IM_DEBUG
         NSLog(@"string complex ");
 #endif


### PR DESCRIPTION
- Backport of JDK-8195675
- Backport of https://github.com/openjdk/jdk/commit/b8f2ec9091f9f7e5f4611991d04dd8aa113b94fd https://github.com/openjdk/jdk/pull/17921

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8195675](https://bugs.openjdk.org/browse/JDK-8195675) needs maintainer approval

### Issue
 * [JDK-8195675](https://bugs.openjdk.org/browse/JDK-8195675): Call to insertText with single character from custom Input Method ignored (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1052/head:pull/1052` \
`$ git checkout pull/1052`

Update a local copy of the PR: \
`$ git checkout pull/1052` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1052`

View PR using the GUI difftool: \
`$ git pr show -t 1052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1052.diff">https://git.openjdk.org/jdk21u-dev/pull/1052.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1052#issuecomment-2411775594)