### PR TITLE
8347911: Limit the length of inflated text chunks

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,6 +142,7 @@ public class PNGImageReader extends ImageReader {
     static final int tRNS_TYPE = 0x74524e53;
     static final int zTXt_TYPE = 0x7a545874;
 
+    static final int MAX_INFLATED_TEXT_LENGTH = 262144;
     static final int PNG_COLOR_GRAY = 0;
     static final int PNG_COLOR_RGB = 2;
     static final int PNG_COLOR_PALETTE = 3;
@@ -670,7 +671,7 @@ public class PNGImageReader extends ImageReader {
     private static byte[] inflate(byte[] b) throws IOException {
         InputStream bais = new ByteArrayInputStream(b);
         try (InputStream iis = new InflaterInputStream(bais)) {
-            return iis.readAllBytes();
+            return iis.readNBytes(MAX_INFLATED_TEXT_LENGTH);
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347911](https://bugs.openjdk.org/browse/JDK-8347911) needs maintainer approval

### Issue
 * [JDK-8347911](https://bugs.openjdk.org/browse/JDK-8347911): Limit the length of inflated text chunks (**Bug** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1371/head:pull/1371` \
`$ git checkout pull/1371`

Update a local copy of the PR: \
`$ git checkout pull/1371` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1371`

View PR using the GUI difftool: \
`$ git pr show -t 1371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1371.diff">https://git.openjdk.org/jdk21u-dev/pull/1371.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1371#issuecomment-2621810360)
</details>
