### PR TITLE
8328402: Implement pausing functionality for the PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -24,6 +24,7 @@
 import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
@@ -187,7 +188,7 @@ public final class PassFailJFrame {
 
     private static final CountDownLatch latch = new CountDownLatch(1);
 
-    private static TimeoutHandler timeoutHandler;
+    private static TimeoutHandlerPanel timeoutHandlerPanel;
 
     /**
      * The description of why the test fails.
@@ -424,10 +425,8 @@ public final class PassFailJFrame {
                                                        int rows, int columns,
                                                        boolean enableScreenCapture) {
         JPanel main = new JPanel(new BorderLayout());
-
-        JLabel testTimeoutLabel = new JLabel("", JLabel.CENTER);
-        timeoutHandler = new TimeoutHandler(testTimeoutLabel, testTimeOut);
-        main.add(testTimeoutLabel, BorderLayout.NORTH);
+        timeoutHandlerPanel = new TimeoutHandlerPanel(testTimeOut);
+        main.add(timeoutHandlerPanel, BorderLayout.NORTH);
 
         JTextComponent text = instructions.startsWith("<html>")
                               ? configureHTML(instructions, rows, columns)
@@ -439,13 +438,13 @@ public final class PassFailJFrame {
         JButton btnPass = new JButton("Pass");
         btnPass.addActionListener((e) -> {
             latch.countDown();
-            timeoutHandler.stop();
+            timeoutHandlerPanel.stop();
         });
 
         JButton btnFail = new JButton("Fail");
         btnFail.addActionListener((e) -> {
             requestFailureReason();
-            timeoutHandler.stop();
+            timeoutHandlerPanel.stop();
         });
 
         JPanel buttonsPanel = new JPanel();
@@ -603,17 +602,35 @@ public final class PassFailJFrame {
     }
 
 
-    private static final class TimeoutHandler implements ActionListener {
-        private final long endTime;
+    private static final class TimeoutHandlerPanel
+            extends JPanel
+            implements ActionListener {
+
+        private static final String PAUSE_BUTTON_LABEL = "Pause";
+        private static final String RESUME_BUTTON_LABEL = "Resume";
+
+        private long endTime;
+        private long pauseTimeLeft;
 
         private final Timer timer;
 
         private final JLabel label;
+        private final JButton button;
 
-        public TimeoutHandler(final JLabel label, final long testTimeOut) {
-            endTime = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(testTimeOut);
+        public TimeoutHandlerPanel(final long testTimeOut) {
+            endTime = System.currentTimeMillis()
+                    + TimeUnit.MINUTES.toMillis(testTimeOut);
 
-            this.label = label;
+            label =  new JLabel("", JLabel.CENTER);
+            button = new JButton(PAUSE_BUTTON_LABEL);
+
+            button.setFocusPainted(false);
+            button.setFont(new Font(Font.DIALOG, Font.BOLD, 10));
+            button.addActionListener(e -> pauseToggle());
+
+            setLayout(new BorderLayout());
+            add(label, BorderLayout.CENTER);
+            add(button, BorderLayout.EAST);
 
             timer = new Timer(1000, this);
             timer.start();
@@ -643,6 +660,22 @@ public final class PassFailJFrame {
             label.setText(String.format(Locale.ENGLISH,
                                         "Test timeout: %02d:%02d:%02d",
                                         hours, minutes, seconds));
+        }
+
+
+        private void pauseToggle() {
+            if (timer.isRunning()) {
+                pauseTimeLeft = endTime - System.currentTimeMillis();
+                timer.stop();
+                label.setEnabled(false);
+                button.setText(RESUME_BUTTON_LABEL);
+            } else {
+                endTime = System.currentTimeMillis() + pauseTimeLeft;
+                updateTime(pauseTimeLeft);
+                timer.start();
+                label.setEnabled(true);
+                button.setText(PAUSE_BUTTON_LABEL);
+            }
         }
 
         public void stop() {


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8328402](https://bugs.openjdk.org/browse/JDK-8328402) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328402](https://bugs.openjdk.org/browse/JDK-8328402): Implement pausing functionality for the PassFailJFrame (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1070/head:pull/1070` \
`$ git checkout pull/1070`

Update a local copy of the PR: \
`$ git checkout pull/1070` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1070`

View PR using the GUI difftool: \
`$ git pr show -t 1070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1070.diff">https://git.openjdk.org/jdk21u-dev/pull/1070.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1070#issuecomment-2426910401)