### PR TITLE
8320676: Manual printer tests have no Pass/Fail buttons, instructions close set 1

### DIFF
--- a/test/jdk/java/awt/print/PageFormat/PageSetupDialog.java
+++ b/test/jdk/java/awt/print/PageFormat/PageSetupDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,333 +21,224 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Checkbox;
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Paper;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+/*
  * @test
- * @bug 4197377
- * @bug 4299145
- * @bug 6358747
- * @bug 6574633
- * @summary Page setup dialog settings
+ * @bug 4197377 4299145 6358747 6574633
  * @key printer
+ * @summary Page setup dialog settings
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual PageSetupDialog
  */
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-
 public class PageSetupDialog extends Frame implements Printable {
+    PrinterJob myPrinterJob;
+    PageFormat myPageFormat;
+    Label pw, ph, pglm, pgiw, pgrm, pgtm, pgih, pgbm;
+    Label myWidthLabel;
+    Label myHeightLabel;
+    Label myImageableXLabel;
+    Label myImageableYLabel;
+    Label myImageableRightLabel;
+    Label myImageableBottomLabel;
+    Label myImageableWidthLabel;
+    Label myImageableHeightLabel;
+    Label myOrientationLabel;
+    Checkbox reverseCB;
+    boolean alpha = false;
+    boolean reverse = false;
 
-  PrinterJob myPrinterJob;
-  PageFormat myPageFormat;
-  Label pw, ph, pglm, pgiw, pgrm, pgtm, pgih, pgbm;
-  Label myWidthLabel;
-  Label myHeightLabel;
-  Label myImageableXLabel;
-  Label myImageableYLabel;
-  Label myImageableRightLabel;
-  Label myImageableBottomLabel;
-  Label myImageableWidthLabel;
-  Label myImageableHeightLabel;
-  Label myOrientationLabel;
-  Checkbox reverseCB;
-  boolean alpha = false;
-  boolean reverse = false;
+    private static final String INSTRUCTIONS =
+            " This test is very flexible and requires much interaction.\n" +
+            " If the platform print dialog supports it, adjust orientation\n" +
+            " and margins and print pages and compare the results with the request.";
 
-  protected void displayPageFormatAttributes() {
-
-    myWidthLabel.setText("Format Width = " + (float)myPageFormat.getWidth());
-    myHeightLabel.setText("Format Height = " + (float)myPageFormat.getHeight());
-    myImageableXLabel.setText
-        ("Format Left Margin = " + (float)myPageFormat.getImageableX());
-    myImageableRightLabel.setText
-        ("Format Right Margin = " + (float)(myPageFormat.getWidth() -
-        (myPageFormat.getImageableX() + myPageFormat.getImageableWidth())));
-    myImageableWidthLabel.setText
-        ("Format ImageableWidth = " + (float)myPageFormat.getImageableWidth());
-    myImageableYLabel.setText
-        ("Format Top Margin = " + (float)myPageFormat.getImageableY());
-    myImageableBottomLabel.setText
-        ("Format Bottom Margin = " + (float)(myPageFormat.getHeight() -
-        (myPageFormat.getImageableY() + myPageFormat.getImageableHeight())));
-    myImageableHeightLabel.setText
-        ("Format ImageableHeight = " + (float)myPageFormat.getImageableHeight());
-    int o = myPageFormat.getOrientation();
-    if (o == PageFormat.LANDSCAPE && reverse) {
-        o = PageFormat.REVERSE_LANDSCAPE;
-        myPageFormat.setOrientation(PageFormat.REVERSE_LANDSCAPE);
-    } else if (o == PageFormat.REVERSE_LANDSCAPE && !reverse) {
-        o = PageFormat.LANDSCAPE;
-        myPageFormat.setOrientation(PageFormat.LANDSCAPE);
+    protected void displayPageFormatAttributes() {
+        myWidthLabel.setText("Format Width = " + myPageFormat.getWidth());
+        myHeightLabel.setText("Format Height = " + myPageFormat.getHeight());
+        myImageableXLabel.setText("Format Left Margin = "
+                + myPageFormat.getImageableX());
+        myImageableRightLabel.setText("Format Right Margin = "
+                + (myPageFormat.getWidth()
+                        - (myPageFormat.getImageableX() + myPageFormat.getImageableWidth())));
+        myImageableWidthLabel.setText("Format ImageableWidth = "
+                + myPageFormat.getImageableWidth());
+        myImageableYLabel.setText("Format Top Margin = "
+                + myPageFormat.getImageableY());
+        myImageableBottomLabel.setText("Format Bottom Margin = "
+                + (myPageFormat.getHeight()
+                        - (myPageFormat.getImageableY() + myPageFormat.getImageableHeight())));
+        myImageableHeightLabel.setText("Format ImageableHeight = "
+                + myPageFormat.getImageableHeight());
+        int o = myPageFormat.getOrientation();
+        if (o == PageFormat.LANDSCAPE && reverse) {
+            o = PageFormat.REVERSE_LANDSCAPE;
+            myPageFormat.setOrientation(PageFormat.REVERSE_LANDSCAPE);
+        } else if (o == PageFormat.REVERSE_LANDSCAPE && !reverse) {
+            o = PageFormat.LANDSCAPE;
+            myPageFormat.setOrientation(PageFormat.LANDSCAPE);
+        }
+        myOrientationLabel.setText
+                ("Format Orientation = " +
+                        (switch (o) {
+                            case PageFormat.PORTRAIT -> "PORTRAIT";
+                            case PageFormat.LANDSCAPE -> "LANDSCAPE";
+                            case PageFormat.REVERSE_LANDSCAPE -> "REVERSE_LANDSCAPE";
+                            default -> "<invalid>";
+                        }));
+        Paper p = myPageFormat.getPaper();
+        pw.setText("Paper Width = " + p.getWidth());
+        ph.setText("Paper Height = " + p.getHeight());
+        pglm.setText("Paper Left Margin = " + p.getImageableX());
+        pgiw.setText("Paper Imageable Width = " + p.getImageableWidth());
+        pgrm.setText("Paper Right Margin = "
+                + (p.getWidth()
+                        - (p.getImageableX() + p.getImageableWidth())));
+        pgtm.setText("Paper Top Margin = " + p.getImageableY());
+        pgih.setText("Paper Imageable Height = " + p.getImageableHeight());
+        pgbm.setText("Paper Bottom Margin = "
+                + (p.getHeight()
+                        - (p.getImageableY() + p.getImageableHeight())));
     }
-    myOrientationLabel.setText
-        ("Format Orientation = " +
-                (o == PageFormat.PORTRAIT ? "PORTRAIT" :
-                 o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
-                 o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
-                 "<invalid>"));
-    Paper p = myPageFormat.getPaper();
-    pw.setText("Paper Width = " + (float)p.getWidth());
-    ph.setText("Paper Height = " + (float)p.getHeight());
-    pglm.setText("Paper Left Margin = " + (float)p.getImageableX());
-    pgiw.setText("Paper Imageable Width = " + (float)p.getImageableWidth());
-    pgrm.setText("Paper Right Margin = " +
-         (float)(p.getWidth() - (p.getImageableX()+p.getImageableWidth())));
-    pgtm.setText("Paper Top Margin = " + (float)p.getImageableY());
-    pgih.setText("Paper Imageable Height = " + (float)p.getImageableHeight());
-    pgbm.setText("Paper Bottom Margin = " +
-       (float)(p.getHeight() - (p.getImageableY()+p.getImageableHeight())));
-  }
 
-  public PageSetupDialog() {
-    super ("Page Dialog Test");
-    myPrinterJob = PrinterJob.getPrinterJob();
-    myPageFormat = new PageFormat();
-    Paper p = new Paper();
-    double margin = 1.5*72;
-    p.setImageableArea(margin, margin,
-                       p.getWidth()-2*margin, p.getHeight()-2*margin);
-    myPageFormat.setPaper(p);
-    Panel c = new Panel();
-    c.setLayout (new GridLayout (9, 2, 0, 0));
-    c.add (reverseCB = new Checkbox("reverse if landscape"));
-    c.add (myOrientationLabel = new Label());
-    c.add (myWidthLabel = new Label());
-    c.add (pw = new Label());
-    c.add (myImageableXLabel = new Label());
-    c.add (pglm = new Label());
-    c.add (myImageableRightLabel = new Label());
-    c.add (pgrm = new Label());
-    c.add (myImageableWidthLabel = new Label());
-    c.add (pgiw = new Label());
-    c.add (myHeightLabel = new Label());
-    c.add (ph = new Label());
-    c.add (myImageableYLabel = new Label());
-    c.add (pgtm = new Label());
-    c.add (myImageableHeightLabel = new Label());
-    c.add (pgih = new Label());
-    c.add (myImageableBottomLabel = new Label());
-    c.add (pgbm = new Label());
+    public PageSetupDialog() {
+        super("Page Dialog Test");
+        myPrinterJob = PrinterJob.getPrinterJob();
+        myPageFormat = new PageFormat();
+        Paper p = new Paper();
+        double margin = 1.5 * 72;
+        p.setImageableArea(margin, margin,
+                p.getWidth() - 2 * margin, p.getHeight() - 2 * margin);
+        myPageFormat.setPaper(p);
+        Panel c = new Panel();
+        c.setLayout(new GridLayout(9, 2, 0, 0));
+        c.add(reverseCB = new Checkbox("reverse if landscape"));
+        c.add(myOrientationLabel = new Label());
+        c.add(myWidthLabel = new Label());
+        c.add(pw = new Label());
+        c.add(myImageableXLabel = new Label());
+        c.add(pglm = new Label());
+        c.add(myImageableRightLabel = new Label());
+        c.add(pgrm = new Label());
+        c.add(myImageableWidthLabel = new Label());
+        c.add(pgiw = new Label());
+        c.add(myHeightLabel = new Label());
+        c.add(ph = new Label());
+        c.add(myImageableYLabel = new Label());
+        c.add(pgtm = new Label());
+        c.add(myImageableHeightLabel = new Label());
+        c.add(pgih = new Label());
+        c.add(myImageableBottomLabel = new Label());
+        c.add(pgbm = new Label());
 
-    reverseCB.addItemListener(new ItemListener() {
-                public void itemStateChanged(ItemEvent e) {
-                       reverse = e.getStateChange() == ItemEvent.SELECTED;
-                       int o = myPageFormat.getOrientation();
-                       if (o == PageFormat.LANDSCAPE ||
-                           o == PageFormat.REVERSE_LANDSCAPE) {
-                           displayPageFormatAttributes();
-                       }
+        reverseCB.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                reverse = e.getStateChange() == ItemEvent.SELECTED;
+                int o = myPageFormat.getOrientation();
+                if (o == PageFormat.LANDSCAPE ||
+                        o == PageFormat.REVERSE_LANDSCAPE) {
+                    displayPageFormatAttributes();
                 }
-    });
+            }
+        });
 
-    add("Center", c);
-    displayPageFormatAttributes();
-    Panel panel = new Panel();
-    Button pageButton = new Button ("Page Setup...");
-    pageButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                        myPageFormat = myPrinterJob.pageDialog (myPageFormat);
-                        displayPageFormatAttributes();
+        add("Center", c);
+        displayPageFormatAttributes();
+        Panel panel = new Panel();
+        Button pageButton = new Button("Page Setup...");
+        pageButton.addActionListener(e -> {
+            myPageFormat = myPrinterJob.pageDialog(myPageFormat);
+            displayPageFormatAttributes();
+        });
+        Button printButton = new Button("Print ...");
+        printButton.addActionListener(e -> {
+            if (myPrinterJob.printDialog()) {
+                myPrinterJob.setPrintable(PageSetupDialog.this, myPageFormat);
+                alpha = false;
+                try {
+                    myPrinterJob.print();
+                } catch (PrinterException pe) {
+                    pe.printStackTrace();
+                    PassFailJFrame.forceFail("Test failed because of PrinterException");
                 }
-    });
-    Button printButton = new Button ("Print ...");
-    printButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                    try {
-                         if (myPrinterJob.printDialog()) {
-                             myPrinterJob.setPrintable(PageSetupDialog.this,
-                                                       myPageFormat);
-                             alpha = false;
-                             myPrinterJob.print();
-                    }
-                    } catch (PrinterException pe ) {
-                    }
+            }
+        });
+        Button printAlphaButton = new Button("Print w/Alpha...");
+        printAlphaButton.addActionListener(e -> {
+            if (myPrinterJob.printDialog()) {
+                myPrinterJob.setPrintable(PageSetupDialog.this, myPageFormat);
+                alpha = true;
+                try {
+                    myPrinterJob.print();
+                } catch (PrinterException pe) {
+                    pe.printStackTrace();
+                    PassFailJFrame.forceFail("Test failed because of PrinterException");
                 }
-    });
-    Button printAlphaButton = new Button ("Print w/Alpha...");
-    printAlphaButton.addActionListener(new ActionListener() {
-           public void actionPerformed (ActionEvent e) {
-                    try {
-                         if (myPrinterJob.printDialog()) {
-                             myPrinterJob.setPrintable(PageSetupDialog.this,
-                                                       myPageFormat);
-                             alpha = true;
-                             myPrinterJob.print();
-                    }
-                    } catch (PrinterException pe ) {
-                    }
-           }
-    });
-    panel.add (pageButton);
-    panel.add (printButton);
-    panel.add (printAlphaButton);
-    add("South", panel);
-    addWindowListener (new WindowAdapter() {
-         public void windowClosing (WindowEvent e) {
-            dispose();
-            System.exit (0);
-         }
+            }
+        });
+        panel.add(pageButton);
+        panel.add(printButton);
+        panel.add(printAlphaButton);
+        add("South", panel);
+        pack();
+    }
 
