### PR TITLE
8339787: Add some additional diagnostic output to java/net/ipv6tests/UdpTest.java

### DIFF
--- a/test/jdk/java/net/ipv6tests/Tests.java
+++ b/test/jdk/java/net/ipv6tests/Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,8 @@ public class Tests {
         }
 
         dprintln ("dest2 = " + dest2);
-
+        dprintln ("sender endpoint = " + s1.getLocalSocketAddress());
+        dprintln ("echo endpoint = " + s2.getLocalSocketAddress());
 
         DatagramPacket r1 = new DatagramPacket (new byte[256], 256);
         DatagramPacket r2 = new DatagramPacket (new byte[256], 256);


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339787](https://bugs.openjdk.org/browse/JDK-8339787) needs maintainer approval

### Issue
 * [JDK-8339787](https://bugs.openjdk.org/browse/JDK-8339787): Add some additional diagnostic output to java/net/ipv6tests/UdpTest.java (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1081/head:pull/1081` \
`$ git checkout pull/1081`

Update a local copy of the PR: \
`$ git checkout pull/1081` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1081`

View PR using the GUI difftool: \
`$ git pr show -t 1081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1081.diff">https://git.openjdk.org/jdk21u-dev/pull/1081.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1081#issuecomment-2432439992)