### PR TITLE
8313633: [macOS] java/awt/dnd/NextDropActionTest/NextDropActionTest.java fails with java.lang.RuntimeException: wrong next drop action!

### DIFF
--- a/test/jdk/java/awt/dnd/NextDropActionTest/NextDropActionTest.java
+++ b/test/jdk/java/awt/dnd/NextDropActionTest/NextDropActionTest.java
@@ -88,7 +88,7 @@ public class NextDropActionTest {
             final DragSourceListener dsl = new DragSourceAdapter() {
                 boolean firstCall = true;
                 public void dragDropEnd(DragSourceDropEvent e) {
-                    System.err.println("DragSourseListener.dragDropEnd(): " +
+                    System.err.println("DragSourceListener.dragDropEnd(): " +
                             " firstCall=" + firstCall +
                             " drop action=" + e.getDropAction());
                     if (firstCall) {
@@ -140,18 +140,22 @@ public class NextDropActionTest {
                 robot.keyRelease(KeyEvent.VK_CONTROL);
                 LOCK.wait(WAIT_TIMEOUT);
             }
+
             if (!firstEnd) {
-                System.err.println("DragSourseListener.dragDropEnd() " +
+                System.err.println("DragSourceListener.dragDropEnd() " +
                         "was not called, returning");
                 return;
             }
+
+            robot.delay(1000);
 
             synchronized (LOCK) {
                 Util.doDragDrop(robot, startPoint, endPoint);
                 LOCK.wait(WAIT_TIMEOUT);
             }
+
             if (!secondEnd) {
-                System.err.println("DragSourseListener.dragDropEnd() " +
+                System.err.println("DragSourceListener.dragDropEnd() " +
                         "was not called, returning");
                 return;
             }
@@ -171,7 +175,7 @@ public class NextDropActionTest {
 
 class Util {
     public static int sign(int n) {
-        return n < 0 ? -1 : n == 0 ? 0 : 1;
+        return Integer.compare(n, 0);
     }
 
     public static void doDragDrop(Robot robot, Point startPoint, Point endPoint) {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313633](https://bugs.openjdk.org/browse/JDK-8313633) needs maintainer approval

### Issue
 * [JDK-8313633](https://bugs.openjdk.org/browse/JDK-8313633): [macOS] java/awt/dnd/NextDropActionTest/NextDropActionTest.java fails with java.lang.RuntimeException: wrong next drop action! (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1338/head:pull/1338` \
`$ git checkout pull/1338`

Update a local copy of the PR: \
`$ git checkout pull/1338` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1338`

View PR using the GUI difftool: \
`$ git pr show -t 1338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1338.diff">https://git.openjdk.org/jdk21u-dev/pull/1338.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1338#issuecomment-2598167500)
</details>
