### PR TITLE
8328185: Convert java/awt/image/MemoryLeakTest/MemoryLeakTest.java applet test to main

### DIFF
--- a/test/jdk/java/awt/image/MemoryLeakTest/MemoryLeakTest.java
+++ b/test/jdk/java/awt/image/MemoryLeakTest/MemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,154 +22,101 @@
  */
 
 /* @test
-   @bug 4078566 6658398
-   @summary Test for a memory leak in Image.
-   @run main/manual MemoryLeakTest
-*/
+ * @bug 4078566 6658398
+ * @requires (os.family == "linux")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Test for a memory leak in Image.
+ * @run main/manual MemoryLeakTest
+ */
 
-import java.applet.Applet;
-import java.lang.*;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 
-class Globals {
-  static boolean testPassed=false;
-  static Thread mainThread=null;
-}
+public class MemoryLeakTest {
+    private static final String INSTRUCTIONS =
+        """
+         Do the following steps on Unix platforms.
+         Maximize and minimize the Memory Leak Test window.
+         Execute the following after minimize.
+             ps -al | egrep -i 'java|PPID'
+         Examine the size of the process under SZ.
+         Maximize and minimize the Memory Leak Test window again.
+         Execute the following after minimize.
+             ps -al | egrep -i 'java|PPID'
+         Examine the size of the process under SZ.
+         If the two SZ values are the same, plus or minus one,
+         then click Pass, else click Fail.
+        """;
 
-public class MemoryLeakTest extends Applet {
-
-public static void main(String args[]) throws Exception {
-  new TestDialog(new Frame(), "MemoryLeakTest").start();
-  new MemoryLeak().start();
-  Globals.mainThread = Thread.currentThread();
-  try {
-    Thread.sleep(300000);
-  } catch (InterruptedException e) {
-    if (!Globals.testPassed)
-      throw new Exception("MemoryLeakTest failed.");
-  }
-}
-
-}
-
-class TestDialog extends Dialog
-    implements ActionListener {
-
-TextArea output;
-Button passButton;
-Button failButton;
-String name;
-
-public TestDialog(Frame frame, String name)
-{
-  super(frame, name + " Pass/Fail Dialog");
-  this.name = name;
-  output = new TextArea(11, 50);
-  add("North", output);
-  output.append("Do the following steps on Solaris only.\n");
-  output.append("Maximize and minimize the Memory Leak Test window.\n");
-  output.append("Execute the following after minimize.\n");
-  output.append("    ps -al | egrep -i 'java|PPID'\n");
-  output.append("Examine the size of the process under SZ.\n");
-  output.append("Maximize and minimize the Memory Leak Test window again.\n");
-  output.append("Execute the following after minimize.\n");
-  output.append("    ps -al | egrep -i 'java|PPID'\n");
-  output.append("Examine the size of the process under SZ.\n");
-  output.append("If the two SZ values are the same, plus or minus one,\n");
-  output.append("then click Pass, else click Fail.");
-  Panel buttonPanel = new Panel();
-  passButton = new Button("Pass");
-  failButton = new Button("Fail");
-  passButton.addActionListener(this);
-  failButton.addActionListener(this);
-  buttonPanel.add(passButton);
-  buttonPanel.add(failButton);
-  add("South", buttonPanel);
-  pack();
-}
-
-public void start()
-{
-  show();
-}
-
-public void actionPerformed(ActionEvent event)
-{
-    if ( event.getSource() == passButton ) {
-      Globals.testPassed = true;
-      System.err.println(name + " Passed.");
-    }
-    else if ( event.getSource() == failButton ) {
-      Globals.testPassed = false;
-      System.err.println(name + " Failed.");
-    }
-    this.dispose();
-    if (Globals.mainThread != null)
-      Globals.mainThread.interrupt();
-}
-
-}
-
-
-class MemoryLeak extends Frame implements ComponentListener
-{
-private Image osImage;
-
-public MemoryLeak()
-{
-    super("Memory Leak Test");
-    setSize(200, 200);
-    addComponentListener(this);
-}
-
-public static void main(String args[])
-{
-   new MemoryLeak().start();
-}
-
-public void start()
-{
-  show();
-}
-
-public void paint(Graphics g) {
-    if (osImage != null) {
-        g.drawImage(osImage, 0, 0, this);
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame
+            .builder()
+            .title("MemoryLeakTest Instructions")
+            .instructions(INSTRUCTIONS)
+            .rows(15)
+            .columns(40)
+            .testUI(MemoryLeak::new)
+            .build()
+            .awaitAndCheck();
     }
 }
 
-public void update(Graphics g)
-{
-    paint(g);
-}
+class MemoryLeak extends Frame implements ComponentListener {
+    private Image osImage;
 
-public void componentResized(ComponentEvent e)
-{
-    Image oldimage = osImage;
-    osImage = createImage(getSize().width, getSize().height);
-    Graphics g = osImage.getGraphics();
-    if (oldimage != null) {
-        g.drawImage(oldimage, 0, 0, getSize().width, getSize().height, this);
-        oldimage.flush();
-    } else {
+    public MemoryLeak() {
+        super("Memory Leak Test");
+        setSize(200, 200);
+        addComponentListener(this);
+    }
+
+    public static void main(String[] args) {
+        new MemoryLeak().start();
+    }
+
+    public void start() {
+        setVisible(true);
+    }
+
+    public void paint(Graphics g) {
+        if (osImage != null) {
+            g.drawImage(osImage, 0, 0, this);
+        }
+    }
+
+    public void update(Graphics g) {
+        paint(g);
+    }
+
+    public void componentResized(ComponentEvent e) {
+        Image oldimage = osImage;
+        osImage = createImage(getSize().width, getSize().height);
+        Graphics g = osImage.getGraphics();
+        if (oldimage != null) {
+            g.drawImage(oldimage, 0, 0, getSize().width, getSize().height, this);
+            oldimage.flush();
+        } else {
+            g.setColor(Color.blue);
+            g.drawLine(0, 0, getSize().width, getSize().height);
+        }
+        g.dispose();
+    }
+
+    public void componentMoved(ComponentEvent e) {}
+
+    public void componentShown(ComponentEvent e) {
+        osImage = createImage(getSize().width, getSize().height);
+        Graphics g = osImage.getGraphics();
         g.setColor(Color.blue);
         g.drawLine(0, 0, getSize().width, getSize().height);
+        g.dispose();
     }
-    g.dispose();
-}
 
-public void componentMoved(ComponentEvent e) {}
-
-public void componentShown(ComponentEvent e)
-{
-    osImage = createImage(getSize().width, getSize().height);
-    Graphics g = osImage.getGraphics();
-    g.setColor(Color.blue);
-    g.drawLine(0, 0, getSize().width, getSize().height);
-    g.dispose();
-}
-
-public void componentHidden(ComponentEvent e) {}
+    public void componentHidden(ComponentEvent e) {}
 
 }


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328185](https://bugs.openjdk.org/browse/JDK-8328185) needs maintainer approval

### Issue
 * [JDK-8328185](https://bugs.openjdk.org/browse/JDK-8328185): Convert java/awt/image/MemoryLeakTest/MemoryLeakTest.java applet test to main (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1245/head:pull/1245` \
`$ git checkout pull/1245`

Update a local copy of the PR: \
`$ git checkout pull/1245` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1245`

View PR using the GUI difftool: \
`$ git pr show -t 1245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1245.diff">https://git.openjdk.org/jdk21u-dev/pull/1245.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1245#issuecomment-2547959526)
</details>
