### PR TITLE
8316893: Compile without -fno-delete-null-pointer-checks

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -862,15 +862,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
     $1_TOOLCHAIN_CFLAGS="${$1_GCC6_CFLAGS}"
 
     $1_WARNING_CFLAGS_JVM="-Wno-format-zero-length -Wtype-limits -Wuninitialized"
-  elif test "x$TOOLCHAIN_TYPE" = xclang; then
-    NO_DELETE_NULL_POINTER_CHECKS_CFLAG="-fno-delete-null-pointer-checks"
-    FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$NO_DELETE_NULL_POINTER_CHECKS_CFLAG],
-        PREFIX: $3,
-        IF_FALSE: [
-            NO_DELETE_NULL_POINTER_CHECKS_CFLAG=
-        ]
-    )
-    $1_TOOLCHAIN_CFLAGS="${NO_DELETE_NULL_POINTER_CHECKS_CFLAG}"
   fi
 
   if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
@@ -1008,17 +999,12 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
 # $2 - Prefix for compiler variables (either BUILD_ or nothing).
 AC_DEFUN([FLAGS_SETUP_GCC6_COMPILER_FLAGS],
 [
-  # These flags are required for GCC 6 builds as undefined behavior in OpenJDK code
-  # runs afoul of the more aggressive versions of these optimizations.
-  # Notably, value range propagation now assumes that the this pointer of C++
-  # member functions is non-null.
-  NO_DELETE_NULL_POINTER_CHECKS_CFLAG="-fno-delete-null-pointer-checks"
-  FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$NO_DELETE_NULL_POINTER_CHECKS_CFLAG],
-      PREFIX: $2, IF_FALSE: [NO_DELETE_NULL_POINTER_CHECKS_CFLAG=""])
+  # This flag is required for GCC 6 builds as undefined behavior in OpenJDK code
+  # runs afoul of the more aggressive versions of this optimization.
   NO_LIFETIME_DSE_CFLAG="-fno-lifetime-dse"
   FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [$NO_LIFETIME_DSE_CFLAG],
       PREFIX: $2, IF_FALSE: [NO_LIFETIME_DSE_CFLAG=""])
-  $1_GCC6_CFLAGS="${NO_DELETE_NULL_POINTER_CHECKS_CFLAG} ${NO_LIFETIME_DSE_CFLAG}"
+  $1_GCC6_CFLAGS="${NO_LIFETIME_DSE_CFLAG}"
 ])
 
 AC_DEFUN_ONCE([FLAGS_SETUP_BRANCH_PROTECTION],


### PR DESCRIPTION
Hi all,
There are some gcc compile warnings which recorded by [JDK-8342304](https://bugs.openjdk.org/browse/JDK-8342304) on linux-riscv64 platform, and the PR [JDK-8316893](https://bugs.openjdk.org/browse/JDK-8316893) fix the gcc compile warnings. So I want to backport [JDK-8316893](https://bugs.openjdk.org/browse/JDK-8316893) to jdk21u-dev.

Additional testing:

- [x] 1. jtreg tests(include tier1/2/3 etc.) with linux-x64 release build
- [x] 2. jtreg tests(include tier1/2/3 etc.) with linux-x64 fastdebug build
- [x] 3. jtreg tests(include tier1/2/3 etc.) with linux-aarch64 release build
- [x] 4. jtreg tests(include tier1/2/3 etc.) with linux-aarch64 fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8316893](https://bugs.openjdk.org/browse/JDK-8316893) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316893](https://bugs.openjdk.org/browse/JDK-8316893): Compile without -fno-delete-null-pointer-checks (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1178/head:pull/1178` \
`$ git checkout pull/1178`

Update a local copy of the PR: \
`$ git checkout pull/1178` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1178`

View PR using the GUI difftool: \
`$ git pr show -t 1178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1178.diff">https://git.openjdk.org/jdk21u-dev/pull/1178.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1178#issuecomment-2495242778)
</details>
