### PR TITLE
8346082: Output JVMTI agent information in hserr files

### DIFF
--- a/src/hotspot/share/prims/jvmtiAgentList.hpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.hpp
@@ -61,7 +61,6 @@ class JvmtiAgentList : AllStatic {
  private:
   static JvmtiAgent* _list;
 
-  static Iterator all();
   static void initialize();
   static void convert_xrun_agents();
 
@@ -81,6 +80,7 @@ class JvmtiAgentList : AllStatic {
 
   static JvmtiAgent* lookup(JvmtiEnv* env, void* f_ptr);
 
+  static Iterator all();
   static Iterator agents() NOT_JVMTI({ Iterator it; return it; });
   static Iterator java_agents();
   static Iterator native_agents();

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -42,6 +42,7 @@
 #include "oops/compressedOops.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/jvmtiAgent.hpp"
+#include "prims/jvmtiAgentList.hpp"
 #include "prims/jvm_misc.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"
@@ -1074,6 +1075,31 @@ void os::print_environment_variables(outputStream* st, const char** env_list) {
       }
     }
   }
+}
+
+void os::print_jvmti_agent_info(outputStream* st) {
+#if INCLUDE_JVMTI
+  const JvmtiAgentList::Iterator it = JvmtiAgentList::all();
+  if (it.has_next()) {
+    st->print_cr("JVMTI agents:");
+  } else {
+    st->print_cr("JVMTI agents: none");
+  }
+  while (it.has_next()) {
+    const JvmtiAgent* agent = it.next();
+    if (agent != nullptr) {
+      const char* dyninfo = agent->is_dynamic() ? "dynamic " : "";
+      const char* instrumentinfo = agent->is_instrument_lib() ? "instrumentlib " : "";
+      const char* loadinfo = agent->is_loaded() ? "loaded" : "not loaded";
+      const char* initinfo = agent->is_initialized() ? "initialized" : "not initialized";
+      const char* optionsinfo = agent->options();
+      const char* pathinfo = agent->os_lib_path();
+      if (optionsinfo == nullptr) optionsinfo = "none";
+      if (pathinfo == nullptr) pathinfo = "none";
+      st->print_cr("%s path:%s, %s, %s, %s%soptions:%s", agent->name(), pathinfo, loadinfo, initinfo, dyninfo, instrumentinfo, optionsinfo);
+    }
+  }
+#endif
 }
 
 void os::print_register_info(outputStream* st, const void* context) {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -775,6 +775,7 @@ class os: AllStatic {
   static void print_summary_info(outputStream* st, char* buf, size_t buflen);
   static void print_memory_info(outputStream* st);
   static void print_dll_info(outputStream* st);
+  static void print_jvmti_agent_info(outputStream* st);
   static void print_environment_variables(outputStream* st, const char** env_list);
   static void print_context(outputStream* st, const void* context);
   static void print_tos_pc(outputStream* st, const void* context);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1259,6 +1259,12 @@ void VMError::report(outputStream* st, bool _verbose) {
     os::print_dll_info(st);
     st->cr();
 
+#if INCLUDE_JVMTI
+  STEP_IF("printing jvmti agent info", _verbose)
+    os::print_jvmti_agent_info(st);
+    st->cr();
+#endif
+
   STEP_IF("printing native decoder state", _verbose)
     Decoder::print_state_on(st);
     st->cr();
@@ -1436,6 +1442,11 @@ void VMError::print_vm_info(outputStream* st) {
   // dynamic libraries, or memory map
   os::print_dll_info(st);
   st->cr();
+
+#if INCLUDE_JVMTI
+  os::print_jvmti_agent_info(st);
+  st->cr();
+#endif
 
   // STEP("printing VM options")
 


### PR DESCRIPTION
os.cpp seems to have diffs in the strides; other files apply cleanly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346082](https://bugs.openjdk.org/browse/JDK-8346082) needs maintainer approval

### Issue
 * [JDK-8346082](https://bugs.openjdk.org/browse/JDK-8346082): Output JVMTI agent information in hserr files (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1328/head:pull/1328` \
`$ git checkout pull/1328`

Update a local copy of the PR: \
`$ git checkout pull/1328` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1328`

View PR using the GUI difftool: \
`$ git pr show -t 1328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1328.diff">https://git.openjdk.org/jdk21u-dev/pull/1328.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1328#issuecomment-2590132483)
</details>
