### PR TITLE
8343491: javax/management/remote/mandatory/connection/DeadLockTest.java failing with NoSuchObjectException: no such object in table

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/connection/DeadLockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DeadLockTest.java
@@ -27,6 +27,10 @@
  * @summary test on a client notification deadlock.
  * @author Shanliang JIANG
  *
+ * @requires vm.compMode != "Xcomp"
+ * @comment Running with -Xcomp is likely to cause a timeout while establishing the connection
+ *          (RMI: java.rmi.NoSuchObjectException: no such object in table).
+ *
  * @run clean DeadLockTest
  * @run build DeadLockTest
  * @run main DeadLockTest
@@ -139,7 +143,7 @@ public class DeadLockTest {
                     try {
                         conn.getDefaultDomain();
                     } catch (IOException ioe) {
-                        // Greate !
+                        // OK
                     }
 
                     synchronized(this) {


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343491](https://bugs.openjdk.org/browse/JDK-8343491) needs maintainer approval

### Issue
 * [JDK-8343491](https://bugs.openjdk.org/browse/JDK-8343491): javax/management/remote/mandatory/connection/DeadLockTest.java failing with NoSuchObjectException: no such object in table (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1379/head:pull/1379` \
`$ git checkout pull/1379`

Update a local copy of the PR: \
`$ git checkout pull/1379` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1379`

View PR using the GUI difftool: \
`$ git pr show -t 1379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1379.diff">https://git.openjdk.org/jdk21u-dev/pull/1379.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1379#issuecomment-2624593769)
</details>
