### PR TITLE
8339475: Clean up return code handling for pthread calls in library coding

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -333,6 +333,7 @@ static void ParkEventLoop() {
 static void MacOSXStartup(int argc, char *argv[]) {
     // Thread already started?
     static jboolean started = false;
+    int rc;
     if (started) {
         return;
     }
@@ -345,12 +346,14 @@ static void MacOSXStartup(int argc, char *argv[]) {
 
     // Fire up the main thread
     pthread_t main_thr;
-    if (pthread_create(&main_thr, NULL, &apple_main, &args) != 0) {
-        JLI_ReportErrorMessageSys("Could not create main thread: %s\n", strerror(errno));
+    rc = pthread_create(&main_thr, NULL, &apple_main, &args);
+    if (rc != 0) {
+        JLI_ReportErrorMessageSys("Could not create main thread, return code: %d\n", rc);
         exit(1);
     }
-    if (pthread_detach(main_thr)) {
-        JLI_ReportErrorMessageSys("pthread_detach() failed: %s\n", strerror(errno));
+    rc = pthread_detach(main_thr);
+    if (rc != 0) {
+        JLI_ReportErrorMessage("pthread_detach() failed, return code: %d\n", rc);
         exit(1);
     }
 

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -200,13 +200,7 @@ JLI_ReportErrorMessage(const char* fmt, ...) {
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessageSys(const char* fmt, ...) {
     va_list vl;
-    char *emsg;
-
-    /*
-     * TODO: its safer to use strerror_r but is not available on
-     * Solaris 8. Until then....
-     */
-    emsg = strerror(errno);
+    char *emsg = strerror(errno);
     if (emsg != NULL) {
         fprintf(stderr, "%s\n", emsg);
     }

--- a/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
+++ b/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
@@ -271,11 +271,13 @@ void
 SplashCreateThread(Splash * splash) {
     pthread_t thr;
     pthread_attr_t attr;
-    int rc;
 
     int rslt = pthread_attr_init(&attr);
     if (rslt != 0) return;
-    rc = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    rslt = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    if (rslt != 0) {
+        fprintf(stderr, "Could not create SplashScreen thread, error number:%d\n", rslt);
+    }
     pthread_attr_destroy(&attr);
 }
 

--- a/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
+++ b/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
@@ -771,11 +771,13 @@ void
 SplashCreateThread(Splash * splash) {
     pthread_t thr;
     pthread_attr_t attr;
-    int rc;
 
     int rslt = pthread_attr_init(&attr);
     if (rslt != 0) return;
-    rc = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    rslt = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    if (rslt != 0) {
+        fprintf(stderr, "Could not create SplashScreen thread, error number:%d\n", rslt);
+    }
     pthread_attr_destroy(&attr);
 }
 


### PR DESCRIPTION
Backport of 8339475 + follow up 8341135

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339475](https://bugs.openjdk.org/browse/JDK-8339475) needs maintainer approval
- [x] [JDK-8341135](https://bugs.openjdk.org/browse/JDK-8341135) needs maintainer approval

### Issues
 * [JDK-8339475](https://bugs.openjdk.org/browse/JDK-8339475): Clean up return code handling for pthread calls in library coding (**Bug** - P4 - Approved)
 * [JDK-8341135](https://bugs.openjdk.org/browse/JDK-8341135): Incorrect format string after JDK-8339475 (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1247/head:pull/1247` \
`$ git checkout pull/1247`

Update a local copy of the PR: \
`$ git checkout pull/1247` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1247`

View PR using the GUI difftool: \
`$ git pr show -t 1247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1247.diff">https://git.openjdk.org/jdk21u-dev/pull/1247.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1247#issuecomment-2548465357)
</details>
