### PR TITLE
8343506: [s390x] multiple test failures with ubsan

### DIFF
--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -2641,7 +2641,7 @@ operand uimmI5() %{
 //   operand type int
 // Unsigned Integer Immediate: 9-bit
 operand SSlenDW() %{
-  predicate(Immediate::is_uimm8(n->get_long()-1));
+  predicate(Immediate::is_uimm8((julong)n->get_long()-1));
   match(ConL);
   op_cost(1);
   format %{ %}


### PR DESCRIPTION
clean backport for [JDK-8343506](https://bugs.openjdk.org/browse/JDK-8343506)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343506](https://bugs.openjdk.org/browse/JDK-8343506) needs maintainer approval

### Issue
 * [JDK-8343506](https://bugs.openjdk.org/browse/JDK-8343506): [s390x] multiple test failures with ubsan (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1157/head:pull/1157` \
`$ git checkout pull/1157`

Update a local copy of the PR: \
`$ git checkout pull/1157` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1157`

View PR using the GUI difftool: \
`$ git pr show -t 1157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1157.diff">https://git.openjdk.org/jdk21u-dev/pull/1157.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1157#issuecomment-2481942980)
</details>
