### PR TITLE
8332158: [XWayland] test/jdk/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -372,7 +372,7 @@ java/awt/Modal/MultipleDialogs/MultipleDialogs3Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs4Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs5Test.java 8198665 macosx-all
 java/awt/Mouse/EnterExitEvents/DragWindowOutOfFrameTest.java 8177326 macosx-all
-java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021,8332158 macosx-all,linux-x64
+java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021 macosx-all
 java/awt/Mouse/EnterExitEvents/FullscreenEnterEventTest.java 8051455 macosx-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersUnitTest_Standard.java 7124407,8302787  macosx-all,windows-all
 java/awt/Mouse/RemovedComponentMouseListener/RemovedComponentMouseListener.java 8157170 macosx-all

--- a/test/jdk/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java
+++ b/test/jdk/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,19 @@
  * @bug 7154048
  * @summary Programmatically resized  window does not receive mouse entered/exited events
  * @author  alexandr.scherbatiy area=awt.event
+ * @library /test/lib
+ * @build   jdk.test.lib.Platform
  * @run main ResizingFrameTest
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import jdk.test.lib.Platform;
 
 public class ResizingFrameTest {
 
@@ -41,6 +48,9 @@ public class ResizingFrameTest {
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
+        if (Platform.isOnWayland()) {
+            return;
+        }
 
         Robot robot = new Robot();
         robot.setAutoDelay(50);


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8332158](https://bugs.openjdk.org/browse/JDK-8332158) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332158](https://bugs.openjdk.org/browse/JDK-8332158): [XWayland] test/jdk/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1294/head:pull/1294` \
`$ git checkout pull/1294`

Update a local copy of the PR: \
`$ git checkout pull/1294` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1294`

View PR using the GUI difftool: \
`$ git pr show -t 1294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1294.diff">https://git.openjdk.org/jdk21u-dev/pull/1294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1294#issuecomment-2563631308)
</details>
