### PR TITLE
8344356: Aarch64: implement -XX:+VerifyActivationFrameSize

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -466,7 +466,13 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
                                               bool verifyoop,
                                               bool generate_poll) {
   if (VerifyActivationFrameSize) {
-    Unimplemented();
+    Label L;
+    sub(rscratch2, rfp, esp);
+    int min_frame_size = (frame::link_offset - frame::interpreter_frame_initial_sp_offset) * wordSize;
+    subs(rscratch2, rscratch2, min_frame_size);
+    br(Assembler::GE, L);
+    stop("broken stack frame");
+    bind(L);
   }
   if (verifyoop) {
     interp_verify_oop(r0, state);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4ddd3dec](https://github.com/openjdk/jdk/commit/4ddd3dec2d0b232d48646ca89b16591b3026aa5c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 20 Nov 2024 and was reviewed by Andrew Haley.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8344356](https://bugs.openjdk.org/browse/JDK-8344356) needs maintainer approval

### Issue
 * [JDK-8344356](https://bugs.openjdk.org/browse/JDK-8344356): Aarch64: implement -XX:+VerifyActivationFrameSize (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1163/head:pull/1163` \
`$ git checkout pull/1163`

Update a local copy of the PR: \
`$ git checkout pull/1163` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1163`

View PR using the GUI difftool: \
`$ git pr show -t 1163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1163.diff">https://git.openjdk.org/jdk21u-dev/pull/1163.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1163#issuecomment-2487169715)
</details>
