### PR TITLE
8344646: The libjsig deprecation warning should go to stderr not stdout

### DIFF
--- a/src/java.base/unix/native/libjsig/jsig.c
+++ b/src/java.base/unix/native/libjsig/jsig.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -102,9 +102,9 @@ static sa_handler_t call_os_signal(int sig, sa_handler_t disp,
 
   if (os_signal == NULL) {
     // Deprecation warning first time through
-    printf(HOTSPOT_VM_DISTRO " VM warning: the use of signal() and sigset() "
-           "for signal chaining was deprecated in version 16.0 and will "
-           "be removed in a future release. Use sigaction() instead.\n");
+    fprintf(stderr, HOTSPOT_VM_DISTRO " VM warning: the use of signal() and sigset() "
+            "for signal chaining was deprecated in version 16.0 and will "
+            "be removed in a future release. Use sigaction() instead.\n");
     if (!is_sigset) {
       os_signal = (signal_function_t)dlsym(RTLD_NEXT, "signal");
     } else {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8344646](https://bugs.openjdk.org/browse/JDK-8344646) needs maintainer approval

### Issue
 * [JDK-8344646](https://bugs.openjdk.org/browse/JDK-8344646): The libjsig deprecation warning should go to stderr not stdout (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1267/head:pull/1267` \
`$ git checkout pull/1267`

Update a local copy of the PR: \
`$ git checkout pull/1267` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1267`

View PR using the GUI difftool: \
`$ git pr show -t 1267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1267.diff">https://git.openjdk.org/jdk21u-dev/pull/1267.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1267#issuecomment-2551354904)
</details>
