### PR TITLE
8319678: Several tests from corelibs areas ignore VM flags

### DIFF
--- a/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
+++ b/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,13 @@
 
 import java.util.stream.Stream;
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.Arguments;
-
 import static java.lang.System.err;
 import static java.lang.System.out;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /*
  * @test
@@ -85,7 +83,7 @@ class UncaughtExceptionsTest {
     @MethodSource("testCases")
     void test(String className, int exitValue, String stdOutMatch, String stdErrMatch) throws Throwable {
         String cmd = "UncaughtExitSimulator$" + className;
-        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(cmd);
+        ProcessBuilder processBuilder = ProcessTools.createTestJavaProcessBuilder(cmd);
         OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(processBuilder);
         outputAnalyzer.shouldHaveExitValue(exitValue);
         outputAnalyzer.stderrShouldMatch(stdErrMatch);

--- a/test/jdk/java/lang/annotation/LoaderLeakTest.java
+++ b/test/jdk/java/lang/annotation/LoaderLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class LoaderLeakTest {
     }
 
     private void runJavaProcessExpectSuccessExitCode(String ... command) throws Throwable {
-        var processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(command)
+        var processBuilder = ProcessTools.createTestJavaProcessBuilder(command)
                                                       .directory(Paths.get(Utils.TEST_CLASSES).toFile());
         ProcessTools.executeCommand(processBuilder).shouldHaveExitValue(0);
     }

--- a/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
+++ b/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,13 @@
  * @test
  * @summary The RMI benchmark test. This java class is used to run the test
  *          under JTREG.
- * @library ../../../../testlibrary ../../
+ * @library ../../../../testlibrary ../../ /test/lib
  * @modules java.desktop
  *          java.rmi/sun.rmi.registry
  *          java.rmi/sun.rmi.server
  *          java.rmi/sun.rmi.transport
  *          java.rmi/sun.rmi.transport.tcp
- * @build TestLibrary bench.BenchInfo bench.HtmlReporter bench.Util
+ * @build TestLibrary bench.BenchInfo bench.HtmlReporter bench.Util jdk.test.lib.process.ProcessTools
  * bench.Benchmark bench.Reporter bench.XmlReporter bench.ConfigFormatException
  * bench.Harness bench.TextReporter bench.rmi.BenchServer
  * bench.rmi.DoubleArrayCalls bench.rmi.LongCalls bench.rmi.ShortCalls
@@ -51,19 +51,12 @@
 
 package bench.rmi;
 
-import bench.ConfigFormatException;
-import bench.Harness;
-import bench.HtmlReporter;
-import bench.Reporter;
-import bench.TextReporter;
-import bench.XmlReporter;
-import static bench.rmi.Main.OutputFormat.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.rmi.AlreadyBoundException;
@@ -76,6 +69,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
+
+import bench.ConfigFormatException;
+import bench.Harness;
+import bench.HtmlReporter;
+import bench.Reporter;
+import bench.TextReporter;
+import bench.XmlReporter;
+import static bench.rmi.Main.OutputFormat.HTML;
+import static bench.rmi.Main.OutputFormat.TEXT;
+import static bench.rmi.Main.OutputFormat.XML;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * RMI/Serialization benchmark tests.
@@ -234,13 +239,6 @@ public class Main {
                     //Setup for client mode, server will fork client process
                     //after its initiation.
                     List<String> clientProcessStr = new ArrayList<>();
-                    clientProcessStr.add(System.getProperty("test.jdk") +
-                            File.separator + "bin" + File.separator + "java");
-                    String classpath = System.getProperty("java.class.path");
-                    if (classpath != null) {
-                        clientProcessStr.add("-cp");
-                        clientProcessStr.add(classpath);
-                    }
                     clientProcessStr.add("-Djava.security.policy=" + TEST_SRC_PATH + "policy.all");
                     clientProcessStr.add("-Djava.security.manager=allow");
                     clientProcessStr.add("-Dtest.src=" + TEST_SRC_PATH);
@@ -276,20 +274,13 @@ public class Main {
                     }
 
                     try {
-                        Process client = new ProcessBuilder(clientProcessStr).
-                                inheritIO().start();
-                        try {
-                            client.waitFor();
-                            int exitValue = client.exitValue();
-                            if (0 != exitValue) {
-                                die("Error: error happened in client process, exitValue = " + exitValue);
-                            }
-                        } finally {
-                            client.destroyForcibly();
-                        }
+                        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(clientProcessStr);
+                        OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(pb);
+                        System.out.println(outputAnalyzer.getOutput());
+                        outputAnalyzer.shouldHaveExitValue(0);
                     } catch (IOException ex) {
                         die("Error: Unable start client process, ex=" + ex.getMessage());
-                    } catch (InterruptedException ex) {
+                    } catch (Exception ex) {
                         die("Error: Error happening to client process, ex=" + ex.getMessage());
                     }
                     break;

--- a/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
+++ b/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 import tests.Helper;
 import tests.JImageGenerator;
 
@@ -32,12 +34,12 @@ import tests.JImageGenerator;
  * @summary Tests whether a custom Hijrah configuration properties file works correctly
  * @bug 8187987
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
- * @library /tools/lib
+ * @library /tools/lib /test/lib
  * @modules java.base/jdk.internal.jimage
  *          jdk.jdeps/com.sun.tools.classfile
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.compiler
- * @build HijrahConfigCheck tests.*
+ * @build HijrahConfigCheck tests.* jdk.test.lib.compiler.CompilerUtils jdk.test.lib.process.ProcessTools
  * @run main/othervm -Xmx1g HijrahConfigTest
  */
 public class HijrahConfigTest {
@@ -66,13 +68,7 @@ public class HijrahConfigTest {
 
         // Run tests
         Path launcher = outputPath.resolve("bin").resolve("java");
-        ProcessBuilder builder = new ProcessBuilder(
-                launcher.toAbsolutePath().toString(), "-ea", "-esa", "HijrahConfigCheck");
-        Process p = builder.inheritIO().start();
-        p.waitFor();
-        int exitValue = p.exitValue();
-        if (exitValue != 0) {
-            throw new RuntimeException("HijrahConfigTest failed. Exit value: " + exitValue);
-        }
+        OutputAnalyzer analyzer =  ProcessTools.executeCommand(launcher.toAbsolutePath().toString(), "-ea", "-esa", "HijrahConfigCheck");
+        analyzer.shouldHaveExitValue(0);
     }
 }

