### PR TITLE
8333647: C2 SuperWord: some additional PopulateIndex tests

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +47,8 @@ import compiler.lib.ir_framework.*;
 public class ArrayIndexFillTest extends VectorizationTestRunner {
 
     private static final int SIZE = 543;
+    private static int init = 0;
+    private static int limit = SIZE;
 
     private int[] a;
 
@@ -101,9 +104,73 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, "=0"})
+    // The ConvI2L can be split through the AddI, creating a mix of
+    // ConvI2L(AddI) and AddL(ConvI2L) cases, which do not vectorize.
+    // See: JDK-8332878
     public long[] fillLongArray() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, ">0"})
+    // The variable init/limit has the consequence that we do not split
+    // the ConvI2L through the AddI.
+    public long[] fillLongArray2() {
+        long[] res = new long[SIZE];
+        for (int i = init; i < limit; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, "=0"})
+    // See: JDK-8332878
+    public float[] fillFloatArray() {
+        float[] res = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, ">0"})
+    public float[] fillFloatArray2() {
+        float[] res = new float[SIZE];
+        for (int i = init; i < limit; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, "=0"})
+    // See: JDK-8332878
+    public double[] fillDoubleArray() {
+        double[] res = new double[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, ">0"})
+    public double[] fillDoubleArray2() {
+        double[] res = new double[SIZE];
+        for (int i = init; i < limit; i++) {
             res[i] = i;
         }
         return res;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +51,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     private static final int SIZE = 543;
     private static       int size = 543;
+    private static       int zero = 0;
 
     private int[] ints;
     private long[] longs;
@@ -113,6 +115,36 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
         }
         return res;
     }
+
+    @Test
+    // Tests that we add a ConvI2L for size, when converting it to long for
+    // the rotateRight rotation input.
+    // However, it currently only seems to vectorize in OSR, so we cannot add IR rules.
+    public long[] longExplicitRotateWithPopulateIndex() {
+        long[] res = new long[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = Long.rotateRight(i, /* some rotation value*/ size);
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.STORE_VECTOR, ">0"})
+    @IR(applyIfCPUFeature = {"avx512f", "true"},
+        counts = {IRNode.ROTATE_RIGHT_V, ">0"})
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, ">0"})
+    // The unknown init/limit values make sure that the rotation does fold badly
+    // like in longExplicitRotateWithPopulateIndex.
+    public long[] longExplicitRotateWithPopulateIndex2() {
+        long[] res = new long[SIZE];
+        for (int i = zero; i < size; i++) {
+            res[i] = Long.rotateRight(i, /* some rotation value*/ size);
+        }
+        return res;
+    }
+
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333647](https://bugs.openjdk.org/browse/JDK-8333647) needs maintainer approval

### Issue
 * [JDK-8333647](https://bugs.openjdk.org/browse/JDK-8333647): C2 SuperWord: some additional PopulateIndex tests (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1281/head:pull/1281` \
`$ git checkout pull/1281`

Update a local copy of the PR: \
`$ git checkout pull/1281` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1281`

View PR using the GUI difftool: \
`$ git pr show -t 1281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1281.diff">https://git.openjdk.org/jdk21u-dev/pull/1281.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1281#issuecomment-2558095201)
</details>
