### PR TITLE
8325730: StringBuilder.toString allocation for the empty String

### DIFF
--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -735,6 +735,9 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
     @Override
     @IntrinsicCandidate
     public synchronized String toString() {
+        if (length() == 0) {
+            return "";
+        }
         if (toStringCache == null) {
             return toStringCache = new String(this, null);
         }

--- a/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -471,8 +471,11 @@ public final class StringBuilder
     @Override
     @IntrinsicCandidate
     public String toString() {
+        if (length() == 0) {
+            return "";
+        }
         // Create a copy, don't share the array
-        return new String(this);
+        return new String(this, null);
     }
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/StringBuffers.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,4 +80,10 @@ public class StringBuffers {
         return blaha.substring(30, 35);
     }
 
+    StringBuffer sb = new StringBuffer();
+
+    @Benchmark
+    public String emptyToString() {
+        return sb.toString();
+    }
 }

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,6 +364,11 @@ public class StringBuilders {
         return sbUtf16.charAt(charAt_index);
     }
 
+    @Benchmark
+    public String emptyToString(Data data) {
+        return data.sbEmpty.toString();
+    }
+
     @State(Scope.Thread)
     public static class Data {
         int i = 0;
@@ -380,6 +385,7 @@ public class StringBuilders {
             }
         }
 
+        StringBuilder sbEmpty;
         String str;
         String utf16Str;
         CharSequence cs;
@@ -398,6 +404,8 @@ public class StringBuilders {
         }
 
         private void generateData() {
+            sbEmpty = new StringBuilder(length);
+
             char[] chars = "abcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
 
             StringBuilder sb = new StringBuilder(length);


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8325730](https://bugs.openjdk.org/browse/JDK-8325730) needs maintainer approval

### Issue
 * [JDK-8325730](https://bugs.openjdk.org/browse/JDK-8325730): StringBuilder.toString allocation for the empty String (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1387/head:pull/1387` \
`$ git checkout pull/1387`

Update a local copy of the PR: \
`$ git checkout pull/1387` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1387`

View PR using the GUI difftool: \
`$ git pr show -t 1387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1387.diff">https://git.openjdk.org/jdk21u-dev/pull/1387.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1387#issuecomment-2636902122)
</details>
