### PR TITLE
8338759: Add extra diagnostic to java/net/InetAddress/ptr/Lookup.java

### DIFF
--- a/test/jdk/java/net/InetAddress/ptr/Lookup.java
+++ b/test/jdk/java/net/InetAddress/ptr/Lookup.java
@@ -114,6 +114,9 @@ public class Lookup {
         // Now check that a reverse lookup will succeed with the dual stack.
         InetAddress ia = InetAddress.getByName(addr);
         String name = ia.getHostName();
+        // output details of dual stack lookup by address
+        System.out.println("dual stack lookup for addr " + addr + " returned IP address " + ia);
+        System.out.println(" with hostname " + name);
 
         System.out.println("(default) " + addr + "--> " + name
                                + " (reversed IPv4: " + ipv4Reversed + ")");


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8338759](https://bugs.openjdk.org/browse/JDK-8338759) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338759](https://bugs.openjdk.org/browse/JDK-8338759): Add extra diagnostic to java/net/InetAddress/ptr/Lookup.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1080/head:pull/1080` \
`$ git checkout pull/1080`

Update a local copy of the PR: \
`$ git checkout pull/1080` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1080`

View PR using the GUI difftool: \
`$ git pr show -t 1080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1080.diff">https://git.openjdk.org/jdk21u-dev/pull/1080.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1080#issuecomment-2432412926)