### PR TITLE
8327460: Compile tests with the same visibility rules as product code

### DIFF
--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -56,22 +56,34 @@ define SetupTestFilesCompilationBody
     $$(error There are duplicate test file names for $1: $$($1_DUPLICATED_NAMES))
   endif
 
+  # Always include common test functionality
+  TEST_CFLAGS := -I$(TOPDIR)/test/lib/native
+
+  ifeq ($(TOOLCHAIN_TYPE), gcc)
+    TEST_CFLAGS += -fvisibility=hidden
+    TEST_LDFLAGS += -Wl,--exclude-libs,ALL
+  else ifeq ($(TOOLCHAIN_TYPE), clang)
+    TEST_CFLAGS += -fvisibility=hidden
+  else ifeq ($(TOOLCHAIN_TYPE), xlc)
+    TEST_CFLAGS += -qvisibility=hidden
+  endif
+
   # The list to depend on starts out empty
   $1 :=
   ifeq ($$($1_TYPE), LIBRARY)
     $1_PREFIX = lib
     $1_OUTPUT_SUBDIR := lib
-    $1_BASE_CFLAGS := $(CFLAGS_JDKLIB)
-    $1_BASE_CXXFLAGS := $(CXXFLAGS_JDKLIB)
-    $1_LDFLAGS := $(LDFLAGS_JDKLIB) $$(call SET_SHARED_LIBRARY_ORIGIN)
+    $1_BASE_CFLAGS := $(CFLAGS_JDKLIB) $$(TEST_CFLAGS)
+    $1_BASE_CXXFLAGS := $(CXXFLAGS_JDKLIB) $$(TEST_CFLAGS)
+    $1_LDFLAGS := $(LDFLAGS_JDKLIB) $$(TEST_LDFLAGS) $$(call SET_SHARED_LIBRARY_ORIGIN)
     $1_COMPILATION_TYPE := LIBRARY
     $1_LOG_TYPE := library
   else ifeq ($$($1_TYPE), PROGRAM)
     $1_PREFIX = exe
     $1_OUTPUT_SUBDIR := bin
-    $1_BASE_CFLAGS := $(CFLAGS_JDKEXE)
-    $1_BASE_CXXFLAGS := $(CXXFLAGS_JDKEXE)
-    $1_LDFLAGS := $(LDFLAGS_JDKEXE) $(LDFLAGS_TESTEXE)
+    $1_BASE_CFLAGS := $(CFLAGS_JDKEXE) $$(TEST_CFLAGS)
+    $1_BASE_CXXFLAGS := $(CXXFLAGS_JDKEXE) $$(TEST_CFLAGS)
+    $1_LDFLAGS := $(LDFLAGS_JDKEXE) $$(TEST_LDFLAGS) $(LDFLAGS_TESTEXE)
     $1_COMPILATION_TYPE := EXECUTABLE
     $1_LOG_TYPE := executable
   else

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,6 @@ BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeJliLaunchTest := \
     -I$(TOPDIR)/src/java.base/$(OPENJDK_TARGET_OS_TYPE)/native/libjli \
     -I$(TOPDIR)/src/java.base/$(OPENJDK_TARGET_OS)/native/libjli
 
-TEST_LIB_NATIVE_SRC := $(TOPDIR)/test/lib/native
-
 # Platform specific setup
 ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXCLUDE += libDirectIO.c libInheritedChannel.c \
@@ -69,14 +67,6 @@ ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX) jvm.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
   BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeNullCallerTest := /EHsc
-
-  # java.lang.foreign tests
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := -I$(TEST_LIB_NATIVE_SRC)
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerUnnamed := -I$(TEST_LIB_NATIVE_SRC)
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerModule := -I$(TEST_LIB_NATIVE_SRC)
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLoaderLookupInvoker := -I$(TEST_LIB_NATIVE_SRC)
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := -I$(TEST_LIB_NATIVE_SRC)
-
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libTracePinnedThreads := jvm.lib
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libNewDirectByteBuffer := $(WIN_LIB_JAVA)
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libGetXSpace := $(WIN_LIB_JAVA)
@@ -88,15 +78,10 @@ else
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libNativeThread := -pthread
 
   # java.lang.foreign tests
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := -I$(TEST_LIB_NATIVE_SRC)
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncStackWalk := -pthread
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := -I$(TEST_LIB_NATIVE_SRC)
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncInvokers := -pthread
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerUnnamed := -I$(TEST_LIB_NATIVE_SRC)
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := -pthread
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLinkerInvokerModule := -I$(TEST_LIB_NATIVE_SRC)
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := -pthread
-  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libLoaderLookupInvoker := -I$(TEST_LIB_NATIVE_SRC)
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := -pthread
 
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libExplicitAttach := -ljvm

