### PR TITLE
8326525: com/sun/tools/attach/BasicTests.java does not verify AgentLoadException case

### DIFF
--- a/test/jdk/com/sun/tools/attach/BasicTests.java
+++ b/test/jdk/com/sun/tools/attach/BasicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,6 +171,7 @@ public class BasicTests {
             System.out.println(" - Test: Load an agent that does not exist");
             try {
                 vm.loadAgent("SilverBullet.jar");
+                throw new RuntimeException("AgentLoadException not thrown as expected!");
             } catch (AgentLoadException x) {
                 System.out.println(" - AgentLoadException thrown as expected!");
             }


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326525](https://bugs.openjdk.org/browse/JDK-8326525) needs maintainer approval

### Issue
 * [JDK-8326525](https://bugs.openjdk.org/browse/JDK-8326525): com/sun/tools/attach/BasicTests.java does not verify AgentLoadException case (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1331/head:pull/1331` \
`$ git checkout pull/1331`

Update a local copy of the PR: \
`$ git checkout pull/1331` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1331`

View PR using the GUI difftool: \
`$ git pr show -t 1331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1331.diff">https://git.openjdk.org/jdk21u-dev/pull/1331.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1331#issuecomment-2595865456)
</details>
