### PR TITLE
8349603: [21u, 17u, 11u] Update GHA JDKs after Jan/25 updates

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,17 +29,17 @@ GTEST_VERSION=1.13.0
 JTREG_VERSION=7.3.1+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.3_9.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=fffa52c22d797b715a962e6c8d11ec7d79b90dd819b5bc51d62137ea4b22a340
-
-MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_mac_hotspot_21.0.3_9.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=f777103aab94330d14a29bd99f3a26d60abbab8e2c375cec9602746096721a7c
+LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.6_7.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=a2650fba422283fbed20d936ce5d2a52906a5414ec17b2f7676dddb87201dbae
 
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
-MACOS_AARCH64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.3_9.tar.gz
-MACOS_AARCH64_BOOT_JDK_SHA256=b6be6a9568be83695ec6b7cb977f4902f7be47d74494c290bc2a5c3c951e254f
+MACOS_AARCH64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.6_7.tar.gz
+MACOS_AARCH64_BOOT_JDK_SHA256=4ef4083919126a3d93e603284b405c7493905497485a92b375f5d6c3e8f7e8f2
+
+MACOS_X64_BOOT_JDK_EXT=tar.gz
+MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_mac_hotspot_21.0.6_7.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=7aacfc400078ad65b7c7de3ec75ff74bf5c2077d6740b350f85ae10be4f71e76
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_windows_hotspot_21.0.3_9.zip
-WINDOWS_X64_BOOT_JDK_SHA256=c43a66cff7a403d56c5c5e1ff10d3d5f95961abf80f97f0e35380594909f0e4d
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_windows_hotspot_21.0.6_7.zip
+WINDOWS_X64_BOOT_JDK_SHA256=897c8eebb0f85a99ccecbd482ebae9a45d88c19d6077054f6529ebab49b6d259


### PR DESCRIPTION
Bumps the GHA JDKs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8349603](https://bugs.openjdk.org/browse/JDK-8349603) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349603](https://bugs.openjdk.org/browse/JDK-8349603): [21u, 17u, 11u] Update GHA JDKs after Jan/25 updates (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1389/head:pull/1389` \
`$ git checkout pull/1389`

Update a local copy of the PR: \
`$ git checkout pull/1389` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1389`

View PR using the GUI difftool: \
`$ git pr show -t 1389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1389.diff">https://git.openjdk.org/jdk21u-dev/pull/1389.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1389#issuecomment-2641050970)
</details>
