### PR TITLE
8319673: Few security tests ignore VM flags

### DIFF
--- a/test/jdk/com/sun/crypto/provider/KeyProtector/IterationCount.java
+++ b/test/jdk/com/sun/crypto/provider/KeyProtector/IterationCount.java
@@ -52,9 +52,6 @@ import jdk.test.lib.process.ProcessTools;
 
 public class IterationCount {
     private static final String clientStr = "CLIENT";
-    private static final String javaBinPath =
-            System.getProperty("java.home", ".") + File.separator + "bin" +
-                    File.separator + "java";
 
     public static void main(String[] args) throws Throwable {
         if (args[0].equals("HOST")) {
@@ -78,22 +75,14 @@ public class IterationCount {
         System.out.println("TEST PASS - OK");
     }
 
-    private static List<String> getBasicCommand() {
-        List<String> cmd = new ArrayList<>();
-        cmd.add(javaBinPath);
-        cmd.add("-cp");
-        cmd.add(System.getProperty("test.classes", "."));
-        return cmd;
-    }
-
     private static void executeCommand(List<String> cmd, String expectedCount)
             throws Throwable {
         cmd.add("--add-opens=java.base/com.sun.crypto.provider=ALL-UNNAMED");
         cmd.add(IterationCount.class.getName());
         cmd.add(clientStr);
         cmd.add(expectedCount);
-        OutputAnalyzer out = ProcessTools.executeCommand(
-                cmd.toArray(new String[cmd.size()]));
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(cmd);
+        OutputAnalyzer out = ProcessTools.executeCommand(pb);
         out.shouldHaveExitValue(0);
     }
 
@@ -102,7 +91,7 @@ public class IterationCount {
         System.out.println("Test setting " +
                 (setValue != null ? setValue : "nothing") +
                 " as a System property");
-        List<String> cmd = getBasicCommand();
+        List<String> cmd = new ArrayList<>();
         if (setValue != null) {
             cmd.add("-Djdk.jceks.iterationCount=" + setValue);
         }
@@ -112,7 +101,7 @@ public class IterationCount {
 
     private static void testSecurity(String expectedCount, String setValue)
             throws Throwable {
-        testSecurity(expectedCount, setValue, getBasicCommand());
+        testSecurity(expectedCount, setValue, new ArrayList<>());
     }
 
     private static void testSecurity(String expectedCount, String setValue,
@@ -140,15 +129,14 @@ public class IterationCount {
                 " the Security one");
         String systemValue = Integer.toString(30000);
         System.out.println("System value: " + systemValue);
-        List<String> cmd = getBasicCommand();
+        List<String> cmd = new ArrayList<>();
         cmd.add("-Djdk.jceks.iterationCount=" + systemValue);
         testSecurity(systemValue, Integer.toString(40000), cmd);
     }
 
     private static void writeJavaSecurityProp(String javaSecurityPath,
             String setValue) throws IOException {
-        try (FileOutputStream fos = new FileOutputStream(
-                new File(javaSecurityPath))) {
+        try (FileOutputStream fos = new FileOutputStream(javaSecurityPath)) {
             fos.write(("jdk.jceks.iterationCount=" + setValue).getBytes());
         }
     }

--- a/test/jdk/java/security/Security/ConfigFileTest.java
+++ b/test/jdk/java/security/Security/ConfigFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -30,7 +31,9 @@ import java.nio.file.*;
 
 import java.security.Provider;
 import java.security.Security;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 /*
@@ -49,6 +52,9 @@ public class ConfigFileTest {
             "Initial security property: postInitTest=shouldNotRecord";
 
     private static boolean overrideDetected = false;
+
+    private static Path COPY_JDK_DIR = Path.of("./jdk-8155246-tmpdir");
+    private static Path COPIED_JAVA = COPY_JDK_DIR.resolve("bin", "java");
 
     public static void main(String[] args) throws Exception {
         Path copyJdkDir = Path.of("./jdk-8155246-tmpdir");
@@ -72,29 +78,29 @@ public class ConfigFileTest {
             String extraPropsFile = Path.of(System.getProperty("test.src"), "override.props").toString();
 
             // sanity test -XshowSettings:security option
-            exerciseShowSettingsSecurity(copiedJava.toString(), "-cp", System.getProperty("test.classes"),
-                    "-Djava.security.debug=all", "-XshowSettings:security", "ConfigFileTest", "runner");
+            exerciseShowSettingsSecurity(buildCommand("-cp", System.getProperty("test.classes"),
+                    "-Djava.security.debug=all", "-XshowSettings:security", "ConfigFileTest", "runner"));
 
             // exercise some debug flags while we're here
             // regular JDK install - should expect success
             exerciseSecurity(0, "java",
-                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
-                    "-Djava.security.debug=all", "-Djavax.net.debug=all", "ConfigFileTest", "runner");
+                    buildCommand("-cp", System.getProperty("test.classes"),
+                    "-Djava.security.debug=all", "-Djavax.net.debug=all", "ConfigFileTest", "runner"));
 
             // given an overriding security conf file that doesn't exist, we shouldn't
             // overwrite the properties from original/master security conf file
             exerciseSecurity(0, "SUN version",
-                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    buildCommand("-cp", System.getProperty("test.classes"),
                     "-Djava.security.debug=all", "-Djavax.net.debug=all",
                     "-Djava.security.properties==file:///" + extraPropsFile + "badFileName",
-                    "ConfigFileTest", "runner");
+                    "ConfigFileTest", "runner"));
 
             // test JDK launch with customized properties file
             exerciseSecurity(0, "NumProviders: 6",
-                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    buildCommand("-cp", System.getProperty("test.classes"),
                     "-Djava.security.debug=all", "-Djavax.net.debug=all",
                     "-Djava.security.properties==file:///" + extraPropsFile,
-                    "ConfigFileTest", "runner");
+                    "ConfigFileTest", "runner"));
 
             // delete the master conf file
             Files.delete(Path.of(copyJdkDir.toString(), "conf",
@@ -102,16 +108,16 @@ public class ConfigFileTest {
 
             // launch JDK without java.security file being present or specified
             exerciseSecurity(1, "Error loading java.security file",
-                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    buildCommand("-cp", System.getProperty("test.classes"),
                     "-Djava.security.debug=all", "-Djavax.net.debug=all",
-                    "ConfigFileTest", "runner");
+                    "ConfigFileTest", "runner"));
 
             // test the override functionality also. Should not be allowed since
             // "security.overridePropertiesFile=true" Security property is missing.
             exerciseSecurity(1, "Error loading java.security file",
-                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    buildCommand("-cp", System.getProperty("test.classes"),
                     "-Djava.security.debug=all", "-Djavax.net.debug=all",
-                    "-Djava.security.properties==file:///" + extraPropsFile, "ConfigFileTest", "runner");
+                    "-Djava.security.properties==file:///" + extraPropsFile, "ConfigFileTest", "runner"));
 
             if (!overrideDetected) {
                 throw new RuntimeException("Override scenario not seen");
@@ -119,8 +125,14 @@ public class ConfigFileTest {
         }
     }
 
-    private static void exerciseSecurity(int exitCode, String output, String... args) throws Exception {
-        ProcessBuilder process = new ProcessBuilder(args);
+    private static ProcessBuilder buildCommand(String... command) {
+        ArrayList<String> args = new ArrayList<>();
+        args.add(COPIED_JAVA.toString());
+        Collections.addAll(args, Utils.prependTestJavaOpts(command));
+        return new ProcessBuilder(args);
+    }
+
+    private static void exerciseSecurity(int exitCode, String output, ProcessBuilder process) throws Exception {
         OutputAnalyzer oa = ProcessTools.executeProcess(process);
         oa.shouldHaveExitValue(exitCode)
                 .shouldContain(output);
@@ -141,8 +153,7 @@ public class ConfigFileTest {
     }
 
     // exercise the -XshowSettings:security launcher
-    private static void exerciseShowSettingsSecurity(String... args) throws Exception {
-        ProcessBuilder process = new ProcessBuilder(args);
+    private static void exerciseShowSettingsSecurity(ProcessBuilder process) throws Exception {
         OutputAnalyzer oa = ProcessTools.executeProcess(process);
         oa.shouldHaveExitValue(0)
                 .shouldContain("Security properties:")

--- a/test/jdk/java/security/Security/ConfigFileTest.java
+++ b/test/jdk/java/security/Security/ConfigFileTest.java
@@ -54,7 +54,7 @@ public class ConfigFileTest {
     private static boolean overrideDetected = false;
 
     private static Path COPY_JDK_DIR = Path.of("./jdk-8155246-tmpdir");
-    private static Path COPIED_JAVA = COPY_JDK_DIR.resolve("bin", "java");
+    private static Path COPIED_JAVA = COPY_JDK_DIR.resolve("bin").resolve("java");
 
     public static void main(String[] args) throws Exception {
         Path copyJdkDir = Path.of("./jdk-8155246-tmpdir");

--- a/test/jdk/sun/security/provider/KeyStore/DKSTest.java
+++ b/test/jdk/sun/security/provider/KeyStore/DKSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class DKSTest {
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
             // Environment variable and system properties referred in domains.cfg used by this Test.
-            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(List.of(
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(List.of(
                     "-Dtest.src=" + TEST_SRC , "-Duser.dir=" + USER_DIR, "DKSTest", "run"));
             pb.environment().putAll(System.getenv());
             pb.environment().put("KEYSTORE_PWD", "test12");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [43029006](https://github.com/openjdk/jdk/commit/430290066c23d09166a84f2f6f89e770c6ba04ff) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. Backport parity with 21.0.5-oracle, the change has been verified, no risk.

The commit being backported was authored by Matthew Donovan on 29 Feb 2024 and was reviewed by Weijun Wang and Hai-May Chao.

The new API `Path resolve(String first, String... more)` was not supported in jdk21u-dev, so I change the line code from `COPY_JDK_DIR.resolve("bin", "java")` to `COPY_JDK_DIR.resolve("bin").resolve("java")` to avoid jdk21 javac genrate compile error, and make this backport uncleanly, all other parts are backport cleanly.

The change has been verified locally, test-fix only, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8319673](https://bugs.openjdk.org/browse/JDK-8319673) needs maintainer approval

### Issue
 * [JDK-8319673](https://bugs.openjdk.org/browse/JDK-8319673): Few security tests ignore VM flags (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1142/head:pull/1142` \
`$ git checkout pull/1142`

Update a local copy of the PR: \
`$ git checkout pull/1142` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1142`

View PR using the GUI difftool: \
`$ git pr show -t 1142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1142.diff">https://git.openjdk.org/jdk21u-dev/pull/1142.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1142#issuecomment-2464175721)
</details>
