### PR TITLE
8348323: Corrupted timezone string in JVM crash log

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1141,8 +1141,7 @@ void os::print_date_and_time(outputStream *st, char* buf, size_t buflen) {
   if (localtime_pd(&tloc, &tz) != nullptr) {
     wchar_t w_buf[80];
     size_t n = ::wcsftime(w_buf, 80, L"%Z", &tz);
-    if (n > 0) {
-      ::wcstombs(buf, w_buf, buflen);
+    if (n > 0 && ::wcstombs(buf, w_buf, buflen) != (size_t)-1) {
       st->print("Time: %s %s", timestring, buf);
     } else {
       st->print("Time: %s", timestring);


### PR DESCRIPTION
Add a error check to "wcstombs" otherwise the "buf" prints junk or corrupted string.

Test performed:

"jcmd < jvm pid > VM.info" for different JVM versions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8348323](https://bugs.openjdk.org/browse/JDK-8348323) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348323](https://bugs.openjdk.org/browse/JDK-8348323): Corrupted timezone string in JVM crash log (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1382/head:pull/1382` \
`$ git checkout pull/1382`

Update a local copy of the PR: \
`$ git checkout pull/1382` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1382`

View PR using the GUI difftool: \
`$ git pr show -t 1382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1382.diff">https://git.openjdk.org/jdk21u-dev/pull/1382.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1382#issuecomment-2632151384)
</details>
