### PR TITLE
8337951: Test sun/security/validator/samedn.sh CertificateNotYetValidException: NotBefore validation

### DIFF
--- a/test/jdk/sun/security/validator/samedn.sh
+++ b/test/jdk/sun/security/validator/samedn.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -62,10 +62,11 @@ $KT -genkeypair -alias ca1 -dname CN=CA -keyalg rsa -sigalg md5withrsa -ext bc -
 $KT -genkeypair -alias ca2 -dname CN=CA -keyalg rsa -sigalg sha1withrsa -ext bc -startdate -1y
 $KT -genkeypair -alias user -dname CN=User -keyalg rsa
 
-# 2. Signing: ca -> user
+# 2. Signing: ca -> user. The startdate is set to 1 minute in the past to ensure the certificate
+# is valid at the time of validation and to prevent any issues with timing discrepancies
 
-$KT -certreq -alias user | $KT -gencert -rfc -alias ca1 > samedn1.certs
-$KT -certreq -alias user | $KT -gencert -rfc -alias ca2 > samedn2.certs
+$KT -certreq -alias user | $KT -gencert -rfc -alias ca1 -startdate -1M > samedn1.certs
+$KT -certreq -alias user | $KT -gencert -rfc -alias ca2 -startdate -1M > samedn2.certs
 
 # 3. Append the ca file
 


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337951](https://bugs.openjdk.org/browse/JDK-8337951) needs maintainer approval

### Issue
 * [JDK-8337951](https://bugs.openjdk.org/browse/JDK-8337951): Test sun/security/validator/samedn.sh CertificateNotYetValidException: NotBefore validation (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1204/head:pull/1204` \
`$ git checkout pull/1204`

Update a local copy of the PR: \
`$ git checkout pull/1204` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1204`

View PR using the GUI difftool: \
`$ git pr show -t 1204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1204.diff">https://git.openjdk.org/jdk21u-dev/pull/1204.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1204#issuecomment-2517663701)
</details>
