### PR TITLE
8321512: runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java fails on 32-bit platforms

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -140,11 +140,6 @@ void G1Arguments::initialize_card_set_configuration() {
                                                     G1RemSetArrayOfCardsEntriesBase << region_size_log_mb));
   }
 
-  // Round to next 8 byte boundary for array to maximize space usage.
-  size_t const cur_size = G1CardSetArray::size_in_bytes(G1RemSetArrayOfCardsEntries);
-  FLAG_SET_ERGO(G1RemSetArrayOfCardsEntries,
-                G1RemSetArrayOfCardsEntries + (uint)(align_up(cur_size, G1CardSetAllocOptions::SlotAlignment) - cur_size) / sizeof(G1CardSetArray::EntryDataType));
-
   // Howl card set container globals.
   if (FLAG_IS_DEFAULT(G1RemSetHowlNumBuckets)) {
     FLAG_SET_ERGO(G1RemSetHowlNumBuckets, G1CardSetHowl::num_buckets(HeapRegion::CardsPerRegion,


### PR DESCRIPTION
A clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8321512](https://bugs.openjdk.org/browse/JDK-8321512) needs maintainer approval

### Issue
 * [JDK-8321512](https://bugs.openjdk.org/browse/JDK-8321512): runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java fails on 32-bit platforms (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1363/head:pull/1363` \
`$ git checkout pull/1363`

Update a local copy of the PR: \
`$ git checkout pull/1363` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1363`

View PR using the GUI difftool: \
`$ git pr show -t 1363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1363.diff">https://git.openjdk.org/jdk21u-dev/pull/1363.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1363#issuecomment-2615726721)
</details>
