### PR TITLE
8342609: jpackage test helper function incorrectly removes a directory instead of its contents only

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -379,7 +379,7 @@ final public class TKit {
             try {
                 final List<Path> paths;
                 if (contentsOnly) {
-                    try (var pathStream = Files.walk(root, 0)) {
+                    try (var pathStream = Files.list(root)) {
                         paths = pathStream.collect(Collectors.toList());
                     }
                 } else {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

Resolved Copyright, probably clean anyways.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8342609](https://bugs.openjdk.org/browse/JDK-8342609) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8342609: jpackage test helper function incorrectly removes a directory instead of its contents only`

### Issue
 * [JDK-8342609](https://bugs.openjdk.org/browse/JDK-8342609): jpackage test helper function incorrectly removes a directory instead of its contents only (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1286/head:pull/1286` \
`$ git checkout pull/1286`

Update a local copy of the PR: \
`$ git checkout pull/1286` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1286`

View PR using the GUI difftool: \
`$ git pr show -t 1286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1286.diff">https://git.openjdk.org/jdk21u-dev/pull/1286.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1286#issuecomment-2559830581)
</details>
