### PR TITLE
Backport f8e0f4f6924220429d14221dfe5906ec450105f3

### DIFF
--- a/src/java.base/share/data/tzdata/VERSION
+++ b/src/java.base/share/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2024b
+tzdata2025a

--- a/src/java.base/share/data/tzdata/antarctica
+++ b/src/java.base/share/data/tzdata/antarctica
@@ -197,6 +197,8 @@ Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
 
 # France & Italy - year-round base
 # Concordia, -750600+1232000, since 2005
+# https://en.wikipedia.org/wiki/Concordia_Station
+# Can use Asia/Singapore, which it has agreed with since inception.
 
 # Germany - year-round base
 # Neumayer III, -704080-0081602, since 2009

--- a/src/java.base/share/data/tzdata/asia
+++ b/src/java.base/share/data/tzdata/asia
@@ -3688,21 +3688,70 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 # be immediately followed by 1845-01-01; see R.H. van Gent's
 # History of the International Date Line
 # https://webspace.science.uu.nl/~gent0113/idl/idl_philippines.htm
-# The rest of the data entries are from Shanks & Pottenger.
 
-# From Jesper Nørgaard Welen (2006-04-26):
-# ... claims that Philippines had DST last time in 1990:
-# http://story.philippinetimes.com/p.x/ct/9/id/145be20cc6b121c0/cid/3e5bbccc730d258c/
-# [a story dated 2006-04-25 by Cris Larano of Dow Jones Newswires,
-# but no details]
-
-# From Paul Eggert (2014-08-14):
-# The following source says DST may be instituted November-January and again
-# March-June, but this is not definite.  It also says DST was last proclaimed
-# during the Ramos administration (1992-1998); but again, no details.
-# Carcamo D. PNoy urged to declare use of daylight saving time.
-# Philippine Star 2014-08-05
-# http://www.philstar.com/headlines/2014/08/05/1354152/pnoy-urged-declare-use-daylight-saving-time
+# From P Chan (2021-05-10):
+# Here's a fairly comprehensive article in Japanese:
+#	https://wiki.suikawiki.org/n/Philippine%20Time
+# (2021-05-16):
+# According to the references listed in the article,
+# the periods that the Philippines (Manila) observed DST or used +9 are:
+#
+# 1936-10-31 24:00 to 1937-01-15 24:00
+#	(Proclamation No. 104, Proclamation No. 126)
+# 1941-12-15 24:00 to 1945-11-30 24:00
+#	(Proclamation No. 789, Proclamation No. 20)
+# 1954-04-11 24:00 to 1954-06-04 24:00
+#	(Proclamation No. 13, Proclamation No. 33)
+# 1977-03-27 24:00 to 1977-09-21 24:00
+#	(Proclamation No. 1629, Proclamation No. 1641)
+# 1990-05-21 00:00 to 1990-07-28 24:00
+#	(National Emergency Memorandum Order No. 17, Executive Order No. 415)
+#
+# Proclamation No. 104 ... October 30, 1936
+#  https://www.officialgazette.gov.ph/1936/10/30/proclamation-no-104-s-1936/
+# Proclamation No. 126 ... January 15, 1937
+#  https://www.officialgazette.gov.ph/1937/01/15/proclamation-no-126-s-1937/
+# Proclamation No. 789 ... December 13, 1941
+#  https://www.officialgazette.gov.ph/1941/12/13/proclamation-no-789-s-1941/
+# Proclamation No. 20 ... November 11, 1945
+#  https://www.officialgazette.gov.ph/1945/11/11/proclamation-no-20-s-1945/
+# Proclamation No. 13 ... April 6, 1954
+#  https://www.officialgazette.gov.ph/1954/04/06/proclamation-no-13-s-1954/
+# Proclamation No. 33 ... June 3, 1954
+#  https://www.officialgazette.gov.ph/1954/06/03/proclamation-no-33-s-1954/
+# Proclamation No. 1629 ... March 25, 1977
+#  https://www.officialgazette.gov.ph/1977/03/25/proclamation-no-1629-s-1977/
+# Proclamation No. 1641 ...May 26, 1977
+#  https://www.officialgazette.gov.ph/1977/05/26/proclamation-no-1641-s-1977/
+# National Emergency Memorandum Order No. 17 ... May 2, 1990
+#  https://www.officialgazette.gov.ph/1990/05/02/national-emergency-memorandum-order-no-17-s-1990/
+# Executive Order No. 415 ... July 20, 1990
+#  https://www.officialgazette.gov.ph/1990/07/20/executive-order-no-415-s-1990/
+#
+# During WWII, Proclamation No. 789 fixed two periods of DST. The first period
+# was set to continue only until January 31, 1942. But Manila was occupied by
+# the Japanese earlier in the month....
+#
+# For the date of the adoption of standard time, Shank[s] gives 1899-05-11.
+# The article is not able to state the basis of that. I guess it was based on
+# a US War Department Circular issued on that date.
+#	https://books.google.com/books?id=JZ1PAAAAYAAJ&pg=RA3-PA8
+#
+# However, according to other sources, standard time was adopted on
+# 1899-09-06.  Also, the LMT was GMT+8:03:52
+#	https://books.google.com/books?id=MOYIAQAAIAAJ&pg=PA521
+#	https://books.google.com/books?id=lSnqqatpYikC&pg=PA21
+#
+# From Paul Eggert (2024-09-05):
+# The penultimate URL in P Chan's email refers to page 521 of
+# Selga M, The Time Service in the Philippines.
+# Proc Pan-Pacific Science Congress. Vol. 1 (1923), 519-532.
+# It says, "The change from the meridian 120° 58' 04" to the 120th implied a
+# change of 3 min. 52s.26 in time; consequently on 6th September, 1899,
+# Manila Observatory gave the noon signal 3 min. 52s.26 later than before".
+#
+# Wikipedia says the US declared Manila liberated on March 4, 1945;
+# this doesn't affect clocks, just our time zone abbreviation and DST flag.
 
 # From Paul Goyette (2018-06-15) with URLs updated by Guy Harris (2024-02-15):
 # In the Philippines, there is a national law, Republic Act No. 10535