-      });
-      //setSize (280, 550);
-      pack();
-      setVisible (true);
-  }
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+        if (pageIndex > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-  public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+        Graphics2D g2d = (Graphics2D) graphics;
+        g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+        g2d.drawString("ORIGIN(" + pageFormat.getImageableX() + "," +
+                pageFormat.getImageableY() + ")", 20, 20);
+        g2d.drawString("X THIS WAY", 200, 50);
+        g2d.drawString("Y THIS WAY", 60, 200);
+        g2d.drawString("Graphics is " + g2d.getClass().getName(), 100, 100);
+        g2d.drawRect(0, 0,
+                (int) pageFormat.getImageableWidth(),
+                (int) pageFormat.getImageableHeight());
+        if (alpha) {
+            g2d.setColor(new Color(0, 0, 255, 192));
+        } else {
+            g2d.setColor(Color.blue);
+        }
+        g2d.drawRect(1, 1,
+                (int) pageFormat.getImageableWidth() - 2,
+                (int) pageFormat.getImageableHeight() - 2);
 
-     if (pageIndex > 0) {
-        return Printable.NO_SUCH_PAGE;
-     }
+        return Printable.PAGE_EXISTS;
+    }
 
-     Graphics2D g2d = (Graphics2D)graphics;
-     g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
-     g2d.drawString("ORIGIN("+pageFormat.getImageableX()+","+
-                             pageFormat.getImageableY()+")", 20, 20);
-     g2d.drawString("X THIS WAY", 200, 50);
-     g2d.drawString("Y THIS WAY", 60 , 200);
-     g2d.drawString("Graphics is " + g2d.getClass().getName(), 100, 100);
-     g2d.drawRect(0,0,(int)pageFormat.getImageableWidth(),
-                      (int)pageFormat.getImageableHeight());
-     if (alpha) {
-       g2d.setColor(new Color(0,0,255,192));
-     } else {
-        g2d.setColor(Color.blue);
-     }
-     g2d.drawRect(1,1,(int)pageFormat.getImageableWidth()-2,
-                      (int)pageFormat.getImageableHeight()-2);
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-     return  Printable.PAGE_EXISTS;
-  }
-
-  public static void main( String[] args) {
-
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test is very flexible and requires much interaction.",
-         "If the platform print dialog supports it, adjust orientation",
-         "and margins and print pages and compare the results with the",
-         "request."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-     new PageSetupDialog();
-  }
-
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(10)
+                .testUI(PageSetupDialog::new)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/Cancel/PrinterJobCancel.java
+++ b/test/jdk/java/awt/print/PrinterJob/Cancel/PrinterJobCancel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,218 +21,98 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterAbortException;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+/*
  * @test
  * @bug 4245280
- * @summary PrinterJob not cancelled when PrinterJob.cancel() is used
  * @key printer
+ * @summary PrinterJob not cancelled when PrinterJob.cancel() is used
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual PrinterJobCancel
  */
