### PR TITLE
8315952: Open source several Swing JToolbar JTooltip JTree tests

### DIFF
--- a/test/jdk/javax/swing/JToolBar/bug4368050.java
+++ b/test/jdk/javax/swing/JToolBar/bug4368050.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4368050
+ * @summary Default toolbar layout manager should be serializable.
+ * @run main bug4368050
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import javax.swing.JToolBar;
+
+public class bug4368050 {
+    public static void main(String[] args) throws Exception {
+        JToolBar toolBar = new JToolBar();
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(toolBar);
+            byte[] buf = baos.toByteArray();
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(buf);
+                 ObjectInputStream ois = new ObjectInputStream(bais)) {
+                ois.readObject();
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4465534.java
+++ b/test/jdk/javax/swing/JToolBar/bug4465534.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4465534
+ * @summary Tests adding borderless button to a toolbar
+ * @run main bug4465534
+ */
+
+import javax.swing.JButton;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+public class bug4465534 {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JToolBar toolbar = new JToolBar();
+            JButton button = new JButton("text");
+            button.setBorder(null);
+            toolbar.add(button);
+        });
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4700351.java
+++ b/test/jdk/javax/swing/JToolBar/bug4700351.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4700351
+ * @summary Checks if JToolBar keeps orientation when dragged off
+ * @key headful
+ * @run main bug4700351
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+import javax.swing.plaf.basic.BasicToolBarUI;
+
+public class bug4700351 {
+    static JFrame fr;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("bug4700351");
+                JToolBar tb = new JToolBar();
+                tb.setOrientation(JToolBar.VERTICAL);
+                fr.add(tb);
+                BasicToolBarUI ui = (javax.swing.plaf.basic.BasicToolBarUI) tb.getUI();
+                if (!ui.isFloating()) {
+                    ui.setFloatingLocation(100, 100);
+                    ui.setFloating(true, tb.getLocation());
+                }
+                if (tb.getOrientation() != JToolBar.VERTICAL) {
+                    throw new RuntimeException("Error: toolbar's orientation " +
+                            "has changed");
+                }
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JToolTip/bug4107843.java
+++ b/test/jdk/javax/swing/JToolTip/bug4107843.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4107843
+ * @summary ToolTipText for JTabbedPane.
+ * @run main bug4107843
+ */
+
+import javax.swing.JButton;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
+public class bug4107843 {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JTabbedPane tp = new JTabbedPane();
+            tp.add("First", new JButton("Button1"));
+            tp.add("Second", new JButton("Button2"));
+            tp.setToolTipTextAt(0, "first button");
+            if (!tp.getToolTipTextAt(0).equals("first button")) {
+                throw new RuntimeException("ToolTipText isn't set " +
+                        "as expected...");
+            }
+            tp.setToolTipTextAt(1, "second button");
+            if (!tp.getToolTipTextAt(1).equals("second button")) {
+                throw new RuntimeException("ToolTipText isn't set " +
+                        "as expected...");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JTree/bug4161685.java
+++ b/test/jdk/javax/swing/JTree/bug4161685.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4161685
+ * @summary JTree now has the public methods setAnchorSelectionPath,
+ * getAnchorSelectionPath, setLeadSelectionPath.
+ * @run main bug4161685
+ */
+
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.TreePath;
+
+public class bug4161685 {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JTree tr = new JTree();
+            TreePath tp = tr.getPathForRow(2);
+            tr.setAnchorSelectionPath(tp);
+            if (tr.getAnchorSelectionPath() != tp) {
+                throw new RuntimeException("AnchorSelectionPath isn't " +
+                        "set correctly...");
+            }
+            tr.setLeadSelectionPath(tp);
+            if (tr.getLeadSelectionPath() != tp) {
+                throw new RuntimeException("LeadSelectionPath isn't " +
+                        "set correctly...");
+            }
+        });
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315952](https://bugs.openjdk.org/browse/JDK-8315952) needs maintainer approval

### Issue
 * [JDK-8315952](https://bugs.openjdk.org/browse/JDK-8315952): Open source several Swing JToolbar JTooltip JTree tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1270/head:pull/1270` \
`$ git checkout pull/1270`

Update a local copy of the PR: \
`$ git checkout pull/1270` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1270`

View PR using the GUI difftool: \
`$ git pr show -t 1270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1270.diff">https://git.openjdk.org/jdk21u-dev/pull/1270.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1270#issuecomment-2553209738)
</details>
