### PR TITLE
8337660: C2: basic blocks with only BoxLock nodes are wrongly treated as empty

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,10 +178,11 @@ int Block::is_Empty() const {
     return success_result;
   }
 
-  // Ideal nodes are allowable in empty blocks: skip them  Only MachNodes
-  // turn directly into code, because only MachNodes have non-trivial
-  // emit() functions.
-  while ((end_idx > 0) && !get_node(end_idx)->is_Mach()) {
+  // Ideal nodes (except BoxLock) are allowable in empty blocks: skip them. Only
+  // Mach and BoxLock nodes turn directly into code via emit().
+  while ((end_idx > 0) &&
+         !get_node(end_idx)->is_Mach() &&
+         !get_node(end_idx)->is_BoxLock()) {
     end_idx--;
   }
 

--- a/test/hotspot/jtreg/compiler/locks/TestSynchronizeWithEmptyBlock.java
+++ b/test/hotspot/jtreg/compiler/locks/TestSynchronizeWithEmptyBlock.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8337660
+ * @summary Test that C2 does not remove blocks with BoxLock nodes that are
+ *          otherwise empty.
+ * @run main/othervm -Xbatch -XX:+UnlockExperimentalVMOptions -XX:LockingMode=1
+ *                   -XX:CompileOnly=compiler.locks.TestSynchronizeWithEmptyBlock::*
+ *                   compiler.locks.TestSynchronizeWithEmptyBlock
+ * @run main/othervm -Xbatch
+ *                   -XX:CompileOnly=compiler.locks.TestSynchronizeWithEmptyBlock::*
+ *                   compiler.locks.TestSynchronizeWithEmptyBlock
+ */
+
+package compiler.locks;
+
+public class TestSynchronizeWithEmptyBlock {
+
+    static int c;
+    static final Object obj = new Object();
+
+    static void test1() {
+        synchronized (TestSynchronizeWithEmptyBlock.class) {
+            int i = 0;
+            while (i < 1000) {
+                i++;
+                if (i < 5);
+            }
+        }
+        synchronized (TestSynchronizeWithEmptyBlock.class) {
+            int i = 0;
+            do {
+                i++;
+                if (i < 4) {
+                    boolean p = true;
+                    int j = 0;
+                    do {
+                        j++;
+                        if (p) {
+                            c++;
+                        }
+                    } while (j < 100);
+                }
+            } while (i < 1000);
+        }
+    }
+
+    static void test2() {
+        synchronized (obj) {
+            for (long i = 0; i < 1_000_000_000_000L; i+=6_500_000_000L) {}
+        }
+        synchronized (obj) {
+            for (long i = 0; i < 1_000_000_000_000L; i+=6_500_000_000L) {}
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test1();
+        }
+        for (int i = 0; i < 10_000; i++) {
+            test2();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

I had to adapt the flags in the run command of the test, 
as the locking mode is experimental in 21:

Error: VM option 'LockingMode' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.
Error: The unlock option must precede 'LockingMode'.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8337660](https://bugs.openjdk.org/browse/JDK-8337660) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337660](https://bugs.openjdk.org/browse/JDK-8337660): C2: basic blocks with only BoxLock nodes are wrongly treated as empty (**Bug** - P2 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1293/head:pull/1293` \
`$ git checkout pull/1293`

Update a local copy of the PR: \
`$ git checkout pull/1293` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1293`

View PR using the GUI difftool: \
`$ git pr show -t 1293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1293.diff">https://git.openjdk.org/jdk21u-dev/pull/1293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1293#issuecomment-2563573418)
</details>
