### PR TITLE
8337826: Improve logging in OCSPTimeout and SimpleOCSPResponder to help diagnose JDK-8309754

### DIFF
--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -574,8 +574,8 @@ public class SimpleOCSPServer {
      */
     private synchronized void log(String message) {
         if (logEnabled || debug != null) {
-            System.out.println("[" + Thread.currentThread().getName() + "]: " +
-                    message);
+            System.out.println("[" + Thread.currentThread().getName() + "][" +
+                    System.currentTimeMillis() + "]: " + message);
         }
     }
 
@@ -729,6 +729,7 @@ public class SimpleOCSPServer {
             // wait out the delay here before any other processing.
             try {
                 if (delayMsec > 0) {
+                    log("Delaying response for " + delayMsec + " milliseconds.");
                     Thread.sleep(delayMsec);
                 }
             } catch (InterruptedException ie) {
@@ -910,6 +911,13 @@ public class SimpleOCSPServer {
          */
         private LocalOcspRequest parseHttpOcspGet(String[] headerTokens,
                 InputStream inStream) throws IOException, CertificateException {
+            // Display the whole request
+            StringBuilder sb = new StringBuilder("OCSP GET REQUEST\n");
+            for (String hTok : headerTokens) {
+                sb.append(hTok).append("\n");
+            }
+            log(sb.toString());
+
             // Before we process the remainder of the GET URL, we should drain
             // the InputStream of any other header data.  We (for now) won't
             // use it, but will display the contents if logging is enabled.
@@ -1001,6 +1009,10 @@ public class SimpleOCSPServer {
         private LocalOcspRequest(byte[] requestBytes) throws IOException,
                 CertificateException {
             Objects.requireNonNull(requestBytes, "Received null input");
+
+            // Display the DER encoding before parsing
+            log("Local OCSP Request Constructor, parsing bytes:\n" +
+                    dumpHexBytes(requestBytes));
 
             DerInputStream dis = new DerInputStream(requestBytes);
 


### PR DESCRIPTION
I'd like to backport it as a follow-up for JDK-8179502

Backport is clean
All related JTREG tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8337826](https://bugs.openjdk.org/browse/JDK-8337826) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337826](https://bugs.openjdk.org/browse/JDK-8337826): Improve logging in OCSPTimeout and SimpleOCSPResponder to help diagnose JDK-8309754 (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1162/head:pull/1162` \
`$ git checkout pull/1162`

Update a local copy of the PR: \
`$ git checkout pull/1162` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1162`

View PR using the GUI difftool: \
`$ git pr show -t 1162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1162.diff">https://git.openjdk.org/jdk21u-dev/pull/1162.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1162#issuecomment-2486859042)
</details>
