### PR TITLE
8345614: Improve AnnotationFormatError message for duplicate annotation interfaces

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -124,7 +124,7 @@ public class AnnotationParser {
                 if (AnnotationType.getInstance(klass).retention() == RetentionPolicy.RUNTIME &&
                     result.put(klass, a) != null) {
                         throw new AnnotationFormatError(
-                            "Duplicate annotation for class: "+klass+": " + a);
+                            "Duplicate annotation " + klass + " in " + container);
             }
         }
         }


### PR DESCRIPTION
Please review this simple backport that includes the offending class file name in addition to the annotation interface name in the error message for annotations of duplicated interface found during parsing.

This pull request contains a backport of commit [7aa0cbc9](https://github.com/openjdk/jdk/commit/7aa0cbc91d90493a3dae973cb8077cfa283c32b4) from openjdk/jdk#22581, authored by @scottmarlow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8345614](https://bugs.openjdk.org/browse/JDK-8345614) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345614](https://bugs.openjdk.org/browse/JDK-8345614): Improve AnnotationFormatError message for duplicate annotation interfaces (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1329/head:pull/1329` \
`$ git checkout pull/1329`

Update a local copy of the PR: \
`$ git checkout pull/1329` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1329`

View PR using the GUI difftool: \
`$ git pr show -t 1329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1329.diff">https://git.openjdk.org/jdk21u-dev/pull/1329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1329#issuecomment-2593261119)
</details>
