### PR TITLE
8331977: Crash: SIGSEGV in dlerror()

### DIFF
--- a/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
+++ b/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,6 @@
  * questions.
  */
 
-import java.nio.file.Path;
-import java.util.List;
-import java.util.ArrayList;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.HelloApp;
 import jdk.jpackage.test.Annotations.Test;
@@ -52,10 +49,11 @@ public class ArgumentsFilteringTest {
     public void test1() {
         JPackageCommand cmd = JPackageCommand.helloAppImage();
         cmd.executeAndAssertHelloAppImageCreated();
-        Path launcherPath = cmd.appLauncherPath();
-        HelloApp.assertApp(launcherPath)
-                .executeAndVerifyOutput(false, List.of("-psn_1_1"),
-                        new ArrayList<>());
+        var appVerifier = HelloApp.assertMainLauncher(cmd);
+        if (appVerifier != null) {
+            appVerifier.execute("-psn_1_1");
+            appVerifier.verifyOutput();
+        }
     }
 
     @Test
@@ -63,9 +61,10 @@ public class ArgumentsFilteringTest {
         JPackageCommand cmd = JPackageCommand.helloAppImage()
                 .addArguments("--arguments", "-psn_2_2");
         cmd.executeAndAssertHelloAppImageCreated();
-        Path launcherPath = cmd.appLauncherPath();
-        HelloApp.assertApp(launcherPath)
-                .executeAndVerifyOutput(false, List.of("-psn_1_1"),
-                        List.of("-psn_2_2"));
+        var appVerifier = HelloApp.assertMainLauncher(cmd);
+        if (appVerifier != null) {
+            appVerifier.execute("-psn_1_1");
+            appVerifier.verifyOutput("-psn_2_2");
+        }
     }
 }

--- a/test/jdk/tools/jpackage/share/ArgumentsTest.java
+++ b/test/jdk/tools/jpackage/share/ArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 import java.nio.file.Path;
 import java.util.List;
 import jdk.jpackage.test.HelloApp;
-import jdk.jpackage.test.Functional.ThrowingConsumer;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.BeforeEach;
 import jdk.jpackage.test.Annotations.Test;
@@ -64,27 +63,19 @@ public class ArgumentsTest {
     @Parameter("Goodbye")
     @Parameter("com.hello/com.hello.Hello")
     public static void testApp(String javaAppDesc) {
-        testIt(javaAppDesc, null);
-    }
-
-    private static void testIt(String javaAppDesc,
-            ThrowingConsumer<JPackageCommand> initializer) {
-
         JPackageCommand cmd = JPackageCommand.helloAppImage(javaAppDesc).addArguments(
                 "--arguments", JPackageCommand.escapeAndJoin(TRICKY_ARGUMENTS));
-        if (initializer != null) {
-            ThrowingConsumer.toConsumer(initializer).accept(cmd);
-        }
 
         cmd.executeAndAssertImageCreated();
 
-        Path launcherPath = cmd.appLauncherPath();
-        if (!cmd.isFakeRuntime(String.format(
-                "Not running [%s] launcher", launcherPath))) {
-            HelloApp.assertApp(launcherPath)
-                    .addDefaultArguments(TRICKY_ARGUMENTS)
-                    .executeAndVerifyOutput();
+        if (!cmd.canRunLauncher("Not running the test")) {
+            return;
         }
+
+        Path launcherPath = cmd.appLauncherPath();
+        HelloApp.assertApp(launcherPath)
+                .addDefaultArguments(TRICKY_ARGUMENTS)
+                .executeAndVerifyOutput();
     }
 
     private final static List<String> TRICKY_ARGUMENTS = List.of(

--- a/test/jdk/tools/jpackage/share/MainClassTest.java
+++ b/test/jdk/tools/jpackage/share/MainClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -234,13 +234,12 @@ public final class MainClassTest {
             cmd.executeAndAssertHelloAppImageCreated();
         } else {
             cmd.executeAndAssertImageCreated();
-            if (!cmd.isFakeRuntime(String.format("Not running [%s]",
-                    cmd.appLauncherPath()))) {
-                List<String> output = new Executor()
-                    .setDirectory(cmd.outputDir())
-                    .setExecutable(cmd.appLauncherPath())
-                    .dumpOutput().saveOutput()
-                    .execute(1).getOutput();
+            var appVerifier = HelloApp.assertMainLauncher(cmd);
+            if (appVerifier != null) {
+                List<String> output = appVerifier
+                        .saveOutput(true)
+                        .expectedExitCode(1)
+                        .execute().getOutput();
                 TKit.assertTextStream(String.format(
                         "Error: Could not find or load main class %s",
                         nonExistingMainClass)).apply(output.stream());

--- a/test/jdk/tools/jpackage/windows/WinRenameTest.java
+++ b/test/jdk/tools/jpackage/windows/WinRenameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import jdk.jpackage.test.HelloApp;
 import jdk.jpackage.test.TKit;
-import jdk.jpackage.test.Functional.ThrowingConsumer;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
 
@@ -50,11 +49,16 @@ public class WinRenameTest {
 
         cmd.executeAndAssertImageCreated();
 
+        if (!cmd.canRunLauncher("Not running the test")) {
+            return;
+        }
+
+        HelloApp.executeLauncherAndVerifyOutput(cmd);
+
         Path launcherPath = cmd.appLauncherPath();
-        HelloApp.assertApp(launcherPath).executeAndVerifyOutput();
 
         String lp = launcherPath.toString();
-        TKit.assertTrue(lp.endsWith(".exe"), "UNexpected launcher path: " + lp);
+        TKit.assertTrue(lp.endsWith(".exe"), "Unexpected launcher path: " + lp);
 
         Path newLauncherPath = Path.of(lp.replaceAll(".exe", ".anything"));
         Files.move(launcherPath, newLauncherPath);


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

I had to resolve MainClassTest as the file was moved to another location.
This is because later "8344326: Move jpackage tests from "jdk.jpackage.tests" package to the default package"
was already backported.
The applied code is unchanged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331977](https://bugs.openjdk.org/browse/JDK-8331977) needs maintainer approval

### Issue
 * [JDK-8331977](https://bugs.openjdk.org/browse/JDK-8331977): Crash: SIGSEGV in dlerror() (**Bug** - P2 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1344/head:pull/1344` \
`$ git checkout pull/1344`

Update a local copy of the PR: \
`$ git checkout pull/1344` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1344`

View PR using the GUI difftool: \
`$ git pr show -t 1344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1344.diff">https://git.openjdk.org/jdk21u-dev/pull/1344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1344#issuecomment-2602694305)
</details>
