### PR TITLE
8342905: Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501 redux

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2672,6 +2672,11 @@ public final class System {
             public String getLoaderNameID(ClassLoader loader) {
                 return loader != null ? loader.nameAndId() : "null";
             }
+
+            @Override
+            public boolean allowSecurityManager() {
+                return System.allowSecurityManager();
+            }
         });
     }
 }

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -981,9 +981,7 @@ public class ForkJoinPool extends AbstractExecutorService {
             boolean isCommon = (pool.workerNamePrefix == null);
             @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
-            if (sm == null)
-                return new ForkJoinWorkerThread(null, pool, true, false);
-            else if (isCommon)
+            if (sm != null && isCommon)
                 return newCommonWithACC(pool);
             else
                 return newRegularWithACC(pool);

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -52,6 +52,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.Condition;
+
+import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.JavaUtilConcurrentFJPAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Unsafe;
@@ -979,9 +981,7 @@ public class ForkJoinPool extends AbstractExecutorService {
         implements ForkJoinWorkerThreadFactory {
         public final ForkJoinWorkerThread newThread(ForkJoinPool pool) {
             boolean isCommon = (pool.workerNamePrefix == null);
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null && isCommon)
+            if (isCommon && JLA.allowSecurityManager())
                 return newCommonWithACC(pool);
             else
                 return newRegularWithACC(pool);
@@ -997,6 +997,8 @@ public class ForkJoinPool extends AbstractExecutorService {
          */
         @SuppressWarnings("removal")
         static volatile AccessControlContext regularACC, commonACC;
+
+        private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
         @SuppressWarnings("removal")
         static ForkJoinWorkerThread newRegularWithACC(ForkJoinPool pool) {

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -579,4 +579,10 @@ public interface JavaLangAccess {
      * explicitly set otherwise <qualified-class-name> @<id>
      */
     String getLoaderNameID(ClassLoader loader);
+
+    /**
+     * Is a security manager already set or allowed to be set
+     * (using -Djava.security.manager=allow)?
+     */
+    boolean allowSecurityManager();
 }

--- a/test/jdk/java/util/concurrent/tck/ForkJoinPool9Test.java
+++ b/test/jdk/java/util/concurrent/tck/ForkJoinPool9Test.java
@@ -79,6 +79,9 @@ public class ForkJoinPool9Test extends JSR166TestCase {
             assertSame(ForkJoinPool.commonPool(), ForkJoinTask.getPool());
             Thread currentThread = Thread.currentThread();
 
+            ClassLoader preexistingContextClassLoader =
+                    currentThread.getContextClassLoader();
+
             Stream.of(systemClassLoader, null).forEach(cl -> {
                 if (randomBoolean())
                     // should always be permitted, without effect
@@ -95,6 +98,11 @@ public class ForkJoinPool9Test extends JSR166TestCase {
                     () -> System.getProperty("foo"),
                     () -> currentThread.setContextClassLoader(
                         classLoaderDistinctFromSystemClassLoader));
+            else {
+                currentThread.setContextClassLoader(classLoaderDistinctFromSystemClassLoader);
+                assertSame(currentThread.getContextClassLoader(), classLoaderDistinctFromSystemClassLoader);
+                currentThread.setContextClassLoader(preexistingContextClassLoader);
+            }
             // TODO ?
 //          if (haveSecurityManager
 //              && Thread.currentThread().getClass().getSimpleName()


### PR DESCRIPTION
Hi,

I would like to propose a [JDK-8342905](https://bugs.openjdk.org/browse/JDK-8342905 "Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501 redux") (openjdk/jdk23u@872ae1347198408ffd62559ca8c1a7420c4a8108) backport from 23u to 21u.

The backport is not clean, for the following reasons:

* The `jdk.internal.access.JavaLangAccess` import context in `ForkJoinPool.java` has changed from 21u to 23u, due to [JDK-8288899](https://bugs.openjdk.org/browse/JDK-8288899 "java/util/concurrent/ExecutorService/CloseTest.java failed with \"InterruptedException: sleep interrupted\"") (openjdk/jdk@667cca9d7aef1ff4abe630cefaac34c0b1646925)
* The `jdk.internal.access.JavaLangAccess::allowSecurityManager` method didn't exist in 21u, so I picked it from [JDK-8296244](https://bugs.openjdk.org/browse/JDK-8296244 "Alternate implementation of user-based authorization Subject APIs that doesn’t depend on Security Manager APIs") (openjdk/jdk@d32746ef4a0ce6fec558274244321991be141698)
    * We don't need [JDK-8296244](https://bugs.openjdk.org/browse/JDK-8296244 "Alternate implementation of user-based authorization Subject APIs that doesn’t depend on Security Manager APIs"), just the access to the `System::allowSecurityManager` private method
    * I don't see [JDK-8296244](https://bugs.openjdk.org/browse/JDK-8296244 "Alternate implementation of user-based authorization Subject APIs that doesn’t depend on Security Manager APIs") as a possible dependency candidate, given it is a much broader change with its own CSR affecting the Java SE API and only approved for 23

This pull request depends on @martinuy's #1181.

#### Testing

As part of our testing, we observed all the tests pass in the following categories:

* `jdk:tier1` (see [GitHub Actions run](https://github.com/franferrax/jdk21u-dev/actions/runs/12126257318))
* `jdk/java/util/concurrent/forkjoin`
* `jdk/java/util/concurrent/tck`

Additionally, an internal test for [JDK-8237117](https://bugs.openjdk.org/browse/JDK-8237117 "Better ForkJoinPool behavior") was executed without issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342905](https://bugs.openjdk.org/browse/JDK-8342905) needs maintainer approval

### Issue
 * [JDK-8342905](https://bugs.openjdk.org/browse/JDK-8342905): Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501 redux (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**) Review applies to [f02d74fb](https://git.openjdk.org/jdk21u-dev/pull/1192/files/f02d74fb73125f57ed1bac82474a0d9a224a35bf)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1192/head:pull/1192` \
`$ git checkout pull/1192`

Update a local copy of the PR: \
`$ git checkout pull/1192` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1192`

View PR using the GUI difftool: \
`$ git pr show -t 1192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1192.diff">https://git.openjdk.org/jdk21u-dev/pull/1192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1192#issuecomment-2513026615)
</details>
