### PR TITLE
Backport afcc2b03afc77f730300e1d92471466d56ed75fb

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -618,7 +618,9 @@ static const Node* get_base_and_offset(const MachNode* mach, intptr_t& offset) {
     // The memory address is computed by 'base' and fed to 'mach' via an
     // indirect memory operand (indicated by offset == 0). The ultimate base and
     // offset can be fetched directly from the inputs and Ideal type of 'base'.
-    offset = base->bottom_type()->isa_oopptr()->offset();
+    const TypeOopPtr* oopptr = base->bottom_type()->isa_oopptr();
+    if (oopptr == nullptr) return nullptr;
+    offset = oopptr->offset();
     // Even if 'base' is not an Ideal AddP node anymore, Matcher::ReduceInst()
     // guarantees that the base address is still available at the same slot.
     base = base->in(AddPNode::Base);


### PR DESCRIPTION
Clean backport of [JDK-8348562](https://bugs.openjdk.org/browse/JDK-8348562). The crashes can be reproduced in 21u by `make run-test TEST="jdk/jfr/api/consumer/streaming/TestFilledChunks.java" JTREG="VM_OPTIONS=-XX:+UseZGC -XX:+ZGenerational"` on linux PPC64le. The fix only adds a null check + bailout where the current implementation crashes with SIGSEGV.