### PR TITLE
8343118: [TESTBUG] java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java fails with rror. Can't find HTML file PrintCheckboxManualTest.html

### DIFF
--- a/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
+++ b/test/jdk/java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,84 +22,52 @@
  */
 
 /*
-  @test
-  @bug 5045936 5055171
-  @summary Tests that there is no ClassCastException thrown in printing
-   checkbox and scrollbar with XAWT
-  @key printer
-  @run applet/manual=yesno PrintCheckboxManualTest.html
-*/
+ * @test
+ * @bug 5045936 5055171
+ * @summary Tests that there is no ClassCastException thrown in printing
+ *          checkbox and scrollbar with XAWT
+ * @key printer
+ * @requires (os.family == "linux")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PrintCheckboxManualTest
+ */
 
-// Note there is no @ in front of test above.  This is so that the
-//  harness will not mistake this file as a test file.  It should
-//  only see the html file as a test file. (the harness runs all
-//  valid test files, so it would run this test twice if this file
-//  were valid as well as the html file.)
-// Also, note the area= after Your Name in the author tag.  Here, you
-//  should put which functional area the test falls in.  See the
-//  AWT-core home page -> test areas and/or -> AWT team  for a list of
-//  areas.
+import java.awt.Button;
+import java.awt.Checkbox;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.PrintJob;
+import java.awt.Scrollbar;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
+public class PrintCheckboxManualTest extends Panel {
 
+    private static final String INSTRUCTIONS = """
+            This test is for Linux with XToolkit ONLY!,
+            1. Click the 'Print' button on the frame
+            2. Select a printer in the print dialog and proceed
+            3. If the frame with checkbox and button on it
+               is printed without any exception test PASSED else FAILED.
+        """;
 
-import java.awt.*;
-import java.awt.event.*;
-
-
-//Manual tests should run as applet tests if possible because they
-// get their environments cleaned up, including AWT threads, any
-// test created threads, and any system resources used by the test
-// such as file descriptors.  (This is normally not a problem as
-// main tests usually run in a separate VM, however on some platforms
-// such as the Mac, separate VMs are not possible and non-applet
-// tests will cause problems).  Also, you don't have to worry about
-// synchronisation stuff in Applet tests the way you do in main
-// tests...
-
-
-public class PrintCheckboxManualTest extends Panel
-{
-    //Declare things used in the test, like buttons and labels here
-    Frame f;
-
-    public static void main(String[] args) {
-        PrintCheckboxManualTest a = new PrintCheckboxManualTest();
-
-        a.init();
-        a.start();
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(PrintCheckboxManualTest::createTestUI)
+                .build()
+                .awaitAndCheck();
     }
 
-    public void init()
-    {
-        //Create instructions for the user here, as well as set up
-        // the environment -- set the layout manager, add buttons,
-        // etc.
-        this.setLayout (new BorderLayout ());
+    private static Frame createTestUI() {
 
-        String[] instructions =
-        {
-            "Linux or Solaris with XToolkit ONLY!",
-            "1. Click the 'Print' button on the frame",
-            "2. Select a printer in the print dialog and proceed",
-            "3. If the frame with checkbox and button on it is printed successfully test PASSED else FAILED"
-        };
-        Sysout.createDialogWithInstructions( instructions );
-
-    }//End  init()
-
-    public void start ()
-    {
-        //Get things going.  Request focus, set size, et cetera
-        setSize (200,200);
-        setVisible(true);
-        validate();
-
-        //What would normally go into main() will probably go here.
-        //Use System.out.println for diagnostic messages that you want
-        // to read after the test is done.
-        //Use Sysout.println for messages you want the tester to read.
-
-        f = new Frame("Print checkbox");
+        Frame f = new Frame("Print checkbox");
         f.setLayout(new GridLayout(2, 2));
         f.setSize(200, 100);
 
@@ -111,185 +79,26 @@ public class PrintCheckboxManualTest extends Panel
         f.add(sb);
 
         Button b = new Button("Print");
-        b.addActionListener(new ActionListener()
-        {
-        public void actionPerformed(ActionEvent ev)
-        {
-                PrintJob pj = Toolkit.getDefaultToolkit().getPrintJob(f, "PrintCheckboxManualTest", null);
-                if (pj != null)
-                {
-                        try
-                        {
-                                Graphics g = pj.getGraphics();
-                                f.printAll(g);
-                                g.dispose();
-                                pj.end();
-                                Sysout.println("Test PASSED");
-                        }
-                        catch (ClassCastException cce)
-                        {
-                                Sysout.println("Test FAILED: ClassCastException");
-//                              throw new RuntimeException("Test FAILED: ClassCastException", cce);
-                        }
-                        catch (Exception e)
-                        {
-                                Sysout.println("Test FAILED: unknown Exception");
-//                              throw new Error("Test FAILED: unknown exception", e);
-                        }
+        b.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                PrintJob pj = Toolkit.getDefaultToolkit().
+                                      getPrintJob(f, "PrintCheckboxManualTest",
+                                                  null);
+                if (pj != null) {
+                    try {
+                        Graphics g = pj.getGraphics();
+                        f.printAll(g);
+                        g.dispose();
+                        pj.end();
+                    } catch (ClassCastException cce) {
+                        throw new RuntimeException("Test FAILED: ClassCastException", cce);
+                    } catch (Exception e) {
+                        throw new Error("Test FAILED: unknown exception", e);
+                    }
                 }
-        }
+            }
         });
         f.add(b);
-
-        f.setVisible(true);
-    }// start()
-
-    //The rest of this class is the actions which perform the test...
-
-    //Use Sysout.println to communicate with the user NOT System.out!!
-    //Sysout.println ("Something Happened!");
-
+        return f;
+    }
 }
-
-/* Place other classes related to the test after this line */
-
-
-
-
-
-/****************************************************
- Standard Test Machinery
- DO NOT modify anything below -- it's a standard
-  chunk of code whose purpose is to make user
-  interaction uniform, and thereby make it simpler
-  to read and understand someone else's test.
- ****************************************************/
-
-/**
- This is part of the standard test machinery.
- It creates a dialog (with the instructions), and is the interface
-  for sending text messages to the user.
- To print the instructions, send an array of strings to Sysout.createDialog
-  WithInstructions method.  Put one line of instructions per array entry.
- To display a message for the tester to see, simply call Sysout.println
-  with the string to be displayed.
- This mimics System.out.println but works within the test harness as well
-  as standalone.
- */
-
-class Sysout
-{
-    private static TestDialog dialog;
-
-    public static void createDialogWithInstructions( String[] instructions )
-    {
-        dialog = new TestDialog( new Frame(), "Instructions" );
-        dialog.printInstructions( instructions );
-        dialog.setVisible(true);
-        println( "Any messages for the tester will display here." );
-    }
-
-    public static void createDialog( )
-    {
-        dialog = new TestDialog( new Frame(), "Instructions" );
-        String[] defInstr = { "Instructions will appear here. ", "" } ;
-        dialog.printInstructions( defInstr );
-        dialog.setVisible(true);
-        println( "Any messages for the tester will display here." );
-    }
-
-
-    public static void printInstructions( String[] instructions )
-    {
-        dialog.printInstructions( instructions );
-    }
-
-
-    public static void println( String messageIn )
-    {
-        dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog
-{
-
-    TextArea instructionsText;
-    TextArea messageText;
-    int maxStringLength = 80;
-
-    //DO NOT call this directly, go through Sysout
-    public TestDialog( Frame frame, String name )
-    {
-        super( frame, name );
-        int scrollBoth = TextArea.SCROLLBARS_BOTH;
-        instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-        add( "North", instructionsText );
-
-        messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-        add("Center", messageText);
-
-        pack();
-
-        setVisible(true);
-    }// TestDialog()
-
-    //DO NOT call this directly, go through Sysout
-    public void printInstructions( String[] instructions )
-    {
-        //Clear out any current instructions
-        instructionsText.setText( "" );
-
-        //Go down array of instruction strings
-
-        String printStr, remainingStr;
-        for( int i=0; i < instructions.length; i++ )
-        {
-            //chop up each into pieces maxSringLength long
-            remainingStr = instructions[ i ];
-            while( remainingStr.length() > 0 )
-            {
-                //if longer than max then chop off first max chars to print
-                if( remainingStr.length() >= maxStringLength )
-                {
-                    //Try to chop on a word boundary
-                    int posOfSpace = remainingStr.
-                        lastIndexOf( ' ', maxStringLength - 1 );
-
-                    if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-                    printStr = remainingStr.substring( 0, posOfSpace + 1 );
-                    remainingStr = remainingStr.substring( posOfSpace + 1 );
-                }
-                //else just print
-                else
-                {
-                    printStr = remainingStr;
-                    remainingStr = "";
-                }
-
-                instructionsText.append( printStr + "\n" );
-
-            }// while
-
-        }// for
-
-    }//printInstructions()
-
-    //DO NOT call this directly, go through Sysout
-    public void displayMessage( String messageIn )
-    {
-        messageText.append( messageIn + "\n" );
-        System.out.println(messageIn);
-    }
-
-}// TestDialog  class


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343118](https://bugs.openjdk.org/browse/JDK-8343118) needs maintainer approval

### Issue
 * [JDK-8343118](https://bugs.openjdk.org/browse/JDK-8343118): [TESTBUG] java/awt/PrintJob/PrintCheckboxTest/PrintCheckboxManualTest.java fails with rror. Can't find HTML file PrintCheckboxManualTest.html (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1342/head:pull/1342` \
`$ git checkout pull/1342`

Update a local copy of the PR: \
`$ git checkout pull/1342` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1342`

View PR using the GUI difftool: \
`$ git pr show -t 1342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1342.diff">https://git.openjdk.org/jdk21u-dev/pull/1342.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1342#issuecomment-2602563425)
</details>