-
-import java.awt.* ;
-import java.awt.print.* ;
-
 public class PrinterJobCancel extends Thread implements Printable {
+    private final PrinterJob pj;
+    private final boolean okayed;
+    private static final String INSTRUCTIONS =
+            "Test that print job cancellation works.\n\n" +
+            "This test starts after clicking OK / Print button.\n" +
+            "While the print job is in progress, the test automatically cancels it.\n" +
+            "The test will complete automatically.";
 
-  PrinterJob pj ;
-  boolean okayed;
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-  public static void main ( String args[] ) {
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
 
-     String[] instructions =
-        {
-         "Test that print job cancellation works.",
-         "You must have a printer available to perform this test.",
-         "This test silently starts a print job and while the job is",
-         "still being printed, cancels the print job",
-         "You should see a message on System.out that the job",
-         "was properly cancelled.",
-         "You will need to kill the application manually since regression",
-         "tests apparently aren't supposed to call System.exit()"
-       };
-
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-      PrinterJobCancel pjc = new PrinterJobCancel() ;
-
-      if (pjc.okayed) {
-          pjc.start();
-          try {
-               Thread.sleep(5000);
-               pjc.pj.cancel();
-          } catch ( InterruptedException e ) {
-          }
-      }
-  }
-
-  public PrinterJobCancel() {
-
-    pj = PrinterJob.getPrinterJob() ;
-    pj.setPrintable(this);
-    okayed = pj.printDialog();
-  }
-
-  public void run() {
-    boolean cancelWorked = false;
-    try {
-        pj.print() ;
+        PrinterJobCancel pjc = new PrinterJobCancel();
+        if (pjc.okayed) {
+            pjc.start();
+            Thread.sleep(5000);
+            pjc.pj.cancel();
+        } else {
+            PassFailJFrame.forceFail("User cancelled printing");
+        }
+        passFailJFrame.awaitAndCheck();
     }
-    catch ( PrinterAbortException paex ) {
-      cancelWorked = true;
-      System.out.println("Job was properly cancelled and we");
-      System.out.println("got the expected PrintAbortException");
+
+    public PrinterJobCancel() {
+        pj = PrinterJob.getPrinterJob();
+        pj.setPrintable(this);
+        okayed = pj.printDialog();
     }
-    catch ( PrinterException prex ) {
-      System.out.println("This is wrong .. we shouldn't be here");
-      System.out.println("Looks like a test failure");
-      prex.printStackTrace() ;
-      //throw prex;
+
+    public void run() {
+        boolean cancelWorked = false;
+        try {
+            pj.print();
+        } catch (PrinterAbortException paex) {
+            cancelWorked = true;
+            System.out.println("Job was properly cancelled and we");
+            System.out.println("got the expected PrintAbortException");
+            PassFailJFrame.forcePass();
+        } catch (PrinterException prex) {
+            prex.printStackTrace();
+            PassFailJFrame.forceFail("Unexpected PrinterException caught:" + prex.getMessage());
+        } finally {
+            System.out.println("DONE PRINTING");
+            if (!cancelWorked) {
+                PassFailJFrame.forceFail("Didn't get the expected PrintAbortException");
+            }
+        }
     }
-    finally {
-       System.out.println("DONE PRINTING");
-       if (!cancelWorked) {
-           System.out.println("Looks like the test failed - we didn't get");
-           System.out.println("the expected PrintAbortException ");
-       }
+
+    @Override
+    public int print(Graphics g, PageFormat pagef, int pidx) {
+        if (pidx > 5) {
+            return (Printable.NO_SUCH_PAGE);
+        }
+
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.translate(pagef.getImageableX(), pagef.getImageableY());
+        g2d.setColor(Color.black);
+        g2d.drawString(("This is page" + (pidx + 1)), 60, 80);
+        // Need to slow things down a bit .. important not to try this
+        // on the event dispatching thread of course.
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException ignored) {
+        }
+
+        return Printable.PAGE_EXISTS;
     }
-    //System.exit(0);
-  }
-
-  public int print(Graphics g, PageFormat pagef, int pidx) {
-
-     if (pidx > 5) {
-        return( Printable.NO_SUCH_PAGE ) ;
-     }
-
-     Graphics2D g2d = (Graphics2D)g;
-     g2d.translate(pagef.getImageableX(), pagef.getImageableY());
-     g2d.setColor(Color.black);
-
-     g2d.drawString(("This is page"+(pidx+1)), 60 , 80);
-     // Need to slow things down a bit .. important not to try this
-     // on the event dispathching thread of course.
-     try {
-          Thread.sleep(2000);
-     } catch (InterruptedException e) {
-     }
-
-     return ( Printable.PAGE_EXISTS );
-  }
-
 }
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintAllFonts.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintAllFonts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,55 +21,63 @@
  * questions.
  */
 
-/**
- *
- * test
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.GraphicsEnvironment;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterJob;
+
+/*
+ * @test
  * @bug 4884389 7183516
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @summary Font specified with face name loses style on printing
  * @run main/manual PrintAllFonts
  */
-
-import java.awt.*;
-import java.awt.print.*;
-import java.awt.GraphicsEnvironment;
-
 public class PrintAllFonts implements Printable {
+    private static final int LINE_HEIGHT = 18;
+    private static final int FONT_SIZE = 14;
 
-    static Font[] allFonts;
-    int fontNum = 0;
-    int startNum = 0;
-    int lineHeight = 18;
-    boolean done = false;
-    int thisPage = 0;
+    private final Font[] allFonts =
+            GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
+    private int fontNum = 0;
+    private int startNum = 0;
+    private int thisPage = 0;
 
+    private static final String INSTRUCTIONS =
+            "This bug is system dependent and is not always reproducible.\n" +
+            "Font names will be printed in two columns.\n" +
+            "First column non synthesised and second column with synthesised italic.\n" +
+            "A passing test will have all text printed with correct font style.";
 
     public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-        String[] instructions =
-        {
-            "You must have a printer available to perform this test and should use Win 98.",
-            "This bug is system dependent and is not always reproducible.",
-            " ",
-            "A passing test will have all text printed with correct font style.",
-        };
-
-        Sysout.createDialog( );
-        Sysout.printInstructions( instructions );
-
-        GraphicsEnvironment ge =
-            GraphicsEnvironment.getLocalGraphicsEnvironment();
-        allFonts = ge.getAllFonts();
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(10)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
 
         PrinterJob pj = PrinterJob.getPrinterJob();
         pj.setPrintable(new PrintAllFonts());
         if (pj.printDialog()) {
-           pj.print();
+            pj.print();
+        } else {
+            PassFailJFrame.forceFail("User cancelled printing");
         }
+        passFailJFrame.awaitAndCheck();
     }
 
+    @Override
     public int print(Graphics g, PageFormat pf, int pageIndex) {
-
         if (fontNum >= allFonts.length && pageIndex > thisPage) {
             return NO_SUCH_PAGE;
         }
@@ -79,18 +87,20 @@ public class PrintAllFonts implements Printable {
         } else {
             fontNum = startNum;
         }
+
+        int fontsPerPage = (int) pf.getImageableHeight() / LINE_HEIGHT - 1;
+        int x = (int) pf.getImageableX() + 10;
+        int y = (int) pf.getImageableY() + LINE_HEIGHT;
+
         g.setColor(Color.black);
-
-        int hgt = (int)pf.getImageableHeight();
-        int fontsPerPage = hgt/lineHeight;
-        int x = (int)pf.getImageableX()+10;
-        int y = (int)pf.getImageableY()+lineHeight;
-
         for (int n = 0; n < fontsPerPage; n++) {
-            Font f = allFonts[fontNum].deriveFont(Font.PLAIN, 16);
+            Font f = allFonts[fontNum].deriveFont(Font.PLAIN, FONT_SIZE);
+            Font fi = allFonts[fontNum].deriveFont(Font.ITALIC, FONT_SIZE);
             g.setFont(f);
             g.drawString(f.getFontName(), x, y);
-            y+= lineHeight;
+            g.setFont(fi);
+            g.drawString(f.getFontName(), (int) (x + pf.getImageableWidth() / 2), y);
+            y += LINE_HEIGHT;
             fontNum++;
             if (fontNum >= allFonts.length) {
                 break;
@@ -99,117 +109,3 @@ public class PrintAllFonts implements Printable {
         return PAGE_EXISTS;
     }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/ValidatePage/ValidatePage.java
+++ b/test/jdk/java/awt/print/PrinterJob/ValidatePage/ValidatePage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,407 +21,283 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.print.PageFormat;
+import java.awt.print.Paper;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import javax.swing.JOptionPane;
+
+/*
  * @test
  * @bug 4252108 6229507
  * @key printer
  * @summary PrinterJob.validatePage() is unimplemented.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual ValidatePage
  */
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-
 public class ValidatePage extends Frame implements Printable {
+    PrinterJob myPrinterJob;
+    PageFormat myPageFormat;
+    Label pw, ph, pglm, pgrm, pgiw, pgih, pgtm, pgbm;
+    TextField tpw, tph, tpglm, tpgtm, tpgiw, tpgih;
+    Label myWidthLabel;
+    Label myHeightLabel;
+    Label myImageableXLabel;
+    Label myImageableYLabel;
+    Label myImageableRightLabel;
+    Label myImageableBottomLabel;
+    Label myImageableWidthLabel;
+    Label myImageableHeightLabel;
+    Label myOrientationLabel;
 
-PrinterJob myPrinterJob;
-PageFormat myPageFormat;
-Label pw, ph, pglm, pgrm, pgiw, pgih, pgtm, pgbm;
-TextField tpw, tph, tpglm, tpgtm, tpgiw, tpgih;
-Label myWidthLabel;
-Label myHeightLabel;
-Label myImageableXLabel;
-Label myImageableYLabel;
-Label myImageableRightLabel;
-Label myImageableBottomLabel;
-Label myImageableWidthLabel;
-Label myImageableHeightLabel;
-Label myOrientationLabel;
+    private static String getOrientation(int o) {
+        return switch (o) {
+            case PageFormat.PORTRAIT -> "PORTRAIT";
+            case PageFormat.LANDSCAPE -> "LANDSCAPE";
+            case PageFormat.REVERSE_LANDSCAPE -> "REVERSE_LANDSCAPE";
+            default -> "<invalid>";
+        };
+    }
 
-  protected void displayPageFormatAttributes() {
-    myWidthLabel.setText ("Format Width = " + drnd(myPageFormat.getWidth()));
-    myHeightLabel.setText ("Format Height = " + drnd(myPageFormat.getHeight()));
-    myImageableXLabel.setText
-        ("Format Left Margin = " + drnd(myPageFormat.getImageableX()));
-    myImageableRightLabel.setText
-        ("Format Right Margin = " + drnd(myPageFormat.getWidth() -
-        (myPageFormat.getImageableX() + myPageFormat.getImageableWidth())));
-    myImageableWidthLabel.setText
-        ("Format ImageableWidth = " + drnd(myPageFormat.getImageableWidth()));
-    myImageableYLabel.setText
-        ("Format Top Margin = " + drnd(myPageFormat.getImageableY()));
-    myImageableBottomLabel.setText
-        ("Format Bottom Margin = " + drnd(myPageFormat.getHeight() -
-        (myPageFormat.getImageableY() + myPageFormat.getImageableHeight())));
-    myImageableHeightLabel.setText
-        ("Format ImageableHeight = " + drnd(myPageFormat.getImageableHeight()));
-    int o = myPageFormat.getOrientation();
-    myOrientationLabel.setText
-        ("Format Orientation = " +
-                (o == PageFormat.PORTRAIT ? "PORTRAIT" :
-                 o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
-                 o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
-                 "<invalid>"));
-    Paper p = myPageFormat.getPaper();
-    pw.setText("Paper Width = " + drnd(p.getWidth()));
-    ph.setText("Paper Height = " + drnd(p.getHeight()));
-    pglm.setText("Paper Left Margin = " + drnd(p.getImageableX()));
-    pgiw.setText("Paper Imageable Width = " + drnd(p.getImageableWidth()));
-    pgih.setText("Paper Imageable Height = " + drnd(p.getImageableHeight()));
+    private void displayPageFormatAttributes() {
+        myWidthLabel.setText("Format Width = " + drnd(myPageFormat.getWidth()));
+        myHeightLabel.setText("Format Height = " + drnd(myPageFormat.getHeight()));
+        myImageableXLabel.setText("Format Left Margin = " + drnd(myPageFormat.getImageableX()));
+        myImageableRightLabel.setText("Format Right Margin = "
+                + drnd(myPageFormat.getWidth()
+                        - (myPageFormat.getImageableX() + myPageFormat.getImageableWidth())));
+        myImageableWidthLabel.setText("Format ImageableWidth = "
+                + drnd(myPageFormat.getImageableWidth()));
+        myImageableYLabel.setText("Format Top Margin = "
+                + drnd(myPageFormat.getImageableY()));
+        myImageableBottomLabel.setText("Format Bottom Margin = "
+                + drnd(myPageFormat.getHeight()
+                        - (myPageFormat.getImageableY() + myPageFormat.getImageableHeight())));
+        myImageableHeightLabel.setText("Format ImageableHeight = "
+                + drnd(myPageFormat.getImageableHeight()));
+        myOrientationLabel.setText("Format Orientation = "
+                + getOrientation(myPageFormat.getOrientation()));
+        Paper p = myPageFormat.getPaper();
+        pw.setText("Paper Width = " + drnd(p.getWidth()));
+        ph.setText("Paper Height = " + drnd(p.getHeight()));
+        pglm.setText("Paper Left Margin = " + drnd(p.getImageableX()));
+        pgiw.setText("Paper Imageable Width = " + drnd(p.getImageableWidth()));
+        pgih.setText("Paper Imageable Height = " + drnd(p.getImageableHeight()));
 
-    pgrm.setText("Paper Right Margin = " +
-         drnd(p.getWidth() - (p.getImageableX()+p.getImageableWidth())));
-    pgtm.setText("Paper Top Margin = " + drnd(p.getImageableY()));
-    pgbm.setText("Paper Bottom Margin = " +
-       drnd(p.getHeight() - (p.getImageableY()+p.getImageableHeight())));
-  }
+        pgrm.setText("Paper Right Margin = "
+                + drnd(p.getWidth()
+                        - (p.getImageableX() + p.getImageableWidth())));
+        pgtm.setText("Paper Top Margin = " + drnd(p.getImageableY()));
+        pgbm.setText("Paper Bottom Margin = "
+                + drnd(p.getHeight()
+                        - (p.getImageableY() + p.getImageableHeight())));
+    }
 
-  static String drnd(double d) {
-      d = d * 10.0 + 0.5;
-      d = Math.floor(d) /10.0;
-      String ds = Double.toString(d);
-      int decimal_pos = ds.indexOf(".");
-      int len = ds.length();
-      if (len > decimal_pos+2) {
-          return ds.substring(0, decimal_pos+2);
-      } else {
-          return ds;
-      }
-  }
+    static String drnd(double d) {
+        return String.format("%.2f", d);
+    }
 
-  public ValidatePage() {
-    super ("Validate Page Test");
-    myPrinterJob = PrinterJob.getPrinterJob();
-    myPageFormat = new PageFormat();
-    Paper p = new Paper();
-    p.setSize(28*72, 21.5 * 72);
-    myPageFormat.setPaper(p);
-    setLayout(new FlowLayout());
-    Panel pfp = new Panel();
-    pfp.setLayout (new GridLayout (9, 1, 0, 0));
-    pfp.add (myOrientationLabel = new Label());
-    pfp.add (myWidthLabel = new Label());
-    pfp.add (myImageableXLabel = new Label());
-    pfp.add (myImageableRightLabel = new Label());
-    pfp.add (myImageableWidthLabel = new Label());
-    pfp.add (myHeightLabel = new Label());
-    pfp.add (myImageableYLabel = new Label());
-    pfp.add (myImageableBottomLabel = new Label());
-    pfp.add (myImageableHeightLabel = new Label());
+    public ValidatePage() {
+        super("Validate Page Test");
+        myPrinterJob = PrinterJob.getPrinterJob();
+        myPageFormat = new PageFormat();
+        Paper p = new Paper();
+        p.setSize(28 * 72, 21.5 * 72);
+        myPageFormat.setPaper(p);
+        setLayout(new FlowLayout());
+        Panel pfp = new Panel();
+        pfp.setLayout(new GridLayout(9, 1, 0, 0));
+        pfp.add(myOrientationLabel = new Label());
+        pfp.add(myWidthLabel = new Label());
+        pfp.add(myImageableXLabel = new Label());
+        pfp.add(myImageableRightLabel = new Label());
+        pfp.add(myImageableWidthLabel = new Label());
+        pfp.add(myHeightLabel = new Label());
+        pfp.add(myImageableYLabel = new Label());
+        pfp.add(myImageableBottomLabel = new Label());
+        pfp.add(myImageableHeightLabel = new Label());
 
-    add(pfp);
+        add(pfp);
 
-    Panel pp = new Panel();
-    pp.setLayout (new GridLayout (8, 1, 0, 0));
-    pp.add (pw = new Label());
-    pp.add (pglm = new Label());
-    pp.add (pgtm = new Label());
-    pp.add (ph = new Label());
-    pp.add (pgiw = new Label());
-    pp.add (pgih = new Label());
-    pp.add (pgrm = new Label());
-    pp.add (pgbm = new Label());
+        Panel pp = new Panel();
+        pp.setLayout(new GridLayout(8, 1, 0, 0));
+        pp.add(pw = new Label());
+        pp.add(pglm = new Label());
+        pp.add(pgtm = new Label());
+        pp.add(ph = new Label());
+        pp.add(pgiw = new Label());
+        pp.add(pgih = new Label());
+        pp.add(pgrm = new Label());
+        pp.add(pgbm = new Label());
 
-    add(pp);
+        add(pp);
 
-    Panel epp = new Panel();
-    epp.setLayout (new GridLayout (6, 2, 0, 0));
+        Panel epp = new Panel();
+        epp.setLayout(new GridLayout(6, 2, 0, 0));
 
-    epp.add(new Label("Page width:"));
-    epp.add (tpw = new TextField());
-    epp.add(new Label("Page height:"));
-    epp.add (tph = new TextField());
-    epp.add(new Label("Left Margin:"));
-    epp.add (tpglm = new TextField());
-    epp.add(new Label("Top margin:"));
-    epp.add (tpgtm = new TextField());
-    epp.add(new Label("Imageable Wid:"));
-    epp.add (tpgiw = new TextField());
-    epp.add(new Label("Imageable Hgt:"));
-    epp.add (tpgih = new TextField());
+        epp.add(new Label("Page width:"));
+        epp.add(tpw = new TextField());
+        epp.add(new Label("Page height:"));
+        epp.add(tph = new TextField());
+        epp.add(new Label("Left Margin:"));
+        epp.add(tpglm = new TextField());
+        epp.add(new Label("Top margin:"));
+        epp.add(tpgtm = new TextField());
+        epp.add(new Label("Imageable Wid:"));
+        epp.add(tpgiw = new TextField());
+        epp.add(new Label("Imageable Hgt:"));
+        epp.add(tpgih = new TextField());
 
-    add(epp);
-       displayPageFormatAttributes();
+        add(epp);
+        displayPageFormatAttributes();
 
-    Panel panel = new Panel();
-    Button defButton = new Button ("Default Page");
-    defButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                        myPageFormat = myPrinterJob.defaultPage();
-                        displayPageFormatAttributes();
-                }
-    });
+        Panel panel = new Panel();
+        Button defButton = new Button("Default Page");
+        defButton.addActionListener(e -> {
+            myPageFormat = myPrinterJob.defaultPage();
+            displayPageFormatAttributes();
+        });
 
-    Button pageButton = new Button ("Page Setup..");
-    pageButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                        myPageFormat = myPrinterJob.pageDialog (myPageFormat);
-                        displayPageFormatAttributes();
-                }
-    });
-    Button printButton = new Button ("Print");
-    printButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                    try {
-                         //if (myPrinterJob.printDialog()) {
-                             myPrinterJob.setPrintable(ValidatePage.this,
-                                                       myPageFormat);
-                             myPrinterJob.print();
-                   // }
-                    } catch (PrinterException pe ) {
-                    }
-                }
-    });
+        Button pageButton = new Button("Page Setup...");
+        pageButton.addActionListener(e -> {
+            myPageFormat = myPrinterJob.pageDialog(myPageFormat);
+            displayPageFormatAttributes();
+        });
+        Button printButton = new Button("Print");
+        printButton.addActionListener(e -> {
+            try {
+                myPrinterJob.setPrintable(ValidatePage.this, myPageFormat);
+                myPrinterJob.print();
+            } catch (PrinterException pe) {
+                pe.printStackTrace();
+                PassFailJFrame.forceFail("Test failed because of PrinterException");
+            }
+        });
 
