### PR TITLE
8340109: Ubsan: ciEnv.cpp:1660:65: runtime error: member call on null pointer of type 'struct CompileTask'

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1674,7 +1674,10 @@ void ciEnv::dump_replay_data_helper(outputStream* out) {
   for (int i = 0; i < objects->length(); i++) {
     objects->at(i)->dump_replay_data(out);
   }
-  dump_compile_data(out);
+
+  if (this->task() != nullptr) {
+    dump_compile_data(out);
+  }
   out->flush();
 }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340109](https://bugs.openjdk.org/browse/JDK-8340109) needs maintainer approval

### Issue
 * [JDK-8340109](https://bugs.openjdk.org/browse/JDK-8340109): Ubsan: ciEnv.cpp:1660:65: runtime error: member call on null pointer of type 'struct CompileTask' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1056/head:pull/1056` \
`$ git checkout pull/1056`

Update a local copy of the PR: \
`$ git checkout pull/1056` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1056`

View PR using the GUI difftool: \
`$ git pr show -t 1056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1056.diff">https://git.openjdk.org/jdk21u-dev/pull/1056.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1056#issuecomment-2416608489)