### PR TITLE
8311656: Shenandoah: Unused ShenandoahSATBAndRemarkThreadsClosure::_claim_token

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -72,7 +72,6 @@ class ShenandoahSATBAndRemarkThreadsClosure : public ThreadClosure {
 private:
   SATBMarkQueueSet& _satb_qset;
   OopClosure* const _cl;
-  uintx _claim_token;
 
 public:
   ShenandoahSATBAndRemarkThreadsClosure(SATBMarkQueueSet& satb_qset, OopClosure* cl) :


### PR DESCRIPTION
Remove `unused _claim_token field` from `ShenandoahSATBAndRemarkThreadsClosure`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8311656](https://bugs.openjdk.org/browse/JDK-8311656) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311656](https://bugs.openjdk.org/browse/JDK-8311656): Shenandoah: Unused ShenandoahSATBAndRemarkThreadsClosure::_claim_token (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1055/head:pull/1055` \
`$ git checkout pull/1055`

Update a local copy of the PR: \
`$ git checkout pull/1055` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1055`

View PR using the GUI difftool: \
`$ git pr show -t 1055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1055.diff">https://git.openjdk.org/jdk21u-dev/pull/1055.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1055#issuecomment-2416351883)