### PR TITLE
8334890: Missing unconditional cross modifying fence in nmethod entry barriers

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -178,13 +178,9 @@ int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
   nmethod* nm = cb->as_nmethod();
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
 
-  if (!bs_nm->is_armed(nm)) {
-    return 0;
-  }
-
-  assert(!nm->is_osr_method(), "Should not reach here");
   // Called upon first entry after being armed
   bool may_enter = bs_nm->nmethod_entry_barrier(nm);
+  assert(!nm->is_osr_method() || may_enter, "OSR nmethods should always be entrant after migration");
 
   // In case a concurrent thread disarmed the nmethod, we need to ensure the new instructions
   // are made visible, by using a cross modify fence. Note that this is synchronous cross modifying
@@ -194,11 +190,11 @@ int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
   // it can be made conditional on the nmethod_patching_type.
   OrderAccess::cross_modify_fence();
 
-  // Diagnostic option to force deoptimization 1 in 3 times. It is otherwise
+  // Diagnostic option to force deoptimization 1 in 10 times. It is otherwise
   // a very rare event.
-  if (DeoptimizeNMethodBarriersALot) {
+  if (DeoptimizeNMethodBarriersALot && !nm->is_osr_method()) {
     static volatile uint32_t counter=0;
-    if (Atomic::add(&counter, 1u) % 3 == 0) {
+    if (Atomic::add(&counter, 1u) % 10 == 0) {
       may_enter = false;
     }
   }
@@ -211,15 +207,6 @@ int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
 }
 
 bool BarrierSetNMethod::nmethod_osr_entry_barrier(nmethod* nm) {
-  // This check depends on the invariant that all nmethods that are deoptimized / made not entrant
-  // are NOT disarmed.
-  // This invariant is important because a method can be deoptimized after the method have been
-  // resolved / looked up by OSR by another thread. By not deoptimizing them we guarantee that
-  // a deoptimized method will always hit the barrier and come to the same conclusion - deoptimize
-  if (!is_armed(nm)) {
-    return true;
-  }
-
   assert(nm->is_osr_method(), "Should not reach here");
   log_trace(nmethod, barrier)("Running osr nmethod entry barrier: " PTR_FORMAT, p2i(nm));
   bool result = nmethod_entry_barrier(nm);


### PR DESCRIPTION
The change adds an unconditional memory barrier to guarantee the instruction fetcher observes the correct updated immediate.

Merge conflict caused by minor context difference (added comment in a mainline): fixed manually.

Testing: jtreg tier 1-3 on arm64 and x64.

**Update.** The backport is controversial: while the functional change is correct and necessary, it introduces a regression in SPECjvm2008: [JDK-8337778](https://bugs.openjdk.org/browse/JDK-8337778)

**Update.**
- https://bugs.openjdk.org/browse/JDK-8337778 is closed with Won't Fix resultion

SPECjvm2008-Derby-ZGC performance on linux-aarch64 is not affected with patch applied to jdk21u
- before:
  - Score on derby: 5375.49 ops/m
  - Score on derby: 5430.11 ops/m
  - Score on derby: 5413.50 ops/m
  - Score on derby: 5363.00 ops/m
  - Score on derby: 5359.83 ops/m
  - Score on derby: 5325.92 ops/m
  - Score on derby: 5464.94 ops/m
  - Score on derby: 5413.74 ops/m
- after:
  - Score on derby: 5476.12 ops/m
  - Score on derby: 5280.42 ops/m
  - Score on derby: 5446.40 ops/m
  - Score on derby: 5402.60 ops/m
  - Score on derby: 5470.78 ops/m
  - Score on derby: 5409.36 ops/m
  - Score on derby: 5403.56 ops/m
  - Score on derby: 5457.11 ops/m

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8334890](https://bugs.openjdk.org/browse/JDK-8334890) needs maintainer approval

### Issue
 * [JDK-8334890](https://bugs.openjdk.org/browse/JDK-8334890): Missing unconditional cross modifying fence in nmethod entry barriers (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1131/head:pull/1131` \
`$ git checkout pull/1131`

Update a local copy of the PR: \
`$ git checkout pull/1131` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1131`

View PR using the GUI difftool: \
`$ git pr show -t 1131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1131.diff">https://git.openjdk.org/jdk21u-dev/pull/1131.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1131#issuecomment-2461183343)
</details>
