### PR TITLE
8343101: Rework BasicTest.testTemp test cases

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestBuilder.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestBuilder.java
@@ -392,6 +392,9 @@ final class TestBuilder implements AutoCloseable {
     }
 
     private static Object fromString(String value, Class toType) {
+        if (toType.isEnum()) {
+            return Enum.valueOf(toType, value);
+        }
         Function<String, Object> converter = conv.get(toType);
         if (converter == null) {
             throw new RuntimeException(String.format(

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import jdk.jpackage.test.TKit;
@@ -264,49 +263,64 @@ public final class BasicTest {
         cmd.executeAndAssertHelloAppImageCreated();
     }
 
+    public static enum TestTempType {
+        TEMPDIR_EMPTY,
+        TEMPDIR_NOT_EMPTY,
+        TEMPDIR_NOT_EXIST,
+    }
+
     /**
      * Test --temp option. Doesn't make much sense for app image as temporary
      * directory is used only on Windows. Test it in packaging mode.
-     * @throws IOException
      */
     @Test
-    @Parameter("true")
-    @Parameter("false")
-    public void testTemp(boolean withExistingTempDir) throws IOException {
+    @Parameter("TEMPDIR_EMPTY")
+    @Parameter("TEMPDIR_NOT_EMPTY")
+    @Parameter("TEMPDIR_NOT_EXIST")
+    public void testTemp(TestTempType type) throws IOException {
         final Path tempRoot = TKit.createTempDirectory("tmp");
 
-        Supplier<PackageTest> createTest = () -> {
-            return new PackageTest()
-            .configureHelloApp()
-            // Force save of package bundle in test work directory.
-            .addInitializer(JPackageCommand::setDefaultInputOutput)
-            .addInitializer(cmd -> {
-                Path tempDir = getTempDirectory(cmd, tempRoot);
-                if (withExistingTempDir) {
-                    Files.createDirectories(tempDir);
-                } else {
-                    Files.createDirectories(tempDir.getParent());
+        var pkgTest = new PackageTest()
+        .configureHelloApp()
+        // Force save of package bundle in test work directory.
+        .addInitializer(JPackageCommand::setDefaultInputOutput)
+        .addInitializer(cmd -> {
+            Path tempDir = getTempDirectory(cmd, tempRoot);
+            switch (type) {
+                    case TEMPDIR_EMPTY -> Files.createDirectories(tempDir);
+                    case TEMPDIR_NOT_EXIST -> Files.createDirectories(tempDir.getParent());
+                    case TEMPDIR_NOT_EMPTY -> {
+                        Files.createDirectories(tempDir);
+                        TKit.createTextFile(tempDir.resolve("foo.txt"), List.of(
+                                "Hello Duke!"));
+                    }
                 }
                 cmd.addArguments("--temp", tempDir);
+            }
+        );
+
+        if (TestTempType.TEMPDIR_NOT_EMPTY.equals(type)) {
+            pkgTest.setExpectedExitCode(1).addBundleVerifier(cmd -> {
+                // Check jpackage didn't use the supplied directory.
+                Path tempDir = getTempDirectory(cmd, tempRoot);
+                String[] tempDirContents = tempDir.toFile().list();
+                TKit.assertStringListEquals(List.of("foo.txt"), List.of(
+                        tempDirContents), String.format(
+                                "Check the contents of the supplied temporary directory [%s]",
+                                tempDir));
+                TKit.assertStringListEquals(List.of("Hello Duke!"),
+                        Files.readAllLines(tempDir.resolve(tempDirContents[0])),
+                        "Check the contents of the file in the supplied temporary directory");
             });
-        };
+        } else {
+            pkgTest.addBundleVerifier(cmd -> {
+                // Check jpackage used the supplied directory.
+                Path tempDir = getTempDirectory(cmd, tempRoot);
+                TKit.assertPathNotEmptyDirectory(tempDir);
+            });
+        }
 
-        createTest.get()
-        .addBundleVerifier(cmd -> {
-            // Check jpackage actually used the supplied directory.
-            Path tempDir = getTempDirectory(cmd, tempRoot);
-            TKit.assertNotEquals(0, tempDir.toFile().list().length,
-                    String.format(
-                            "Check jpackage wrote some data in the supplied temporary directory [%s]",
-                            tempDir));
-        })
-        .run(PackageTest.Action.CREATE);
-
-        createTest.get()
-        // Temporary directory should not be empty,
-        // jpackage should exit with error.
-        .setExpectedExitCode(1)
-        .run(PackageTest.Action.CREATE);
+        pkgTest.run(PackageTest.Action.CREATE);
     }
 
     @Test

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -316,7 +316,7 @@ public final class BasicTest {
             pkgTest.addBundleVerifier(cmd -> {
                 // Check jpackage used the supplied directory.
                 Path tempDir = getTempDirectory(cmd, tempRoot);
-                TKit.assertPathNotEmptyDirectory(tempDir);
+                TKit.assertDirectoryNotEmpty(tempDir);
             });
         }
 


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

I include follow-up JDK-8343178, without that the test does not compile.

Two clean backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8343101](https://bugs.openjdk.org/browse/JDK-8343101) needs maintainer approval
- [x] [JDK-8343178](https://bugs.openjdk.org/browse/JDK-8343178) needs maintainer approval
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8343101](https://bugs.openjdk.org/browse/JDK-8343101): Rework BasicTest.testTemp test cases (**Enhancement** - P4 - Approved)
 * [JDK-8343178](https://bugs.openjdk.org/browse/JDK-8343178): Test BasicTest.java javac compile fails cannot find symbol (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1278/head:pull/1278` \
`$ git checkout pull/1278`

Update a local copy of the PR: \
`$ git checkout pull/1278` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1278`

View PR using the GUI difftool: \
`$ git pr show -t 1278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1278.diff">https://git.openjdk.org/jdk21u-dev/pull/1278.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1278#issuecomment-2558060364)
</details>
