### PR TITLE
8343396: Use OperatingSystem, Architecture, and OSVersion in jpackage tests

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -61,14 +61,13 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toSet;
 import java.util.stream.Stream;
+import jdk.internal.util.OperatingSystem;
 import jdk.jpackage.test.Functional.ExceptionBox;
 import jdk.jpackage.test.Functional.ThrowingConsumer;
 import jdk.jpackage.test.Functional.ThrowingRunnable;
 import jdk.jpackage.test.Functional.ThrowingSupplier;
 
 final public class TKit {
-
-    private static final String OS = System.getProperty("os.name").toLowerCase();
 
     public static final Path TEST_SRC_ROOT = Functional.identity(() -> {
         Path root = Path.of(System.getProperty("test.src"));
@@ -176,15 +175,15 @@ final public class TKit {
     }
 
     public static boolean isWindows() {
-        return (OS.contains("win"));
+        return OperatingSystem.isWindows();
     }
 
     public static boolean isOSX() {
-        return (OS.contains("mac"));
+        return OperatingSystem.isMacOS();
     }
 
     public static boolean isLinux() {
-        return ((OS.contains("nix") || OS.contains("nux")));
+        return OperatingSystem.isLinux();
     }
 
     public static boolean isLinuxAPT() {

--- a/test/jdk/tools/jpackage/macosx/HostArchPkgTest.java
+++ b/test/jdk/tools/jpackage/macosx/HostArchPkgTest.java
@@ -28,6 +28,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
+import jdk.internal.util.Architecture;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.PackageTest;
 import jdk.jpackage.test.PackageType;
@@ -73,7 +74,7 @@ public class HostArchPkgTest {
                     "/installer-gui-script/options/@hostArchitectures",
                     doc, XPathConstants.STRING);
 
-        if ("aarch64".equals(System.getProperty("os.arch"))) {
+        if (Architecture.isAARCH64()) {
             TKit.assertEquals(v, "arm64",
                     "Check value of \"hostArchitectures\" attribute");
         } else {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8343396](https://bugs.openjdk.org/browse/JDK-8343396) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343396](https://bugs.openjdk.org/browse/JDK-8343396): Use OperatingSystem, Architecture, and OSVersion in jpackage tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1303/head:pull/1303` \
`$ git checkout pull/1303`

Update a local copy of the PR: \
`$ git checkout pull/1303` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1303`

View PR using the GUI difftool: \
`$ git pr show -t 1303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1303.diff">https://git.openjdk.org/jdk21u-dev/pull/1303.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1303#issuecomment-2571593750)
</details>
