### PR TITLE
8343923: GHA: Switch to Xcode 15 on MacOS AArch64 runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
     with:
       platform: macos-aarch64
       runs-on: 'macos-14'
-      xcode-toolset-version: '14.3.1'
+      xcode-toolset-version: '15.4'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-aarch64 == 'true'
@@ -309,6 +309,7 @@ jobs:
       platform: macos-x64
       bootjdk-platform: macos-x64
       runs-on: macos-13
+      xcode-toolset-version: '14.3.1'
 
   test-macos-aarch64:
     name: macos-aarch64
@@ -319,6 +320,7 @@ jobs:
       platform: macos-aarch64
       bootjdk-platform: macos-aarch64
       runs-on: macos-14
+      xcode-toolset-version: '15.4'
 
   test-windows-x64:
     name: windows-x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ on:
       runs-on:
         required: true
         type: string
+      xcode-toolset-version:
+        required: false
+        type: string
 
 env:
   # These are needed to make the MSYS2 bash work properly
@@ -147,7 +150,7 @@ jobs:
         run: |
           # On macOS we need to install some dependencies for testing
           brew install make
-          sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_${{ inputs.xcode-toolset-version }}.app/Contents/Developer
           # This will make GNU make available as 'make' and not only as 'gmake'
           echo '/usr/local/opt/make/libexec/gnubin' >> $GITHUB_PATH
         if: runner.os == 'macOS'


### PR DESCRIPTION
Clean backport of [JDK-8343923](https://bugs.openjdk.org/browse/JDK-8343923). Required because of https://github.com/actions/runner-images/issues/10703. Local build with Xcode 15.4 on a MacBook Pro M1 has worked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343923](https://bugs.openjdk.org/browse/JDK-8343923) needs maintainer approval

### Issue
 * [JDK-8343923](https://bugs.openjdk.org/browse/JDK-8343923): GHA: Switch to Xcode 15 on MacOS AArch64 runners (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1159/head:pull/1159` \
`$ git checkout pull/1159`

Update a local copy of the PR: \
`$ git checkout pull/1159` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1159`

View PR using the GUI difftool: \
`$ git pr show -t 1159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1159.diff">https://git.openjdk.org/jdk21u-dev/pull/1159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1159#issuecomment-2482728909)
</details>
