### PR TITLE
8343128: PassFailJFrame.java test result: Error. Bad action for script: build}

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -184,21 +184,23 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  *
  * <p id="jtregTagsForTest">
  * Add the following jtreg tags before the test class declaration
- * {@snippet :
+ * <pre><code>
  * /*
- *  * @test
+ *  * &#64;test
  *  * @summary Sample manual test
  *  * @library /java/awt/regtesthelpers
  *  * @build PassFailJFrame
  *  * @run main/manual SampleManualTest
- * }
- * and the closing comment tag <code>*&#47;</code>.
+ *  *&#47;
+ * </code></pre>
  * <p>
  * The {@code @library} tag points to the location of the
  * {@code PassFailJFrame} class in the source code;
  * the {@code @build} tag makes jtreg compile the {@code PassFailJFrame} class,
  * and finally the {@code @run} tag specifies it is a manual
  * test and the class to run.
+ * <p>
+ * Don't forget to update the name of the class to run in the {@code @run} tag.
  *
  * <h2 id="usingBuilder">Using {@code Builder}</h2>
  * Use methods of the {@link Builder Builder} class to set or change


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343128](https://bugs.openjdk.org/browse/JDK-8343128) needs maintainer approval

### Issue
 * [JDK-8343128](https://bugs.openjdk.org/browse/JDK-8343128): PassFailJFrame.java test result: Error. Bad action for script: build} (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1256/head:pull/1256` \
`$ git checkout pull/1256`

Update a local copy of the PR: \
`$ git checkout pull/1256` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1256`

View PR using the GUI difftool: \
`$ git pr show -t 1256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1256.diff">https://git.openjdk.org/jdk21u-dev/pull/1256.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1256#issuecomment-2550645868)
</details>
