### PR TITLE
8334490: Normalize string with locale invariant `toLowerCase()`

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -35,6 +35,7 @@ import java.security.PrivilegedAction;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import static java.util.Locale.ROOT;
 
 public class Platform {
     public  static final String vmName      = privilegedGetProperty("java.vm.name");
@@ -134,7 +135,7 @@ public class Platform {
     }
 
     private static boolean isOs(String osname) {
-        return osName.toLowerCase().startsWith(osname.toLowerCase());
+        return osName.toLowerCase(ROOT).startsWith(osname.toLowerCase(ROOT));
     }
 
     public static String getOsName() {
@@ -175,15 +176,15 @@ public class Platform {
     }
 
     public static boolean isDebugBuild() {
-        return (jdkDebug.toLowerCase().contains("debug"));
+        return (jdkDebug.toLowerCase(ROOT).contains("debug"));
     }
 
     public static boolean isSlowDebugBuild() {
-        return (jdkDebug.toLowerCase().equals("slowdebug"));
+        return (jdkDebug.toLowerCase(ROOT).equals("slowdebug"));
     }
 
     public static boolean isFastDebugBuild() {
-        return (jdkDebug.toLowerCase().equals("fastdebug"));
+        return (jdkDebug.toLowerCase(ROOT).equals("fastdebug"));
     }
 
     public static String getVMVersion() {
@@ -350,8 +351,8 @@ public class Platform {
     }
 
     public static boolean isOracleLinux7() {
-        if (System.getProperty("os.name").toLowerCase().contains("linux") &&
-                System.getProperty("os.version").toLowerCase().contains("el")) {
+        if (System.getProperty("os.name").toLowerCase(ROOT).contains("linux") &&
+                System.getProperty("os.version").toLowerCase(ROOT).contains("el")) {
             Pattern p = Pattern.compile("el(\\d+)");
             Matcher m = p.matcher(System.getProperty("os.version"));
             if (m.find()) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [265a0f55](https://github.com/openjdk/jdk/commit/265a0f5547d0ddb220391aef679c122768f02a00) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Naoto Sato on 20 Jun 2024 and was reviewed by Justin Lu, Daniel Fuchs, Lance Andersen and Roger Riggs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334490](https://bugs.openjdk.org/browse/JDK-8334490) needs maintainer approval

### Issue
 * [JDK-8334490](https://bugs.openjdk.org/browse/JDK-8334490): Normalize string with locale invariant `toLowerCase()` (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1197/head:pull/1197` \
`$ git checkout pull/1197`

Update a local copy of the PR: \
`$ git checkout pull/1197` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1197`

View PR using the GUI difftool: \
`$ git pr show -t 1197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1197.diff">https://git.openjdk.org/jdk21u-dev/pull/1197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1197#issuecomment-2514915264)
</details>
