### PR TITLE
8346108: [21u][BACKOUT] 8337994: [REDO] Native memory leak when not recording any events

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -756,15 +756,6 @@ static void write_classloaders() {
     CompositeCldCallback callback(&_subsystem_callback, &ccldwwc);
     do_class_loaders();
   }
-  if (is_initial_typeset_for_chunk()) {
-    CldPtr bootloader = get_cld(Universe::boolArrayKlassObj());
-    assert(bootloader != nullptr, "invariant");
-    if (IS_NOT_SERIALIZED(bootloader)) {
-      write__classloader(_writer, bootloader);
-      assert(IS_SERIALIZED(bootloader), "invariant");
-      cldw.add(1);
-    }
-  }
   _artifacts->tally(cldw);
 }
 

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -634,7 +634,11 @@ static void write_thread_local_buffer(JfrChunkWriter& chunkwriter, Thread* t) {
 
 size_t JfrRecorderService::flush() {
   size_t total_elements = flush_metadata(_chunkwriter);
-  total_elements = flush_storage(_storage, _chunkwriter);
+  const size_t storage_elements = flush_storage(_storage, _chunkwriter);
+  if (0 == storage_elements) {
+    return total_elements;
+  }
+  total_elements += storage_elements;
   if (_string_pool.is_modified()) {
     total_elements += flush_stringpool(_string_pool, _chunkwriter);
   }


### PR DESCRIPTION
The backport fo 8337994 causes test failures, so I want to back it out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346108](https://bugs.openjdk.org/browse/JDK-8346108) needs maintainer approval

### Issue
 * [JDK-8346108](https://bugs.openjdk.org/browse/JDK-8346108): [21u][BACKOUT] 8337994: [REDO] Native memory leak when not recording any events (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1226/head:pull/1226` \
`$ git checkout pull/1226`

Update a local copy of the PR: \
`$ git checkout pull/1226` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1226`

View PR using the GUI difftool: \
`$ git pr show -t 1226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1226.diff">https://git.openjdk.org/jdk21u-dev/pull/1226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1226#issuecomment-2539298090)
</details>
