### PR TITLE
8333144: docker tests do not work when ubsan is configured

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -323,6 +323,7 @@ public class DockerTestUtils {
                                            String baseImageVersion) throws Exception {
         String template =
             "FROM %s:%s\n" +
+            "RUN apt-get install libubsan1\n" +
             "COPY /jdk /jdk\n" +
             "ENV JAVA_HOME=/jdk\n" +
             "CMD [\"/bin/bash\"]\n";


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333144](https://bugs.openjdk.org/browse/JDK-8333144) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8333144: docker tests do not work when ubsan is configured`

### Issue
 * [JDK-8333144](https://bugs.openjdk.org/browse/JDK-8333144): docker tests do not work when ubsan is configured (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1161/head:pull/1161` \
`$ git checkout pull/1161`

Update a local copy of the PR: \
`$ git checkout pull/1161` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1161`

View PR using the GUI difftool: \
`$ git pr show -t 1161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1161.diff">https://git.openjdk.org/jdk21u-dev/pull/1161.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1161#issuecomment-2483513104)
</details>
