### PR TITLE
8335288: SunPKCS11 initialization will call C_GetMechanismInfo on unsupported mechanisms

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -27,7 +27,7 @@ package sun.security.pkcs11;
 
 import java.io.*;
 import java.util.*;
-
+import java.util.stream.Collectors;
 import java.security.*;
 import java.security.interfaces.*;
 
@@ -1235,7 +1235,11 @@ public final class SunPKCS11 extends AuthProvider {
                 ("Token info for token in slot " + slotID + ":");
             System.out.println(token.tokenInfo);
         }
+
         long[] supportedMechanisms = p11.C_GetMechanismList(slotID);
+        Set<Long> supportedMechSet =
+                Arrays.stream(supportedMechanisms).boxed().collect
+                (Collectors.toCollection(HashSet::new));
 
         // Create a map from the various Descriptors to the "most
         // preferred" mechanism that was defined during the
@@ -1244,10 +1248,9 @@ public final class SunPKCS11 extends AuthProvider {
         // the earliest entry.  When asked for "DES/CBC/PKCS5Padding", we
         // return a CKM_DES_CBC_PAD.
         final Map<Descriptor,Integer> supportedAlgs =
-                                        new HashMap<Descriptor,Integer>();
+                new HashMap<Descriptor,Integer>();
 
-        for (int i = 0; i < supportedMechanisms.length; i++) {
-            long longMech = supportedMechanisms[i];
+        for (long longMech : supportedMechanisms) {
             CK_MECHANISM_INFO mechInfo = token.getMechanismInfo(longMech);
             if (showInfo) {
                 System.out.println("Mechanism " +
@@ -1281,13 +1284,19 @@ public final class SunPKCS11 extends AuthProvider {
             for (Descriptor d : ds) {
                 Integer oldMech = supportedAlgs.get(d);
                 if (oldMech == null) {
+                    // check all required mechs are supported
                     if (d.requiredMechs != null) {
-                        // Check that other mechanisms required for the
-                        // service are supported before listing it as
-                        // available for the first time.
-                        for (int requiredMech : d.requiredMechs) {
-                            if (token.getMechanismInfo(
-                                    requiredMech & 0xFFFFFFFFL) == null) {
+                        for (int reqMech : d.requiredMechs) {
+                            long longReqMech = reqMech & 0xFFFFFFFFL;
+                            if (!config.isEnabled(longReqMech) ||
+                                    !supportedMechSet.contains(longReqMech) /*||
+                                    brokenMechanisms.contains(longReqMech)*/) {
+                                if (showInfo) {
+                                    System.out.println("DISABLED " + d.type +
+                                        " " + d.algorithm +
+                                        " due to no support for req'd mech " +
+                                        Functions.getMechanismName(longReqMech));
+                                }
                                 continue descLoop;
                             }
                         }
@@ -1300,7 +1309,7 @@ public final class SunPKCS11 extends AuthProvider {
                                 (d.type == SIG &&
                                 (mechInfo.flags & CKF_SIGN) == 0)) {
                             if (showInfo) {
-                                System.out.println("DISABLED " +  d.type +
+                                System.out.println("DISABLED " + d.type +
                                         " " + d.algorithm +
                                         " due to partial support");
                             }
@@ -1324,7 +1333,6 @@ public final class SunPKCS11 extends AuthProvider {
                     }
                 }
             }
-
         }
 
         // register algorithms in provider

--- a/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.cfg
+++ b/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.cfg
@@ -1,0 +1,14 @@
+name = NSS
+
+showInfo = true
+
+slot = 1
+
+library = ${pkcs11test.nss.lib}
+
+disabledMechanisms = {
+    CKM_SHA224_HMAC
+    CKM_SHA256_HMAC
+}
+
+nssArgs = "configdir='${pkcs11test.nss.db}' certPrefix='' keyPrefix=''"

--- a/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.java
+++ b/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8335288
+ * @library /test/lib ..
+ * @modules jdk.crypto.cryptoki
+ * @summary check that if any required mech is unavailable, then the
+ * mechanism will be unavailable as well.
+ * @run testng/othervm RequiredMechCheck
+ */
+import java.nio.file.Path;
+import java.security.Provider;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKeyFactory;
+
+import jtreg.SkippedException;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class RequiredMechCheck extends PKCS11Test {
+
+    private static record TestData(String serviceType, String algo,
+            boolean disabled) {}
+
+    private static TestData[] testValues = {
+        new TestData("MAC", "HmacPBESHA1", false),
+        new TestData("MAC", "HmacPBESHA224", true),
+        new TestData("MAC", "HmacPBESHA256", true),
+        new TestData("MAC", "HmacPBESHA384", false),
+        new TestData("MAC", "HmacPBESHA512", false),
+        new TestData("SKF", "PBEWithHmacSHA1AndAES_128", false),
+        new TestData("SKF", "PBEWithHmacSHA224AndAES_128", true),
+        new TestData("SKF", "PBEWithHmacSHA256AndAES_128", true),
+        new TestData("SKF", "PBEWithHmacSHA384AndAES_128", false),
+        new TestData("SKF", "PBEWithHmacSHA512AndAES_128", false),
+        new TestData("CIP", "PBEWithHmacSHA1AndAES_128", false),
+        new TestData("CIP", "PBEWithHmacSHA224AndAES_128", true),
+        new TestData("CIP", "PBEWithHmacSHA256AndAES_128", true),
+        new TestData("CIP", "PBEWithHmacSHA384AndAES_128", false),
+        new TestData("CIP", "PBEWithHmacSHA512AndAES_128", false),
+    };
+
+    @BeforeClass
+    public void setUp() throws Exception {
+        Path configPath = Path.of(BASE).resolve("RequiredMechCheck.cfg");
+        System.setProperty("CUSTOM_P11_CONFIG", configPath.toString());
+    }
+
+    @Test
+    public void test() throws Exception {
+        try {
+            main(new RequiredMechCheck());
+        } catch (SkippedException se) {
+            throw new SkipException("One or more tests are skipped");
+        }
+    }
+
+    public void main(Provider p) throws Exception {
+        for (TestData td : testValues) {
+            String desc = td.serviceType + " " + td.algo;
+            Object t;
+            try {
+                switch (td.serviceType) {
+                    case "MAC":
+                        t = Mac.getInstance(td.algo, p);
+                    break;
+                    case "SKF":
+                        t = SecretKeyFactory.getInstance(td.algo, p);
+                    break;
+                    case "CIP":
+                        t = Cipher.getInstance(td.algo, p);
+                    break;
+                    default:
+                        throw new RuntimeException("Unsupported Test Type!");
+                }
+
+                if (td.disabled) {
+                    throw new RuntimeException("Fail, no NSAE for " + desc);
+                } else {
+                    System.out.println("Ok, getInstance() works for " + desc);
+                }
+            } catch (NoSuchAlgorithmException e) {
+                if (td.disabled) {
+                    System.out.println("Ok, NSAE thrown for " + desc);
+                } else {
+                    throw new RuntimeException("Unexpected Ex for " + desc, e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

I removed brokenMechanisms.contains() from the code. brokenMechanisms
was introduced by https://bugs.openjdk.org/browse/JDK-8324585 which is not 
in 21. But this is a change that might be backported at some point, so I 
think we should leave the code in there so that it's easier to recover it 
in this case.  I also wrote a note in 8324585 to do so.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8335288](https://bugs.openjdk.org/browse/JDK-8335288) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335288](https://bugs.openjdk.org/browse/JDK-8335288): SunPKCS11 initialization will call C_GetMechanismInfo on unsupported mechanisms (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1283/head:pull/1283` \
`$ git checkout pull/1283`

Update a local copy of the PR: \
`$ git checkout pull/1283` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1283`

View PR using the GUI difftool: \
`$ git pr show -t 1283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1283.diff">https://git.openjdk.org/jdk21u-dev/pull/1283.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1283#issuecomment-2558487039)
</details>
