### PR TITLE
8346713: [testsuite] NeverActAsServerClassMachine breaks TestPLABAdaptToMinTLABSize.java TestPinnedHumongousFragmentation.java TestPinnedObjectContents.java

### DIFF
--- a/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
+++ b/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
@@ -24,17 +24,29 @@
 package gc;
 
 /*
- * @test TestPLABAdaptToMinTLABSize
+ * @test TestPLABAdaptToMinTLABSizeG1
  * @bug 8289137
  * @summary Make sure that Young/OldPLABSize adapt to MinTLABSize setting.
- * @requires vm.gc.Parallel | vm.gc.G1
+ * @requires vm.gc.G1
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver gc.TestPLABAdaptToMinTLABSize
+ * @run driver gc.TestPLABAdaptToMinTLABSize -XX:+UseG1GC
+ */
+
+/*
+ * @test TestPLABAdaptToMinTLABSizeParallel
+ * @bug 8289137
+ * @summary Make sure that Young/OldPLABSize adapt to MinTLABSize setting.
+ * @requires vm.gc.Parallel
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver gc.TestPLABAdaptToMinTLABSize -XX:+UseParallelGC
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -68,9 +80,10 @@ public class TestPLABAdaptToMinTLABSize {
     }
 
     public static void main(String[] args) throws Exception {
-        runTest(true, "-XX:MinTLABSize=100k");
+        String gc = args[0];
+        runTest(true, gc, "-XX:MinTLABSize=100k");
         // Should not succeed when explicitly specifying invalid combination.
-        runTest(false, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
-        runTest(false, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
+        runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
+        runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
     }
 }


### PR DESCRIPTION
Only `TestPLABAdaptToMinTLABSize.java` is a clean backport.
`TestPinnedHumongousFragmentation.java` and `TestPinnedObjectContents.java` did not exist in JDK 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346713](https://bugs.openjdk.org/browse/JDK-8346713) needs maintainer approval

### Issue
 * [JDK-8346713](https://bugs.openjdk.org/browse/JDK-8346713): [testsuite] NeverActAsServerClassMachine breaks TestPLABAdaptToMinTLABSize.java TestPinnedHumongousFragmentation.java TestPinnedObjectContents.java (**Bug** - P4 - Approved)


### Reviewers
 * [Alexey Bakhtin](https://openjdk.org/census#abakhtin) (@alexeybakhtin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1277/head:pull/1277` \
`$ git checkout pull/1277`

Update a local copy of the PR: \
`$ git checkout pull/1277` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1277`

View PR using the GUI difftool: \
`$ git pr show -t 1277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1277.diff">https://git.openjdk.org/jdk21u-dev/pull/1277.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1277#issuecomment-2557989721)
</details>
