### PR TITLE
8339542: compiler/codecache/CheckSegmentedCodeCache.java fails

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -149,7 +149,9 @@ public class CheckSegmentedCodeCache {
         // Fails if code heap sizes do not add up
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+SegmentedCodeCache",
                                                               "-XX:ReservedCodeCacheSize=10M",
-                                                              "-XX:NonNMethodCodeHeapSize=5M",
+                                                              // After fixing a round_down issue with large page sizes (JDK-8334564),
+                                                              // 5M is a bit too small for NonNMethodCodeHeap
+                                                              "-XX:NonNMethodCodeHeapSize=6M",
                                                               "-XX:ProfiledCodeHeapSize=5M",
                                                               "-XX:NonProfiledCodeHeapSize=5M",
                                                               "-version");


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339542](https://bugs.openjdk.org/browse/JDK-8339542) needs maintainer approval

### Issue
 * [JDK-8339542](https://bugs.openjdk.org/browse/JDK-8339542): compiler/codecache/CheckSegmentedCodeCache.java fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1318/head:pull/1318` \
`$ git checkout pull/1318`

Update a local copy of the PR: \
`$ git checkout pull/1318` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1318`

View PR using the GUI difftool: \
`$ git pr show -t 1318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1318.diff">https://git.openjdk.org/jdk21u-dev/pull/1318.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1318#issuecomment-2583328222)
</details>
