### PR TITLE
8226938: [TEST_BUG]GTK L&F: There is no Details button in FileChooser Dialog

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/bug4587721.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4587721.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4587721
+ * @summary Tests if JFileChooser details view chops off text
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4587721
+ */
+
+import java.awt.Font;
+import java.util.Enumeration;
+
+import javax.swing.JFileChooser;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.plaf.FontUIResource;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+
+public class bug4587721 {
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel(new MetalLookAndFeel());
+
+        String instructions = """
+                Click on the Details button in JFileChooser Window.
+                If the filename text is chopped off by height,
+                then Press FAIL else Press PASS.
+                """;
+
+        PassFailJFrame.builder()
+                .title("bug4587721")
+                .instructions(instructions)
+                .columns(40)
+                .testUI(bug4587721::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFileChooser createUI() {
+        setFonts();
+        JFileChooser fc = new JFileChooser();
+        return fc;
+    }
+
+    public static void setFonts() {
+        UIDefaults defaults = UIManager.getDefaults();
+        Enumeration keys = defaults.keys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            if (defaults.get(key) instanceof Font)
+                UIManager.put(key, new FontUIResource(new Font("Courier", Font.BOLD, 30)));
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8226938](https://bugs.openjdk.org/browse/JDK-8226938) needs maintainer approval

### Issue
 * [JDK-8226938](https://bugs.openjdk.org/browse/JDK-8226938): [TEST_BUG]GTK L&amp;F: There is no Details button in FileChooser Dialog (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1370/head:pull/1370` \
`$ git checkout pull/1370`

Update a local copy of the PR: \
`$ git checkout pull/1370` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1370`

View PR using the GUI difftool: \
`$ git pr show -t 1370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1370.diff">https://git.openjdk.org/jdk21u-dev/pull/1370.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1370#issuecomment-2621783801)
</details>
