### PR TITLE
8342765: [21u] RTM tests assume UnlockExperimentalVMOptions is disabled by default

### DIFF
--- a/test/hotspot/jtreg/compiler/rtm/cli/RTMGenericCommandLineOptionTest.java
+++ b/test/hotspot/jtreg/compiler/rtm/cli/RTMGenericCommandLineOptionTest.java
@@ -145,7 +145,9 @@ public abstract class RTMGenericCommandLineOptionTest {
             CommandLineOptionTest.verifySameJVMStartup(
                     new String[] { experimentalOptionError },
                     new String[] { errorMessage }, shouldFailMessage,
-                    shouldFailMessage, ExitCode.FAIL, optionValue);
+                    shouldFailMessage, ExitCode.FAIL,
+                    "-XX:-UnlockExperimentalVMOptions",
+                    optionValue);
             // verify that it could be passed if experimental options
             // are unlocked
             CommandLineOptionTest.verifySameJVMStartup(null,

--- a/test/hotspot/jtreg/compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
+++ b/test/hotspot/jtreg/compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
@@ -60,12 +60,14 @@ public class TestUseRTMForStackLocksOptionOnUnsupportedConfig
                 new String[] { experimentalOptionError }, null,
                 shouldFailMessage, shouldFailMessage + "%nError message "
                         + "should be shown", ExitCode.FAIL,
+                "-XX:-UnlockExperimentalVMOptions",
                 prepareOptionValue("true"));
 
         CommandLineOptionTest.verifySameJVMStartup(
                 new String[]{ experimentalOptionError }, null,
                 shouldFailMessage, shouldFailMessage + "%nError message "
                         + "should be shown", ExitCode.FAIL,
+                "-XX:-UnlockExperimentalVMOptions",
                 prepareOptionValue("false"));
 
         String shouldPassMessage = String.format("VM option '%s' is "


### PR DESCRIPTION
Distros with Graal integration will have `UnlockExperimentalVMOptions` enabled, causing several tests in this directory to fail:

* compiler/rtm/cli/TestRTMAbortThresholdOption.java
* compiler/rtm/cli/TestRTMLockingCalculationDelayOption.java
* compiler/rtm/cli/TestRTMLockingThresholdOption.java
* compiler/rtm/cli/TestRTMSpinLoopCountOption.java
* compiler/rtm/cli/TestUseRTMForStackLocksOptionOnUnsupportedConfig.java
* compiler/rtm/cli/TestUseRTMXendForLockBusyOption.java

This modified the tests to explicitly use `-XX:-UnlockExperimentalVMOptions` when they expecting that context.

Note that this directory of tests was removed by https://bugs.openjdk.org/browse/JDK-8329141 as part of JDK24.

Tested using a locally-built JDK+Graal distro, where these tests fails before the change and passes when its applied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342765](https://bugs.openjdk.org/browse/JDK-8342765) needs maintainer approval

### Issue
 * [JDK-8342765](https://bugs.openjdk.org/browse/JDK-8342765): [21u] RTM tests assume UnlockExperimentalVMOptions is disabled by default (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1073/head:pull/1073` \
`$ git checkout pull/1073`

Update a local copy of the PR: \
`$ git checkout pull/1073` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1073`

View PR using the GUI difftool: \
`$ git pr show -t 1073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1073.diff">https://git.openjdk.org/jdk21u-dev/pull/1073.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1073#issuecomment-2427888232)