### PR TITLE
8322983: Virtual Threads: exclude 2 tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -107,7 +107,9 @@ vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemor
 
 gc/arguments/TestNewSizeThreadIncrease.java 0000000 generic-all
 gc/g1/TestSkipRebuildRemsetPhase.java 0000000 generic-all
+runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java JDK-8346442 generic-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 0000000 generic-all
+runtime/logging/LoaderConstraintsTest.java JDK-8346442 generic-all
 runtime/Thread/AsyncExceptionOnMonitorEnter.java 0000000 generic-all
 runtime/Thread/StopAtExit.java 0000000 generic-all
 runtime/handshake/HandshakeWalkStackTest.java 0000000 generic-all


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cf28fd4c](https://github.com/openjdk/jdk/commit/cf28fd4cbc6507eb69fcfeb33622316eb5b6b0c5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Evgeny Nikitin on 20 Dec 2024 and was reviewed by Jaikiran Pai, Leonid Mesnik and SendaoYan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322983](https://bugs.openjdk.org/browse/JDK-8322983) needs maintainer approval

### Issue
 * [JDK-8322983](https://bugs.openjdk.org/browse/JDK-8322983): Virtual Threads: exclude 2 tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1285/head:pull/1285` \
`$ git checkout pull/1285`

Update a local copy of the PR: \
`$ git checkout pull/1285` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1285`

View PR using the GUI difftool: \
`$ git pr show -t 1285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1285.diff">https://git.openjdk.org/jdk21u-dev/pull/1285.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1285#issuecomment-2559660734)
</details>
