### PR TITLE
8333235: vmTestbase/nsk/jdb/kill/kill001/kill001.java fails with C1

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,6 +141,16 @@ class MyThread extends Thread {
         expectedException = e;
     }
 
+
+    static public int[] trash;
+
+    void methodForException() {
+        trash = new int[10];
+        for (int i = 0; ;i++) {
+            trash[i % trash.length] = i;
+        }
+    }
+
     public void run() {
         // Concatenate strings in advance to avoid lambda calculations later
         String ThreadFinished = "Thread finished: " + this.name;
@@ -156,8 +166,9 @@ class MyThread extends Thread {
         try {
             synchronized (kill001a.lock) { }
             // We need some code that does an invoke here to make sure the async exception
-            // gets thrown before we leave the try block. Printing a log message works well.
-            kill001a.log.display("exited synchronized");
+            // gets thrown before we leave the try block.
+            // The methodForException should work until exception is thrown.
+            methodForException();
         } catch (Throwable t) {
             if (t == expectedException) {
                 kill001a.log.display(CaughtExpected);


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333235](https://bugs.openjdk.org/browse/JDK-8333235) needs maintainer approval

### Issue
 * [JDK-8333235](https://bugs.openjdk.org/browse/JDK-8333235): vmTestbase/nsk/jdb/kill/kill001/kill001.java fails with C1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1136/head:pull/1136` \
`$ git checkout pull/1136`

Update a local copy of the PR: \
`$ git checkout pull/1136` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1136`

View PR using the GUI difftool: \
`$ git pr show -t 1136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1136.diff">https://git.openjdk.org/jdk21u-dev/pull/1136.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1136#issuecomment-2461813659)
</details>
