### PR TITLE
Backport 49501fe9c4d0fc4d6285ba4f5d403754e5a147bd

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -171,6 +171,7 @@ public class Log {
      * the given <code>argsHandler</code>.
      */
     public Log(PrintStream stream, ArgumentParser argsParser) {
+        this(stream);
         traceLevel = argsParser.getTraceLevel();
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