-    Button chooseButton = new Button ("Printer..");
-    chooseButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                            myPrinterJob.printDialog();
-                }
-    });
+        Button chooseButton = new Button("Printer...");
+        chooseButton.addActionListener(e -> myPrinterJob.printDialog());
 
-    Button validateButton = new Button ("Validate Page");
-    validateButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                        myPageFormat = myPrinterJob.validatePage(myPageFormat);
-                        displayPageFormatAttributes();
-                }
-    });
-    Button setButton = new Button ("Set Paper");
-    setButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                  try {
-                      Paper p = new Paper();
-                      double pwid = Double.parseDouble(tpw.getText());
-                      double phgt = Double.parseDouble(tph.getText());
-                      double pimx = Double.parseDouble(tpglm.getText());
-                      double pimy = Double.parseDouble(tpgtm.getText());
-                      double pimwid = Double.parseDouble(tpgiw.getText());
-                      double pimhgt = Double.parseDouble(tpgih.getText());
-                      p.setSize(pwid, phgt);
-                      p.setImageableArea(pimx, pimy, pimwid, pimhgt);
-                      myPageFormat.setPaper(p);
-                            displayPageFormatAttributes();
-                  } catch (NumberFormatException nfe) {
-                  }
-                }
-    });
-    panel.add (setButton);
-    panel.add (defButton);
-    panel.add (pageButton);
-    panel.add (chooseButton);
-    panel.add (validateButton);
-    panel.add (printButton);
-    add(panel);
-    TextArea ta = new TextArea(7, 60);
-    String ls = System.getProperty("line.Separator", "\n");
-    ta.setText(
-        "When validating a page, the process is 1st to find the closest matching " + ls +
-        "paper size, next to make sure the requested imageable area fits within " + ls +
-        "the printer's imageable area for that paper size. Finally the top and " + ls +
-        "left margins will be shrunk if they are too great for the adjusted " + ls +
-        "imageable area to fit at that position. They will shrink by the minimum" + ls +
-        "needed to accomodate the imageable area."+ls+ls+
-        "To test 6229507, put the minimum margins (all 0s) in Page Setup dialog."+ls+
-        "Compare Imageable width, height, and margins of portrait against landscape.");
-    ta.setEditable(false);
-    add(ta);
+        Button validateButton = new Button("Validate Page");
+        validateButton.addActionListener(e -> {
+            myPageFormat = myPrinterJob.validatePage(myPageFormat);
+            displayPageFormatAttributes();
+        });
+        Button setButton = new Button("Set Paper");
+        setButton.addActionListener(e -> {
+            try {
+                Paper p1 = new Paper();
+                double pwid = Double.parseDouble(tpw.getText());
+                double phgt = Double.parseDouble(tph.getText());
+                double pimx = Double.parseDouble(tpglm.getText());
+                double pimy = Double.parseDouble(tpgtm.getText());
+                double pimwid = Double.parseDouble(tpgiw.getText());
+                double pimhgt = Double.parseDouble(tpgih.getText());
+                p1.setSize(pwid, phgt);
+                p1.setImageableArea(pimx, pimy, pimwid, pimhgt);
+                myPageFormat.setPaper(p1);
+                displayPageFormatAttributes();
+            } catch (NumberFormatException nfe) {
+                JOptionPane.showMessageDialog(ValidatePage.this,
+                        "NumberFormatException occurred", "Error",
+                        JOptionPane.ERROR_MESSAGE);
+            }
+        });
+        panel.add(setButton);
+        panel.add(defButton);
+        panel.add(pageButton);
+        panel.add(chooseButton);
+        panel.add(validateButton);
+        panel.add(printButton);
+        add(panel);
+        TextArea ta = new TextArea(10, 45);
+        ta.setText(
+                "When validating a page, the process is 1st to find the closest matching \n" +
+                "paper size, next to make sure the requested imageable area fits within \n" +
+                "the printer's imageable area for that paper size. Finally the top and \n" +
+                "left margins will be shrunk if they are too great for the adjusted \n" +
+                "imageable area to fit at that position. They will shrink by the minimum\n" +
+                "needed to accommodate the imageable area.\n \n \n" +
+                "To test 6229507, put the minimum margins (all 0s) in Page Setup dialog.\n" +
+                "Compare Imageable width, height, and margins of portrait against landscape.");
 
