### PR TITLE
8341037: Use standard layouts in DefaultFrameIconTest.java and MenuCrash.java

### DIFF
--- a/test/jdk/java/awt/Frame/DefaultFrameIconTest.java
+++ b/test/jdk/java/awt/Frame/DefaultFrameIconTest.java
@@ -50,19 +50,9 @@ public class DefaultFrameIconTest {
                 .instructions(INSTRUCTIONS)
                 .columns(45)
                 .testUI(DefaultFrameIconTest::createAndShowUI)
-                .positionTestUI(DefaultFrameIconTest::positionTestWindows)
+                .positionTestUIRightRow()
                 .build()
                 .awaitAndCheck();
-    }
-
-    private static void positionTestWindows(List<? extends Window> testWindows,
-                                            PassFailJFrame.InstructionUI instructionUI) {
-        int gap = 5;
-        int x = instructionUI.getLocation().x + instructionUI.getSize().width + gap;
-        for (Window w : testWindows) {
-            w.setLocation(x, instructionUI.getLocation().y);
-            x += w.getWidth() + gap;
-        }
     }
 
     private static List<Window> createAndShowUI() {

--- a/test/jdk/java/awt/Frame/MenuCrash.java
+++ b/test/jdk/java/awt/Frame/MenuCrash.java
@@ -62,7 +62,7 @@ public class MenuCrash {
                 .instructions(INSTRUCTIONS)
                 .columns(45)
                 .testUI(MenuCrash::createAndShowUI)
-                .positionTestUI(MenuCrash::positionTestWindows)
+                .positionTestUIRightRow()
                 .build()
                 .awaitAndCheck();
     }
@@ -79,16 +79,6 @@ public class MenuCrash {
         frame2.validate();
 
         return List.of(frame1, frame2);
-    }
-
-    private static void positionTestWindows(List<? extends Window> testWindows,
-                                            PassFailJFrame.InstructionUI instructionUI) {
-        int gap = 5;
-        int x = instructionUI.getLocation().x + instructionUI.getSize().width + gap;
-        for (Window w : testWindows) {
-            w.setLocation(x, instructionUI.getLocation().y);
-            x += w.getWidth() + gap;
-        }
     }
 
     static class MenuFrame extends Frame {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341037](https://bugs.openjdk.org/browse/JDK-8341037) needs maintainer approval

### Issue
 * [JDK-8341037](https://bugs.openjdk.org/browse/JDK-8341037): Use standard layouts in DefaultFrameIconTest.java and MenuCrash.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1347/head:pull/1347` \
`$ git checkout pull/1347`

Update a local copy of the PR: \
`$ git checkout pull/1347` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1347`

View PR using the GUI difftool: \
`$ git pr show -t 1347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1347.diff">https://git.openjdk.org/jdk21u-dev/pull/1347.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1347#issuecomment-2604690378)
</details>
