### PR TITLE
8314909: tools/jpackage/windows/Win8282351Test.java fails with java.lang.AssertionError: Expected [0]. Actual [1618]:

### DIFF
--- a/test/jdk/tools/jpackage/TEST.properties
+++ b/test/jdk/tools/jpackage/TEST.properties
@@ -1,3 +1,12 @@
 keys=jpackagePlatformPackage
 requires.properties=jpackage.test.SQETest
 maxOutputSize=2000000
+
+# Run jpackage tests on windows platform sequentially.
+# Having "share" directory in the list affects tests on other platforms.
+# The better option would be:
+#   if (platfrom == windowws) {
+#     exclusiveAccess.dirs=share windows
+#   }
+# but conditionals are not supported by jtreg configuration files.
+exclusiveAccess.dirs=share windows


### PR DESCRIPTION
I backport this to improve testing on win.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314909](https://bugs.openjdk.org/browse/JDK-8314909) needs maintainer approval

### Issue
 * [JDK-8314909](https://bugs.openjdk.org/browse/JDK-8314909): tools/jpackage/windows/Win8282351Test.java fails with java.lang.AssertionError: Expected [0]. Actual [1618]: (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1225/head:pull/1225` \
`$ git checkout pull/1225`

Update a local copy of the PR: \
`$ git checkout pull/1225` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1225`

View PR using the GUI difftool: \
`$ git pr show -t 1225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1225.diff">https://git.openjdk.org/jdk21u-dev/pull/1225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1225#issuecomment-2538690608)
</details>
