### PR TITLE
8313374: --enable-ccache's CCACHE_BASEDIR breaks builds

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -215,7 +215,21 @@ DEPENDENCY_TARGET_SED_PATTERN := \
 # The fix-deps-file macro is used to adjust the contents of the generated make
 # dependency files to contain paths compatible with make.
 #
+REWRITE_PATHS_RELATIVE = false
 ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT)-$(FILE_MACRO_CFLAGS), false-)
+  REWRITE_PATHS_RELATIVE = true
+endif
+
+# CCACHE_BASEDIR needs fix-deps-file as makefiles use absolute filenames for
+# object files while CCACHE_BASEDIR will make ccache relativize all paths for
+# its compiler. The compiler then produces relative dependency files.
+# make does not know a relative and absolute filename is the same so it will
+# ignore such dependencies.
+ifneq ($(CCACHE), )
+  REWRITE_PATHS_RELATIVE = true
+endif
+
+ifeq ($(REWRITE_PATHS_RELATIVE), true)
   # Need to handle -I flags as both '-Ifoo' and '-I foo'.
   MakeCommandRelative = \
       $(CD) $(WORKSPACE_ROOT) && \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [571c435e](https://github.com/openjdk/jdk/commit/571c435e1a34dcf08fd7545d531c258c9116ea79) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Kratochvil on 23 Aug 2023 and was reviewed by Erik Joelsson.

Without this PR, the jdk build with --enable-ccache can't generate comments in -XX:+PrintInterpreter, this PR fix the build issue. So I want to backport this PR to jdk21u-dev from jdk22.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313374](https://bugs.openjdk.org/browse/JDK-8313374) needs maintainer approval

### Issue
 * [JDK-8313374](https://bugs.openjdk.org/browse/JDK-8313374): --enable-ccache's CCACHE_BASEDIR breaks builds (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1066/head:pull/1066` \
`$ git checkout pull/1066`

Update a local copy of the PR: \
`$ git checkout pull/1066` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1066`

View PR using the GUI difftool: \
`$ git pr show -t 1066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1066.diff">https://git.openjdk.org/jdk21u-dev/pull/1066.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1066#issuecomment-2422467739)