### PR TITLE
8336012: Fix usages of jtreg-reserved properties

### DIFF
--- a/test/jdk/java/lang/invoke/PrivateInvokeTest.java
+++ b/test/jdk/java/lang/invoke/PrivateInvokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,8 +67,6 @@ public class PrivateInvokeTest {
         String vstr = System.getProperty(THIS_CLASS.getSimpleName()+".verbose");
         if (vstr == null)
             vstr = System.getProperty(THIS_CLASS.getName()+".verbose");
-        if (vstr == null)
-            vstr = System.getProperty("test.verbose");
         if (vstr != null)  verbose = Integer.parseInt(vstr);
     }
     private static int referenceKind(Method m) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e6c5aa7a](https://github.com/openjdk/jdk/commit/e6c5aa7a6cb54c647d261facdcffa6a410849627) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christian Stein on 10 Jul 2024 and was reviewed by Jonathan Gibbons.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336012](https://bugs.openjdk.org/browse/JDK-8336012) needs maintainer approval

### Issue
 * [JDK-8336012](https://bugs.openjdk.org/browse/JDK-8336012): Fix usages of jtreg-reserved properties (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1196/head:pull/1196` \
`$ git checkout pull/1196`

Update a local copy of the PR: \
`$ git checkout pull/1196` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1196`

View PR using the GUI difftool: \
`$ git pr show -t 1196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1196.diff">https://git.openjdk.org/jdk21u-dev/pull/1196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1196#issuecomment-2515592285)
</details>
