### PR TITLE
8333116: test/jdk/tools/jpackage/share/ServiceTest.java test fails

### DIFF
--- a/test/jdk/tools/jpackage/share/ServiceTest.java
+++ b/test/jdk/tools/jpackage/share/ServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,9 @@ import jdk.jpackage.test.TKit;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile ServiceTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=360 -Xmx512m
+ *  --add-opens jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED
+ *  jdk.jpackage.test.Main
  *  --jpt-run=ServiceTest
  */
 public class ServiceTest {


### PR DESCRIPTION
I backport this to keep the 21u tests up to date.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333116](https://bugs.openjdk.org/browse/JDK-8333116) needs maintainer approval

### Issue
 * [JDK-8333116](https://bugs.openjdk.org/browse/JDK-8333116): test/jdk/tools/jpackage/share/ServiceTest.java test fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1220/head:pull/1220` \
`$ git checkout pull/1220`

Update a local copy of the PR: \
`$ git checkout pull/1220` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1220`

View PR using the GUI difftool: \
`$ git pr show -t 1220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1220.diff">https://git.openjdk.org/jdk21u-dev/pull/1220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1220#issuecomment-2536304241)
</details>
