### PR TITLE
8338668: Test javax/swing/JFileChooser/8080628/bug8080628.java doesn't test for GTK L&F

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/8080628/bug8080628.java
+++ b/test/jdk/javax/swing/JFileChooser/8080628/bug8080628.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,17 @@ import sun.swing.SwingUtilities2;
  * @test
  * @bug 8080628
  * @summary No mnemonics on Open and Save buttons in JFileChooser.
- * @author Alexey Ivanov
+ * @requires os.family != "linux"
+ * @modules java.desktop/sun.swing
+ * @run main bug8080628
+ */
+
+/*
+ * @test
+ * @bug 8080628
+ * @key headful
+ * @summary No mnemonics on Open and Save buttons in JFileChooser.
+ * @requires os.family == "linux"
  * @modules java.desktop/sun.swing
  * @run main bug8080628
  */
@@ -81,8 +91,10 @@ public class bug8080628 {
                 try {
                     UIManager.setLookAndFeel(info.getClassName());
                 } catch (final UnsupportedLookAndFeelException ignored) {
+                    System.out.println("Unsupported L&F: " + info.getClassName());
                     continue;
                 }
+                System.out.println("Testing L&F: " + info.getClassName());
 
                 for (Locale locale : LOCALES) {
                     for (String key : MNEMONIC_KEYS) {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338668](https://bugs.openjdk.org/browse/JDK-8338668) needs maintainer approval

### Issue
 * [JDK-8338668](https://bugs.openjdk.org/browse/JDK-8338668): Test javax/swing/JFileChooser/8080628/bug8080628.java doesn't test for GTK L&amp;F (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1203/head:pull/1203` \
`$ git checkout pull/1203`

Update a local copy of the PR: \
`$ git checkout pull/1203` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1203`

View PR using the GUI difftool: \
`$ git pr show -t 1203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1203.diff">https://git.openjdk.org/jdk21u-dev/pull/1203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1203#issuecomment-2517645669)
</details>
