### PR TITLE
Backport daa67f45f0c17d4087eb51a708193d6db124b426

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +27,8 @@
  * @summary Basic test for creationTime attribute on platforms/file systems
  *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib
- * @build jdk.test.lib.Platform
  * @comment We see this failing with "UnsatisfiedLinkError: Native Library ...libCreationTimeHelper.so already loaded in another classloader". Thus run as othervm
- * @run main/othervm CreationTime
+ * @run main/othervm/native CreationTime
  */
 
 /* @test id=cwd
@@ -36,8 +36,7 @@
  *     that support it, tests using the test scratch directory, the test
  *     scratch directory maybe at diff disk partition to /tmp on linux.
  * @library  ../.. /test/lib
- * @build jdk.test.lib.Platform
- * @run main/native CreationTime .
+ * @run main/othervm/native CreationTime .
  */
 
 import java.nio.file.Path;
@@ -50,8 +49,6 @@ import jdk.test.lib.Platform;
 import jtreg.SkippedException;
 
 public class CreationTime {
-
-    private static final java.io.PrintStream err = System.err;
 
     /**
      * Reads the creationTime attribute
@@ -78,14 +75,9 @@ public class CreationTime {
         FileTime creationTime = creationTime(file);
         Instant now = Instant.now();
         if (Math.abs(creationTime.toMillis()-now.toEpochMilli()) > 10000L) {
-            System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
-            // If the file system doesn't support birth time, then skip this test
-            if (creationTime.toMillis() == 0) {
-                throw new SkippedException("birth time not support for: " + file);
-            } else {
-                err.println("File creation time reported as: " + creationTime);
-                throw new RuntimeException("Expected to be close to: " + now);
-            }
+            System.err.println("creationTime.toMillis() == " + creationTime.toMillis());
+            System.err.println("File creation time reported as: " + creationTime);
+            throw new RuntimeException("Expected to be close to: " + now);
         }
 
         /**
@@ -107,7 +99,12 @@ public class CreationTime {
             }
         } else if (Platform.isLinux()) {
             // Creation time read depends on statx system call support
-            supportsCreationTimeRead = CreationTimeHelper.linuxIsCreationTimeSupported();
+            try {
+                supportsCreationTimeRead = CreationTimeHelper.
+                        linuxIsCreationTimeSupported(file.toAbsolutePath().toString());
+            } catch (Throwable e) {
+                supportsCreationTimeRead = false;
+            }
             // Creation time updates are not supported on Linux
             supportsCreationTimeWrite = false;
         }
@@ -122,8 +119,11 @@ public class CreationTime {
             Instant plusHour = Instant.now().plusSeconds(60L * 60L);
             Files.setLastModifiedTime(file, FileTime.from(plusHour));
             FileTime current = creationTime(file);
-            if (!current.equals(creationTime))
+            if (!current.equals(creationTime)) {
+                System.err.println("current = " + current);
+                System.err.println("creationTime = " + creationTime);
                 throw new RuntimeException("Creation time should not have changed");
+            }
         }
 
         /**

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -27,6 +27,7 @@
  * @summary Basic test for creationTime attribute on platforms/file systems
  *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib
+ * @build jdk.test.lib.Platform
  * @comment We see this failing with "UnsatisfiedLinkError: Native Library ...libCreationTimeHelper.so already loaded in another classloader". Thus run as othervm
  * @run main/othervm/native CreationTime
  */
@@ -36,6 +37,7 @@
  *     that support it, tests using the test scratch directory, the test
  *     scratch directory maybe at diff disk partition to /tmp on linux.
  * @library  ../.. /test/lib
+ * @build jdk.test.lib.Platform
  * @run main/othervm/native CreationTime .
  */
 

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +21,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 public class CreationTimeHelper {
 
     static {
@@ -27,5 +29,5 @@ public class CreationTimeHelper {
     }
 
     // Helper so as to determine 'statx' support on the runtime system
-    static native boolean linuxIsCreationTimeSupported();
+    static native boolean linuxIsCreationTimeSupported(String file);
 }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +22,113 @@
  * questions.
  */
 #include "jni.h"
+#include <stdbool.h>
 #if defined(__linux__)
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <bits/types.h>
 #include <dlfcn.h>
+#ifndef STATX_BASIC_STATS
+#define STATX_BASIC_STATS 0x000007ffU
 #endif
+#ifndef STATX_BTIME
+#define STATX_BTIME 0x00000800U
+#endif
+#ifndef RTLD_DEFAULT
+#define RTLD_DEFAULT RTLD_LOCAL
+#endif
+#ifndef AT_SYMLINK_NOFOLLOW
+#define AT_SYMLINK_NOFOLLOW 0x100
+#endif
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+
+/*
+ * Timestamp structure for the timestamps in struct statx.
+ */
+struct my_statx_timestamp {
+        __int64_t   tv_sec;
+        __uint32_t  tv_nsec;
+        __int32_t   __reserved;
+};
+
+/*
+ * struct statx used by statx system call on >= glibc 2.28
+ * systems
+ */
+struct my_statx
+{
+  __uint32_t stx_mask;
+  __uint32_t stx_blksize;
+  __uint64_t stx_attributes;
+  __uint32_t stx_nlink;
+  __uint32_t stx_uid;
+  __uint32_t stx_gid;
+  __uint16_t stx_mode;
+  __uint16_t __statx_pad1[1];
+  __uint64_t stx_ino;
+  __uint64_t stx_size;
+  __uint64_t stx_blocks;
+  __uint64_t stx_attributes_mask;
+  struct my_statx_timestamp stx_atime;
+  struct my_statx_timestamp stx_btime;
+  struct my_statx_timestamp stx_ctime;
+  struct my_statx_timestamp stx_mtime;
+  __uint32_t stx_rdev_major;
+  __uint32_t stx_rdev_minor;
+  __uint32_t stx_dev_major;
+  __uint32_t stx_dev_minor;
+  __uint64_t __statx_pad2[14];
+};
+
+typedef int statx_func(int dirfd, const char *restrict pathname, int flags,
+                       unsigned int mask, struct my_statx *restrict statxbuf);
+
+static statx_func* my_statx_func = NULL;
+#endif  //#defined(__linux__)
 
 // static native boolean linuxIsCreationTimeSupported()
 JNIEXPORT jboolean JNICALL
-Java_CreationTimeHelper_linuxIsCreationTimeSupported(JNIEnv *env, jclass cls)
-{
+Java_CreationTimeHelper_linuxIsCreationTimeSupported(JNIEnv *env, jclass cls, jstring file) {
 #if defined(__linux__)
-    void* statx_func = dlsym(RTLD_DEFAULT, "statx");
-    return statx_func != NULL ? JNI_TRUE : JNI_FALSE;
+    struct my_statx stx = {0};
+    int ret, atflag = AT_SYMLINK_NOFOLLOW;
+    unsigned int mask = STATX_BASIC_STATS | STATX_BTIME;
+
+    my_statx_func = (statx_func*) dlsym(RTLD_DEFAULT, "statx");
+    if (my_statx_func == NULL) {
+        return false;
+    }
+
+    if (file == NULL) {
+        printf("input file error!\n");
+        return JNI_FALSE;
+    }
+    const char *utfChars = (*env)->GetStringUTFChars(env, file, NULL);
+    if (utfChars == NULL) {
+        printf("jstring convert to char array error!\n");
+        return JNI_FALSE;
+    }
+
+    ret = my_statx_func(AT_FDCWD, utfChars, atflag, mask, &stx);
+
+    if (file != NULL && utfChars != NULL) {
+        (*env)->ReleaseStringUTFChars(env, file, utfChars);
+    }
+
+    if (ret != 0) {
+        return JNI_FALSE;
+    }
+
+    // On some systems where statx is available but birth time might still not
+    // be supported as it's file system specific. The only reliable way to
+    // check for supported or not is looking at the filled in STATX_BTIME bit
+    // in the returned statx buffer mask.
+    if ((stx.stx_mask & STATX_BTIME) != 0)
+        return JNI_TRUE;
+    return JNI_FALSE;
 #else
     return JNI_FALSE;
 #endif


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f56a1541](https://github.com/openjdk/jdk/commit/f56a154132f7e66b1b65adfa2aa937119999b14a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 14 Oct 2024 and was reviewed by Chen Liang, Severin Gehwolf, Magnus Ihse Bursie and Brian Burkhalter.

The original PR use FFM API to call native library, but we can't use FFM API in jdk21u directly, and the original PR dependency the file `test/lib/native/export.h`, this file not exists in jdk21 repository. So we use JNI instead of FFM API. Before this PR, the file `test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c` and `test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java` already exists cause this PR can't backport cleanly.

Additional testing:

- [x] linux-x64 build at alinux3, and run the test passed.
- [x] linux-x64 build at centos7 docker container, and run the test passed.
- [x] linux-64 compile libCreationTimeHelper.c at `centos6 docker container(glibc2.12)` by gcc 11.2.0 use below command

`libCreationTimeHelper.c` compile test command:
```shell
gcc test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c -Ibuild/linux-x86_64-server-release/jdk/include -I build/linux-x86_64-server-release/jdk/include/linux -c
```

Thanks!