### PR TITLE
8322754: click JComboBox when dialog about to close causes IllegalComponentStateException

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -921,7 +921,7 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
             if (e.getSource() == list) {
                 return;
             }
-            if (!SwingUtilities.isLeftMouseButton(e) || !comboBox.isEnabled())
+            if (!SwingUtilities.isLeftMouseButton(e) || !comboBox.isEnabled() || !comboBox.isShowing())
                 return;
 
             if ( comboBox.isEditable() ) {

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 8322754
+ * @summary Verifies clicking JComboBox during frame closure causes Exception
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ComboPopupBug
+ */
+
+public class ComboPopupBug {
+    private static final String instructionsText = """
+            This test is used to verify that clicking on JComboBox
+            when frame containing it is about to close should not
+            cause IllegalStateException.
+
+            A JComboBox is shown with Close button at the bottom.
+            Click on Close and then click on JComboBox arrow button
+            to try to show combobox popup.
+            If IllegalStateException is thrown, test will automatically Fail
+            otherwise click Pass.  """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("ComboPopup Instructions")
+                .instructions(instructionsText)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(35)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame("ComboPopup");
+
+            JComboBox cb = new JComboBox();
+            cb.setEditable(true);
+            cb.addItem("test");
+            cb.addItem("test2");
+            cb.addItem("test3");
+            frame.getContentPane().add(cb, "North");
+
+            JButton b = new JButton("Close");
+            b.addActionListener(
+                (e)->{
+                    try {
+                        Thread.sleep(3000);
+                    }
+                    catch (Exception ex) {
+                    }
+                    frame.setVisible(false);
+
+                });
+            frame.getContentPane().add(b, "South");
+            frame.setSize(200, 200);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I would like to fix this issue in 21, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322754](https://bugs.openjdk.org/browse/JDK-8322754) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8322754: click JComboBox when dialog about to close causes IllegalComponentStateException`

### Issue
 * [JDK-8322754](https://bugs.openjdk.org/browse/JDK-8322754): click JComboBox when dialog about to close causes IllegalComponentStateException (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1093/head:pull/1093` \
`$ git checkout pull/1093`

Update a local copy of the PR: \
`$ git checkout pull/1093` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1093`

View PR using the GUI difftool: \
`$ git pr show -t 1093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1093.diff">https://git.openjdk.org/jdk21u-dev/pull/1093.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1093#issuecomment-2435203706)