### PR TITLE
8324838: test_nmt_locationprinting.cpp broken in the gcc windows build

### DIFF
--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,7 @@ static void test_for_live_c_heap_block(size_t sz, ssize_t offset) {
   FREE_C_HEAP_ARRAY(char, c);
 }
 
+#ifdef LINUX
 static void test_for_dead_c_heap_block(size_t sz, ssize_t offset) {
   if (!MemTracker::enabled()) {
     return;
@@ -92,6 +93,7 @@ static void test_for_dead_c_heap_block(size_t sz, ssize_t offset) {
   hdr->revive();
   FREE_C_HEAP_ARRAY(char, c);
 }
+#endif
 
 TEST_VM(NMT, location_printing_cheap_live_1) { test_for_live_c_heap_block(2 * K, 0); }              // start of payload
 TEST_VM(NMT, location_printing_cheap_live_2) { test_for_live_c_heap_block(2 * K, -7); }             // into header


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324838](https://bugs.openjdk.org/browse/JDK-8324838) needs maintainer approval

### Issue
 * [JDK-8324838](https://bugs.openjdk.org/browse/JDK-8324838): test_nmt_locationprinting.cpp broken in the gcc windows build (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1343/head:pull/1343` \
`$ git checkout pull/1343`

Update a local copy of the PR: \
`$ git checkout pull/1343` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1343`

View PR using the GUI difftool: \
`$ git pr show -t 1343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1343.diff">https://git.openjdk.org/jdk21u-dev/pull/1343.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1343#issuecomment-2602623715)
</details>
