### PR TITLE
8342508: Use latch in BasicMenuUI/bug4983388.java instead of delay

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
@@ -26,28 +26,41 @@
  * @key headful
  * @bug 4983388 8015600
  * @summary shortcuts on menus do not work on JDS
- * @author Oleg Mokhovikov
  * @library ../../../../regtesthelpers
  * @build Util
  * @run main bug4983388
  */
 
-import java.awt.*;
-import javax.swing.*;
-import javax.swing.event.MenuListener;
-import javax.swing.event.MenuEvent;
+import java.awt.Robot;
 import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class bug4983388 {
-    static volatile boolean bMenuSelected = false;
     static JFrame frame;
 
+    private static final CountDownLatch menuSelected = new CountDownLatch(1);
+
     private static class TestMenuListener implements MenuListener {
+        @Override
         public void menuCanceled(MenuEvent e) {}
+        @Override
         public void menuDeselected(MenuEvent e) {}
+
+        @Override
         public void menuSelected(MenuEvent e) {
             System.out.println("menuSelected");
-            bMenuSelected = true;
+            menuSelected.countDown();
         }
     }
 
@@ -56,28 +69,24 @@ public class bug4983388 {
         JMenu menu = new JMenu("File");
         menu.setMnemonic('F');
         menuBar.add(menu);
-        frame = new JFrame();
+        menu.addMenuListener(new TestMenuListener());
+
+        frame = new JFrame("bug4983388");
         frame.setJMenuBar(menuBar);
         frame.setLocationRelativeTo(null);
-        frame.pack();
+        frame.setSize(250, 100);
         frame.setVisible(true);
-        MenuListener listener = new TestMenuListener();
-        menu.addMenuListener(listener);
     }
 
     public static void main(String[] args) throws Exception {
-
         try {
             UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
         } catch (UnsupportedLookAndFeelException | ClassNotFoundException ex) {
-            System.err.println("GTKLookAndFeel is not supported on this platform. Using defailt LaF for this platform.");
+            System.err.println("GTKLookAndFeel is not supported on this platform. "
+                               + "Using default LaF for this platform.");
         }
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
-            }
-        });
+        SwingUtilities.invokeAndWait(bug4983388::createAndShowGUI);
 
         Robot robot = new Robot();
         robot.setAutoDelay(50);
@@ -85,13 +94,13 @@ public class bug4983388 {
         robot.delay(500);
 
         Util.hitMnemonics(robot, KeyEvent.VK_F);
-        robot.waitForIdle();
-        robot.delay(500);
 
-        SwingUtilities.invokeAndWait(() -> frame.dispose());
-
-        if (!bMenuSelected) {
-            throw new RuntimeException("shortcuts on menus do not work");
+        try {
+            if (!menuSelected.await(1, SECONDS)) {
+                throw new RuntimeException("shortcuts on menus do not work");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(frame::dispose);
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342508](https://bugs.openjdk.org/browse/JDK-8342508) needs maintainer approval

### Issue
 * [JDK-8342508](https://bugs.openjdk.org/browse/JDK-8342508): Use latch in BasicMenuUI/bug4983388.java instead of delay (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1326/head:pull/1326` \
`$ git checkout pull/1326`

Update a local copy of the PR: \
`$ git checkout pull/1326` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1326`

View PR using the GUI difftool: \
`$ git pr show -t 1326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1326.diff">https://git.openjdk.org/jdk21u-dev/pull/1326.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1326#issuecomment-2586716691)
</details>
