### PR TITLE
8342669: [21u] Fix TestArrayAllocatorMallocLimit after backport of JDK-8315097

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
@@ -51,7 +51,7 @@ public class TestArrayAllocatorMallocLimit {
   private static final String printFlagsFinalPattern = " *size_t *" + flagName + " *:?= *(\\d+) *\\{experimental\\} *";
 
   public static void testDefaultValue()  throws Exception {
-    ProcessBuilder pb = GCArguments.createLimitedTestJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createTestJavaProcessBuilder(
       "-XX:+UnlockExperimentalVMOptions", "-XX:+PrintFlagsFinal", "-version");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
…K-8315097

The obvious fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342669](https://bugs.openjdk.org/browse/JDK-8342669) needs maintainer approval

### Issue
 * [JDK-8342669](https://bugs.openjdk.org/browse/JDK-8342669): [21u] Fix TestArrayAllocatorMallocLimit after backport of JDK-8315097 (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1069/head:pull/1069` \
`$ git checkout pull/1069`

Update a local copy of the PR: \
`$ git checkout pull/1069` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1069`

View PR using the GUI difftool: \
`$ git pr show -t 1069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1069.diff">https://git.openjdk.org/jdk21u-dev/pull/1069.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1069#issuecomment-2426135477)