### PR TITLE
8338550: Do libubsan1 installation in test container only if requested

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -321,10 +321,11 @@ public class DockerTestUtils {
 
     private static void generateDockerFile(Path dockerfile, String baseImage,
                                            String baseImageVersion) throws Exception {
-        String template =
-            "FROM %s:%s\n" +
-            "RUN apt-get install libubsan1\n" +
-            "COPY /jdk /jdk\n" +
+        String template = "FROM %s:%s\n";
+        if (baseImage.contains("ubuntu") && DockerfileConfig.isUbsan()) {
+            template += "RUN apt-get update && apt-get install -y libubsan1\n";
+        }
+        template = template + "COPY /jdk /jdk\n" +
             "ENV JAVA_HOME=/jdk\n" +
             "CMD [\"/bin/bash\"]\n";
         String dockerFileStr = String.format(template, baseImage, baseImageVersion);

--- a/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
@@ -37,6 +37,11 @@ import jdk.test.lib.Platform;
 // Note: base image version should not be an empty string. Use "latest" to get the latest version.
 
 public class DockerfileConfig {
+
+    public static boolean isUbsan() {
+        return Boolean.getBoolean("jdk.test.docker.image.isUbsan");
+    }
+
     public static String getBaseImageName() {
         String name = System.getProperty("jdk.test.docker.image.name");
         if (name != null) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338550](https://bugs.openjdk.org/browse/JDK-8338550) needs maintainer approval

### Issue
 * [JDK-8338550](https://bugs.openjdk.org/browse/JDK-8338550): Do libubsan1 installation in test container only if requested (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1165/head:pull/1165` \
`$ git checkout pull/1165`

Update a local copy of the PR: \
`$ git checkout pull/1165` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1165`

View PR using the GUI difftool: \
`$ git pr show -t 1165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1165.diff">https://git.openjdk.org/jdk21u-dev/pull/1165.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1165#issuecomment-2487909376)
</details>
