### PR TITLE
8343102: Remove `--compress` from jlink command lines from jpackage tests

### DIFF
--- a/test/jdk/tools/jpackage/share/RuntimeImageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.Functional;
 import jdk.jpackage.test.Annotations.Test;
-import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.JavaTool;
@@ -54,10 +53,7 @@ import jdk.jpackage.test.Executor;
 public class RuntimeImageTest {
 
     @Test
-    @Parameter("0")
-    @Parameter("1")
-    @Parameter("2")
-    public static void test(String compression) throws Exception {
+    public static void test() throws Exception {
         final Path workDir = TKit.createTempDirectory("runtime").resolve("data");
         final Path jlinkOutputDir = workDir.resolve("temp.runtime");
         Files.createDirectories(jlinkOutputDir.getParent());
@@ -67,7 +63,6 @@ public class RuntimeImageTest {
         .dumpOutput()
         .addArguments(
                 "--output", jlinkOutputDir.toString(),
-                "--compress=" + compression,
                 "--add-modules", "ALL-MODULE-PATH",
                 "--strip-debug",
                 "--no-header-files",

--- a/test/jdk/tools/jpackage/share/RuntimePackageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimePackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,6 @@ public class RuntimePackageTest {
                 .dumpOutput()
                 .addArguments(
                         "--output", runtimeImageDir.toString(),
-                        "--compress=0",
                         "--add-modules", "ALL-MODULE-PATH",
                         "--strip-debug",
                         "--no-header-files",


### PR DESCRIPTION
I backport this to keep 21u testing up to date.

Trivial resolves, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343102](https://bugs.openjdk.org/browse/JDK-8343102) needs maintainer approval

### Issue
 * [JDK-8343102](https://bugs.openjdk.org/browse/JDK-8343102): Remove `--compress` from jlink command lines from jpackage tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1219/head:pull/1219` \
`$ git checkout pull/1219`

Update a local copy of the PR: \
`$ git checkout pull/1219` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1219`

View PR using the GUI difftool: \
`$ git pr show -t 1219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1219.diff">https://git.openjdk.org/jdk21u-dev/pull/1219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1219#issuecomment-2536255850)
</details>
