### PR TITLE
8336911: ZGC: Division by zero in heuristics after JDK-8332717

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -535,6 +535,19 @@ static double calculate_young_to_old_worker_ratio(const ZDirectorStats& stats) {
   const size_t reclaimed_per_old_gc = stats._old_stats._stat_heap._reclaimed_avg;
   const double current_young_bytes_freed_per_gc_time = double(reclaimed_per_young_gc) / double(young_gc_time);
   const double current_old_bytes_freed_per_gc_time = double(reclaimed_per_old_gc) / double(old_gc_time);
+
+  if (current_young_bytes_freed_per_gc_time == 0.0) {
+    if (current_old_bytes_freed_per_gc_time == 0.0) {
+      // Neither young nor old collections have reclaimed any memory.
+      // Give them equal priority.
+      return 1.0;
+    }
+
+    // Only old collections have reclaimed memory.
+    // Prioritize old.
+    return ZOldGCThreads;
+  }
+
   const double old_vs_young_efficiency_ratio = current_old_bytes_freed_per_gc_time / current_young_bytes_freed_per_gc_time;
 
   return old_vs_young_efficiency_ratio;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336911](https://bugs.openjdk.org/browse/JDK-8336911) needs maintainer approval

### Issue
 * [JDK-8336911](https://bugs.openjdk.org/browse/JDK-8336911): ZGC: Division by zero in heuristics after JDK-8332717 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1149/head:pull/1149` \
`$ git checkout pull/1149`

Update a local copy of the PR: \
`$ git checkout pull/1149` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1149`

View PR using the GUI difftool: \
`$ git pr show -t 1149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1149.diff">https://git.openjdk.org/jdk21u-dev/pull/1149.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1149#issuecomment-2473604177)
</details>
