### PR TITLE
8341111: open source several AWT tests including menu shortcut tests

### DIFF
--- a/test/jdk/java/awt/MenuShortcut/ActionCommandTest.java
+++ b/test/jdk/java/awt/MenuShortcut/ActionCommandTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4079449
+ * @key headful
+ * @summary MenuItem objects return null if they are activated by shortcut
+ */
+
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import static java.awt.event.KeyEvent.VK_CONTROL;
+import static java.awt.event.KeyEvent.VK_META;
+
+public class ActionCommandTest implements ActionListener {
+
+    static volatile Frame frame;
+    static volatile boolean event = false;
+    static volatile boolean failed = false;
+    static final String ITEMTEXT = "Testitem";
+
+    static void createUI() {
+        frame = new Frame("ActionCommand Menu Shortcut Test");
+        MenuBar mb = new MenuBar();
+        Menu m = new Menu("Test");
+        MenuItem mi = new MenuItem(ITEMTEXT, new MenuShortcut(KeyEvent.VK_T));
+        mi.addActionListener(new ActionCommandTest());
+        m.add(mi);
+        mb.add(m);
+        frame.setMenuBar(mb);
+        frame.setBounds(50, 400, 200, 200);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args ) throws Exception {
+
+        EventQueue.invokeAndWait(ActionCommandTest::createUI);
+        try {
+            Robot robot = new Robot();
+
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            // Ensure window has focus
+            Point p = frame.getLocationOnScreen();
+            robot.mouseMove(p.x + frame.getWidth() / 2, p.y + frame.getHeight() / 2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            // invoke short cut.
+            robot.keyPress(KeyEvent.VK_T);
+            robot.delay(50);
+            robot.keyRelease(KeyEvent.VK_T);
+            robot.waitForIdle();
+            robot.delay(2000);
+        } finally  {
+            if (frame != null) {
+                EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+        if (failed) {
+           throw new RuntimeException("No actioncommand");
+        }
+    }
+
+    // Since no ActionCommand is set, this should be the menuitem's label.
+    public void actionPerformed(ActionEvent e) {
+        event = true;
+        String s = e.getActionCommand();
+        if (s == null || !s.equals(ITEMTEXT)) {
+            failed = true;
+        }
+    }
+
+}

--- a/test/jdk/java/awt/MenuShortcut/CheckMenuShortcut.java
+++ b/test/jdk/java/awt/MenuShortcut/CheckMenuShortcut.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4167811
+ * @summary tests that shortcuts work for Checkbox menu items
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CheckMenuShortcut
+*/
+
+import java.awt.CheckboxMenuItem;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.Panel;
+import java.awt.Rectangle;
+import java.awt.TextArea;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
+
+public class CheckMenuShortcut implements ActionListener, ItemListener {
+
+     static final String INSTRUCTIONS = """
+         A window that contains a text area will be displayed.
+         The window will have a menu labeled 'Window Menu'.  Click on the menu to see its items.
+
+         The two menu items should have shortcuts which in order are : Ctrl-A, Ctrl-I.
+         On macOS these will be Command-A, Command-I.
+
+         If the second item only has the label 'checkbox item' and no shortcut
+         ie none of Ctrl-I or Ctrl-i, or Command-I or Command-i on macOS painted on it, the test FAILS.
+
+         The same second item - labeled 'checkbox item' is in fact a Checkbox menu item.
+         The menu item should NOT be checked (eg no tick mark).
+
+         Dismiss the menu by clicking inside the window, do not select any of menu items.
+         After that press Ctrl-i, (Command-i on macOS).
+
+         After that click on the menu again. If the second menu item 'checkbox item' is now
+         checked, the test PASSES, if it is not checked, the test FAILS.
+       """;
+
+    public static void main(String[] args) throws Exception {
+       PassFailJFrame.builder()
+                .title("CheckboxMenuItem Shortcut Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(60)
+                .logArea()
+                .testUI(CheckMenuShortcut::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+
+    static Frame createUI() {
+
+        MenuBar mainMenu;
+        Menu menu;
+        MenuItem action;
+        CheckboxMenuItem item;
+        TextArea pane;
+
+        boolean isMac = System.getProperty("os.name").startsWith("Mac");
+        String ctrlA = (isMac) ? "Command-A" : "Ctrl-A";
+        String ctrlI = (isMac) ? "Command-I" : "Ctrl-I";
+
+        CheckMenuShortcut cms = new CheckMenuShortcut();
+        Frame frame = new Frame("CheckMenuShortcut");
+
+        mainMenu = new MenuBar();
+        menu = new Menu("Window Menu");
+
+        action = new MenuItem("action");
+        action.setShortcut(new MenuShortcut(KeyEvent.VK_A, false));
+        action.addActionListener(cms);
+        action.setActionCommand("action");
+        menu.add(action);
+
+        item = new CheckboxMenuItem("checkbox item", false);
+        item.setShortcut(new MenuShortcut(KeyEvent.VK_I,false));
+        item.addItemListener(cms);
+        item.addActionListener(cms);
+        menu.add(item);
+
+        mainMenu.add(menu);
+
+        frame.setMenuBar(mainMenu);
+
+        pane = new TextArea(ctrlA + " -- action menu test\n", 10, 40, TextArea.SCROLLBARS_VERTICAL_ONLY);
+        Dimension mySize = frame.getSize();
+        Insets myIns = frame.getInsets();
+        pane.setBounds(new Rectangle(mySize.width - myIns.left - myIns.right,
+                                     mySize.height - myIns.top - myIns.bottom));
+        pane.setLocation(myIns.left,myIns.top);
+        frame.add(pane);
+
+        pane.append(ctrlI + " -- item menu test\n");
+
+        frame.pack();
+        return frame;
+    }
+
+    public void itemStateChanged(ItemEvent evt) {
+        PassFailJFrame.log("Got item: " + evt.getItem() + "\n");
+    }
+
+    public void actionPerformed(ActionEvent evt) {
+        PassFailJFrame.log("Got action: " + evt.getActionCommand() + "\n");
+    }
+}

--- a/test/jdk/java/awt/MenuShortcut/FunctionKeyShortcut.java
+++ b/test/jdk/java/awt/MenuShortcut/FunctionKeyShortcut.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4034665
+ * @key headful
+ * @summary Function keys should work correctly as shortcuts
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import static java.awt.event.KeyEvent.VK_CONTROL;
+import static java.awt.event.KeyEvent.VK_META;
+
+public class FunctionKeyShortcut implements ActionListener {
+
+    static volatile Frame frame;
+    static volatile boolean event = false;
+    static volatile boolean failed = false;
+
+    static final boolean isMac = System.getProperty("os.name").contains("OS X");
+
+    static void createUI() {
+        frame = new Frame("Function Key Menu Shortcut Test");
+        MenuBar mb = new MenuBar();
+        Menu m = new Menu("Test");
+        MenuItem mi1 = new MenuItem("Function key 1", new MenuShortcut(KeyEvent.VK_F1));
+        MenuItem mi2 = new MenuItem("Function key 2", new MenuShortcut(KeyEvent.VK_F2));
+        MenuItem mi3 = new MenuItem("Function key 3", new MenuShortcut(KeyEvent.VK_F3));
+        MenuItem mi4 = new MenuItem("Function key 4", new MenuShortcut(KeyEvent.VK_F4));
+        MenuItem mi5 = new MenuItem("Function key 5", new MenuShortcut(KeyEvent.VK_F5));
+        MenuItem mi6 = new MenuItem("Function key 6", new MenuShortcut(KeyEvent.VK_F6));
+        MenuItem mi7 = new MenuItem("Function key 7", new MenuShortcut(KeyEvent.VK_F7));
+        MenuItem mi8 = new MenuItem("Function key 8", new MenuShortcut(KeyEvent.VK_F8));
+        MenuItem mi9 = new MenuItem("Function key 8", new MenuShortcut(KeyEvent.VK_F9));
+
+        FunctionKeyShortcut fks = new FunctionKeyShortcut();
+        mi1.addActionListener(fks);
+        mi2.addActionListener(fks);
+        mi3.addActionListener(fks);
+        mi4.addActionListener(fks);
+        mi5.addActionListener(fks);
+        mi6.addActionListener(fks);
+        mi7.addActionListener(fks);
+        mi8.addActionListener(fks);
+        mi9.addActionListener(fks);
+
+        m.add(mi1);
+        m.add(mi2);
+        m.add(mi3);
+        m.add(mi4);
+        m.add(mi5);
+        m.add(mi6);
+        m.add(mi7);
+        m.add(mi8);
+        m.add(mi9);
+
+        mb.add(m);
+        frame.setMenuBar(mb);
+        frame.setBounds(50,400,200,200);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args ) throws Exception {
+
+        EventQueue.invokeAndWait(FunctionKeyShortcut::createUI);
+        try {
+            Robot robot = new Robot();
+
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            // Ensure window has focus
+            Point p = frame.getLocationOnScreen();
+            robot.mouseMove(p.x + frame.getWidth() / 2, p.y + frame.getHeight() / 2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            int mod = (isMac) ? KeyEvent.VK_META : KeyEvent.VK_CONTROL;
+            robot.keyPress(mod);
+            robot.keyPress(KeyEvent.VK_F1);
+            robot.delay(50);
+            robot.keyRelease(KeyEvent.VK_F1);
+            robot.keyRelease(mod);
+            robot.waitForIdle();
+            robot.delay(2000);
+        } finally  {
+            if (frame != null) {
+                EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+        if (!event || failed) {
+           throw new RuntimeException("No actioncommand");
+        }
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        System.out.println("Got " + e);
+        String s = e.getActionCommand();
+        event = true;
+        if (s == null || !s.equals("Function key 1")) {
+            failed = true;
+        }
+    }
+
+}

--- a/test/jdk/java/awt/MenuShortcut/MenuItemShortcutReplaceTest.java
+++ b/test/jdk/java/awt/MenuShortcut/MenuItemShortcutReplaceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4080225
+ * @summary A replaced menu shortcut does not draw in the menu.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuItemShortcutReplaceTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+
+/*
+ * Manual test because visual verification of the shortcut being painted is required.
+ */
+
+public class MenuItemShortcutReplaceTest implements ActionListener {
+
+    static boolean isMac = System.getProperty("os.name").startsWith("Mac");
+    static String shortcut = (isMac) ? "Cmd" : "Ctrl";
+    static String instructions =
+         "1. On the frame 'MenuItem Shortcut Replace Test' click on the Menu 'Click here'.\n" +
+         "   You will see a MenuItem 'MenuItem1' with the shortcut key displayed as" +
+         " '" + shortcut + "+M'.\n" +
+         "2. Click the 'Change Shortcutkey' button.\n" +
+         "3. Now click on the Menu again to see the MenuItem.\n" +
+         "4. If the shortcut key displayed near the MenuItem is changed to " +
+         "'" + shortcut + "+C', press 'Pass' else press 'Fail'";
+
+    public static void main(String[] args) throws Exception {
+       PassFailJFrame.builder()
+                .title("MenuItem Shortcut Replace Test Instructions")
+                .instructions(instructions)
+                .columns(60)
+                .logArea()
+                .testUI(MenuItemShortcutReplaceTest::createUI)
+                .build()
+                .awaitAndCheck();
+
+    }
+
+    static volatile Button change;
+    static volatile MenuItem mi;
+    static volatile MenuShortcut ms;
+
+    static Frame createUI() {
+        Frame frame = new Frame("MenuItem Shortcut Replace Test");
+        MenuBar mb = new MenuBar();
+        change = new Button("Change ShortcutKey");
+        Panel p = new Panel();
+        p.add(change);
+        MenuItemShortcutReplaceTest misrt = new MenuItemShortcutReplaceTest();
+        change.addActionListener(misrt);
+        Menu m = new Menu("Click here");
+        mb.add(m);
+        mi = new MenuItem("MenuItem1");
+        m.add(mi);
+        mi.addActionListener(misrt);
+        frame.setMenuBar(mb);
+        //Set the shortcut key for the menuitem
+        ms = new MenuShortcut(KeyEvent.VK_M);
+        mi.setShortcut(ms);
+        frame.add(p, BorderLayout.SOUTH);
+        frame.setSize(300, 300);
+        return frame;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        //change the shortcut key
+        if (e.getSource() == change) {
+            ms = new MenuShortcut(KeyEvent.VK_C);
+            mi.setShortcut(ms);
+            PassFailJFrame.log("Shortcut key set to "+shortcut+"C");
+        }
+        if (e.getSource() == mi) {
+            PassFailJFrame.log("MenuItem Selected");
+        }
+    }
+}

--- a/test/jdk/java/awt/grab/CursorTest.java
+++ b/test/jdk/java/awt/grab/CursorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6364746 6400007
+ * @summary Cursor should be changed correctly while Swing menu is open (input is grabbed).
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CursorTest
+*/
+
+import java.awt.FlowLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+public class CursorTest {
+
+    static final String INSTRUCTIONS = """
+        After the test starts you will see a frame titled "Cursor Test Window",
+        with two menus in the menubar (menu1 and menu2), and a textfield and
+        a button, labeled "JButton".
+        1. Open menu1 (it should be small and fit within the border of the frame),
+        2. Verify that the pointer image (cursor) is the default desktop cursor.
+        3. Move the mouse over the text field - the cursor should change its shape to caret,
+        4. Move the mouse over the button - the cursor should be default one,
+        5. Move the mouse to the border of the frame - cursor should be a resize one
+           (exact shape is dependent on the border you move over),
+        6. Move the mouse out of the frame - cursor should be default one,
+        7. Perform steps 2-6 in reverse order (after this the mouse should be over the open menu1),
+        8. Open menu2, it should be big enough to not fit within the frame,
+        9. Repeat steps 2-7 (you should end up with mouse over opened menu2 :),
+        10. Close the menu.
+        11. If on every step the cursor was as described, press Pass, press Fail otherwise.
+        """;
+
+    static JFrame createUI() {
+
+        JButton but = new JButton("JButton");
+        JPanel panel = new JPanel();
+        JTextField jtf = new JTextField("JTextField", 20);
+
+        JFrame.setDefaultLookAndFeelDecorated(true);
+        JFrame frame = new JFrame("Cursor Test Window");
+        frame.setLayout(new FlowLayout());
+        panel.add(but);
+
+        frame.getContentPane().add(jtf);
+        frame.getContentPane().add(panel);
+
+        JMenu menu1 = new JMenu("menu1");
+        menu1.add(new JMenuItem("menu1,item1"));
+        JMenuBar mb = new JMenuBar();
+        mb.add(menu1);
+        JMenu menu2 = new JMenu("menu2");
+        for (int i = 0; i < 10; i++) {
+            menu2.add(new JMenuItem("menu2,item"+i));
+        }
+        mb.add(menu2);
+        frame.setJMenuBar(mb);
+        frame.pack();
+        return frame;
+    }
+
+    public static void main(String[] args) throws Exception {
+       PassFailJFrame.builder()
+                .title("Cursor Test")
+                .instructions(INSTRUCTIONS)
+                .columns(60)
+                .testUI(CursorTest::createUI)
+                .build()
+                .awaitAndCheck();
+
+    }
+}

--- a/test/jdk/java/awt/grab/SystemMenuTest.java
+++ b/test/jdk/java/awt/grab/SystemMenuTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6364741
+ * @key headful
+ * @requires (os.family == "windows")
+ * @summary REG: Using frame's menu actions does not make swing menu disappear on WinXP,
+ *          since Mustang-b53
+ */
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.Point;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+
+public class SystemMenuTest implements MenuListener {
+
+    static volatile JMenu menu;
+    static volatile JMenu sub_menu;
+    static volatile JFrame frame;
+
+    static volatile int selectCount = 0;
+    static volatile int deselectCount = 0;
+    static volatile boolean failed = false;
+    static volatile String reason = "none";
+
+    static void createUI() {
+        SystemMenuTest smt = new SystemMenuTest();
+        sub_menu = new JMenu("SubMenu");
+        sub_menu.addMenuListener(smt);
+        sub_menu.add(new JMenuItem("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+        sub_menu.add(new JMenuItem("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"));
+        menu = new JMenu("Menu");
+        menu.addMenuListener(smt);
+        menu.add(sub_menu);
+        JMenuBar mb = new JMenuBar();
+        mb.add(menu);
+
+        frame = new JFrame("JFrame");
+        frame.setJMenuBar(mb);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        Robot robot = new Robot();
+
+        SwingUtilities.invokeAndWait(SystemMenuTest::createUI);
+
+        try {
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            Point p = menu.getLocationOnScreen();
+            robot.mouseMove(p.x + menu.getWidth() / 2, p.y + menu.getHeight() / 2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            p = sub_menu.getLocationOnScreen();
+            robot.mouseMove(p.x + sub_menu.getWidth() / 2, p.y + sub_menu.getHeight() /2 );
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            // Alt-Space to invoke System Menu, should close Swing menus.
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_SPACE);
+            robot.delay(50);
+            robot.keyRelease(KeyEvent.VK_SPACE);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.waitForIdle();
+            robot.delay(2000);
+
+            if (selectCount != 2 || deselectCount != 2) {
+                throw new RuntimeException("unexpected selection count " + selectCount + ", " + deselectCount);
+            }
+            if (failed) {
+                throw new RuntimeException("Failed because " + reason);
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
+        }
+    }
+
+    public void menuCanceled(MenuEvent e) {
+       System.out.println("cancelled"+e.getSource());
+    }
+
+    public void menuDeselected(MenuEvent e) {
+       deselectCount++;
+       if (selectCount != 2) {
+          failed = true;
+          reason = "deselect without two selects";
+       }
+       System.out.println("deselected"+e.getSource());
+    }
+
+    public void menuSelected(MenuEvent e) {
+       if (deselectCount != 0) {
+          failed = true;
+          reason = "select without non-zero deselects";
+       }
+       selectCount++;
+       System.out.println("selected"+e.getSource());
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341111](https://bugs.openjdk.org/browse/JDK-8341111) needs maintainer approval
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8341111: open source several AWT tests including menu shortcut tests`

### Issue
 * [JDK-8341111](https://bugs.openjdk.org/browse/JDK-8341111): open source several AWT tests including menu shortcut tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1346/head:pull/1346` \
`$ git checkout pull/1346`

Update a local copy of the PR: \
`$ git checkout pull/1346` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1346`

View PR using the GUI difftool: \
`$ git pr show -t 1346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1346.diff">https://git.openjdk.org/jdk21u-dev/pull/1346.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1346#issuecomment-2604690894)
</details>