@@ -3720,24 +3769,26 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 # influence of the sources.  There is no current abbreviation for DST,
 # so use "PDT", the usual American style.
 
-# From P Chan (2021-05-10):
-# Here's a fairly comprehensive article in Japanese:
-# https://wiki.suikawiki.org/n/Philippine%20Time
-# From Paul Eggert (2021-05-10):
-# The info in the Japanese table has not been absorbed (yet) below.
-
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Phil	1936	only	-	Nov	1	0:00	1:00	D
-Rule	Phil	1937	only	-	Feb	1	0:00	0	S
-Rule	Phil	1954	only	-	Apr	12	0:00	1:00	D
-Rule	Phil	1954	only	-	Jul	1	0:00	0	S
-Rule	Phil	1978	only	-	Mar	22	0:00	1:00	D
-Rule	Phil	1978	only	-	Sep	21	0:00	0	S
+Rule	Phil	1936	only	-	Oct	31	24:00	1:00	D
+Rule	Phil	1937	only	-	Jan	15	24:00	0	S
+Rule	Phil	1941	only	-	Dec	15	24:00	1:00	D
+# The following three rules were canceled by Japan:
+#Rule	Phil	1942	only	-	Jan	31	24:00	0	S
+#Rule	Phil	1942	only	-	Mar	 1	 0:00	1:00	D
+#Rule	Phil	1942	only	-	Jun	30	24:00	0	S
+Rule	Phil	1945	only	-	Nov	30	24:00	0	S
+Rule	Phil	1954	only	-	Apr	11	24:00	1:00	D
+Rule	Phil	1954	only	-	Jun	 4	24:00	0	S
+Rule	Phil	1977	only	-	Mar	27	24:00	1:00	D
+Rule	Phil	1977	only	-	Sep	21	24:00	0	S
+Rule	Phil	1990	only	-	May	21	 0:00	1:00	D
+Rule	Phil	1990	only	-	Jul	28	24:00	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Manila	-15:56:00 -	LMT	1844 Dec 31
-			8:04:00 -	LMT	1899 May 11
-			8:00	Phil	P%sT	1942 May
-			9:00	-	JST	1944 Nov
+Zone	Asia/Manila	-15:56:08 -	LMT	1844 Dec 31
+			8:03:52 -	LMT	1899 Sep  6  4:00u
+			8:00	Phil	P%sT	1942 Feb 11 24:00
+			9:00	-	JST	1945 Mar  4
 			8:00	Phil	P%sT
 
 # Bahrain

