### PR TITLE
8346881: [ubsan] logSelection.cpp:154:24  / logSelectionList.cpp:72:94 : runtime error: applying non-zero offset 1 to null pointer

### DIFF
--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,9 @@ bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
       break;
     }
     tmp_decorators |= mask(d);
-    token = comma_pos + 1;
+    if (comma_pos != nullptr) {
+      token = comma_pos + 1;
+    }
   } while (comma_pos != nullptr);
   os::free(args_copy);
   if (result) {

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,9 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
       return LogSelection::Invalid;
     }
     tags[ntags++] = tag;
-    cur_tag = plus_pos + 1;
+    if (plus_pos != nullptr) {
+      cur_tag = plus_pos + 1;
+    }
   } while (plus_pos != nullptr);
 
   for (size_t i = 0; i < ntags; i++) {

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ bool LogSelectionList::parse(const char* str, outputStream* errstream) {
   }
   char* copy = os::strdup_check_oom(str, mtLogging);
   // Split string on commas
-  for (char *comma_pos = copy, *cur = copy; success && comma_pos != nullptr; cur = comma_pos + 1) {
+  for (char *comma_pos = copy, *cur = copy; success; cur = comma_pos + 1) {
     if (_nselections == MaxSelections) {
       if (errstream != nullptr) {
         errstream->print_cr("Can not have more than " SIZE_FORMAT " log selections in a single configuration.",
@@ -82,6 +82,10 @@ bool LogSelectionList::parse(const char* str, outputStream* errstream) {
       break;
     }
     _selections[_nselections++] = selection;
+
+    if (comma_pos == nullptr) {
+      break;
+    }
   }
 
   os::free(copy);


### PR DESCRIPTION
copyright years had to be adjusted

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346881](https://bugs.openjdk.org/browse/JDK-8346881) needs maintainer approval

### Issue
 * [JDK-8346881](https://bugs.openjdk.org/browse/JDK-8346881): [ubsan] logSelection.cpp:154:24  / logSelectionList.cpp:72:94 : runtime error: applying non-zero offset 1 to null pointer (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1399/head:pull/1399` \
`$ git checkout pull/1399`

Update a local copy of the PR: \
`$ git checkout pull/1399` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1399`

View PR using the GUI difftool: \
`$ git pr show -t 1399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1399.diff">https://git.openjdk.org/jdk21u-dev/pull/1399.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1399#issuecomment-2651030970)
</details>
