### PR TITLE
8340899: Remove wildcard bound in PositionWindows.positionTestWindows

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -552,7 +552,7 @@ public final class PassFailJFrame {
          * @param testWindows the list of test windows
          * @param instructionUI information about the instruction frame
          */
-        void positionTestWindows(List<? extends Window> testWindows,
+        void positionTestWindows(List<Window> testWindows,
                                  InstructionUI instructionUI);
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340899](https://bugs.openjdk.org/browse/JDK-8340899) needs maintainer approval

### Issue
 * [JDK-8340899](https://bugs.openjdk.org/browse/JDK-8340899): Remove wildcard bound in PositionWindows.positionTestWindows (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1086/head:pull/1086` \
`$ git checkout pull/1086`

Update a local copy of the PR: \
`$ git checkout pull/1086` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1086`

View PR using the GUI difftool: \
`$ git pr show -t 1086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1086.diff">https://git.openjdk.org/jdk21u-dev/pull/1086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1086#issuecomment-2432573593)