### PR TITLE
8316907: Fix nonnull-compare warnings

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -726,7 +726,6 @@ void ArchDesc::build_pipe_classes(FILE *fp_cpp) {
   fprintf(fp_cpp, "  }\n");
   fprintf(fp_cpp, "#endif\n\n");
 #endif
-  fprintf(fp_cpp, "  assert(this, \"null pipeline info\");\n");
   fprintf(fp_cpp, "  assert(pred, \"null predecessor pipline info\");\n\n");
   fprintf(fp_cpp, "  if (pred->hasFixedLatency())\n    return (pred->fixedLatency());\n\n");
   fprintf(fp_cpp, "  // If this is not an operand, then assume a dependence with 0 latency\n");

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1059,11 +1059,6 @@ void CodeSection::print(const char* name) {
 }
 
 void CodeBuffer::print() {
-  if (this == nullptr) {
-    tty->print_cr("null CodeBuffer pointer");
-    return;
-  }
-
   tty->print_cr("CodeBuffer:");
   for (int n = 0; n < (int)SECT_LIMIT; n++) {
     // print each section


### PR DESCRIPTION
Hi all,
There are some gcc compile warnings which recorded by [JDK-8342304](https://bugs.openjdk.org/browse/JDK-8342304) on linux-riscv64 platform, and the PR [JDK-8316893](https://bugs.openjdk.org/browse/JDK-8316893) fix the gcc compile warnings. So I want to backport [JDK-8316893](https://bugs.openjdk.org/browse/JDK-8316893) to jdk21u-dev. But before backport [JDK-8316893](https://bugs.openjdk.org/browse/JDK-8316893), we should backport [JDK-8316907](https://bugs.openjdk.org/browse/JDK-8316907) first, [JDK-8316907](https://bugs.openjdk.org/browse/JDK-8316907) solve  nonnull-compare warnings emitted by GCC after removing `-fno-delete-null-pointer-checks`.

Additional testing:

- [x] 1. jtreg tests(include tier1/2/3 etc.) with linux-x64 release build
- [x] 2. jtreg tests(include tier1/2/3 etc.) with linux-x64 fastdebug build
- [x] 3. jtreg tests(include tier1/2/3 etc.) with linux-aarch64 release build
- [x] 4. jtreg tests(include tier1/2/3 etc.) with linux-aarch64 fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316907](https://bugs.openjdk.org/browse/JDK-8316907) needs maintainer approval

### Issue
 * [JDK-8316907](https://bugs.openjdk.org/browse/JDK-8316907): Fix nonnull-compare warnings (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1172/head:pull/1172` \
`$ git checkout pull/1172`

Update a local copy of the PR: \
`$ git checkout pull/1172` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1172`

View PR using the GUI difftool: \
`$ git pr show -t 1172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1172.diff">https://git.openjdk.org/jdk21u-dev/pull/1172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1172#issuecomment-2490286272)
</details>
