### PR TITLE
8316428: G1: Nmethod count statistics only count last code root set iterated

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -830,7 +830,7 @@ public:
       // Scan the code root list attached to the current region
       r->code_roots_do(&cl);
 
-      _code_roots_scanned = cl.count();
+      _code_roots_scanned += cl.count();
 
       event.commit(GCId::current(), _worker_id, G1GCPhaseTimes::phase_name(_code_roots_phase));
     }


### PR DESCRIPTION
Auto suggested description:
This pull request contains a backport of commit [fab372d3](https://github.com/openjdk/jdk/commit/fab372d3a23b17f64ae4306e28bdb0bc511f4912) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Schatzl on 19 Sep 2023 and was reviewed by Ivan Walulya and Albert Mingkun Yang.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8316428](https://bugs.openjdk.org/browse/JDK-8316428) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316428](https://bugs.openjdk.org/browse/JDK-8316428): G1: Nmethod count statistics only count last code root set iterated (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1096/head:pull/1096` \
`$ git checkout pull/1096`

Update a local copy of the PR: \
`$ git checkout pull/1096` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1096`

View PR using the GUI difftool: \
`$ git pr show -t 1096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1096.diff">https://git.openjdk.org/jdk21u-dev/pull/1096.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1096#issuecomment-2435537265)