### PR TITLE
8325038: runtime/cds/appcds/ProhibitedPackage.java can fail with UseLargePages

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/ProhibitedPackage.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ProhibitedPackage.java
@@ -54,7 +54,7 @@ public class ProhibitedPackage {
             // will be ignored during dumping.
             TestCommon.dump(appJar,  classlist, "-Xlog:cds")
                 .shouldContain("Dumping")
-                .shouldContain("[cds] Prohibited package for non-bootstrap classes: java/lang/Prohibited.class")
+                .shouldContain("Prohibited package for non-bootstrap classes: java/lang/Prohibited.class")
                 .shouldHaveExitValue(0);
         }
 


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325038](https://bugs.openjdk.org/browse/JDK-8325038) needs maintainer approval

### Issue
 * [JDK-8325038](https://bugs.openjdk.org/browse/JDK-8325038): runtime/cds/appcds/ProhibitedPackage.java can fail with UseLargePages (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1135/head:pull/1135` \
`$ git checkout pull/1135`

Update a local copy of the PR: \
`$ git checkout pull/1135` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1135`

View PR using the GUI difftool: \
`$ git pr show -t 1135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1135.diff">https://git.openjdk.org/jdk21u-dev/pull/1135.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1135#issuecomment-2461794982)
</details>
