### PR TITLE
8332917: failure_handler should execute gdb "info threads" command on linux

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -49,7 +49,7 @@ native.locks.app=lslocks
 native.locks.args=-u --pid %p
 
 native.stack.app=gdb
-native.stack.args=--pid=%p\0-batch\0-ex\0thread apply all backtrace
+native.stack.args=--pid=%p\0-batch\0-ex\0info threads\0-ex\0thread apply all backtrace
 native.stack.args.delimiter=\0
 native.stack.params.repeat=6
 
@@ -63,7 +63,7 @@ native.core.timeout=600000
 cores=native.gdb
 native.gdb.app=gdb
 # Assume that java standard laucher has been used
-native.gdb.args=%java\0-c\0%p\0-batch\0-ex\0thread apply all backtrace
+native.gdb.args=%java\0-c\0%p\0-batch\0-ex\0info threads\0-ex\0thread apply all backtrace
 native.gdb.args.delimiter=\0
 
 ################################################################################


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332917](https://bugs.openjdk.org/browse/JDK-8332917) needs maintainer approval

### Issue
 * [JDK-8332917](https://bugs.openjdk.org/browse/JDK-8332917): failure_handler should execute gdb "info threads" command on linux (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1369/head:pull/1369` \
`$ git checkout pull/1369`

Update a local copy of the PR: \
`$ git checkout pull/1369` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1369`

View PR using the GUI difftool: \
`$ git pr show -t 1369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1369.diff">https://git.openjdk.org/jdk21u-dev/pull/1369.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1369#issuecomment-2621546908)
</details>
