### PR TITLE
8338571: [TestBug] DefaultCloseOperation.java test not working as expected wrt instruction after JDK-8325851 fix

### DIFF
--- a/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
+++ b/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
@@ -99,7 +99,6 @@ public class DefaultCloseOperation extends JPanel {
 
         CloseOpFrame testFrame = new CloseOpFrame();
         testFrame.setLocationRelativeTo(null);
-        PassFailJFrame.addTestWindow(testFrame);
 
         add(new JLabel("JFrame Default Close Operation:"));
         frameCloseOp = new JComboBox<>();
@@ -127,7 +126,6 @@ public class DefaultCloseOperation extends JPanel {
 
         testDialog = new CloseOpDialog(testFrame);
         testDialog.setLocationRelativeTo(null);
-        PassFailJFrame.addTestWindow(testDialog);
 
         add(new JLabel("JDialog Default Close Operation:"));
         dialogCloseOp = new JComboBox<>();


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338571](https://bugs.openjdk.org/browse/JDK-8338571) needs maintainer approval

### Issue
 * [JDK-8338571](https://bugs.openjdk.org/browse/JDK-8338571): [TestBug] DefaultCloseOperation.java test not working as expected wrt instruction after JDK-8325851 fix (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1380/head:pull/1380` \
`$ git checkout pull/1380`

Update a local copy of the PR: \
`$ git checkout pull/1380` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1380`

View PR using the GUI difftool: \
`$ git pr show -t 1380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1380.diff">https://git.openjdk.org/jdk21u-dev/pull/1380.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1380#issuecomment-2624619473)
</details>
