### PR TITLE
8319640: ClassicFormat::parseObject (from DateTimeFormatter) does not conform to the javadoc and may leak DateTimeException

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -2296,29 +2296,23 @@ public final class DateTimeFormatter {
             DateTimeParseContext context;
             try {
                 context = formatter.parseUnresolved0(text, pos);
-            } catch (IndexOutOfBoundsException ex) {
-                if (pos.getErrorIndex() < 0) {
-                    pos.setErrorIndex(0);
+                if (context == null) {
+                    if (pos.getErrorIndex() < 0) {
+                        pos.setErrorIndex(0);
+                    }
+                    return null;
                 }
-                return null;
-            }
-            if (context == null) {
-                if (pos.getErrorIndex() < 0) {
-                    pos.setErrorIndex(0);
-                }
-                return null;
-            }
-            try {
                 TemporalAccessor resolved = context.toResolved(formatter.resolverStyle, formatter.resolverFields);
                 if (parseType == null) {
                     return resolved;
                 }
                 return resolved.query(parseType);
             } catch (RuntimeException ex) {
-                pos.setErrorIndex(0);
+                if (pos.getErrorIndex() < 0) {
+                    pos.setErrorIndex(0);
+                }
                 return null;
             }
         }
     }
-
 }

--- a/test/jdk/java/time/test/java/time/format/TestDateTimeParsing.java
+++ b/test/jdk/java/time/test/java/time/format/TestDateTimeParsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,15 +62,19 @@ package test.java.time.format;
 import static java.time.temporal.ChronoField.AMPM_OF_DAY;
 import static java.time.temporal.ChronoField.EPOCH_DAY;
 import static java.time.temporal.ChronoField.HOUR_OF_AMPM;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.INSTANT_SECONDS;
 import static java.time.temporal.ChronoField.MICRO_OF_SECOND;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.OFFSET_SECONDS;
 import static java.time.temporal.ChronoField.SECOND_OF_DAY;
 import static java.util.Locale.US;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
+import java.text.ParsePosition;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -80,7 +84,9 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.SignStyle;
 import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -88,7 +94,7 @@ import org.testng.annotations.Test;
 /**
  * @test
  * @summary Test parsing of edge cases.
- * @bug 8223773 8272473
+ * @bug 8223773 8272473 8319640
  */
 public class TestDateTimeParsing {
 
@@ -236,5 +242,31 @@ public class TestDateTimeParsing {
                 throw e;
             }
         }
+    }
+
+    // Checks ::toFormat().parseObject(text, pos) do not throw DateTimeException
+    @Test
+    public void test_toFormat_2arg_null_return_on_DateTimeException() {
+        var f = new DateTimeFormatterBuilder()
+            .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+            .optionalEnd()
+            .optionalStart()
+            .appendOffset("+HHmm", "Z")
+            .optionalEnd()
+            .toFormatter(Locale.ROOT)
+            .toFormat();
+        assertNull(f.parseObject("17-30", new ParsePosition(0)));
+    }
+
+    // Checks ::toFormat().parseObject(text, pos) do not throw IOOBE
+    @Test
+    public void test_toFormat_2arg_null_return_on_IOOBE() {
+        var date = "2023-11-13";
+        assertNull(DateTimeFormatter.ISO_LOCAL_DATE
+                .toFormat()
+                .parseObject(date, new ParsePosition(date.length() + 1)));
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fe0ccdf5](https://github.com/openjdk/jdk/commit/fe0ccdf5f8a5559a608d2e2cd2b6aecbe245c5ec) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Naoto Sato on 13 Nov 2023 and was reviewed by Roger Riggs, Iris Clark, Justin Lu and Joe Wang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8319640](https://bugs.openjdk.org/browse/JDK-8319640) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319640](https://bugs.openjdk.org/browse/JDK-8319640): ClassicFormat::parseObject (from DateTimeFormatter) does not conform to the javadoc and may leak DateTimeException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1101/head:pull/1101` \
`$ git checkout pull/1101`

Update a local copy of the PR: \
`$ git checkout pull/1101` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1101`

View PR using the GUI difftool: \
`$ git pr show -t 1101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1101.diff">https://git.openjdk.org/jdk21u-dev/pull/1101.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1101#issuecomment-2442860211)
</details>