-    addWindowListener (new WindowAdapter() {
-         public void windowClosing (WindowEvent e) {
-            dispose();
-            System.exit (0);
-         }
+        ta.setEditable(false);
+        add(ta);
+        setSize(700, 500);
+    }
 
-      });
-      setSize (500, 630);
-      setVisible (true);
-  }
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+        if (pageIndex > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-  public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+        System.out.println("Format Orientation = "
+                + getOrientation(pageFormat.getOrientation()));
 
-     if (pageIndex > 0) {
-        return Printable.NO_SUCH_PAGE;
-     }
+        Graphics2D g2d = (Graphics2D) graphics;
 
-     Graphics2D g2d = (Graphics2D)graphics;
+        System.out.println(g2d.getTransform());
+        System.out.println("ix=" + pageFormat.getImageableX() +
+                           " iy=" + pageFormat.getImageableY());
+        g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+        g2d.drawString("ORIGIN", 20, 20);
+        g2d.drawString("X THIS WAY", 200, 50);
+        g2d.drawString("Y THIS WAY", 60, 200);
+        g2d.drawRect(0, 0,
+                    (int) pageFormat.getImageableWidth(),
+                    (int) pageFormat.getImageableHeight());
+        g2d.setColor(Color.blue);
+        g2d.drawRect(1, 1,
+                    (int) pageFormat.getImageableWidth() - 2,
+                    (int) pageFormat.getImageableHeight() - 2);
 
-    int o = pageFormat.getOrientation();
+        return Printable.PAGE_EXISTS;
+    }
 
