### PR TITLE
8341024: [test] build/AbsPathsInImage.java fails with OOM when using ubsan-enabled binaries

### DIFF
--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -40,7 +40,7 @@ import java.util.zip.ZipInputStream;
  * @bug 8226346
  * @summary Check all output files for absolute path fragments
  * @requires !vm.debug
- * @run main AbsPathsInImage
+ * @run main/othervm -Xmx900m AbsPathsInImage
  */
 public class AbsPathsInImage {
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8341024](https://bugs.openjdk.org/browse/JDK-8341024) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341024](https://bugs.openjdk.org/browse/JDK-8341024): [test] build/AbsPathsInImage.java fails with OOM when using ubsan-enabled binaries (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1057/head:pull/1057` \
`$ git checkout pull/1057`

Update a local copy of the PR: \
`$ git checkout pull/1057` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1057`

View PR using the GUI difftool: \
`$ git pr show -t 1057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1057.diff">https://git.openjdk.org/jdk21u-dev/pull/1057.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1057#issuecomment-2416819548)