### PR TITLE
8327986: ASAN reports use-after-free in DirectivesParserTest.empty_object_vm

### DIFF
--- a/test/hotspot/gtest/compiler/test_directivesParser.cpp
+++ b/test/hotspot/gtest/compiler/test_directivesParser.cpp
@@ -31,15 +31,16 @@
 
 class DirectivesParserTest : public ::testing::Test{
  protected:
-  const char* const _locale;
+  char* const _locale;
   ResourceMark rm;
   stringStream stream;
   // These tests require the "C" locale to correctly parse decimal values
-  DirectivesParserTest() : _locale(setlocale(LC_NUMERIC, NULL)) {
+  DirectivesParserTest() : _locale(os::strdup(setlocale(LC_NUMERIC, nullptr), mtTest)) {
     setlocale(LC_NUMERIC, "C");
   }
   ~DirectivesParserTest() {
     setlocale(LC_NUMERIC, _locale);
+    os::free(_locale);
   }
 
   void test_negative(const char* text) {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

I had to resolve because of NULL/nullptr difference.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8327986](https://bugs.openjdk.org/browse/JDK-8327986) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327986](https://bugs.openjdk.org/browse/JDK-8327986): ASAN reports use-after-free in DirectivesParserTest.empty_object_vm (**Bug** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1356/head:pull/1356` \
`$ git checkout pull/1356`

Update a local copy of the PR: \
`$ git checkout pull/1356` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1356`

View PR using the GUI difftool: \
`$ git pr show -t 1356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1356.diff">https://git.openjdk.org/jdk21u-dev/pull/1356.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1356#issuecomment-2610899997)
</details>