-     System.out.println("Format Orientation = " +
-                (o == PageFormat.PORTRAIT ? "PORTRAIT" :
-                 o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
-                 o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
-                 "<invalid>"));
-     System.out.println(g2d.getTransform());
-     System.out.println("ix="+pageFormat.getImageableX()+
-                       " iy="+pageFormat.getImageableY());
-     g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
-     g2d.drawString("ORIGIN", 20, 20);
-     g2d.drawString("X THIS WAY", 200, 50);
-     g2d.drawString("Y THIS WAY", 60 , 200);
-     g2d.drawRect(0,0,(int)pageFormat.getImageableWidth(),
-                      (int)pageFormat.getImageableHeight());
-     g2d.setColor(Color.blue);
-     g2d.drawRect(1,1,(int)pageFormat.getImageableWidth()-2,
-                      (int)pageFormat.getImageableHeight()-2);
+    private static final String INSTRUCTIONS =
+            "This test is very flexible and requires much interaction.\n" +
+            "There are several buttons.\n\n" +
+            "Set Paper: if all fields are valid numbers it sets the Paper object.\n" +
+            "This is used to create arbitrary nonsensical paper sizes to help\n" +
+            "test validatePage.\n\n" +
+            "Default Page: sets a default page. This should always be valid.\n\n" +
+            "Page Setup: brings up the page dialog. You must OK this dialog\n" +
+            "for it to have any effect. You can use this to set different size,\n" +
+            "orientation and margins - which of course affect imageable area.\n\n" +
+            "Printer: Used to set the current printer. Useful because current\n" +
+            "printer affects the choice of paper sizes available.\n" +
+            "You must OK this dialog for it to have any effect.\n\n" +
+            "Validate Page:The most important button in the test.\n" +
+            "By setting nonsensical or valid papers with varying margins etc,\n" +
+            "this should always find the closest match within the limits of\n" +
+            "what is possible on the current printer.\n\n" +
+            "Print: to the current printer. Not vital for this test request.";
 
