### PR TITLE
8345684: OperatingSystemMXBean.getSystemCpuLoad() throws NPE

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -274,8 +274,13 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     }
 
     private boolean isCpuSetSameAsHostCpuSet() {
-        if (containerMetrics != null && containerMetrics.getCpuSetCpus() != null) {
-            return containerMetrics.getCpuSetCpus().length == getHostOnlineCpuCount0();
+        if (containerMetrics != null) {
+            // The return value may change (including from non-null to null) and
+            // the call may involve I/O, so keep the result in a local variable.
+            int[] cpuSetCpus = containerMetrics.getCpuSetCpus();
+            if (cpuSetCpus != null) {
+                return cpuSetCpus.length == getHostOnlineCpuCount0();
+            }
         }
         return false;
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345684](https://bugs.openjdk.org/browse/JDK-8345684) needs maintainer approval

### Issue
 * [JDK-8345684](https://bugs.openjdk.org/browse/JDK-8345684): OperatingSystemMXBean.getSystemCpuLoad() throws NPE (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1211/head:pull/1211` \
`$ git checkout pull/1211`

Update a local copy of the PR: \
`$ git checkout pull/1211` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1211`

View PR using the GUI difftool: \
`$ git pr show -t 1211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1211.diff">https://git.openjdk.org/jdk21u-dev/pull/1211.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1211#issuecomment-2527902265)
</details>