--- a/src/java.base/share/data/tzdata/australasia
+++ b/src/java.base/share/data/tzdata/australasia
@@ -1262,10 +1262,10 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # The 1992 ending date used in the rules is a best guess;
 # it matches what was used in the past.
 
-# The Australian Bureau of Meteorology FAQ
-# http://www.bom.gov.au/faq/faqgen.htm
-# (1999-09-27) writes that Giles Meteorological Station uses
-# South Australian time even though it's located in Western Australia.
+# From Christopher Hunt (2006-11-21), after an advance warning
+# from Jesper Nørgaard Welen (2006-11-01):
+# WA are trialing DST for three years.
+# http://www.parliament.wa.gov.au/parliament/bills.nsf/9A1B183144403DA54825721200088DF1/$File/Bill175-1B.pdf
 
 # From Paul Eggert (2018-04-01):
 # The Guardian Express of Perth, Australia reported today that the
@@ -1277,54 +1277,10 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # https://www.communitynews.com.au/guardian-express/news/exclusive-daylight-savings-coming-wa-summer-2018/
 # [The article ends with "Today's date is April 1."]
 
-# Queensland
-
-# From Paul Eggert (2018-02-26):
-# I lack access to the following source for Queensland DST:
-# Pearce C. History of daylight saving time in Queensland.
-# Queensland Hist J. 2017 Aug;23(6):389-403
-# https://search.informit.com.au/documentSummary;dn=994682348436426;res=IELHSS
-
-# From George Shepherd via Simon Woodhead via Robert Elz (1991-03-06):
-# #   The state of QUEENSLAND.. [ Courtesy Qld. Dept Premier Econ&Trade Devel ]
-# #						[ Dec 1990 ]
-# ...
-# Zone	Australia/Queensland	10:00	AQ	%sST
-# ...
-# Rule	AQ	1971	only	-	Oct	lastSun	2:00	1:00	D
-# Rule	AQ	1972	only	-	Feb	lastSun	3:00	0	E
-# Rule	AQ	1989	max	-	Oct	lastSun	2:00	1:00	D
-# Rule	AQ	1990	max	-	Mar	Sun>=1	3:00	0	E
-
-# From Bradley White (1989-12-24):
-# "Australia/Queensland" now observes daylight time (i.e. from
-# October 1989).
-
-# From Bradley White (1991-03-04):
-# A recent excerpt from an Australian newspaper...
-# ...Queensland...[has] agreed to end daylight saving
-# at 3am tomorrow (March 3)...
-
-# From John Mackin (1991-03-06):
-# I can certainly confirm for my part that Daylight Saving in NSW did in fact
-# end on Sunday, 3 March.  I don't know at what hour, though.  (It surprised
-# me.)
-
-# From Bradley White (1992-03-08):
-# ...there was recently a referendum in Queensland which resulted
-# in the experimental daylight saving system being abandoned. So, ...
-# ...
-# Rule	QLD	1989	1991	-	Oct	lastSun	2:00	1:00	D
-# Rule	QLD	1990	1992	-	Mar	Sun>=1	3:00	0	S
-# ...
-
-# From Arthur David Olson (1992-03-08):
-# The chosen rules the union of the 1971/1972 change and the 1989-1992 changes.
-
-# From Christopher Hunt (2006-11-21), after an advance warning
-# from Jesper Nørgaard Welen (2006-11-01):
-# WA are trialing DST for three years.
-# http://www.parliament.wa.gov.au/parliament/bills.nsf/9A1B183144403DA54825721200088DF1/$File/Bill175-1B.pdf
+# The Australian Bureau of Meteorology FAQ
+# http://www.bom.gov.au/faq/faqgen.htm
+# (1999-09-27) writes that Giles Meteorological Station uses
+# South Australian time even though it's located in Western Australia.
 
 # From Rives McDow (2002-04-09):
 # The most interesting region I have found consists of three towns on the
