### PR TITLE
8328753: Open source few Undecorated Frame tests

### DIFF
--- a/test/jdk/java/awt/Frame/FrameDialogMixedTest.java
+++ b/test/jdk/java/awt/Frame/FrameDialogMixedTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Dialog;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+
+/*
+ * @test
+ * @bug 4340727
+ * @summary Tests that undecorated property is set correctly
+ *          when Frames and Dialogs are mixed.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FrameDialogMixedTest
+ */
+
+public class FrameDialogMixedTest {
+    private static final int SIZE = 100;
+
+    private static final String INSTRUCTIONS = """
+            When the test starts, a RED UNDECORATED Frame is seen.
+            Click on "Create Dialog" button, you should see a GREEN UNDECORATED Dialog.
+            If both the frame and the dialog are undecorated press PASS otherwise FAIL.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .title("Undecorated Frame & Dialog Test Instructions")
+                      .instructions(INSTRUCTIONS)
+                      .rows((int) INSTRUCTIONS.lines().count() + 2)
+                      .columns(40)
+                      .testUI(FrameDialogMixedTest::createUI)
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame frame = new Frame("Undecorated Frame");
+        frame.setSize(SIZE, SIZE);
+        frame.setBackground(Color.RED);
+        frame.setUndecorated(true);
+        frame.setLayout(new FlowLayout(FlowLayout.CENTER));
+
+        Button button = new Button("Create Dialog");
+        button.addActionListener(e -> {
+            Dialog dialog = new Dialog(frame);
+            Point frameLoc = frame.getLocationOnScreen();
+            dialog.setBounds(frameLoc.x + frame.getSize().width + 5,
+                             frameLoc.y,
+                             SIZE, SIZE);
+            dialog.setBackground(Color.GREEN);
+            dialog.setUndecorated(true);
+            dialog.setVisible(true);
+        });
+
+        frame.add(button);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
+++ b/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Stream;
+import javax.imageio.ImageIO;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4862945
+ * @summary Undecorated frames miss certain mwm functions in the mwm hints.
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @run main MaximizeUndecoratedTest
+ */
+
+public class MaximizeUndecoratedTest {
+    private static final int SIZE = 300;
+    private static final int OFFSET = 2;
+
+    private static Frame frame;
+    private static Robot robot;
+
+    private static volatile Dimension screenSize;
+    private static volatile Rectangle maxBounds;
+
+    public static void main(String[] args) throws Exception {
+        if (!Toolkit.getDefaultToolkit()
+                    .isFrameStateSupported(Frame.MAXIMIZED_BOTH)) {
+            throw new SkippedException("Test is not applicable as"
+                    + " the Window manager does not support MAXIMIZATION");
+        }
+
+        try {
+            robot = new Robot();
+
+            EventQueue.invokeAndWait(MaximizeUndecoratedTest::createUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                maxBounds = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                                               .getMaximumWindowBounds();
+                System.out.println("Maximum Window Bounds: " + maxBounds);
+                frame.setExtendedState(Frame.MAXIMIZED_BOTH);
+            });
+            robot.waitForIdle();
+            robot.delay(500);
+
+            // Colors sampled at top-left, top-right, bottom-right & bottom-left
+            // corners of maximized frame.
+            Point[] points = new Point[] {
+                    new Point(maxBounds.x + OFFSET, maxBounds.y + OFFSET),
+                    new Point(maxBounds.width - OFFSET, maxBounds.y + OFFSET),
+                    new Point(maxBounds.width - OFFSET, maxBounds.height - OFFSET),
+                    new Point(maxBounds.x + OFFSET, maxBounds.height - OFFSET)
+            };
+
+            if (!Stream.of(points)
+                       .map(p -> robot.getPixelColor(p.x, p.y))
+                       .allMatch(c -> c.equals(Color.GREEN))) {
+                saveScreenCapture();
+                throw new RuntimeException("Test Failed !! Frame not maximized.");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.setExtendedState(Frame.NORMAL);
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createUI() {
+        frame = new Frame("Test Maximization of Frame");
+        frame.setSize(SIZE, SIZE);
+        frame.setBackground(Color.GREEN);
+        frame.setResizable(true);
+        frame.setUndecorated(true);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void saveScreenCapture() {
+        BufferedImage image = robot.createScreenCapture(new Rectangle(new Point(),
+                                                                      screenSize));
+        try {
+            ImageIO.write(image, "png", new File("MaximizedFrame.png"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
+++ b/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
@@ -50,7 +50,7 @@ import jtreg.SkippedException;
 
 public class MaximizeUndecoratedTest {
     private static final int SIZE = 300;
-    private static final int OFFSET = 2;
+    private static final int OFFSET = 5;
 
     private static Frame frame;
     private static Robot robot;

--- a/test/jdk/java/awt/Frame/MinimizeUndecoratedTest.java
+++ b/test/jdk/java/awt/Frame/MinimizeUndecoratedTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.imageio.ImageIO;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @key headful
+ * @bug 6251941
+ * @summary Undecorated frames should be minimizable.
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @run main MinimizeUndecoratedTest
+ */
+
+public class MinimizeUndecoratedTest {
+    private static final int SIZE = 300;
+    private static final CountDownLatch isMinimized = new CountDownLatch(1);
+
+    private static Frame frame;
+    private static Robot robot;
+
+    private static volatile Point frameLoc;
+
+    public static void main(String[] args) throws Exception {
+        if (!Toolkit.getDefaultToolkit()
+                    .isFrameStateSupported(Frame.ICONIFIED)) {
+            throw new SkippedException("Test is not applicable as"
+                    + " the Window manager does not support MINIMIZATION");
+        }
+
+        try {
+            robot = new Robot();
+            EventQueue.invokeAndWait(MinimizeUndecoratedTest::createUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> frameLoc = frame.getLocationOnScreen());
+
+            Color beforeColor = robot.getPixelColor(frameLoc.x + SIZE / 2,
+                                                    frameLoc.y + SIZE / 2);
+
+            EventQueue.invokeAndWait(() -> frame.setExtendedState(Frame.ICONIFIED));
+            robot.waitForIdle();
+            robot.delay(500);
+
+            if (!isMinimized.await(8, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Window iconified event not received.");
+            }
+
+            EventQueue.invokeAndWait(() -> System.out.println("Frame state: "
+                                                              + frame.getExtendedState()));
+            Color afterColor = robot.getPixelColor(frameLoc.x + SIZE / 2,
+                                                   frameLoc.y + SIZE / 2);
+
+            if (beforeColor.equals(afterColor)) {
+                saveScreenCapture();
+                throw new RuntimeException("Color before & after minimization : "
+                                           + beforeColor + " vs " + afterColor + "\n"
+                                           + "Test Failed !! Frame not minimized.");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.setExtendedState(Frame.NORMAL);
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createUI() {
+        frame = new Frame("Test Minimization of Frame");
+        frame.setSize(SIZE, SIZE);
+        frame.setBackground(Color.GREEN);
+        frame.setResizable(true);
+        frame.setUndecorated(true);
+        frame.addWindowStateListener(new WindowAdapter() {
+            @Override
+            public void windowStateChanged(WindowEvent e) {
+                if (e.getNewState() == Frame.ICONIFIED) {
+                    System.out.println("Window iconified event received.");
+                    isMinimized.countDown();
+                }
+            }
+        });
+
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void saveScreenCapture() {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        BufferedImage image = robot.createScreenCapture(new Rectangle(new Point(),
+                                                                      screenSize));
+        try {
+            ImageIO.write(image, "png", new File("MinimizedFrame.png"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle.

I include follow-up fix JDK-8337886.

Tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328753](https://bugs.openjdk.org/browse/JDK-8328753) needs maintainer approval
- [x] [JDK-8337886](https://bugs.openjdk.org/browse/JDK-8337886) needs maintainer approval

### Issues
 * [JDK-8328753](https://bugs.openjdk.org/browse/JDK-8328753): Open source few Undecorated Frame tests (**Bug** - P4 - Approved)
 * [JDK-8337886](https://bugs.openjdk.org/browse/JDK-8337886): java/awt/Frame/MaximizeUndecoratedTest.java fails in OEL due to a slight color difference (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1228/head:pull/1228` \
`$ git checkout pull/1228`

Update a local copy of the PR: \
`$ git checkout pull/1228` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1228`

View PR using the GUI difftool: \
`$ git pr show -t 1228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1228.diff">https://git.openjdk.org/jdk21u-dev/pull/1228.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1228#issuecomment-2541163308)
</details>
