### PR TITLE
8331993: Add counting leading/trailing zero tests for Integer

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestDisableAutoVectOpcodes.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestDisableAutoVectOpcodes.java
@@ -117,7 +117,7 @@ public class TestDisableAutoVectOpcodes {
     }
 
     @Test
-    @IR(failOn = {IRNode.COUNTTRAILINGZEROS_VL})
+    @IR(failOn = {IRNode.COUNT_TRAILING_ZEROS_VL})
     public void testNumberOfTrailingZeros() {
         for (int i = 0; i < SIZE; ++i) {
             inta[i] = Long.numberOfTrailingZeros(longa[i]);
@@ -125,7 +125,7 @@ public class TestDisableAutoVectOpcodes {
     }
 
     @Test
-    @IR(failOn = {IRNode.COUNTLEADINGZEROS_VL})
+    @IR(failOn = {IRNode.COUNT_LEADING_ZEROS_VL})
     public void testNumberOfLeadingZeros() {
         for (int i = 0; i < SIZE; ++i) {
             inta[i] = Long.numberOfLeadingZeros(longa[i]);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1068,14 +1068,24 @@ public class IRNode {
         vectorNode(POPCOUNT_VL, "PopCountVL", TYPE_LONG);
     }
 
-    public static final String COUNTTRAILINGZEROS_VL = VECTOR_PREFIX + "COUNTTRAILINGZEROS_VL" + POSTFIX;
+    public static final String COUNT_TRAILING_ZEROS_VL = VECTOR_PREFIX + "COUNT_TRAILING_ZEROS_VL" + POSTFIX;
     static {
-        vectorNode(COUNTTRAILINGZEROS_VL, "CountTrailingZerosV", TYPE_LONG);
+        vectorNode(COUNT_TRAILING_ZEROS_VL, "CountTrailingZerosV", TYPE_LONG);
     }
 
-    public static final String COUNTLEADINGZEROS_VL = VECTOR_PREFIX + "COUNTLEADINGZEROS_VL" + POSTFIX;
+    public static final String COUNT_TRAILING_ZEROS_VI = VECTOR_PREFIX + "COUNT_TRAILING_ZEROS_VI" + POSTFIX;
     static {
-        vectorNode(COUNTLEADINGZEROS_VL, "CountLeadingZerosV", TYPE_LONG);
+        vectorNode(COUNT_TRAILING_ZEROS_VI, "CountTrailingZerosV", TYPE_INT);
+    }
+
+    public static final String COUNT_LEADING_ZEROS_VL = VECTOR_PREFIX + "COUNT_LEADING_ZEROS_VL" + POSTFIX;
+    static {
+        vectorNode(COUNT_LEADING_ZEROS_VL, "CountLeadingZerosV", TYPE_LONG);
+    }
+
+    public static final String COUNT_LEADING_ZEROS_VI = VECTOR_PREFIX + "COUNT_LEADING_ZEROS_VI" + POSTFIX;
+    static {
+        vectorNode(COUNT_LEADING_ZEROS_VI, "CountLeadingZerosV", TYPE_INT);
     }
 
     public static final String POPULATE_INDEX = PREFIX + "POPULATE_INDEX" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
@@ -39,8 +39,10 @@ import java.util.Random;
 import jdk.test.lib.Asserts;
 
 public class TestNumberOfContinuousZeros {
-    private long[] input;
-    private int[] output;
+    private long[] inputLong;
+    private int[] outputLong;
+    private int[] inputInt;
+    private int[] outputInt;
     private static final int LEN = 1024;
     private Random rng;
 
@@ -49,39 +51,71 @@ public class TestNumberOfContinuousZeros {
     }
 
     public TestNumberOfContinuousZeros() {
-        input = new long[LEN];
-        output = new int[LEN];
+        inputLong = new long[LEN];
+        outputLong = new int[LEN];
+        inputInt = new int[LEN];
+        outputInt = new int[LEN];
         rng = new Random(42);
         for (int i = 0; i < LEN; ++i) {
-            input[i] = rng.nextLong();
+            inputLong[i] = rng.nextLong();
+            inputInt[i] = rng.nextInt();
         }
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTTRAILINGZEROS_VL, "> 0"})
-    public void vectorizeNumberOfTrailingZeros() {
+    @IR(counts = {IRNode.COUNT_TRAILING_ZEROS_VL, "> 0"})
+    public void vectorizeNumberOfTrailingZerosLong() {
         for (int i = 0; i < LEN; ++i) {
-            output[i] = Long.numberOfTrailingZeros(input[i]);
+            outputLong[i] = Long.numberOfTrailingZeros(inputLong[i]);
         }
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTLEADINGZEROS_VL, "> 0"})
-    public void vectorizeNumberOfLeadingZeros() {
+    @IR(counts = {IRNode.COUNT_LEADING_ZEROS_VL, "> 0"})
+    public void vectorizeNumberOfLeadingZerosLong() {
         for (int i = 0; i < LEN; ++i) {
-            output[i] = Long.numberOfLeadingZeros(input[i]);
+            outputLong[i] = Long.numberOfLeadingZeros(inputLong[i]);
         }
     }
 
-    @Run(test = {"vectorizeNumberOfTrailingZeros", "vectorizeNumberOfLeadingZeros"})
-    public void checkResult() {
-        vectorizeNumberOfTrailingZeros();
+    @Run(test = {"vectorizeNumberOfTrailingZerosLong", "vectorizeNumberOfLeadingZerosLong"})
+    public void checkResultLong() {
+        vectorizeNumberOfTrailingZerosLong();
         for (int i = 0; i < LEN; ++i) {
-            Asserts.assertEquals(output[i], Long.numberOfTrailingZeros(input[i]));
+            Asserts.assertEquals(outputLong[i], Long.numberOfTrailingZeros(inputLong[i]));
         }
-        vectorizeNumberOfLeadingZeros();
+        vectorizeNumberOfLeadingZerosLong();
         for (int i = 0; i < LEN; ++i) {
-            Asserts.assertEquals(output[i], Long.numberOfLeadingZeros(input[i]));
+            Asserts.assertEquals(outputLong[i], Long.numberOfLeadingZeros(inputLong[i]));
+        }
+    }
+
+
+    @Test
+    @IR(counts = {IRNode.COUNT_TRAILING_ZEROS_VI, "> 0"})
+    public void vectorizeNumberOfTrailingZerosInt() {
+        for (int i = 0; i < LEN; ++i) {
+            outputInt[i] = Integer.numberOfTrailingZeros(inputInt[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNT_LEADING_ZEROS_VI, "> 0"})
+    public void vectorizeNumberOfLeadingZerosInt() {
+        for (int i = 0; i < LEN; ++i) {
+            outputInt[i] = Integer.numberOfLeadingZeros(inputInt[i]);
+        }
+    }
+
+    @Run(test = {"vectorizeNumberOfTrailingZerosInt", "vectorizeNumberOfLeadingZerosInt"})
+    public void checkResultInt() {
+        vectorizeNumberOfTrailingZerosInt();
+        for (int i = 0; i < LEN; ++i) {
+            Asserts.assertEquals(outputInt[i], Integer.numberOfTrailingZeros(inputInt[i]));
+        }
+        vectorizeNumberOfLeadingZerosInt();
+        for (int i = 0; i < LEN; ++i) {
+            Asserts.assertEquals(outputInt[i], Integer.numberOfLeadingZeros(inputInt[i]));
         }
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [675fbe69](https://github.com/openjdk/jdk/commit/675fbe699ed1aad37f34429cbe1f4f3e029be03f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Hamlin Li on 10 May 2024 and was reviewed by Christian Hagedorn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331993](https://bugs.openjdk.org/browse/JDK-8331993) needs maintainer approval

### Issue
 * [JDK-8331993](https://bugs.openjdk.org/browse/JDK-8331993): Add counting leading/trailing zero tests for Integer (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1194/head:pull/1194` \
`$ git checkout pull/1194`

Update a local copy of the PR: \
`$ git checkout pull/1194` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1194`

View PR using the GUI difftool: \
`$ git pr show -t 1194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1194.diff">https://git.openjdk.org/jdk21u-dev/pull/1194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1194#issuecomment-2515488349)
</details>