@@ -1381,6 +1337,59 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 # From Paul Eggert (2006-12-15):
 # For lack of better info, assume the tradition dates back to the
 # introduction of standard time in 1895.
+
+# From Stuart Bishop (2024-11-12):
+# An article discussing the in-use but technically unofficial timezones
+# in the Western Australian portion of the Nullarbor Plain.
+# https://www.abc.net.au/news/2024-11-22/outback-wa-properties-strange-time-zones/104542494
+# From Paul Eggert (2024-11-12):
+# As the article says, the Eyre Bird Observatory and nearby sheep stations
+# can use Tokyo time.  Other possibilities include Asia/Chita, Asia/Seoul,
+# and Asia/Jayapura.
+
+# Queensland
+
+# From Paul Eggert (2018-02-26):
+# I lack access to the following source for Queensland DST:
+# Pearce C. History of daylight saving time in Queensland.
+# Queensland Hist J. 2017 Aug;23(6):389-403
+# https://search.informit.com.au/documentSummary;dn=994682348436426;res=IELHSS
+
+# From George Shepherd via Simon Woodhead via Robert Elz (1991-03-06):
+# #   The state of QUEENSLAND.. [ Courtesy Qld. Dept Premier Econ&Trade Devel ]
+# #						[ Dec 1990 ]
+# ...
+# Zone	Australia/Queensland	10:00	AQ	%sST
+# ...
+# Rule	AQ	1971	only	-	Oct	lastSun	2:00	1:00	D
+# Rule	AQ	1972	only	-	Feb	lastSun	3:00	0	E
+# Rule	AQ	1989	max	-	Oct	lastSun	2:00	1:00	D
+# Rule	AQ	1990	max	-	Mar	Sun>=1	3:00	0	E
+
+# From Bradley White (1989-12-24):
+# "Australia/Queensland" now observes daylight time (i.e. from
+# October 1989).
+
+# From Bradley White (1991-03-04):
+# A recent excerpt from an Australian newspaper...
+# ...Queensland...[has] agreed to end daylight saving
+# at 3am tomorrow (March 3)...
+
+# From John Mackin (1991-03-06):
+# I can certainly confirm for my part that Daylight Saving in NSW did in fact
+# end on Sunday, 3 March.  I don't know at what hour, though.  (It surprised
+# me.)
+
+# From Bradley White (1992-03-08):
+# ...there was recently a referendum in Queensland which resulted
+# in the experimental daylight saving system being abandoned. So, ...
+# ...
+# Rule	QLD	1989	1991	-	Oct	lastSun	2:00	1:00	D
+# Rule	QLD	1990	1992	-	Mar	Sun>=1	3:00	0	S
+# ...
+
+# From Arthur David Olson (1992-03-08):
+# The chosen rules the union of the 1971/1972 change and the 1989-1992 changes.
 
 
 # southeast Australia

--- a/src/java.base/share/data/tzdata/etcetera
+++ b/src/java.base/share/data/tzdata/etcetera
@@ -74,6 +74,10 @@ Link	Etc/GMT				GMT
 # so we moved the names into the Etc subdirectory.
 # Also, the time zone abbreviations are now compatible with %z.
 
+# There is no "Etc/Unknown" entry, as CLDR says that "Etc/Unknown"
+# corresponds to an unknown or invalid time zone, and things would get
+# confusing if Etc/Unknown were made valid here.
+
 Zone	Etc/GMT-14	14	-	%z
 Zone	Etc/GMT-13	13	-	%z
 Zone	Etc/GMT-12	12	-	%z

