### PR TITLE
8337066: Repeated call of StringBuffer.reverse with double byte string returns wrong result

### DIFF
--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -648,6 +648,20 @@ Block* PhaseCFG::insert_anti_dependences(Block* LCA, Node* load, bool verify) {
   // The anti-dependence constraints apply only to the fringe of this tree.
 
   Node* initial_mem = load->in(MemNode::Memory);
+  // We don't optimize the memory graph for pinned loads, so we may need to raise the
+  // root of our search tree through the corresponding slices of MergeMem nodes to
+  // get to the node that really creates the memory state for this slice.
+  if (load_alias_idx >= Compile::AliasIdxRaw) {
+    while (initial_mem->is_MergeMem()) {
+      MergeMemNode* mm = initial_mem->as_MergeMem();
+      Node* p = mm->memory_at(load_alias_idx);
+      if (p != mm->base_memory()) {
+        initial_mem = p;
+      } else {
+        break;
+      }
+    }
+  }
   worklist_store.push(initial_mem);
   worklist_visited.push(initial_mem);
   worklist_mem.push(nullptr);

--- a/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyForPinnedLoads.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyForPinnedLoads.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8337066
+ * @summary Test that MergeMem is skipped when looking for stores
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,java.lang.StringUTF16::reverse
+ *                   compiler.controldependency.TestAntiDependencyForPinnedLoads
+ */
+
+package compiler.controldependency;
+
+public class TestAntiDependencyForPinnedLoads {
+    public static void main(String[] args) {
+        for(int i = 0; i < 50_000; i++) {
+            String str = "YYYY年MM月DD日";
+            StringBuffer strBuffer = new StringBuffer(str);
+            String revStr = strBuffer.reverse().toString();
+            if (!revStr.equals("日DD月MM年YYYY")) throw new InternalError("FAIL");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337066](https://bugs.openjdk.org/browse/JDK-8337066) needs maintainer approval

### Issue
 * [JDK-8337066](https://bugs.openjdk.org/browse/JDK-8337066): Repeated call of StringBuffer.reverse with double byte string returns wrong result (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1116/head:pull/1116` \
`$ git checkout pull/1116`

Update a local copy of the PR: \
`$ git checkout pull/1116` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1116`

View PR using the GUI difftool: \
`$ git pr show -t 1116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1116.diff">https://git.openjdk.org/jdk21u-dev/pull/1116.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1116#issuecomment-2450715392)
</details>
