### PR TITLE
8329322: Convert PageFormat/Orient.java to use PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/print/PageFormat/Orient.java
+++ b/test/jdk/java/awt/print/PageFormat/Orient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,64 +21,47 @@
  * questions.
  */
 
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.geom.Ellipse2D;
+import java.awt.print.Book;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
 /*
-  @test
-  @bug 4236095
-  @summary  Confirm that the you get three pages of output, one
-            each in portrait, landscape, and reverse landscape
-            orientations.
-  @key printer
-  @run main/manual Orient
-*/
-
-
-//*** global search and replace Orient with name of the test ***
-
-/**
- * Orient.java
- *
- * summary:
+ * @test
+ * @bug 4236095
+ * @summary  Confirm that you get three pages of output, one
+ *           each in portrait, landscape and reverse landscape
+ *           orientations.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @key printer
+ * @run main/manual Orient
  */
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.geom.*;
-import java.awt.print.*;
-
-// This test is a "main" test as applets would need Runtime permission
-// "queuePrintJob".
-
 public class Orient implements Printable {
+    private static final String INSTRUCTIONS =
+            """
+             This test will automatically initiate a print.
 
-   private static void init()
-    {
-        //*** Create instructions for the user here ***
+             A passing test will print three pages each containing a large oval
+             with the text describing the orientation: PORTRAIT, LANDSCAPE
+             or REVERSE_LANDSCAPE, inside of it. The first page will
+             be emitted in portrait orientation, the second page in landscape
+             orientation and the third page in reverse-landscape orientation.
 
-        String[] instructions =
-        {
-         "On-screen inspection is not possible for this printing-specific",
-         "test therefore its only output is three printed pages.",
-         "To be able to run this test it is required to have a default",
-         "printer configured in your user environment.",
-         "",
-         "Visual inspection of the printed page is needed. A passing",
-         "test will print three pages each containing a large oval ",
-         "with the text describing the orientation: PORTRAIT, LANDSCAPE",
-         "or REVERSE_LANDSCAPE, inside of it. The first page will ",
-         "be emitted in portait orientation, the second page in landscape ",
-         "orientation and the third page in reverse-landscape orientation. ",
-         "On each page the oval will be wholly within the imageable area ",
-         "of the page. In a failing test the oval on the third page ",
-         "will be clipped against the imageable area.",
-         "Axes will indicate the direction of increasing X and Y"
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+             On each page the oval will be wholly within the imageable area of the page.
+             Axes will indicate the direction of increasing X and Y.
 
+             Test failed if the oval on the page clipped against the imageable area.
+            """;
+
+    private static void printOrientationJob() throws PrinterException {
         PrinterJob pjob = PrinterJob.getPrinterJob();
-
         Book book = new Book();
-
         // Page 1
         PageFormat portrait = pjob.defaultPage();
         portrait.setOrientation(PageFormat.PORTRAIT);
@@ -95,366 +78,47 @@ public class Orient implements Printable {
         book.append(new Orient(), reverseLandscape);
 
         pjob.setPageable(book);
-        try {
-            pjob.print();
-        } catch (PrinterException e) {
-            e.printStackTrace();
-        }
 
-    }//End  init()
+        pjob.print();
+    }
 
+    @Override
     public int print(Graphics g, PageFormat pf, int pageIndex) {
-
-        Graphics2D g2d = (Graphics2D)g;
+        Graphics2D g2d = (Graphics2D) g;
         g2d.translate(pf.getImageableX(), pf.getImageableY());
         drawGraphics(g2d, pf);
         return Printable.PAGE_EXISTS;
     }
 
     void drawGraphics(Graphics2D g, PageFormat pf) {
-        double iw = pf.getImageableWidth();
-        double ih = pf.getImageableHeight();
-
+        String orientation = switch (pf.getOrientation()) {
+            case PageFormat.PORTRAIT -> "PORTRAIT";
+            case PageFormat.LANDSCAPE -> "LANDSCAPE";
+            case PageFormat.REVERSE_LANDSCAPE -> "REVERSE_LANDSCAPE";
+            default -> "INVALID";
+        };
         g.setColor(Color.black);
-        String orientation;
-        switch (pf.getOrientation()) {
-           case PageFormat.PORTRAIT  : orientation = "PORTRAIT";
-                                       break;
-           case PageFormat.LANDSCAPE : orientation = "LANDSCAPE";
-                                       break;
-           case PageFormat.REVERSE_LANDSCAPE :
-                                       orientation = "REVERSE_LANDSCAPE";
-                                       break;
-           default                   : orientation = "INVALID";
-        }
         g.drawString(orientation, 100, 300);
-        g.draw(new Ellipse2D.Double(0, 0, iw, ih));
-        g.drawString("(0,0)", 5,15);
-        g.drawLine(0,0,300,0);
-        g.drawString("X", 300,15);
-        g.drawLine(0,0,0,300);
-        g.drawString("Y",5,300);
+        g.draw(new Ellipse2D.Double(0, 0,
+                pf.getImageableWidth(), pf.getImageableHeight()));
+        g.drawString("(0,0)", 5, 15);
+        g.drawLine(0, 0, 300, 0);
+        g.drawString("X", 300, 15);
+        g.drawLine(0, 0, 0, 300);
+        g.drawString("Y", 5, 300);
     }
 
+    public static void main(String args[]) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-   /*****************************************************
-     Standard Test Machinery Section
-      DO NOT modify anything in this section -- it's a
-      standard chunk of code which has all of the
-      synchronisation necessary for the test harness.
-      By keeping it the same in all tests, it is easier
-      to read and understand someone else's test, as
-      well as insuring that all tests behave correctly
-      with the test harness.
-     There is a section following this for test-defined
-      classes
-   ******************************************************/
-   private static boolean theTestPassed = false;
-   private static boolean testGeneratedInterrupt = false;
-   private static String failureMessage = "";
-
-   private static Thread mainThread = null;
-
-   private static int sleepTime = 300000;
-
-   public static void main( String args[] ) throws InterruptedException
-    {
-      mainThread = Thread.currentThread();
-      try
-       {
-         init();
-       }
-      catch( TestPassedException e )
-       {
-         //The test passed, so just return from main and harness will
-         // interepret this return as a pass
-         return;
-       }
-      //At this point, neither test passed nor test failed has been
-      // called -- either would have thrown an exception and ended the
-      // test, so we know we have multiple threads.
-
-      //Test involves other threads, so sleep and wait for them to
-      // called pass() or fail()
-      try
-       {
-         Thread.sleep( sleepTime );
-         //Timed out, so fail the test
-         throw new RuntimeException( "Timed out after " + sleepTime/1000 + " seconds" );
-       }
-      catch (InterruptedException e)
-       {
-         if( ! testGeneratedInterrupt ) throw e;
-
-         //reset flag in case hit this code more than once for some reason (just safety)
-         testGeneratedInterrupt = false;
-         if ( theTestPassed == false )
-          {
-            throw new RuntimeException( failureMessage );
-          }
-       }
-
-    }//main
-
-   public static synchronized void setTimeoutTo( int seconds )
-    {
-      sleepTime = seconds * 1000;
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
+        printOrientationJob();
+        passFailJFrame.awaitAndCheck();
     }
-
-   public static synchronized void pass()
-    {
-      Sysout.println( "The test passed." );
-      Sysout.println( "The test is over, hit  Ctl-C to stop Java VM" );
-      //first check if this is executing in main thread
-      if ( mainThread == Thread.currentThread() )
-       {
-         //Still in the main thread, so set the flag just for kicks,
-         // and throw a test passed exception which will be caught
-         // and end the test.
-         theTestPassed = true;
-         throw new TestPassedException();
-       }
-      //pass was called from a different thread, so set the flag and interrupt
-      // the main thead.
-      theTestPassed = true;
-      testGeneratedInterrupt = true;
-      mainThread.interrupt();
-    }//pass()
-
-   public static synchronized void fail()
-    {
-      //test writer didn't specify why test failed, so give generic
-      fail( "it just plain failed! :-)" );
-    }
-
-   public static synchronized void fail( String whyFailed )
-    {
-      Sysout.println( "The test failed: " + whyFailed );
-      Sysout.println( "The test is over, hit  Ctl-C to stop Java VM" );
-      //check if this called from main thread
-      if ( mainThread == Thread.currentThread() )
-       {
-         //If main thread, fail now 'cause not sleeping
-         throw new RuntimeException( whyFailed );
-       }
-      theTestPassed = false;
-      testGeneratedInterrupt = true;
-      failureMessage = whyFailed;
-      mainThread.interrupt();
-    }//fail()
-
- }// class Orient
-
-//This exception is used to exit from any level of call nesting
-// when it's determined that the test has passed, and immediately
-// end the test.
-class TestPassedException extends RuntimeException
- {
- }
-
-//*********** End Standard Test Machinery Section **********
-
-
-//************ Begin classes defined for the test ****************
-
-// make listeners in a class defined here, and instantiate them in init()
-
-/* Example of a class which may be written as part of a test
-class NewClass implements anInterface
- {
-   static int newVar = 0;
-
-   public void eventDispatched(AWTEvent e)
-    {
-      //Counting events to see if we get enough
-      eventCount++;
-
-      if( eventCount == 20 )
-       {
-         //got enough events, so pass
-
-         Orient.pass();
-       }
-      else if( tries == 20 )
-       {
-         //tried too many times without getting enough events so fail
-
-         Orient.fail();
-       }
-
-    }// eventDispatched()
-
- }// NewClass class
-
-*/
-
-
-//************** End classes defined for the test *******************
-
-
-
-
-/****************************************************
- Standard Test Machinery
- DO NOT modify anything below -- it's a standard
-  chunk of code whose purpose is to make user
-  interaction uniform, and thereby make it simpler
-  to read and understand someone else's test.
- ****************************************************/
-
-/**
- This is part of the standard test machinery.
- It creates a dialog (with the instructions), and is the interface
-  for sending text messages to the user.
- To print the instructions, send an array of strings to Sysout.createDialog
-  WithInstructions method.  Put one line of instructions per array entry.
- To display a message for the tester to see, simply call Sysout.println
-  with the string to be displayed.
- This mimics System.out.println but works within the test harness as well
-  as standalone.
- */
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog implements ActionListener
- {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-   Panel  buttonP = new Panel();
-   Button passB = new Button( "pass" );
-   Button failB = new Button( "fail" );
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      passB = new Button( "pass" );
-      passB.setActionCommand( "pass" );
-      passB.addActionListener( this );
-      buttonP.add( "East", passB );
-
-      failB = new Button( "fail" );
-      failB.setActionCommand( "fail" );
-      failB.addActionListener( this );
-      buttonP.add( "West", failB );
-
-      add( "South", buttonP );
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
-   //catch presses of the passed and failed buttons.
-   //simply call the standard pass() or fail() static methods of
-   //Orient
-   public void actionPerformed( ActionEvent e )
-    {
-      if( e.getActionCommand() == "pass" )
-       {
-         Orient.pass();
-       }
-      else
-       {
-         Orient.fail();
-       }
-    }
-
- }// TestDialog  class
+}


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329322](https://bugs.openjdk.org/browse/JDK-8329322) needs maintainer approval

### Issue
 * [JDK-8329322](https://bugs.openjdk.org/browse/JDK-8329322): Convert PageFormat/Orient.java to use PassFailJFrame (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1333/head:pull/1333` \
`$ git checkout pull/1333`

Update a local copy of the PR: \
`$ git checkout pull/1333` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1333`

View PR using the GUI difftool: \
`$ git pr show -t 1333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1333.diff">https://git.openjdk.org/jdk21u-dev/pull/1333.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1333#issuecomment-2597627656)
</details>