-     return  Printable.PAGE_EXISTS;
-  }
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-  public static void main( String[] args) {
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test is very flexible and requires much interaction.",
-         "There are several buttons.",
-         "Set Paper: if all fields are valid numbers it sets the Paper object.",
-         "This is used to create arbitrary nonsensical paper sizes to help",
-         "test validatePage.",
-         "Default Page: sets a default page. This should always be valid.",
-         "Page Setup: brings up the page dialog. You must OK this dialog",
-         "for it to have any effect. You can use this to set different size,",
-         "orientation and margins - which of course affect imageable area.",
-         "Printer: Used to set the current printer. Useful because current",
-         "printer affects the choice of paper sizes available.",
-         "You must OK this dialog for it to have any effect.",
-         "Validate Page:",
-         "The most important button in the test. By setting nonsensical",
-         "or valid papers with varying margins etc, this should always find",
-         "the closest",
-         "match within the limits of what is possible on the current printer.",
-         "Print: to the current printer. Not vital for this test.",
-         "request."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-     new ValidatePage();
-  }
-
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(10)
+                .testUI(ValidatePage::new)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/raster/RasterTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/raster/RasterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,248 +21,129 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+/*
  * @test
  * @bug 4242639
  * @summary Printing quality problem on Canon and NEC
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual RasterTest
  */
