### PR TITLE
8340969: jdk/jfr/startupargs/TestStartDuration.java should be marked as flagless

### DIFF
--- a/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary Start a recording with duration. Verify recording stops.
  * @key jfr
  * @requires vm.hasJFR
+ * @requires vm.flagless
  * @library /test/lib /test/jdk
  * @run main jdk.jfr.startupargs.TestStartDuration
  */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [470701f0](https://github.com/openjdk/jdk/commit/470701f0bb269834cc0e1cb40f7d34e92226454b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Leonid Mesnik on 6 Dec 2024 and was reviewed by SendaoYan and Erik Gahlin.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340969](https://bugs.openjdk.org/browse/JDK-8340969) needs maintainer approval

### Issue
 * [JDK-8340969](https://bugs.openjdk.org/browse/JDK-8340969): jdk/jfr/startupargs/TestStartDuration.java should be marked as flagless (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1208/head:pull/1208` \
`$ git checkout pull/1208`

Update a local copy of the PR: \
`$ git checkout pull/1208` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1208`

View PR using the GUI difftool: \
`$ git pr show -t 1208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1208.diff">https://git.openjdk.org/jdk21u-dev/pull/1208.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1208#issuecomment-2524798295)
</details>
