### PR TITLE
8343599: Kmem limit and max values swapped when printing container information

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -241,9 +241,9 @@ void CgroupV1Subsystem::print_version_specific_info(outputStream* st) {
   jlong kmem_limit = kernel_memory_limit_in_bytes();
   jlong kmem_max_usage = kernel_memory_max_usage_in_bytes();
 
+  OSContainer::print_container_helper(st, kmem_limit, "kernel_memory_limit_in_bytes");
   OSContainer::print_container_helper(st, kmem_usage, "kernel_memory_usage_in_bytes");
-  OSContainer::print_container_helper(st, kmem_limit, "kernel_memory_max_usage_in_bytes");
-  OSContainer::print_container_helper(st, kmem_max_usage, "kernel_memory_limit_in_bytes");
+  OSContainer::print_container_helper(st, kmem_max_usage, "kernel_memory_max_usage_in_bytes");
 }
 
 char * CgroupV1Subsystem::cpu_cpuset_cpus() {


### PR DESCRIPTION
Backport of JDK-8343599 Kmem limit and max values swapped when printing container information

Clean backport.
Passed tier1 tests.

The only failing tier1 test is java/foreign/nested/TestNested.java which is failing due to preview API on the current master as well with:

`(use --enable-preview to enable preview APIs)
...  is a preview API and is disabled by default.`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343599](https://bugs.openjdk.org/browse/JDK-8343599) needs maintainer approval

### Issue
 * [JDK-8343599](https://bugs.openjdk.org/browse/JDK-8343599): Kmem limit and max values swapped when printing container information (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1341/head:pull/1341` \
`$ git checkout pull/1341`

Update a local copy of the PR: \
`$ git checkout pull/1341` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1341`

View PR using the GUI difftool: \
`$ git pr show -t 1341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1341.diff">https://git.openjdk.org/jdk21u-dev/pull/1341.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1341#issuecomment-2600120653)
</details>
