### PR TITLE
Backport 726f854b141dc2f6474e81c7bcf12608bf6577ae

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -884,10 +884,17 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         final Path rootDir = isImagePackageType() ? outputBundle() : pathToUnpackedPackageFile(
                 appInstallationDirectory());
 
-        try ( Stream<Path> walk = ThrowingSupplier.toSupplier(() -> Files.walk(
-                rootDir)).get()) {
-            List<String> files = walk.filter(path -> path.getFileName().equals(
-                    filename)).map(Path::toString).toList();
+        try ( Stream<Path> walk = ThrowingSupplier.toSupplier(() -> {
+            if (TKit.isLinux() && rootDir.equals(Path.of("/"))) {
+                // Installed package with split app image on Linux. Iterate
+                // through package file list instead of the entire file system.
+                return LinuxHelper.getPackageFiles(this);
+            } else {
+                return Files.walk(rootDir);
+            }
+        }).get()) {
+            List<String> files = walk.filter(path -> filename.equals(
+                    path.getFileName())).map(Path::toString).toList();
 
             if (expectedPath == null) {
                 TKit.assertStringListEquals(List.of(), files, String.format(


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.