### PR TITLE
8327924: Simplify TrayIconScalingTest.java

### DIFF
--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -85,28 +85,27 @@ public class TrayIconScalingTest {
             System.out.println("SystemTray is not supported");
             return;
         }
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
-                .title("TrayIcon Test Instructions")
-                .instructions(INSTRUCTIONS)
-                .testTimeOut(8)
-                .rows(25)
-                .columns(70)
-                .screenCapture()
-                .build();
 
-        createAndShowGUI();
-        // does not have a test window,
-        // hence only the instruction frame is positioned
-        PassFailJFrame.positionTestWindow(null,
-                PassFailJFrame.Position.HORIZONTAL);
+        createAndShowTrayIcon();
+
         try {
-            passFailJFrame.awaitAndCheck();
+            PassFailJFrame.builder()
+                    .title("TrayIcon Test Instructions")
+                    .instructions(INSTRUCTIONS)
+                    .testTimeOut(8)
+                    .rows(25)
+                    .columns(70)
+                    .screenCapture()
+                    .build()
+                    .awaitAndCheck();
         } finally {
-            tray.remove(icon);
+            if (tray != null) {
+                tray.remove(icon);
+            }
         }
     }
 
-    private static void createAndShowGUI() {
+    private static void createAndShowTrayIcon() {
         ArrayList<Image> imageList = new ArrayList<>();
         for (int size = 16; size <= 48; size += 4) {
             imageList.add(createIcon(size));
@@ -120,7 +119,7 @@ public class TrayIconScalingTest {
         try {
             tray.add(icon);
         } catch (AWTException e) {
-            throw new RuntimeException("Error while adding icon to system tray");
+            throw new RuntimeException("Error while adding icon to system tray", e);
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327924](https://bugs.openjdk.org/browse/JDK-8327924) needs maintainer approval

### Issue
 * [JDK-8327924](https://bugs.openjdk.org/browse/JDK-8327924): Simplify TrayIconScalingTest.java (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1133/head:pull/1133` \
`$ git checkout pull/1133`

Update a local copy of the PR: \
`$ git checkout pull/1133` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1133`

View PR using the GUI difftool: \
`$ git pr show -t 1133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1133.diff">https://git.openjdk.org/jdk21u-dev/pull/1133.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1133#issuecomment-2461753429)
</details>
