### PR TITLE
8340365: Position the first window of a window list

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -344,11 +344,9 @@ public final class PassFailJFrame {
                         builder.positionWindows
                                .positionTestWindows(unmodifiableList(builder.testWindows),
                                                     builder.instructionUIHandler));
-            } else if (builder.testWindows.size() == 1) {
+            } else {
                 Window window = builder.testWindows.get(0);
                 positionTestWindow(window, builder.position);
-            } else {
-                positionTestWindow(null, builder.position);
             }
         }
         showAllWindows();


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8340365](https://bugs.openjdk.org/browse/JDK-8340365) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340365](https://bugs.openjdk.org/browse/JDK-8340365): Position the first window of a window list (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1085/head:pull/1085` \
`$ git checkout pull/1085`

Update a local copy of the PR: \
`$ git checkout pull/1085` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1085`

View PR using the GUI difftool: \
`$ git pr show -t 1085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1085.diff">https://git.openjdk.org/jdk21u-dev/pull/1085.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1085#issuecomment-2432551790)