-import java.awt.*;
-import java.awt.geom.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import java.awt.Toolkit;
-import java.awt.image.BufferedImage;
-
-
 public class RasterTest extends Frame implements ActionListener {
+    private final RasterCanvas c;
+    private static final String INSTRUCTIONS =
+            "This test uses rendering operations which force the implementation\n" +
+            "to print the page as a raster\n" +
+            "You should see two square images, the 1st containing overlapping\n" +
+            "composited squares, the lower image shows a gradient paint.\n" +
+            "The printed output should match the on-screen display, although\n" +
+            "only colour printers will be able to accurately reproduce the\n" +
+            "subtle color changes.";
 
- private RasterCanvas c;
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
- public static void main(String args[]) {
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test uses rendering operations which force the implementation",
-         "to print the page as a raster",
-         "You should see two square images, the 1st containing overlapping",
-         "composited squares, the lower image shows a gradient paint.",
-         "The printed output should match the on-screen display, although",
-         "only colour printers will be able to accurately reproduce the",
-         "subtle color changes."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .testUI(RasterTest::new)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 
-    RasterTest f = new RasterTest();
-    f.show();
- }
-
- public RasterTest() {
+    public RasterTest() {
         super("Java 2D Raster Printing");
 
-    c = new RasterCanvas();
-    add("Center", c);
+        c = new RasterCanvas();
+        add("Center", c);
 
-    Button printButton = new Button("Print");
-    printButton.addActionListener(this);
-    add("South", printButton);
-
-    addWindowListener(new WindowAdapter() {
-       public void windowClosing(WindowEvent e) {
-             System.exit(0);
-            }
-    });
-
-    pack();
-
+        Button printButton = new Button("Print");
+        printButton.addActionListener(this);
+        add("South", printButton);
+        pack();
         setBackground(Color.white);
+    }
 
- }
+    public void actionPerformed(ActionEvent e) {
+        PrinterJob pj = PrinterJob.getPrinterJob();
 
- public void actionPerformed(ActionEvent e) {
+        if (pj.printDialog()) {
+            pj.setPrintable(c);
+            try {
+                pj.print();
+            } catch (PrinterException pe) {
+                pe.printStackTrace();
+                PassFailJFrame.forceFail("Test failed because of PrinterException");
+            }
+        }
+    }
 
-   PrinterJob pj = PrinterJob.getPrinterJob();
+    private static class RasterCanvas extends Canvas implements Printable {
+        @Override
+        public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
+            if (pgIndex > 0) {
+                return Printable.NO_SUCH_PAGE;
+            }
 
-   if (pj != null && pj.printDialog()) {
-       pj.setPrintable(c);
-       try {
-            pj.print();
-      } catch (PrinterException pe) {
-      } finally {
-         System.err.println("PRINT RETURNED");
-      }
-   }
+            Graphics2D g2d = (Graphics2D) g;
+            g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+            doPaint(g2d);
+
+            return Printable.PAGE_EXISTS;
+        }
+
+        @Override
+        public void paint(Graphics g) {
+            doPaint(g);
+        }
+
+        private void doPaint(Graphics g) {
+            BufferedImage bimg = new BufferedImage(200, 200,
+                    BufferedImage.TYPE_INT_ARGB);
+            Graphics ig = bimg.getGraphics();
+            Color alphared = new Color(255, 0, 0, 128);
+            Color alphagreen = new Color(0, 255, 0, 128);
+            Color alphablue = new Color(0, 0, 255, 128);
+            ig.setColor(alphared);
+            ig.fillRect(0, 0, 200, 200);
+            ig.setColor(alphagreen);
+            ig.fillRect(25, 25, 150, 150);
+            ig.setColor(alphablue);
+            ig.fillRect(75, 75, 125, 125);
+            g.drawImage(bimg, 10, 25, this);
+            ig.dispose();
+
+            GradientPaint gp =
+                    new GradientPaint(10.0f, 10.0f, alphablue, 210.0f, 210.0f, alphared, true);
+
+            Graphics2D g2 = (Graphics2D) g;
+            g2.setPaint(gp);
+            g2.fillRect(10, 240, 200, 200);
+        }
+
+        @Override
+        public Dimension getPreferredSize() {
+            return new Dimension(500, 500);
+        }
+    }
 }
-
-
- class RasterCanvas extends Canvas implements Printable {
-
-
-    public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-      if (pgIndex > 0)
-         return Printable.NO_SUCH_PAGE;
-
-         Graphics2D g2d= (Graphics2D)g;
-         g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-         doPaint(g2d);
-      return Printable.PAGE_EXISTS;
-    }
-
-    public void paint(Graphics g) {
-       doPaint(g);
-    }
-
-    public void paintComponent(Graphics g) {
-       doPaint(g);
-    }
-
-    public void doPaint(Graphics g) {
-        Graphics2D g2 = (Graphics2D)g;
-
-        g2.setColor(Color.black);
-
-        BufferedImage bimg = new BufferedImage(200, 200,
-                                                 BufferedImage.TYPE_INT_ARGB);
-        Graphics ig = bimg.getGraphics();
-        Color alphared = new Color(255, 0, 0, 128);
-        Color alphagreen = new Color(0, 255, 0, 128);
-        Color alphablue = new Color(0, 0, 255, 128);
-        ig.setColor(alphared);
-        ig.fillRect(0,0,200,200);
-        ig.setColor(alphagreen);
-        ig.fillRect(25,25,150,150);
-        ig.setColor(alphablue);
-        ig.fillRect(75,75,125,125);
-        g.drawImage(bimg, 10, 25, this);
-
-        GradientPaint gp =
-         new GradientPaint(10.0f, 10.0f, alphablue, 210.0f, 210.0f, alphared, true);
-        g2.setPaint(gp);
-        g2.fillRect(10, 240, 200, 200);
-
-     }
-
-    public Dimension getPreferredSize() {
-        return new Dimension(500, 500);
-    }
-
- }
-
-}
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320676](https://bugs.openjdk.org/browse/JDK-8320676) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320676](https://bugs.openjdk.org/browse/JDK-8320676): Manual printer tests have no Pass/Fail buttons, instructions close set 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1332/head:pull/1332` \
`$ git checkout pull/1332`

Update a local copy of the PR: \
`$ git checkout pull/1332` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1332`

View PR using the GUI difftool: \
`$ git pr show -t 1332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1332.diff">https://git.openjdk.org/jdk21u-dev/pull/1332.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1332#issuecomment-2595893301)
</details>