--- a/src/jdk.jpackage/macosx/native/applauncher/MacLauncher.cpp
+++ b/src/jdk.jpackage/macosx/native/applauncher/MacLauncher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,13 +23,14 @@
  * questions.
  */
 
-#include "AppLauncher.h"
 #include "app.h"
+#include "AppLauncher.h"
+#include "ErrorHandling.h"
 #include "FileUtils.h"
+#include "jni.h"
+#include "JvmLauncher.h"
 #include "PackageFile.h"
 #include "UnixSysInfo.h"
-#include "JvmLauncher.h"
-#include "ErrorHandling.h"
 
 
 namespace {
@@ -89,7 +90,7 @@ void initJvmLauncher() {
 } // namespace
 
 
-int main(int argc, char *argv[]) {
+JNIEXPORT int main(int argc, char *argv[]) {
     if (jvmLauncher) {
         // This is the call from the thread spawned by JVM.
         // Skip initialization phase as we have done this already in the first

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/libLinkToNativeRBP.c
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/libLinkToNativeRBP.c
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT int foo() {
   return 0;

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -125,7 +125,7 @@ public class TestDwarf {
                         new DwarfConstraint(1, "Java_TestDwarf_crashNativeMultipleMethods", "libTestDwarf.c", 70));
         }
         runAndCheck(new Flags(TestDwarf.class.getCanonicalName(), "nativeDereferenceNull"),
-                    new DwarfConstraint(0, "dereference_null", "libTestDwarfHelper.h", 44));
+                    new DwarfConstraint(0, "dereference_null", "libTestDwarfHelper.h", 46));
     }
 
     // The full pattern accepts lines like:

--- a/test/hotspot/jtreg/runtime/ErrorHandling/libTestDwarfHelper.h
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/libTestDwarfHelper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,10 @@
  * questions.
  */
 
-#include "jni.h"
 #include <stdio.h>
+
+#include "export.h"
+#include "jni.h"
 
 void unused1() {
 }
@@ -39,7 +41,7 @@ void unused4() {
 void unused5() {
 }
 
-void dereference_null() {
+EXPORT void dereference_null() {
   int* x = (int*)0;
   *x = 34; // Crash
 }

--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -213,11 +213,7 @@ public class CallGeneratorHelper extends NativeTestHelper {
     static void generateDowncalls(boolean header) {
         if (header) {
             System.out.println(
-                "#ifdef _WIN64\n" +
-                "#define EXPORT __declspec(dllexport)\n" +
-                "#else\n" +
-                "#define EXPORT\n" +
-                "#endif\n"
+                "#include \"export.h\"\n"
             );
 
             for (int j = 1; j <= MAX_FIELDS; j++) {
@@ -267,11 +263,7 @@ public class CallGeneratorHelper extends NativeTestHelper {
     static void generateUpcalls(boolean header) {
         if (header) {
             System.out.println(
-                "#ifdef _WIN64\n" +
-                "#define EXPORT __declspec(dllexport)\n" +
-                "#else\n" +
-                "#define EXPORT\n" +
-                "#endif\n"
+                "#include \"export.h\"\n"
             );
 
             for (int j = 1; j <= MAX_FIELDS; j++) {

--- a/test/jdk/java/foreign/arraystructs/libArrayStructs.c
+++ b/test/jdk/java/foreign/arraystructs/libArrayStructs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 struct S1 { char f0[1]; };
 struct S2 { char f0[2]; };

--- a/test/jdk/java/foreign/capturecallstate/libCaptureCallState.c
+++ b/test/jdk/java/foreign/capturecallstate/libCaptureCallState.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,7 @@
 
 #include <errno.h>
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void set_errno_V(int value) {
     errno = value;

--- a/test/jdk/java/foreign/dontrelease/libDontRelease.c
+++ b/test/jdk/java/foreign/dontrelease/libDontRelease.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,6 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void test_ptr(void* ptr) {}

--- a/test/jdk/java/foreign/libAddressDereference.c
+++ b/test/jdk/java/foreign/libAddressDereference.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,7 @@
  *
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void* get_addr(void* align) {
     return align;

--- a/test/jdk/java/foreign/libIntrinsics.c
+++ b/test/jdk/java/foreign/libIntrinsics.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,7 @@
 
 #include <stdbool.h>
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void empty() {
 }

--- a/test/jdk/java/foreign/libLibraryLookup.c
+++ b/test/jdk/java/foreign/libLibraryLookup.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,7 @@
  *
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 int count = 0;
 

--- a/test/jdk/java/foreign/libLookupTest.c
+++ b/test/jdk/java/foreign/libLookupTest.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,7 @@
  *
  */
 
- #ifdef _WIN64
- #define EXPORT __declspec(dllexport)
- #else
- #define EXPORT
- #endif
+#include "export.h"
 
- EXPORT void f() { }
- EXPORT int c = 42;
-
+EXPORT void f() { }
+EXPORT int c = 42;

--- a/test/jdk/java/foreign/libNull.c
+++ b/test/jdk/java/foreign/libNull.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,8 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
-
 #include <stddef.h>
+
+#include "export.h"
 
 EXPORT void* get_null() { return NULL; }

--- a/test/jdk/java/foreign/libSafeAccess.c
+++ b/test/jdk/java/foreign/libSafeAccess.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,7 @@
  *
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 struct Point {
     int x;

--- a/test/jdk/java/foreign/libTestUpcallHighArity.c
+++ b/test/jdk/java/foreign/libTestUpcallHighArity.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 struct S_PDI { void* p0; double p1; int p2; };
 

--- a/test/jdk/java/foreign/libTestUpcallStructScope.c
+++ b/test/jdk/java/foreign/libTestUpcallStructScope.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 struct S_PDI { void* p0; double p1; int p2; };
 

--- a/test/jdk/java/foreign/loaderLookup/lookup/libFoo.c
+++ b/test/jdk/java/foreign/loaderLookup/lookup/libFoo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,7 @@
 
 #include <stdio.h>
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void foo(void) {
     // do nothing

--- a/test/jdk/java/foreign/nested/libNested.c
+++ b/test/jdk/java/foreign/nested/libNested.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 struct S1{ double f0; long long f1; double f2; int f3; };
 union U1{ short f0; long long f1; short f2; char f3[4][3]; };

--- a/test/jdk/java/foreign/normalize/libNormalize.c
+++ b/test/jdk/java/foreign/normalize/libNormalize.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 // we use 'int' here to make sure the native code doesn't touch any of the bits
 // the important part is that our Java code performs argument normalization

--- a/test/jdk/java/foreign/passheapsegment/libPassHeapSegment.c
+++ b/test/jdk/java/foreign/passheapsegment/libPassHeapSegment.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void test_args(void* ptr) {}
 

--- a/test/jdk/java/foreign/shared.h
+++ b/test/jdk/java/foreign/shared.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,18 +21,14 @@
  * questions.
  */
 
+#include "export.h"
+
 #ifdef __clang__
 #pragma clang optimize off
 #elif defined __GNUC__
 #pragma GCC optimize ("O0")
 #elif defined _MSC_BUILD
 #pragma optimize( "", off )
-#endif
-
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
 #endif
 
 struct S_I { int p0; };

--- a/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
+++ b/test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
@@ -22,13 +22,8 @@
  *
  */
 
+#include "export.h"
 #include "testlib_threads.h"
-
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
 
 typedef void (*CB_t)(void);
 

--- a/test/jdk/java/foreign/stackwalk/libReentrantUpcalls.c
+++ b/test/jdk/java/foreign/stackwalk/libReentrantUpcalls.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,7 @@
  *
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void do_recurse(int depth, void (*cb)(int, void*)) {
     cb(depth, cb);

--- a/test/jdk/java/foreign/stackwalk/libStackWalk.c
+++ b/test/jdk/java/foreign/stackwalk/libStackWalk.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,7 @@
  *
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void foo(void (*cb)(void)) {
     cb();

--- a/test/jdk/java/foreign/trivial/libTrivial.c
+++ b/test/jdk/java/foreign/trivial/libTrivial.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,7 @@
 
 #include <errno.h>
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void empty() {}
 

--- a/test/jdk/java/foreign/upcalldeopt/libUpcallDeopt.c
+++ b/test/jdk/java/foreign/upcalldeopt/libUpcallDeopt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void foo(void (*cb)(int, int, int, int), int a0, int a1, int a2, int a3) {
     cb(a0, a1, a2, a3);

--- a/test/jdk/java/foreign/virtual/libVirtual.c
+++ b/test/jdk/java/foreign/virtual/libVirtual.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,7 @@
  *
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT int funcA() {
     return 1;

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libImplicitAttach.c
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libImplicitAttach.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,15 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-#include <stdio.h>
+
 #include <pthread.h>
+#include <stdio.h>
+
+#include "export.h"
 
 #define STACK_SIZE 0x100000
 
 /**
  * Creates n threads to execute the given function.
  */
-void start_threads(int n, void *(*f)(void *)) {
+EXPORT void start_threads(int n, void *(*f)(void *)) {
     pthread_t tid;
     pthread_attr_t attr;
     int i;

--- a/test/jdk/tools/launcher/exeJliLaunchTest.c
+++ b/test/jdk/tools/launcher/exeJliLaunchTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,10 @@
  * tools. The rest of the files will be linked in.
  */
 
+#include "export.h"
 #include "java.h"
 
-int
+EXPORT int
 main(int argc, char **args)
 {
     //avoid null-terminated array of arguments to test JDK-8303669

--- a/test/lib/native/export.h
+++ b/test/lib/native/export.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,15 @@
  * questions.
  */
 
-#include "export.h"
+#ifndef TEST_LIB_NATIVE_EXPORT_H
+#define TEST_LIB_NATIVE_EXPORT_H
 
-EXPORT int compar(const void* e0, const void* e1) {
-    int i0 = *((int*) e0);
-    int i1 = *((int*) e1);
-    return i0 - i1;
-}
+#ifdef _WIN64
+  #define EXPORT __declspec(dllexport)
+#elif defined(__GNUC__)
+  #define EXPORT __attribute__((visibility("default")))
+#else
+  #define EXPORT
+#endif
+
+#endif // TEST_LIB_NATIVE_EXPORT_H

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libCallOverhead.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libCallOverhead.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void func() {}
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libPtr.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libPtr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,13 +23,9 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
-
 #include <stddef.h>
+
+#include "export.h"
 
 EXPORT long long id_long_long(long long value) {
   return value;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libUpcalls.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libUpcalls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,7 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "export.h"
 
 EXPORT void blank(void (*cb)(void)) {
     cb();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/support/libPoint.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/support/libPoint.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,16 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-#include <stdlib.h>
+
 #include <math.h>
+#include <stdlib.h>
 
+#include "export.h"
 #include "points.h"
-
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
 
 EXPORT double distance(Point p1, Point p2) {
     int xDist = abs(p1.x - p2.x);


### PR DESCRIPTION
I would like to backport this to keep the test suite close to head.
This simplifies later backports.

I had to resolve some files.

test/jdk/java/foreign/critical/libCritical.c
This was added by "8254693: Add Panama feature to pass heap segments to native code". Omitted.

patching file test/jdk/java/foreign/libLibraryLookup.c
patching file test/jdk/java/foreign/libLookupTest.c
test/jdk/java/foreign/libSafeAccess.c
Resolved because "8310643: Misformatted copyright messages in FFM" is not in 21

patching file test/jdk/java/foreign/nested/libNested.c
patching file test/jdk/java/foreign/shared.h
Resolved because "8318175: AIX PPC64: Handle alignment of double in structs" is not in 21 

patching file test/jdk/java/foreign/stackwalk/libAsyncStackWalk.cpp
Resolved because "8324799: Use correct extension for C++ test headers" is not in 21.

patching file test/jdk/java/foreign/stackwalk/libReentrantUpcalls.c
patching file test/jdk/java/foreign/stackwalk/libStackWalk.c
Resolved because "8310643: Misformatted copyright messages in FFM" is not in 21

test/lib/jdk/test/lib/thread/libVThreadPinner.c
This was added by "8320707: Virtual thread test updates", which was backported to 21.
But this file was dropped from the backport as it is not applicable to 21.

test/micro/org/openjdk/bench/java/lang/foreign/libCriticalCalls.c
This was added by "8254693: Add Panama feature to pass heap segments to native code". Omitted.

Executed affected tests and micro benchmarks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327460](https://bugs.openjdk.org/browse/JDK-8327460) needs maintainer approval

### Issue
 * [JDK-8327460](https://bugs.openjdk.org/browse/JDK-8327460): Compile tests with the same visibility rules as product code (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1301/head:pull/1301` \
`$ git checkout pull/1301`

Update a local copy of the PR: \
`$ git checkout pull/1301` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1301`

View PR using the GUI difftool: \
`$ git pr show -t 1301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1301.diff">https://git.openjdk.org/jdk21u-dev/pull/1301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1301#issuecomment-2569035354)
</details>
