### PR TITLE
8343877: Test AsyncClose.java intermittent fails - Socket.getInputStream().read() wasn't preempted

### DIFF
--- a/test/jdk/java/net/Socket/asyncClose/Socket_getOutputStream_write.java
+++ b/test/jdk/java/net/Socket/asyncClose/Socket_getOutputStream_write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,20 +66,22 @@ public class Socket_getOutputStream_write extends AsyncCloseTest implements Runn
     public AsyncCloseTest go() {
         try {
             InetAddress lh = InetAddress.getLocalHost();
-            ServerSocket ss = new ServerSocket(0, 0, lh);
-            s.connect( new InetSocketAddress(lh, ss.getLocalPort()) );
-            Socket s2 = ss.accept();
-            Thread thr = new Thread(this);
-            thr.start();
-            latch.await();
-            Thread.sleep(1000);
-            s.close();
-            thr.join();
+            try (ServerSocket ss = new ServerSocket(0, 0, lh)) {
+                s.connect(new InetSocketAddress(lh, ss.getLocalPort()));
+                try (Socket s2 = ss.accept()) {
+                    Thread thr = new Thread(this);
+                    thr.start();
+                    latch.await();
+                    Thread.sleep(1000);
+                    s.close();
+                    thr.join();
+                }
 
-            if (isClosed()) {
-                return passed();
-            } else {
-                return failed("Socket.getOutputStream().write() wasn't preempted");
+                if (isClosed()) {
+                    return passed();
+                } else {
+                    return failed("Socket.getOutputStream().write() wasn't preempted");
+                }
             }
         } catch (Exception x) {
             failed(x.getMessage());


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [752e1629](https://github.com/openjdk/jdk/commit/752e1629555f0ec8630373ec87b049afdd709ea6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jaikiran Pai on 14 Nov 2024 and was reviewed by Daniel Fuchs, Mark Sheppard, SendaoYan and Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8343877](https://bugs.openjdk.org/browse/JDK-8343877) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343877](https://bugs.openjdk.org/browse/JDK-8343877): Test AsyncClose.java intermittent fails - Socket.getInputStream().read() wasn't preempted (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1174/head:pull/1174` \
`$ git checkout pull/1174`

Update a local copy of the PR: \
`$ git checkout pull/1174` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1174`

View PR using the GUI difftool: \
`$ git pr show -t 1174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1174.diff">https://git.openjdk.org/jdk21u-dev/pull/1174.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1174#issuecomment-2492987640)
</details>
