### PR TITLE
8343884: [s390x]  Disallow OptoScheduling

### DIFF
--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -302,6 +302,12 @@ void VM_Version::initialize() {
   if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {
     FLAG_SET_DEFAULT(UseUnalignedAccesses, true);
   }
+
+  // The OptoScheduling information is not maintained in s390.ad.
+  if (OptoScheduling) {
+    warning("OptoScheduling is not supported on this CPU.");
+    FLAG_SET_DEFAULT(OptoScheduling, false);
+  }
 }
 
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7540fa21](https://github.com/openjdk/jdk/commit/7540fa2147ff8fc9c652ef13548f72f27e2809a8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 19 Nov 2024 and was reviewed by Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343884](https://bugs.openjdk.org/browse/JDK-8343884) needs maintainer approval

### Issue
 * [JDK-8343884](https://bugs.openjdk.org/browse/JDK-8343884): [s390x]  Disallow OptoScheduling (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1164/head:pull/1164` \
`$ git checkout pull/1164`

Update a local copy of the PR: \
`$ git checkout pull/1164` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1164`

View PR using the GUI difftool: \
`$ git pr show -t 1164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1164.diff">https://git.openjdk.org/jdk21u-dev/pull/1164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1164#issuecomment-2487357058)
</details>
