### PR TITLE
8325610: CTW: Add StressIncrementalInlining to stress options

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -302,6 +302,7 @@ public class CtwRunner {
                 "-XX:+StressGCM",
                 "-XX:+StressIGVN",
                 "-XX:+StressCCP",
+                "-XX:+StressIncrementalInlining",
                 // StressSeed is uint
                 "-XX:StressSeed=" + rng.nextInt(Integer.MAX_VALUE)));
 


### PR DESCRIPTION
Backporting JDK-8325610: CTW: Add StressIncrementalInlining to stress options. Adds -XX:+StressIncrementalInlining omitted arg to CTW test. Ran GHA Sanity Checks and local Tier 1 and Tier 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325610](https://bugs.openjdk.org/browse/JDK-8325610) needs maintainer approval

### Issue
 * [JDK-8325610](https://bugs.openjdk.org/browse/JDK-8325610): CTW: Add StressIncrementalInlining to stress options (**Enhancement** - P4 - Approved)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1064/head:pull/1064` \
`$ git checkout pull/1064`

Update a local copy of the PR: \
`$ git checkout pull/1064` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1064`

View PR using the GUI difftool: \
`$ git pr show -t 1064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1064.diff">https://git.openjdk.org/jdk21u-dev/pull/1064.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1064#issuecomment-2420653009)