### PR TITLE
8332866: Crash in ImageIO JPEG decoding when MEM_STATS in enabled

### DIFF
--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -666,8 +666,6 @@ static void imageio_reset(JNIEnv *env,
 static void imageio_dispose(j_common_ptr info) {
 
     if (info != NULL) {
-        free(info->err);
-        info->err = NULL;
         if (info->is_decompressor) {
             j_decompress_ptr dinfo = (j_decompress_ptr) info;
             free(dinfo->src);
@@ -678,6 +676,8 @@ static void imageio_dispose(j_common_ptr info) {
             cinfo->dest = NULL;
         }
         jpeg_destroy(info);
+        free(info->err);
+        info->err = NULL;
         free(info);
     }
 }


### PR DESCRIPTION
Backporting JDK-8332866: Crash in ImageIO JPEG decoding when MEM_STATS in enabled, which ensures we are clearing memory correctly if printing of memory statistic logs is enabled. Patch should be clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332866](https://bugs.openjdk.org/browse/JDK-8332866) needs maintainer approval

### Issue
 * [JDK-8332866](https://bugs.openjdk.org/browse/JDK-8332866): Crash in ImageIO JPEG decoding when MEM_STATS in enabled (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1058/head:pull/1058` \
`$ git checkout pull/1058`

Update a local copy of the PR: \
`$ git checkout pull/1058` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1058`

View PR using the GUI difftool: \
`$ git pr show -t 1058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1058.diff">https://git.openjdk.org/jdk21u-dev/pull/1058.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1058#issuecomment-2417474840)