### PR TITLE
8328085: C2: Use after free in PhaseChaitin::Register_Allocate()

### DIFF
--- a/src/hotspot/share/opto/postaloc.cpp
+++ b/src/hotspot/share/opto/postaloc.cpp
@@ -402,7 +402,6 @@ bool PhaseChaitin::eliminate_copy_of_constant(Node* val, Node* n,
 // as they get encountered with the merge node and keep adding these defs to the merge inputs.
 void PhaseChaitin::merge_multidefs() {
   Compile::TracePhase tp("mergeMultidefs", &timers[_t_mergeMultidefs]);
-  ResourceMark rm;
   // Keep track of the defs seen in registers and collect their uses in the block.
   RegToDefUseMap reg2defuse(_max_reg, _max_reg, RegDefUse());
   for (uint i = 0; i < _cfg.number_of_blocks(); i++) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit https://github.com/openjdk/jdk/commit/93aa7e2fcf87c4dc62de4ea71be543ee677b11be.

The commit being backported was authored by Richard Reingruber on 21 Nov 2024 and was reviewed by Tobias Hartmann and Martin Doerr.

The original commit did not apply because the `TracePhase` constructor used above the removed line was changed.
EDIT: the bot considers the backport to be clean.
// Actually I had to resolve the minimal conflict I mentioned above.

I'd consider the risk medium. There could be scenarios with higher memory usage in c2 register allocation.
DaCapo tests didn't show higher memory usage.
(the measuring code was part of the [original pull request](https://github.com/openjdk/jdk/pull/22200/commits))

```
Max. ResourceArea size in KB after C2 PhaseChaitin::merge_multidefs

DaCapo Benchmark        Basline        Pull Request

avrora                     2167               2167
batik                      2600               2509
biojava                    3125               3125
cassandra                   482                514
eclipse                    3408               3400
fop                        2863               2895
graphchi                   1331               1331
h2                         3204               3290
h2o                         638                514
jme                        2160               2160
jython                     9617               9649
kafka                      2577               2586
luindex                    2738               2902
lusearch                   2645               2645
pmd                        2931               2723
spring                     2958               3383
sunflow                    1437               1437
tomcat                     2668               2643
tradebeans                 2975               2663
tradesoap                  3124               2663
xalan                      3025               2826
zxing                      2473               2505
```

The fix passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests.
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le and AIX.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328085](https://bugs.openjdk.org/browse/JDK-8328085) needs maintainer approval

### Issue
 * [JDK-8328085](https://bugs.openjdk.org/browse/JDK-8328085): C2: Use after free in PhaseChaitin::Register_Allocate() (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1217/head:pull/1217` \
`$ git checkout pull/1217`

Update a local copy of the PR: \
`$ git checkout pull/1217` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1217`

View PR using the GUI difftool: \
`$ git pr show -t 1217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1217.diff">https://git.openjdk.org/jdk21u-dev/pull/1217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1217#issuecomment-2539872197)
</details>
