### PR TITLE
8327098: GTest needs larger combination limit

### DIFF
--- a/src/hotspot/share/logging/logSelectionList.hpp
+++ b/src/hotspot/share/logging/logSelectionList.hpp
@@ -37,7 +37,7 @@ class LogTagSet;
 // Consists of ordered LogSelections, i.e. "tag1+tag2=level1,tag3*=level2".
 class LogSelectionList : public StackObj {
  public:
-  static const size_t MaxSelections = 256;
+  static const size_t MaxSelections = 320;
 
  private:
   friend void LogConfiguration::configure_stdout(LogLevelType, int, ...);


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327098](https://bugs.openjdk.org/browse/JDK-8327098) needs maintainer approval

### Issue
 * [JDK-8327098](https://bugs.openjdk.org/browse/JDK-8327098): GTest needs larger combination limit (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1354/head:pull/1354` \
`$ git checkout pull/1354`

Update a local copy of the PR: \
`$ git checkout pull/1354` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1354`

View PR using the GUI difftool: \
`$ git pr show -t 1354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1354.diff">https://git.openjdk.org/jdk21u-dev/pull/1354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1354#issuecomment-2610410220)
</details>
