### PR TITLE
8313905: Checked_cast assert in CDS compare_by_loader

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -597,9 +597,9 @@ public:
     ClassLoaderData* loader_b = b[0]->class_loader_data();
 
     if (loader_a != loader_b) {
-      return intx(loader_a) - intx(loader_b);
+      return primitive_compare(loader_a, loader_b);
     } else {
-      return intx(a[0]) - intx(b[0]);
+      return primitive_compare(a[0], b[0]);
     }
   }
 

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1364,6 +1364,10 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
   return k0 == k1;
 }
 
+template<typename K> int primitive_compare(const K& k0, const K& k1) {
+  return ((k0 < k1) ? -1 : (k0 == k1) ? 0 : 1);
+}
+
 //----------------------------------------------------------------------------------------------------
 
 // Allow use of C++ thread_local when approved - see JDK-8282469.


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

Resolved because "8313564: Fix -Wconversion warnings in classfile code" is not in 21.
Probably clean anyways.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8313905](https://bugs.openjdk.org/browse/JDK-8313905) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313905](https://bugs.openjdk.org/browse/JDK-8313905): Checked_cast assert in CDS compare_by_loader (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1290/head:pull/1290` \
`$ git checkout pull/1290`

Update a local copy of the PR: \
`$ git checkout pull/1290` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1290`

View PR using the GUI difftool: \
`$ git pr show -t 1290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1290.diff">https://git.openjdk.org/jdk21u-dev/pull/1290.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1290#issuecomment-2561947278)
</details>
