### PR TITLE
8341881: [REDO] java/nio/file/attribute/BasicFileAttributeView/CreationTime.java#tmp fails on alinux3

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +29,7 @@
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
  * @comment We see this failing with "UnsatisfiedLinkError: Native Library ...libCreationTimeHelper.so already loaded in another classloader". Thus run as othervm
- * @run main/othervm CreationTime
+ * @run main/othervm/native CreationTime
  */
 
 /* @test id=cwd
@@ -37,7 +38,7 @@
  *     scratch directory maybe at diff disk partition to /tmp on linux.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
- * @run main/native CreationTime .
+ * @run main/othervm/native CreationTime .
  */
 
 import java.nio.file.Path;
@@ -50,8 +51,6 @@ import jdk.test.lib.Platform;
 import jtreg.SkippedException;
 
 public class CreationTime {
-
-    private static final java.io.PrintStream err = System.err;
 
     /**
      * Reads the creationTime attribute
@@ -78,14 +77,9 @@ public class CreationTime {
         FileTime creationTime = creationTime(file);
         Instant now = Instant.now();
         if (Math.abs(creationTime.toMillis()-now.toEpochMilli()) > 10000L) {
-            System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
-            // If the file system doesn't support birth time, then skip this test
-            if (creationTime.toMillis() == 0) {
-                throw new SkippedException("birth time not support for: " + file);
-            } else {
-                err.println("File creation time reported as: " + creationTime);
-                throw new RuntimeException("Expected to be close to: " + now);
-            }
+            System.err.println("creationTime.toMillis() == " + creationTime.toMillis());
+            System.err.println("File creation time reported as: " + creationTime);
+            throw new RuntimeException("Expected to be close to: " + now);
         }
 
         /**
@@ -107,7 +101,12 @@ public class CreationTime {
             }
         } else if (Platform.isLinux()) {
             // Creation time read depends on statx system call support
-            supportsCreationTimeRead = CreationTimeHelper.linuxIsCreationTimeSupported();
+            try {
+                supportsCreationTimeRead = CreationTimeHelper.
+                        linuxIsCreationTimeSupported(file.toAbsolutePath().toString());
+            } catch (Throwable e) {
+                supportsCreationTimeRead = false;
+            }
             // Creation time updates are not supported on Linux
             supportsCreationTimeWrite = false;
         }
@@ -122,8 +121,11 @@ public class CreationTime {
             Instant plusHour = Instant.now().plusSeconds(60L * 60L);
             Files.setLastModifiedTime(file, FileTime.from(plusHour));
             FileTime current = creationTime(file);
-            if (!current.equals(creationTime))
+            if (!current.equals(creationTime)) {
+                System.err.println("current = " + current);
+                System.err.println("creationTime = " + creationTime);
                 throw new RuntimeException("Creation time should not have changed");
+            }
         }
 
         /**

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +21,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 public class CreationTimeHelper {
 
     static {
@@ -27,5 +29,5 @@ public class CreationTimeHelper {
     }
 
     // Helper so as to determine 'statx' support on the runtime system
-    static native boolean linuxIsCreationTimeSupported();
+    static native boolean linuxIsCreationTimeSupported(String file);
 }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +22,113 @@
  * questions.
  */
 #include "jni.h"
+#include <stdbool.h>
 #if defined(__linux__)
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <bits/types.h>
 #include <dlfcn.h>
+#ifndef STATX_BASIC_STATS
+#define STATX_BASIC_STATS 0x000007ffU
 #endif
+#ifndef STATX_BTIME
+#define STATX_BTIME 0x00000800U
+#endif
+#ifndef RTLD_DEFAULT
+#define RTLD_DEFAULT RTLD_LOCAL
+#endif
+#ifndef AT_SYMLINK_NOFOLLOW
+#define AT_SYMLINK_NOFOLLOW 0x100
+#endif
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+
+/*
+ * Timestamp structure for the timestamps in struct statx.
+ */
+struct my_statx_timestamp {
+        __int64_t   tv_sec;
+        __uint32_t  tv_nsec;
+        __int32_t   __reserved;
+};
+
+/*
+ * struct statx used by statx system call on >= glibc 2.28
+ * systems
+ */
+struct my_statx
+{
+  __uint32_t stx_mask;
+  __uint32_t stx_blksize;
+  __uint64_t stx_attributes;
+  __uint32_t stx_nlink;
+  __uint32_t stx_uid;
+  __uint32_t stx_gid;
+  __uint16_t stx_mode;
+  __uint16_t __statx_pad1[1];
+  __uint64_t stx_ino;
+  __uint64_t stx_size;
+  __uint64_t stx_blocks;
+  __uint64_t stx_attributes_mask;
+  struct my_statx_timestamp stx_atime;
+  struct my_statx_timestamp stx_btime;
+  struct my_statx_timestamp stx_ctime;
+  struct my_statx_timestamp stx_mtime;
+  __uint32_t stx_rdev_major;
+  __uint32_t stx_rdev_minor;
+  __uint32_t stx_dev_major;
+  __uint32_t stx_dev_minor;
+  __uint64_t __statx_pad2[14];
+};
+
+typedef int statx_func(int dirfd, const char *restrict pathname, int flags,
+                       unsigned int mask, struct my_statx *restrict statxbuf);
+
+static statx_func* my_statx_func = NULL;
+#endif  //#defined(__linux__)
 
 // static native boolean linuxIsCreationTimeSupported()
 JNIEXPORT jboolean JNICALL
-Java_CreationTimeHelper_linuxIsCreationTimeSupported(JNIEnv *env, jclass cls)
-{
+Java_CreationTimeHelper_linuxIsCreationTimeSupported(JNIEnv *env, jclass cls, jstring file) {
 #if defined(__linux__)
-    void* statx_func = dlsym(RTLD_DEFAULT, "statx");
-    return statx_func != NULL ? JNI_TRUE : JNI_FALSE;
+    struct my_statx stx = {0};
+    int ret, atflag = AT_SYMLINK_NOFOLLOW;
+    unsigned int mask = STATX_BASIC_STATS | STATX_BTIME;
+
+    my_statx_func = (statx_func*) dlsym(RTLD_DEFAULT, "statx");
+    if (my_statx_func == NULL) {
+        return false;
+    }
+
+    if (file == NULL) {
+        printf("input file error!\n");
+        return JNI_FALSE;
+    }
+    const char *utfChars = (*env)->GetStringUTFChars(env, file, NULL);
+    if (utfChars == NULL) {
+        printf("jstring convert to char array error!\n");
+        return JNI_FALSE;
+    }
+
+    ret = my_statx_func(AT_FDCWD, utfChars, atflag, mask, &stx);
+
+    if (file != NULL && utfChars != NULL) {
+        (*env)->ReleaseStringUTFChars(env, file, utfChars);
+    }
+
+    if (ret != 0) {
+        return JNI_FALSE;
+    }
+
+    // On some systems where statx is available but birth time might still not
+    // be supported as it's file system specific. The only reliable way to
+    // check for supported or not is looking at the filled in STATX_BTIME bit
+    // in the returned statx buffer mask.
+    if ((stx.stx_mask & STATX_BTIME) != 0)
+        return JNI_TRUE;
+    return JNI_FALSE;
 #else
     return JNI_FALSE;
 #endif

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -26,8 +26,8 @@
 #if defined(__linux__)
 #include <stdio.h>
 #include <string.h>
+#include <sys/types.h>
 #include <sys/stat.h>
-#include <bits/types.h>
 #include <dlfcn.h>
 #ifndef STATX_BASIC_STATS
 #define STATX_BASIC_STATS 0x000007ffU
@@ -45,13 +45,20 @@
 #define AT_FDCWD -100
 #endif
 
+#ifndef __GLIBC__
+// Alpine doesn't know these types, define them
+typedef unsigned int       __uint32_t;
+typedef unsigned short     __uint16_t;
+typedef unsigned long int  __uint64_t;
+#endif
+
 /*
  * Timestamp structure for the timestamps in struct statx.
  */
 struct my_statx_timestamp {
-        __int64_t   tv_sec;
+        int64_t   tv_sec;
         __uint32_t  tv_nsec;
-        __int32_t   __reserved;
+        int32_t   __reserved;
 };
 
 /*


### PR DESCRIPTION
Hi all,

This PR backport [JDK-8341881](https://bugs.openjdk.org/browse/JDK-8341881) and [JDK-8341881](https://bugs.openjdk.org/browse/JDK-8341881) together, and this PR fix test bug which cause test fails on some Linux distribution. Change has been verified locally, risk is low.

The original PR of [JDK-8341881](https://bugs.openjdk.org/browse/JDK-8341881) use FFM API to call native library, but we can't use FFM API in jdk21u directly, and the original PR dependency the file `test/lib/native/export.h`, this file not exists in jdk21 repository. So we use JNI instead of FFM API. Before this PR, the file `test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c` and `test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java` already exists cause this PR can't backport cleanly.

[JDK-8341881](https://bugs.openjdk.org/browse/JDK-8341881) backport is cleanly.

Additional testing:

- [x] linux-x64 build at alinux3, and run the test passed.
- [x] linux-x64 build at centos7 docker container, and run the test passed.
- [x] linux-64 compile libCreationTimeHelper.c at `centos6 docker container(glibc2.12)` by gcc 11.2.0 use below command
- [x] linux-64 compile libCreationTimeHelper.c at `adoptopenjdk/alpine3_build_image docker container` use below command

`libCreationTimeHelper.c` compile test command:
```shell
gcc test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c -Ibuild/linux-x86_64-server-release/jdk/include -I build/linux-x86_64-server-release/jdk/include/linux -c
```

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342145](https://bugs.openjdk.org/browse/JDK-8342145) needs maintainer approval
- [x] [JDK-8341881](https://bugs.openjdk.org/browse/JDK-8341881) needs maintainer approval

### Issues
 * [JDK-8341881](https://bugs.openjdk.org/browse/JDK-8341881): [REDO] java/nio/file/attribute/BasicFileAttributeView/CreationTime.java#tmp fails on alinux3 (**Bug** - P3 - Approved)
 * [JDK-8342145](https://bugs.openjdk.org/browse/JDK-8342145): File libCreationTimeHelper.c compile fails on Alpine (**Bug** - P2 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) Review applies to [846f1b57](https://git.openjdk.org/jdk21u-dev/pull/1068/files/846f1b578c4c04b1fc41db457d5f2429c7cbde06)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1068/head:pull/1068` \
`$ git checkout pull/1068`

Update a local copy of the PR: \
`$ git checkout pull/1068` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1068`

View PR using the GUI difftool: \
`$ git pr show -t 1068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1068.diff">https://git.openjdk.org/jdk21u-dev/pull/1068.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1068#issuecomment-2423788802)
</details>
