### PR TITLE
8337994: [REDO] Native memory leak when not recording any events

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -756,6 +756,15 @@ static void write_classloaders() {
     CompositeCldCallback callback(&_subsystem_callback, &ccldwwc);
     do_class_loaders();
   }
+  if (is_initial_typeset_for_chunk()) {
+    CldPtr bootloader = get_cld(Universe::boolArrayKlassObj());
+    assert(bootloader != nullptr, "invariant");
+    if (IS_NOT_SERIALIZED(bootloader)) {
+      write__classloader(_writer, bootloader);
+      assert(IS_SERIALIZED(bootloader), "invariant");
+      cldw.add(1);
+    }
+  }
   _artifacts->tally(cldw);
 }
 

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -634,11 +634,7 @@ static void write_thread_local_buffer(JfrChunkWriter& chunkwriter, Thread* t) {
 
 size_t JfrRecorderService::flush() {
   size_t total_elements = flush_metadata(_chunkwriter);
-  const size_t storage_elements = flush_storage(_storage, _chunkwriter);
-  if (0 == storage_elements) {
-    return total_elements;
-  }
-  total_elements += storage_elements;
+  total_elements = flush_storage(_storage, _chunkwriter);
   if (_string_pool.is_modified()) {
     total_elements += flush_stringpool(_string_pool, _chunkwriter);
   }


### PR DESCRIPTION
(not a clean backport)
Reworked to avoid https://github.com/openjdk/jdk/pull/17328/files  backport

Functional jtreg1-3 tests are Ok.
Manual testing: the reproducer shows the problem is fixed with the change (see comments below)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337994](https://bugs.openjdk.org/browse/JDK-8337994) needs maintainer approval

### Issue
 * [JDK-8337994](https://bugs.openjdk.org/browse/JDK-8337994): [REDO] Native memory leak when not recording any events (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1095/head:pull/1095` \
`$ git checkout pull/1095`

Update a local copy of the PR: \
`$ git checkout pull/1095` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1095`

View PR using the GUI difftool: \
`$ git pr show -t 1095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1095.diff">https://git.openjdk.org/jdk21u-dev/pull/1095.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1095#issuecomment-2442326361)
</details>
