### PR TITLE
8325525: Create jtreg test case for JDK-8325203

### DIFF
--- a/test/jdk/tools/jpackage/apps/ChildProcessAppLauncher.java
+++ b/test/jdk/tools/jpackage/apps/ChildProcessAppLauncher.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ChildProcessAppLauncher {
+
+    public static void main(String[] args) throws IOException {
+            String calcPath = Path.of(System.getenv("SystemRoot"), "system32", "calc.exe").toString();
+            ProcessBuilder processBuilder = new ProcessBuilder(calcPath);
+            Process process = processBuilder.start();
+            System.out.println("Calc id=" + process.pid());
+            System.exit(0);
+    }
+}

--- a/test/jdk/tools/jpackage/apps/ChildProcessAppLauncher.java
+++ b/test/jdk/tools/jpackage/apps/ChildProcessAppLauncher.java
@@ -26,12 +26,17 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 public class ChildProcessAppLauncher {
-
-    public static void main(String[] args) throws IOException {
-            String calcPath = Path.of(System.getenv("SystemRoot"), "system32", "calc.exe").toString();
-            ProcessBuilder processBuilder = new ProcessBuilder(calcPath);
+    public static void main(String[] args) throws IOException, InterruptedException {
+        if (args.length == 1 && "noexit".equals(args[0])) {
+            var lock = new Object();
+            synchronized (lock) {
+                lock.wait();
+            }
+        } else {
+            var childPath = System.getProperty("jpackage.app-path"); // get the path to the current jpackage app launcher
+            ProcessBuilder processBuilder = new ProcessBuilder(childPath, "noexit"); //ChildProcessAppLauncher acts as third party app
             Process process = processBuilder.start();
-            System.out.println("Calc id=" + process.pid());
-            System.exit(0);
+            System.out.println("Child id=" + process.pid());
+        }
     }
 }

--- a/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
+++ b/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8325203
+ * @summary Test that Jpackage windows executable application kills the launched 3rd party application
+ *          when System.exit(0) is invoked along with terminating java program.
+ * @library ../helpers
+ * @library /test/lib
+ * @requires os.family == "windows"
+ * @build WinChildProcessTest
+ * @build jdk.jpackage.test.*
+ * @build WinChildProcessTest
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=WinChildProcessTest
+ *
+ */
+
+import java.util.List;
+import java.util.Optional;
+
+import java.nio.file.Path;
+
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Executor;
+import jdk.jpackage.test.TKit;
+
+public class WinChildProcessTest {
+    private static final Path TEST_APP_JAVA = TKit.TEST_SRC_ROOT
+            .resolve("apps/ChildProcessAppLauncher.java");
+
+    @Test
+    public static void test() throws Throwable {
+        long calcPid = 0;
+        try {
+            JPackageCommand cmd = JPackageCommand
+                    .helloAppImage(TEST_APP_JAVA + "*Hello");
+
+            // Create the image of the third party application launcher
+            cmd.executeAndAssertImageCreated();
+
+            // Start the third party application launcher and dump and save the
+            // output of the application
+            List<String> output = new Executor().saveOutput().dumpOutput()
+                    .setExecutable(cmd.appLauncherPath().toAbsolutePath())
+                    .execute(0).getOutput();
+            String pidStr = output.get(0);
+
+            // parse calculator PID
+            calcPid = Long.parseLong(pidStr.split("=", 2)[1]);
+
+            // Check whether the termination of third party application launcher
+            // also terminating the launched third party application
+            // If third party application is not terminated the test is
+            // successful else failure
+            Optional<ProcessHandle> processHandle = ProcessHandle.of(calcPid);
+            boolean isAlive = processHandle.isPresent()
+                    && processHandle.get().isAlive();
+            System.out.println("Is Alive " + isAlive);
+            TKit.assertTrue(isAlive, "Check is calculator process is alive");
+        } finally {
+            // Kill only a specific calculator instance
+            Runtime.getRuntime().exec("taskkill /F /PID " + calcPid);
+        }
+    }
+}

--- a/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
+++ b/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
@@ -53,7 +53,7 @@ public class WinChildProcessTest {
 
     @Test
     public static void test() throws Throwable {
-        long calcPid = 0;
+        long childPid = 0;
         try {
             JPackageCommand cmd = JPackageCommand
                     .helloAppImage(TEST_APP_JAVA + "*Hello");
@@ -68,21 +68,20 @@ public class WinChildProcessTest {
                     .execute(0).getOutput();
             String pidStr = output.get(0);
 
-            // parse calculator PID
-            calcPid = Long.parseLong(pidStr.split("=", 2)[1]);
+            // parse child PID
+            childPid = Long.parseLong(pidStr.split("=", 2)[1]);
 
             // Check whether the termination of third party application launcher
             // also terminating the launched third party application
             // If third party application is not terminated the test is
             // successful else failure
-            Optional<ProcessHandle> processHandle = ProcessHandle.of(calcPid);
+            Optional<ProcessHandle> processHandle = ProcessHandle.of(childPid);
             boolean isAlive = processHandle.isPresent()
                     && processHandle.get().isAlive();
-            System.out.println("Is Alive " + isAlive);
-            TKit.assertTrue(isAlive, "Check is calculator process is alive");
+            TKit.assertTrue(isAlive, "Check is child process is alive");
         } finally {
-            // Kill only a specific calculator instance
-            Runtime.getRuntime().exec("taskkill /F /PID " + calcPid);
+            // Kill only a specific child instance
+            Runtime.getRuntime().exec("taskkill /F /PID " + childPid);
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.5-oracle.

I include follow-up 8336315.

Both are clean backports.  Test passes on win.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336315](https://bugs.openjdk.org/browse/JDK-8336315) needs maintainer approval
- [x] [JDK-8325525](https://bugs.openjdk.org/browse/JDK-8325525) needs maintainer approval

### Issues
 * [JDK-8325525](https://bugs.openjdk.org/browse/JDK-8325525): Create jtreg test case for JDK-8325203 (**Enhancement** - P4 - Approved)
 * [JDK-8336315](https://bugs.openjdk.org/browse/JDK-8336315): tools/jpackage/windows/WinChildProcessTest.java Failed: Check is calculator process is alive (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1160/head:pull/1160` \
`$ git checkout pull/1160`

Update a local copy of the PR: \
`$ git checkout pull/1160` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1160`

View PR using the GUI difftool: \
`$ git pr show -t 1160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1160.diff">https://git.openjdk.org/jdk21u-dev/pull/1160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1160#issuecomment-2483208572)
</details>
