### PR TITLE
8344526: RISC-V: implement -XX:+VerifyActivationFrameSize

### DIFF
--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -527,7 +527,14 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
                                               Register Rs) {
   // Pay attention to the argument Rs, which is acquiesce in t0.
   if (VerifyActivationFrameSize) {
-    Unimplemented();
+    Label L;
+    sub(t1, fp, esp);
+    int min_frame_size =
+      (frame::link_offset - frame::interpreter_frame_initial_sp_offset + frame::metadata_words) * wordSize;
+    sub(t1, t1, min_frame_size);
+    bgez(t1, L);
+    stop("broken stack frame");
+    bind(L);
   }
   if (verifyoop && state == atos) {
     verify_oop(x10);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4fbf2720](https://github.com/openjdk/jdk/commit/4fbf272017d2f6933e66f8a67cb88e3ffc42339e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 21 Nov 2024 and was reviewed by Hamlin Li and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8344526](https://bugs.openjdk.org/browse/JDK-8344526) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344526](https://bugs.openjdk.org/browse/JDK-8344526): RISC-V: implement -XX:+VerifyActivationFrameSize (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1171/head:pull/1171` \
`$ git checkout pull/1171`

Update a local copy of the PR: \
`$ git checkout pull/1171` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1171`

View PR using the GUI difftool: \
`$ git pr show -t 1171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1171.diff">https://git.openjdk.org/jdk21u-dev/pull/1171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1171#issuecomment-2489930857)
</details>
