### PR TITLE
8321818: vmTestbase/nsk/stress/strace/strace015.java failed with 'Cannot read the array length because "<local4>" is null'

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,6 +125,11 @@ public class strace007 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,6 +129,11 @@ public class strace008 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 4) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,6 +129,11 @@ public class strace009 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace010.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,6 +145,11 @@ public class strace010 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace011.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,6 +149,11 @@ public class strace011 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,6 +151,11 @@ public class strace012 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace013.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace013.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,6 +130,11 @@ public class strace013 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 3) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace014.java
@@ -140,6 +140,11 @@ public class strace014 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 4) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,6 +138,11 @@ public class strace015 extends StraceBase {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 3) {
                 complain("wrong lengths of stack traces:\n\t"


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ea50c54a](https://github.com/openjdk/jdk/commit/ea50c54a14d39fcedabe8426a14eaec27ab24af2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by David Holmes on 18 Dec 2024 and was reviewed by Leonid Mesnik and Hamlin Li.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321818](https://bugs.openjdk.org/browse/JDK-8321818) needs maintainer approval

### Issue
 * [JDK-8321818](https://bugs.openjdk.org/browse/JDK-8321818): vmTestbase/nsk/stress/strace/strace015.java failed with 'Cannot read the array length because "&lt;local4&gt;" is null' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1254/head:pull/1254` \
`$ git checkout pull/1254`

Update a local copy of the PR: \
`$ git checkout pull/1254` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1254`

View PR using the GUI difftool: \
`$ git pr show -t 1254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1254.diff">https://git.openjdk.org/jdk21u-dev/pull/1254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1254#issuecomment-2550515988)
</details>
