### PR TITLE
8341235: Improve default instruction frame title in PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -44,6 +44,7 @@ import java.awt.image.RenderedImage;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -287,9 +288,15 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  */
 public final class PassFailJFrame {
 
-    private static final String TITLE = "Test Instruction Frame";
+    /** A default title for the instruction frame. */
+    private static final String TITLE = "Test Instructions";
+
+    /** A default test timeout. */
     private static final long TEST_TIMEOUT = 5;
+
+    /** A default number of rows for displaying the test instructions. */
     private static final int ROWS = 10;
+    /** A default number of columns for displaying the test instructions. */
     private static final int COLUMNS = 40;
 
     /**
@@ -302,7 +309,7 @@ public final class PassFailJFrame {
      */
     private static final String FAILURE_REASON = "Failure Reason:\n";
     /**
-     * The failure reason message when the user didn't provide one.
+     * The failure reason message when the user doesn't provide one.
      */
     private static final String EMPTY_REASON = "(no reason provided)";
 
@@ -1790,9 +1797,41 @@ public final class PassFailJFrame {
             return new PassFailJFrame(this);
         }
 
+        /**
+         * Returns the file name of the test, if the {@code test.file} property
+         * is defined, concatenated with {@code " - "} which serves as a prefix
+         * to the default instruction frame title;
+         * or an empty string if the {@code test.file} property is not defined.
+         *
+         * @return the prefix to the default title:
+         *         either the file name of the test or an empty string
+         *
+         * @see <a href="https://openjdk.org/jtreg/tag-spec.html#testvars">jtreg
+         * test-specific system properties and environment variables</a>
+         */
+        private static String getTestFileNamePrefix() {
+            String testFile = System.getProperty("test.file");
+            if (testFile == null) {
+                return "";
+            }
+
+            return Paths.get(testFile).getFileName().toString()
+                   + " - ";
+        }
+
+        /**
+         * Validates the state of the builder and
+         * expands parameters that have no assigned values
+         * to their default values.
+         *
+         * @throws IllegalStateException if no instructions are provided,
+         *              or if {@code PositionWindows} implementation is
+         *              provided but neither window creator nor
+         *              test window list are set
+         */
         private void validate() {
             if (title == null) {
-                title = TITLE;
+                title = getTestFileNamePrefix() + TITLE;
             }
 
             if (instructions == null || instructions.isEmpty()) {


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341235](https://bugs.openjdk.org/browse/JDK-8341235) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341235](https://bugs.openjdk.org/browse/JDK-8341235): Improve default instruction frame title in PassFailJFrame (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1121/head:pull/1121` \
`$ git checkout pull/1121`

Update a local copy of the PR: \
`$ git checkout pull/1121` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1121`

View PR using the GUI difftool: \
`$ git pr show -t 1121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1121.diff">https://git.openjdk.org/jdk21u-dev/pull/1121.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1121#issuecomment-2454182479)
</details>