--- a/src/java.base/share/data/tzdata/europe
+++ b/src/java.base/share/data/tzdata/europe
@@ -1170,7 +1170,7 @@ Zone Atlantic/Faroe	-0:27:04 -	LMT	1908 Jan 11 # Tórshavn
 # However, Greenland will change to Daylight Saving Time again in 2024
 # and onwards.
 
-# From a contributor who wishes to remain anonymous for now (2023-10-29):
+# From Jule Dabars (2023-10-29):
 # https://www.dr.dk/nyheder/seneste/i-nat-skal-uret-stilles-en-time-tilbage-men-foerste-gang-sker-det-ikke-i-groenland
 # with a link to that page:
 # https://naalakkersuisut.gl/Nyheder/2023/10/2710_sommertid

--- a/src/java.base/share/data/tzdata/factory
+++ b/src/java.base/share/data/tzdata/factory
@@ -31,5 +31,15 @@
 # time zone abbreviation "-00", indicating that the actual time zone
 # is unknown.
 
+# TZ="Factory" was added to TZDB in 1989, and in 2016 its abbreviation
+# was changed to "-00" from a longish English-language error message.
+# Around 2010, CLDR added "Etc/Unknown" for use with TZDB, to stand
+# for an unknown or invalid time zone.  These two notions differ:
+# TZ="Factory" is a valid timezone, so tzalloc("Factory") succeeds, whereas
+# TZ="Etc/Unknown" is invalid and tzalloc("Etc/Unknown") fails.
+# Also, a downstream distributor could modify Factory to be a
+# default timezone suitable for the devices it manufactures,
+# whereas that cannot happen for Etc/Unknown.
+
 # Zone	NAME	STDOFF	RULES	FORMAT
 Zone	Factory	0	-	-00

--- a/src/java.base/share/data/tzdata/leapseconds
+++ b/src/java.base/share/data/tzdata/leapseconds
@@ -92,11 +92,11 @@ Leap	2016	Dec	31	23:59:60	+	S
 # Any additional leap seconds will come after this.
 # This Expires line is commented out for now,
 # so that pre-2020a zic implementations do not reject this file.
-#Expires 2025	Jun	28	00:00:00
+#Expires 2025	Dec	28	00:00:00
 
 # POSIX timestamps for the data in this file:
-#updated 1720104763 (2024-07-04 14:52:43 UTC)
-#expires 1751068800 (2025-06-28 00:00:00 UTC)
+#updated 1736208000 (2025-01-07 00:00:00 UTC)
+#expires 1766880000 (2025-12-28 00:00:00 UTC)
 
 #	Updated through IERS Bulletin C (https://hpiers.obspm.fr/iers/bul/bulc/bulletinc.dat)
-#	File expires on 28 June 2025
+#	File expires on 28 December 2025

--- a/src/java.base/share/data/tzdata/northamerica
+++ b/src/java.base/share/data/tzdata/northamerica
@@ -50,9 +50,12 @@
 # in New York City (1869-10).  His 1870 proposal was based on Washington, DC,
 # but in 1872-05 he moved the proposed origin to Greenwich.
 
-# From Paul Eggert (2018-03-20):
+# From Paul Eggert (2024-11-18):
 # Dowd's proposal left many details unresolved, such as where to draw
-# lines between time zones.  The key individual who made time zones
+# lines between time zones.  Sandford Fleming of the Canadian Pacific Railway
+# argued for Dowd's proposal in 1876, and Cleveland Abbe of the American
+# Meteorology Society published a report in 1879 recommending four US time
+# zones based on GMT.  However, the key individual who made time zones
 # work in the US was William Frederick Allen - railway engineer,
 # managing editor of the Travelers' Guide, and secretary of the
 # General Time Convention, a railway standardization group.  Allen
@@ -2654,7 +2657,7 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 # http://puentelibre.mx/noticia/ciudad_juarez_cambio_horario_noviembre_2022/
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Mexico	1931	only	-	April	30	0:00	1:00	D
+Rule	Mexico	1931	only	-	Apr	30	0:00	1:00	D
 Rule	Mexico	1931	only	-	Oct	1	0:00	0	S
 Rule	Mexico	1939	only	-	Feb	5	0:00	1:00	D
 Rule	Mexico	1939	only	-	Jun	25	0:00	0	S

