### PR TITLE
8333360: PrintNullString.java doesn't use float arguments

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
@@ -148,7 +148,7 @@ public class PrintNullString extends Frame {
             // API 3: null & empty drawString(Iterator, int, int);
             try {
                 g2d.drawString(nullIterator, 20, 120);
-                g2d.drawString("FAILURE: No NPE for null iterator, float", 20, 120);
+                g2d.drawString("FAILURE: No NPE for null iterator, int", 20, 120);
             } catch (NullPointerException e) {
                 g2d.drawString("caught expected NPE for null iterator, int", 20, 120);
             }
@@ -169,7 +169,7 @@ public class PrintNullString extends Frame {
             }
 
             try {
-                g2d.drawString(emptyIterator, 20, 180);
+                g2d.drawString(emptyIterator, 20.0f, 180.0f);
                 g2d.drawString("FAILURE: No IAE for empty iterator, float", 20, 180);
             } catch (IllegalArgumentException e) {
                 g2d.drawString("caught expected IAE for empty iterator, float", 20, 180);


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8333360](https://bugs.openjdk.org/browse/JDK-8333360) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333360](https://bugs.openjdk.org/browse/JDK-8333360): PrintNullString.java doesn't use float arguments (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1238/head:pull/1238` \
`$ git checkout pull/1238`

Update a local copy of the PR: \
`$ git checkout pull/1238` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1238`

View PR using the GUI difftool: \
`$ git pr show -t 1238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1238.diff">https://git.openjdk.org/jdk21u-dev/pull/1238.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1238#issuecomment-2545052981)
</details>
