### PR TITLE
8334305: Remove all code for  nsk.share.Log verbose mode

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ public class MatMul {
     }
 
     public int run() {
-        log = new Log(System.out, verbose);
+        log = new Log(System.out);
         log.display("Parallel matrix multiplication test");
 
         Matrix a = Matrix.randomMatrix(dim);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launchnosuspend/launchnosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launchnosuspend/launchnosuspend001.java
@@ -71,7 +71,6 @@ public class launchnosuspend001 {
 
         argHandler = new ArgumentHandler(args);
         log = new Log(this.out, argHandler);
-        //log.enableVerbose(true);
     }
 
     private PrintStream out;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter_tagged/HeapFilter.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter_tagged/HeapFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,6 @@ public class HeapFilter extends DebugeeClass {
         log = new Log(out, argHandler);
         testObjects = new Object[]{new TaggedClass(),
                                    new UntaggedClass()};
-        log.enableVerbose(true);
         log.display("Verifying reachable objects.");
         status = checkStatus(status);
         testObjects = null;

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ public class isexceeded001 {
     public static int run(String[] argv, PrintStream out) {
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         Log log = new Log(out, argHandler);
-        log.enableVerbose(true);
 
         monitor = Monitor.getMemoryMonitor(log, argHandler);
         List pools = monitor.getMemoryPoolMBeans();

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ public class isexceeded001 {
     public static int run(String[] argv, PrintStream out) {
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         Log log = new Log(out, argHandler);
-        log.enableVerbose(true); // show log output
 
         MemoryMonitor monitor = Monitor.getMemoryMonitor(log, argHandler);
         List pools = monitor.getMemoryPoolMBeans();

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/lowmem/lowmem001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/lowmem/lowmem001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class lowmem001 extends ThreadedGCTest {
 
     @Override
     public void run() {
-        Log log = new Log(System.out, true);
+        Log log = new Log(System.out);
         // System.err is duplicated into buffer
         // it should be empty
         MyStream stream = new MyStream(System.err);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODTestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class AODTestRunner {
     protected AODRunnerArgParser argParser;
 
     protected AODTestRunner(String[] args) {
-        log = new Log(System.out, true);
+        log = new Log(System.out);
 
         argParser = createArgParser(args);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AbstractJarAgent.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AbstractJarAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,7 +157,7 @@ abstract public class AbstractJarAgent {
         if (name == null)
             throw new TestBug("Agent name wasn't specified");
 
-        log = new Log(System.out, true);
+        log = new Log(System.out);
     }
 
     /*

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/DummyTargetApplication.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/DummyTargetApplication.java
@@ -39,7 +39,7 @@ it sends signal that it is ready for test and waits for signal permitting finish
  */
 public class DummyTargetApplication {
 
-    protected Log log = new Log(System.out, true);
+    protected Log log = new Log(System.out);
 
     protected AODTargetArgParser argParser;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/TargetApplicationWaitingAgents.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/TargetApplicationWaitingAgents.java
@@ -213,7 +213,7 @@ public class TargetApplicationWaitingAgents {
             if (targetApplicationInitialized)
                 throw new TestBug("TargetApplication already initialized");
 
-            log = new Log(System.out, true);
+            log = new Log(System.out);
 
             argParser = createArgParser(args);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/JVMTITest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/JVMTITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class JVMTITest {
 
         AgentsAttacher attacher = new AgentsAttacher(Utils.findCurrentVMIdUsingJPS(jdkPath),
                 agents,
-                new Log(System.out, true));
+                new Log(System.out));
         attacher.attachAgents();
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/coverage/parentheses/Parentheses.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/coverage/parentheses/Parentheses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class Parentheses {
 
     public void run() throws IOException, ReflectiveOperationException {
 
-        log = new Log(System.out, verbose);
+        log = new Log(System.out);
 
         InstructionSequence instructionSequence = null;
         for (int i = 0; i < iterations * stressOptions.getIterationsFactor(); i++) {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334305](https://bugs.openjdk.org/browse/JDK-8334305) needs maintainer approval

### Issue
 * [JDK-8334305](https://bugs.openjdk.org/browse/JDK-8334305): Remove all code for  nsk.share.Log verbose mode (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1334/head:pull/1334` \
`$ git checkout pull/1334`

Update a local copy of the PR: \
`$ git checkout pull/1334` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1334`

View PR using the GUI difftool: \
`$ git pr show -t 1334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1334.diff">https://git.openjdk.org/jdk21u-dev/pull/1334.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1334#issuecomment-2597676363)
</details>
