### PR TITLE
8342701: [PPC64] TestOSRLotsOfLocals.java crashes

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -135,9 +135,20 @@ void LIR_Assembler::osr_entry() {
   // copied into place by code emitted in the IR.
 
   Register OSR_buf = osrBufferPointer()->as_register();
-  { assert(frame::interpreter_frame_monitor_size() == BasicObjectLock::size(), "adjust code below");
-    int monitor_offset = BytesPerWord * method()->max_locals() +
-      (2 * BytesPerWord) * (number_of_locks - 1);
+  {
+    assert(frame::interpreter_frame_monitor_size() == BasicObjectLock::size(), "adjust code below");
+
+    const int locals_space = BytesPerWord * method()->max_locals();
+    int monitor_offset = locals_space + (2 * BytesPerWord) * (number_of_locks - 1);
+    bool use_OSR_bias = false;
+
+    if (!Assembler::is_simm16(monitor_offset + BytesPerWord) && number_of_locks > 0) {
+      // Offsets too large for ld instructions. Use bias.
+      __ add_const_optimized(OSR_buf, OSR_buf, locals_space);
+      monitor_offset -= locals_space;
+      use_OSR_bias = true;
+    }
+
     // SharedRuntime::OSR_migration_begin() packs BasicObjectLocks in
     // the OSR buffer using 2 word entries: first the lock and then
     // the oop.
@@ -162,6 +173,11 @@ void LIR_Assembler::osr_entry() {
       __ std(R0, ml.disp(), ml.base());
       __ ld(R0, slot_offset + 1*BytesPerWord, OSR_buf);
       __ std(R0, mo.disp(), mo.base());
+    }
+
+    if (use_OSR_bias) {
+      // Restore.
+      __ sub_const_optimized(OSR_buf, OSR_buf, locals_space);
     }
   }
 }


### PR DESCRIPTION
Clean backport of [JDK-8342701](https://bugs.openjdk.org/browse/JDK-8342701).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8342701](https://bugs.openjdk.org/browse/JDK-8342701) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342701](https://bugs.openjdk.org/browse/JDK-8342701): [PPC64] TestOSRLotsOfLocals.java crashes (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1076/head:pull/1076` \
`$ git checkout pull/1076`

Update a local copy of the PR: \
`$ git checkout pull/1076` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1076`

View PR using the GUI difftool: \
`$ git pr show -t 1076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1076.diff">https://git.openjdk.org/jdk21u-dev/pull/1076.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1076#issuecomment-2429490724)