### PR TITLE
8344993: [21u] [REDO] Backport JDK-8327501 and JDK-8328366 to JDK 21

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -981,9 +981,7 @@ public class ForkJoinPool extends AbstractExecutorService {
             boolean isCommon = (pool.workerNamePrefix == null);
             @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
-            if (sm == null)
-                return new ForkJoinWorkerThread(null, pool, true, false);
-            else if (isCommon)
+            if (sm != null && isCommon)
                 return newCommonWithACC(pool);
             else
                 return newRegularWithACC(pool);

--- a/test/jdk/java/util/concurrent/tck/ForkJoinPool9Test.java
+++ b/test/jdk/java/util/concurrent/tck/ForkJoinPool9Test.java
@@ -79,6 +79,9 @@ public class ForkJoinPool9Test extends JSR166TestCase {
             assertSame(ForkJoinPool.commonPool(), ForkJoinTask.getPool());
             Thread currentThread = Thread.currentThread();
 
+            ClassLoader preexistingContextClassLoader =
+                    currentThread.getContextClassLoader();
+
             Stream.of(systemClassLoader, null).forEach(cl -> {
                 if (randomBoolean())
                     // should always be permitted, without effect
@@ -95,6 +98,11 @@ public class ForkJoinPool9Test extends JSR166TestCase {
                     () -> System.getProperty("foo"),
                     () -> currentThread.setContextClassLoader(
                         classLoaderDistinctFromSystemClassLoader));
+            else {
+                currentThread.setContextClassLoader(classLoaderDistinctFromSystemClassLoader);
+                assertSame(currentThread.getContextClassLoader(), classLoaderDistinctFromSystemClassLoader);
+                currentThread.setContextClassLoader(preexistingContextClassLoader);
+            }
             // TODO ?
 //          if (haveSecurityManager
 //              && Thread.currentThread().getClass().getSimpleName()


### PR DESCRIPTION
Hi,

In this PR I back out 8341989 for 8327501 and 8328366 to be re-introduced to JDK 21u. I plan to propose a backport of 8342905 thereafter. Reversion of 8341989 was clean.

Thanks,
Martin.-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8344993](https://bugs.openjdk.org/browse/JDK-8344993) needs maintainer approval

### Issue
 * [JDK-8344993](https://bugs.openjdk.org/browse/JDK-8344993): [21u] [REDO] Backport JDK-8327501 and JDK-8328366 to JDK 21 (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1181/head:pull/1181` \
`$ git checkout pull/1181`

Update a local copy of the PR: \
`$ git checkout pull/1181` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1181`

View PR using the GUI difftool: \
`$ git pr show -t 1181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1181.diff">https://git.openjdk.org/jdk21u-dev/pull/1181.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1181#issuecomment-2499158318)
</details>
