### PR TITLE
8333391: Test com/sun/jdi/InterruptHangTest.java failed: Thread was never interrupted during sleep

### DIFF
--- a/test/jdk/com/sun/jdi/InterruptHangTest.java
+++ b/test/jdk/com/sun/jdi/InterruptHangTest.java
@@ -62,8 +62,10 @@ class InterruptHangTarg {
         for (int ii = 0; ii < 200; ii++) {
             answer++;
             try {
-                // Give other thread a chance to run
-                Thread.sleep(100);
+                // Give other thread a chance to interrupt. Normally only a very short
+                // sleep is needed, but we need to account for unexpected delays in
+                // the interrupt due to machine and network hiccups.
+                Thread.sleep(10*1000);
             } catch (InterruptedException ee) {
                 System.out.println("Debuggee interruptee: interrupted at iteration: "
                                    + ii);


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

Resolved. Several virtual threads changes touched this file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8333391](https://bugs.openjdk.org/browse/JDK-8333391) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333391](https://bugs.openjdk.org/browse/JDK-8333391): Test com/sun/jdi/InterruptHangTest.java failed: Thread was never interrupted during sleep (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1202/head:pull/1202` \
`$ git checkout pull/1202`

Update a local copy of the PR: \
`$ git checkout pull/1202` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1202`

View PR using the GUI difftool: \
`$ git pr show -t 1202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1202.diff">https://git.openjdk.org/jdk21u-dev/pull/1202.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1202#issuecomment-2517591060)
</details>
