### PR TITLE
8308429: jvmti/StopThread/stopthrd007 failed with "NoClassDefFoundError: Could not initialize class jdk.internal.misc.VirtualThreads"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ import java.io.PrintStream;
 
 import nsk.share.*;
 import nsk.share.jvmti.*;
+
+import java.util.concurrent.locks.LockSupport;
 
 public class stopthrd007 extends DebugeeClass {
 
@@ -65,6 +67,11 @@ public class stopthrd007 extends DebugeeClass {
         argHandler = new ArgumentHandler(argv);
         log = new Log(out, argHandler);
         timeout = argHandler.getWaitTime() * 60 * 1000;
+
+        // Unpark virtual threads to load jdk.internal.misc.VirtualThreads
+        // and avoid NoClassDefFoundError if ThreadDeath is happen during unlock.
+        Thread vt = Thread.startVirtualThread(LockSupport::park);
+        LockSupport.unpark(vt);
 
         log.display("Debugee started");
 


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8308429](https://bugs.openjdk.org/browse/JDK-8308429) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308429](https://bugs.openjdk.org/browse/JDK-8308429): jvmti/StopThread/stopthrd007 failed with "NoClassDefFoundError: Could not initialize class jdk.internal.misc.VirtualThreads" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1134/head:pull/1134` \
`$ git checkout pull/1134`

Update a local copy of the PR: \
`$ git checkout pull/1134` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1134`

View PR using the GUI difftool: \
`$ git pr show -t 1134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1134.diff">https://git.openjdk.org/jdk21u-dev/pull/1134.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1134#issuecomment-2461780655)
</details>