--- a/test/jdk/sun/misc/EscapePath.java
+++ b/test/jdk/sun/misc/EscapePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,19 @@
 /* @test
  * @bug 4359123
  * @summary  Test loading of classes with # in the path
+ * @library /test/lib
+ * @build jdk.test.lib.process.ProcessTools
+ * @run main EscapePath
  */
-import java.io.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class EscapePath {
 
@@ -75,14 +86,19 @@ public class EscapePath {
         fos.close();
     }
 
-    private static void invokeJava() throws Exception {
-        String command = System.getProperty("java.home") +
-                         File.separator + "bin" + File.separator +
-                         "java -classpath " + "a#b/ Hello";
-        Process p = Runtime.getRuntime().exec(command);
-        p.waitFor();
-        int result = p.exitValue();
-        if (result != 0)
-            throw new RuntimeException("Path encoding failure.");
+    private static void invokeJava() {
+        List<String> commands = new ArrayList<>();
+
+        commands.add("-classpath");
+        commands.add("a#b");
+        commands.add("Hello");
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(commands);
+
+        try {
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(pb);
+            outputAnalyzer.shouldHaveExitValue(0);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

Resolved HijrahConfigTest.java because "8315444: Convert test/jdk/tools to Classfile API" is not in 21

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319678](https://bugs.openjdk.org/browse/JDK-8319678) needs maintainer approval

### Issue
 * [JDK-8319678](https://bugs.openjdk.org/browse/JDK-8319678): Several tests from corelibs areas ignore VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1169/head:pull/1169` \
`$ git checkout pull/1169`

Update a local copy of the PR: \
`$ git checkout pull/1169` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1169`

View PR using the GUI difftool: \
`$ git pr show -t 1169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1169.diff">https://git.openjdk.org/jdk21u-dev/pull/1169.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1169#issuecomment-2488979068)
</details>
