### PR TITLE
8333317: Test sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java failed with: Invalid ECDH ServerKeyExchange signature

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -82,7 +82,7 @@ public abstract class PKCS11Test {
 
     // Version of the NSS artifact. This coincides with the version of
     // the NSS version
-    private static final String NSS_BUNDLE_VERSION = "3.96";
+    private static final String NSS_BUNDLE_VERSION = "3.101";
     private static final String NSSLIB = "jpg.tests.jdk.nsslib";
 
     static double nss_version = -1;

--- a/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
+++ b/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,12 @@ public class TestDSAKeyLength extends PKCS11Test {
 
     @Override
     protected boolean skipTest(Provider provider) {
-        if (isNSS(provider) && (getNSSVersion() == 0.0 || getNSSVersion() >= 3.14)) {
-            System.out.println("Skip testing NSS " + getNSSVersion());
+        double version = getNSSVersion();
+        String[] versionStrs = Double.toString(version).split("\\.");
+        int major = Integer.parseInt(versionStrs[0]);
+        int minor = Integer.parseInt(versionStrs[1]);
+        if (isNSS(provider) && (version == 0.0 || (major >= 3 && minor >= 14))) {
+            System.out.println("Skip testing NSS " + version);
             return true;
         }
 


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

Skipped ProblemList, test is not listed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333317](https://bugs.openjdk.org/browse/JDK-8333317) needs maintainer approval

### Issue
 * [JDK-8333317](https://bugs.openjdk.org/browse/JDK-8333317): Test sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java failed with: Invalid ECDH ServerKeyExchange signature (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1071/head:pull/1071` \
`$ git checkout pull/1071`

Update a local copy of the PR: \
`$ git checkout pull/1071` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1071`

View PR using the GUI difftool: \
`$ git pr show -t 1071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1071.diff">https://git.openjdk.org/jdk21u-dev/pull/1071.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1071#issuecomment-2426930389)