--- a/src/java.base/share/data/tzdata/southamerica
+++ b/src/java.base/share/data/tzdata/southamerica
@@ -1710,7 +1710,7 @@ Rule	Para	2005	2009	-	Mar	Sun>=8	0:00	0	-
 # and that on the first Sunday of the month of October, it is to be set
 # forward 60 minutes, in all the territory of the Paraguayan Republic.
 # ...
-Rule	Para	2010	max	-	Oct	Sun>=1	0:00	1:00	-
+Rule	Para	2010	2024	-	Oct	Sun>=1	0:00	1:00	-
 Rule	Para	2010	2012	-	Apr	Sun>=8	0:00	0	-
 #
 # From Steffen Thorsen (2013-03-07):
@@ -1729,14 +1729,35 @@ Rule	Para	2010	2012	-	Apr	Sun>=8	0:00	0	-
 # https://www.abc.com.py/politica/2023/07/12/promulgacion-el-cambio-de-hora-sera-por-ley/
 # From Carlos Raúl Perasso (2023-07-27):
 # http://silpy.congreso.gov.py/descarga/ley-144138
-Rule	Para	2013	max	-	Mar	Sun>=22	0:00	0	-
+Rule	Para	2013	2024	-	Mar	Sun>=22	0:00	0	-
+#
+# From Heitor David Pinto (2024-09-24):
+# Today the Congress of Paraguay passed a bill to observe UTC-3 permanently....
+# The text of the bill says that it would enter into force on the first
+# Sunday in October 2024, the same date currently scheduled to start DST....
+# https://silpy.congreso.gov.py/web/expediente/132531
+# (2024-10-14):
+# The president approved the law on 11 October 2024,
+# and it was officially published on 14 October 2024.
+# https://www.gacetaoficial.gov.py/index/detalle_publicacion/89723
+# The text of the law says that it enters into force on the first
+# Sunday in October 2024 (6 October 2024).  But the constitution
+# prohibits retroactive effect, and the civil code says that laws
+# enter into force on the day after their publication or on the day
+# that they specify, and it also says that they don't have retroactive
+# effect.  So I think that the time change on 6 October 2024 should
+# still be considered as DST according to the previous law, and
+# permanently UTC-3 from 15 October 2024 according to the new law....
+# https://www.constituteproject.org/constitution/Paraguay_2011
+# https://www.oas.org/dil/esp/codigo_civil_paraguay.pdf
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Asuncion	-3:50:40 -	LMT	1890
 			-3:50:40 -	AMT	1931 Oct 10 # Asunción Mean Time
 			-4:00	-	%z	1972 Oct
 			-3:00	-	%z	1974 Apr
-			-4:00	Para	%z
+			-4:00	Para	%z	2024 Oct 15
+			-3:00	-	%z
 
 # Peru
 #

--- a/src/java.base/share/data/tzdata/zone.tab
+++ b/src/java.base/share/data/tzdata/zone.tab
@@ -333,7 +333,7 @@ PF	-0900-13930	Pacific/Marquesas	Marquesas Islands
 PF	-2308-13457	Pacific/Gambier	Gambier Islands
 PG	-0930+14710	Pacific/Port_Moresby	most of Papua New Guinea
 PG	-0613+15534	Pacific/Bougainville	Bougainville
-PH	+1435+12100	Asia/Manila
+PH	+143512+1205804	Asia/Manila
 PK	+2452+06703	Asia/Karachi
 PL	+5215+02100	Europe/Warsaw
 PM	+4703-05620	America/Miquelon

--- a/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
@@ -1,1 +1,1 @@
-tzdata2024b
+tzdata2025a


### PR DESCRIPTION
Backport of https://bugs.openjdk.org/browse/JDK-8347965
Changes to Update Timezone Data to 2025a

Clean backport.
Passed tier1 tests. Except the java/foreign/nested/TestNested.java which is failing on master as well due to preview API which is disabled by default
Passed gtests.