### PR TITLE
8347129: cpuset cgroups controller is required for no good reason

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -36,7 +36,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 // controller names have to match the *_IDX indices
-static const char* cg_controller_name[] = { "cpu", "cpuset", "cpuacct", "memory", "pids" };
+static const char* cg_controller_name[] = { "cpuset", "cpu", "cpuacct", "memory", "pids" };
 
 CgroupSubsystem* CgroupSubsystemFactory::create() {
   CgroupV1MemoryController* memory = nullptr;
@@ -160,9 +160,10 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
   char buf[MAXPATHLEN+1];
   char *p;
   bool is_cgroupsV2;
-  // true iff all required controllers, memory, cpu, cpuset, cpuacct are enabled
+  // true iff all required controllers, memory, cpu, cpuacct are enabled
   // at the kernel level.
   // pids might not be enabled on older Linux distros (SLES 12.1, RHEL 7.1)
+  // cpuset might not be enabled on newer Linux distros (Fedora 41)
   bool all_required_controllers_enabled;
 
   /*
@@ -194,6 +195,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
       cg_infos[MEMORY_IDX]._hierarchy_id = hierarchy_id;
       cg_infos[MEMORY_IDX]._enabled = (enabled == 1);
     } else if (strcmp(name, "cpuset") == 0) {
+      log_debug(os, container)("Detected optional cpuset controller entry in %s", proc_cgroups);
       cg_infos[CPUSET_IDX]._name = os::strdup(name);
       cg_infos[CPUSET_IDX]._hierarchy_id = hierarchy_id;
       cg_infos[CPUSET_IDX]._enabled = (enabled == 1);
@@ -217,8 +219,8 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
   is_cgroupsV2 = true;
   all_required_controllers_enabled = true;
   for (int i = 0; i < CG_INFO_LENGTH; i++) {
-    // pids controller is optional. All other controllers are required
-    if (i != PIDS_IDX) {
+    // pids and cpuset controllers are optional. All other controllers are required
+    if (i != PIDS_IDX && i != CPUSET_IDX) {
       is_cgroupsV2 = is_cgroupsV2 && cg_infos[i]._hierarchy_id == 0;
       all_required_controllers_enabled = all_required_controllers_enabled && cg_infos[i]._enabled;
     }


### PR DESCRIPTION
Clean backport. Affects JDK 21u as well on systems with kernel 6.12+

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347129](https://bugs.openjdk.org/browse/JDK-8347129) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8347129: cpuset cgroups controller is required for no good reason`

### Issue
 * [JDK-8347129](https://bugs.openjdk.org/browse/JDK-8347129): cpuset cgroups controller is required for no good reason (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1366/head:pull/1366` \
`$ git checkout pull/1366`

Update a local copy of the PR: \
`$ git checkout pull/1366` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1366`

View PR using the GUI difftool: \
`$ git pr show -t 1366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1366.diff">https://git.openjdk.org/jdk21u-dev/pull/1366.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1366#issuecomment-2619700349)
</details>
