### PR TITLE
8321470: ThreadLocal.nextHashCode can be static final

### DIFF
--- a/src/java.base/share/classes/java/lang/ThreadLocal.java
+++ b/src/java.base/share/classes/java/lang/ThreadLocal.java
@@ -97,7 +97,7 @@ public class ThreadLocal<T> {
      * The next hash code to be given out. Updated atomically. Starts at
      * zero.
      */
-    private static AtomicInteger nextHashCode =
+    private static final AtomicInteger nextHashCode =
         new AtomicInteger();
 
     /**


### PR DESCRIPTION
Backporting JDK-8321470: ThreadLocal.nextHashCode can be static final. Minor change makes the variable final (it is already static). Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321470](https://bugs.openjdk.org/browse/JDK-8321470) needs maintainer approval

### Issue
 * [JDK-8321470](https://bugs.openjdk.org/browse/JDK-8321470): ThreadLocal.nextHashCode can be static final (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1099/head:pull/1099` \
`$ git checkout pull/1099`

Update a local copy of the PR: \
`$ git checkout pull/1099` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1099`

View PR using the GUI difftool: \
`$ git pr show -t 1099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1099.diff">https://git.openjdk.org/jdk21u-dev/pull/1099.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1099#issuecomment-2439770742)
</details>
