### PR TITLE
8342958: Use jvmArgs consistently in microbenchmarks

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -602,7 +602,7 @@ define SetupRunMicroTestBody
     $1_JMH_JVM_ARGS += $$(MICRO_VM_OPTIONS) $$(MICRO_JAVA_OPTIONS)
   endif
 
-  $1_MICRO_VM_OPTIONS := -jvmArgs $(call ShellQuote,$$($1_JMH_JVM_ARGS))
+  $1_MICRO_VM_OPTIONS := -jvmArgsPrepend $(call ShellQuote,$$($1_JMH_JVM_ARGS))
 
   ifneq ($$(MICRO_ITER), )
     $1_MICRO_ITER := -i $$(MICRO_ITER)

--- a/test/micro/org/openjdk/bench/java/lang/ObjectHashCode.java
+++ b/test/micro/org/openjdk/bench/java/lang/ObjectHashCode.java
@@ -50,37 +50,37 @@ public class ObjectHashCode {
     // Experimental hashCode generation schemes. See synchronizer.cpp get_next_hash
     /*
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=0"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=0"})
     public int mode_0() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=1"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=1"})
     public int mode_1() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=2"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=2"})
     public int mode_2() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=3"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=3"})
     public int mode_3() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=4"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=4"})
     public int mode_4() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=5"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=5"})
     public int mode_5() {
         return System.identityHashCode(new Object());
     }

--- a/test/micro/org/openjdk/bench/java/lang/ScopedValues.java
+++ b/test/micro/org/openjdk/bench/java/lang/ScopedValues.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.ScopedValuesData.*;
 @Measurement(iterations=10, time=1)
 @Threads(1)
 @Fork(value = 1,
-      jvmArgsPrepend = {"-Djmh.executor.class=org.openjdk.bench.java.lang.ScopedValuesExecutorService",
+      jvmArgs = {"-Djmh.executor.class=org.openjdk.bench.java.lang.ScopedValuesExecutorService",
                         "-Djmh.executor=CUSTOM",
                         "-Djmh.blackhole.mode=COMPILER",
                         "--enable-preview"})

--- a/test/micro/org/openjdk/bench/java/lang/StringHashCode.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringHashCode.java
@@ -96,7 +96,7 @@ public class StringHashCode {
     @State(Scope.Thread)
     @Warmup(iterations = 5, time = 1)
     @Measurement(iterations = 5, time = 1)
-    @Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED"})
+    @Fork(value = 3, jvmArgs = {"--add-exports", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED"})
     public static class Algorithm {
 
         private final static String alphabet = "abcdefghijklmnopqrstuvwxyz";

--- a/test/micro/org/openjdk/bench/java/lang/StringTemplateFMT.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringTemplateFMT.java
@@ -45,7 +45,7 @@ import static java.util.FormatProcessor.FMT;
 @State(Scope.Benchmark)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class StringTemplateFMT {
 
     public String s = "str";

--- a/test/micro/org/openjdk/bench/java/lang/foreign/BulkOps.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/BulkOps.java
@@ -51,7 +51,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class BulkOps {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadConstant.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.foreign.CallOverheadHelper.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
 public class CallOverheadConstant {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadVirtual.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadVirtual.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.foreign.CallOverheadHelper.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
 public class CallOverheadVirtual {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LinkUpcall.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LinkUpcall.java
@@ -47,7 +47,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
 public class LinkUpcall extends CLayouts {
 
     static final Linker LINKER = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverConstant extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
@@ -47,7 +47,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverNew extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNewHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNewHeap.java
@@ -47,7 +47,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverNewHeap extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
 public class LoopOverNonConstant extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantFP.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverNonConstantFP {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
@@ -49,7 +49,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverNonConstantHeap extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
@@ -55,7 +55,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverNonConstantMapped extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverNonConstantShared extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverOfAddress extends JavaLayouts {
 
     static final int ITERATIONS = 1_000_000;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedBuffer.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedBuffer.java
@@ -49,7 +49,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverPollutedBuffer {
 
     static final int ELEM_SIZE = 1_000_000;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
@@ -46,7 +46,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class LoopOverPollutedSegments extends JavaLayouts {
 
     static final int ELEM_SIZE = 1_000_000;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverSlice.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverSlice.java
@@ -49,7 +49,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
 
 public class LoopOverSlice {
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentVsBits.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentVsBits.java
@@ -60,7 +60,7 @@ import static java.nio.ByteOrder.BIG_ENDIAN;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED", "--enable-preview"})
+@Fork(value = 3, jvmArgs = {"--enable-native-access=ALL-UNNAMED", "--enable-preview"})
 public class MemorySegmentVsBits {
 
     public static final VarHandle LONG_ARRAY_VH = MethodHandles.byteArrayViewVarHandle(long[].class, BIG_ENDIAN);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySessionClose.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySessionClose.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class MemorySessionClose {
 
     static final int ALLOC_SIZE = 1024;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
@@ -52,7 +52,7 @@ import java.util.function.ToIntFunction;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class ParallelSum extends JavaLayouts {
 
     final static int CARRIER_SIZE = 4;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
 public class PointerInvoke extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
@@ -46,7 +46,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
 public class QSort extends CLayouts {
 
     static final Linker abi = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -50,7 +50,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
 public class StrLenTest extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/TestAdaptVarHandles.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/TestAdaptVarHandles.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class TestAdaptVarHandles extends JavaLayouts {
 
     static class IntBox {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/TestLoadBytes.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/TestLoadBytes.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "-Dforeign.restricted=permit",
         "--enable-native-access", "ALL-UNNAMED",
         "--enable-preview"})

--- a/test/micro/org/openjdk/bench/java/lang/foreign/UnrolledAccess.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/UnrolledAccess.java
@@ -40,7 +40,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
 public class UnrolledAccess extends JavaLayouts {
 
     static final Unsafe U = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
@@ -45,7 +45,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
 public class Upcalls extends CLayouts {
 
     static final Linker abi = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
@@ -47,7 +47,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 public class VarHandleExact {
 
     static final VarHandle exact;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgs = "--enable-preview")
 @State(Scope.Benchmark)
 public class PointerBench {
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAccess.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAccess.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class PointsAccess {
 
     BBPoint BBPoint;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAlloc.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAlloc.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class PointsAlloc {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsDistance.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsDistance.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class PointsDistance {
 
     BBPoint jniP1;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsFree.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsFree.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class PointsFree {
 
     JNIPoint jniPoint;

--- a/test/micro/org/openjdk/bench/java/lang/invoke/Wrappers.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/Wrappers.java
@@ -45,7 +45,7 @@ import sun.invoke.util.Wrapper;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
-@Fork(value = 3, jvmArgsAppend = "--add-exports=java.base/sun.invoke.util=ALL-UNNAMED")
+@Fork(value = 3, jvmArgs = "--add-exports=java.base/sun.invoke.util=ALL-UNNAMED")
 public class Wrappers {
 
     public static Class<?>[] PRIM_CLASSES = {

--- a/test/micro/org/openjdk/bench/java/net/NetworkInterfaceLookup.java
+++ b/test/micro/org/openjdk/bench/java/net/NetworkInterfaceLookup.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
-@Fork(value = 2, jvmArgsAppend = "--add-opens=java.base/java.net=ALL-UNNAMED")
+@Fork(value = 2, jvmArgs = "--add-opens=java.base/java.net=ALL-UNNAMED")
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 public class NetworkInterfaceLookup {

--- a/test/micro/org/openjdk/bench/java/net/SocketChannelConnectionSetup.java
+++ b/test/micro/org/openjdk/bench/java/net/SocketChannelConnectionSetup.java
@@ -125,7 +125,7 @@ public class SocketChannelConnectionSetup {
 
         opt = new OptionsBuilder()
                 .include(org.openjdk.bench.java.net.SocketChannelConnectionSetup.class.getSimpleName())
-                .jvmArgsPrepend("-Djdk.net.useFastTcpLoopback=true")
+                .jvmArgs("-Djdk.net.useFastTcpLoopback=true")
                 .warmupForks(1)
                 .forks(2)
                 .build();

--- a/test/micro/org/openjdk/bench/java/net/ThreadLocalParseUtil.java
+++ b/test/micro/org/openjdk/bench/java/net/ThreadLocalParseUtil.java
@@ -48,7 +48,7 @@ import static java.lang.invoke.MethodType.methodType;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsAppend = "--add-exports=java.base/sun.net.www=ALL-UNNAMED")
+@Fork(value = 1, jvmArgs = "--add-exports=java.base/sun.net.www=ALL-UNNAMED")
 public class ThreadLocalParseUtil {
 
     private static final MethodHandle MH_DECODE;

--- a/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
+++ b/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
@@ -45,7 +45,7 @@ import static sun.security.util.DisabledAlgorithmConstraints.PROPERTY_TLS_DISABL
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)

--- a/test/micro/org/openjdk/bench/java/security/CacheBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CacheBench.java
@@ -44,7 +44,7 @@ import sun.security.util.Cache;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 public class CacheBench {

--- a/test/micro/org/openjdk/bench/java/security/CipherSuiteBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CipherSuiteBench.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
 
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.ssl=ALL-UNNAMED", "--add-opens", "java.base/sun.security.ssl=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/sun.security.ssl=ALL-UNNAMED", "--add-opens", "java.base/sun.security.ssl=ALL-UNNAMED"})
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @BenchmarkMode(Mode.Throughput)

--- a/test/micro/org/openjdk/bench/java/security/HSS.java
+++ b/test/micro/org/openjdk/bench/java/security/HSS.java
@@ -55,7 +55,7 @@ import sun.security.util.RawKeySpec;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 
 // Tests 1-2 are from RFC 8554, Appendix F.
 

--- a/test/micro/org/openjdk/bench/java/security/MessageDigests.java
+++ b/test/micro/org/openjdk/bench/java/security/MessageDigests.java
@@ -47,7 +47,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
+@Fork(jvmArgs = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class MessageDigests {
 
     @Param({"64", "16384"})

--- a/test/micro/org/openjdk/bench/java/security/PKCS12KeyStores.java
+++ b/test/micro/org/openjdk/bench/java/security/PKCS12KeyStores.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.annotations.*;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @BenchmarkMode(Mode.AverageTime)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
+@Fork(jvmArgs = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class PKCS12KeyStores {
 
     private static final char[] PASS = "changeit".toCharArray();

--- a/test/micro/org/openjdk/bench/java/security/ProtectionDomainBench.java
+++ b/test/micro/org/openjdk/bench/java/security/ProtectionDomainBench.java
@@ -123,7 +123,7 @@ public class ProtectionDomainBench {
     }
 
     @Benchmark
-    @Fork(value = 3, jvmArgsPrepend={"-Djava.security.manager=allow"})
+    @Fork(value = 3, jvmArgs={"-Djava.security.manager=allow"})
     public void withSecurityManager()  throws ClassNotFoundException {
         work();
     }

--- a/test/micro/org/openjdk/bench/java/security/Signatures.java
+++ b/test/micro/org/openjdk/bench/java/security/Signatures.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
+@Fork(jvmArgs = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class Signatures {
     private static Signature signer;
 

--- a/test/micro/org/openjdk/bench/java/util/ListArgs.java
+++ b/test/micro/org/openjdk/bench/java/util/ListArgs.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
  */
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "-verbose:gc", "-XX:+UseParallelGC", "-Xms4g", "-Xmx4g", "-Xint" })
+@Fork(value = 3, jvmArgs = { "-verbose:gc", "-XX:+UseParallelGC", "-Xms4g", "-Xmx4g", "-Xint" })
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 public class ListArgs {

--- a/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
+@Fork(value = 3, jvmArgs = {"-Xms1g", "-Xmx1g"})
 public class StringJoinerBenchmark {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/javax/crypto/AES.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/AES.java
@@ -59,19 +59,19 @@ public class AES {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend = {"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseAES", "-XX:-UseAESIntrinsics"})
+    @Fork(jvmArgs = {"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseAES", "-XX:-UseAESIntrinsics"})
     public byte[] testBaseline() throws Exception {
         return cipher.doFinal(src);
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAES", "-XX:-UseAESIntrinsics"})
+    @Fork(jvmArgs = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAES", "-XX:-UseAESIntrinsics"})
     public byte[] testUseAes() throws Exception {
         return cipher.doFinal(src);
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAES", "-XX:+UseAESIntrinsics"})
+    @Fork(jvmArgs = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAES", "-XX:+UseAESIntrinsics"})
     public byte[] testUseAesIntrinsics() throws Exception {
         return cipher.doFinal(src);
     }

--- a/test/micro/org/openjdk/bench/javax/crypto/AESReinit.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/AESReinit.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
+@Fork(value = 3, jvmArgs = {"-Xms1g", "-Xmx1g"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)

--- a/test/micro/org/openjdk/bench/javax/crypto/Crypto.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/Crypto.java
@@ -51,7 +51,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5)
 @Measurement(iterations = 10)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 5)
+@Fork(jvmArgs = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 5)
 public class Crypto {
 
     @Param({"64", "1024", "16384"})

--- a/test/micro/org/openjdk/bench/javax/crypto/full/CryptoBase.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/CryptoBase.java
@@ -45,7 +45,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 
-@Fork(jvmArgsAppend = {"-XX:+AlwaysPreTouch"}, value = 5)
+@Fork(jvmArgs = {"-XX:+AlwaysPreTouch"}, value = 5)
 @Warmup(iterations = 3, time = 3)
 @Measurement(iterations = 8, time = 2)
 @OutputTimeUnit(TimeUnit.SECONDS)

--- a/test/micro/org/openjdk/bench/javax/crypto/full/Poly1305DigestBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/Poly1305DigestBench.java
@@ -41,7 +41,7 @@ import java.nio.ByteBuffer;
 
 @Measurement(iterations = 3, time = 10)
 @Warmup(iterations = 3, time = 10)
-@Fork(value = 1, jvmArgsAppend = {"--add-opens", "java.base/com.sun.crypto.provider=ALL-UNNAMED"})
+@Fork(value = 1, jvmArgs = {"--add-opens", "java.base/com.sun.crypto.provider=ALL-UNNAMED"})
 public class Poly1305DigestBench extends CryptoBase {
     public static final int SET_SIZE = 128;
 

--- a/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
@@ -45,7 +45,7 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @Warmup(iterations = 2)
 @Measurement(iterations = 4)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",

--- a/test/micro/org/openjdk/bench/jdk/classfile/GenerateStackMaps.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/GenerateStackMaps.java
@@ -55,7 +55,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.attribute=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED",

--- a/test/micro/org/openjdk/bench/jdk/classfile/RebuildMethodBodies.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/RebuildMethodBodies.java
@@ -39,7 +39,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.instruction=ALL-UNNAMED"})

--- a/test/micro/org/openjdk/bench/jdk/classfile/RepeatedModelTraversal.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/RepeatedModelTraversal.java
@@ -38,7 +38,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile.components=ALL-UNNAMED"})
 @Warmup(iterations = 3)

--- a/test/micro/org/openjdk/bench/jdk/classfile/Write.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Write.java
@@ -65,7 +65,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.V12;
  */
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.classfile=ALL-UNNAMED",

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/ArrayMismatchBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/ArrayMismatchBenchmark.java
@@ -47,7 +47,7 @@ import java.util.random.RandomGenerator;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class ArrayMismatchBenchmark {
 
     @Param({"9", "257", "100000"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/BlackScholes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/BlackScholes.java
@@ -39,7 +39,7 @@ import java.util.function.IntUnaryOperator;
 @State(Scope.Thread)
 @Warmup(iterations = 3, time = 5)
 @Measurement(iterations = 3, time = 5)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class BlackScholes {
 
     @Param("1024")

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/EqualsIgnoreCaseBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/EqualsIgnoreCaseBenchmark.java
@@ -46,7 +46,7 @@ import static jdk.incubator.vector.VectorOperators.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 3, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class EqualsIgnoreCaseBenchmark {
     static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
     private byte[] a;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class IndexInRangeBenchmark {
     @Param({"7", "256", "259", "512"})
     private int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexVectorBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexVectorBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class IndexVectorBenchmark {
     @Param({"1024"})
     private int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/LoadMaskedIOOBEBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/LoadMaskedIOOBEBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class LoadMaskedIOOBEBenchmark {
     @Param({"1026"})
     private int inSize;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskCastOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskCastOperationsBenchmark.java
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskCastOperationsBenchmark {
     VectorMask<Byte> bmask64;
     VectorMask<Byte> bmask128;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskFromLongBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskFromLongBenchmark.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskFromLongBenchmark {
     private static final int ITERATION = 20000;
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskQueryOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskQueryOperationsBenchmark.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskQueryOperationsBenchmark {
     @Param({"128","256","512"})
     int bits;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskedLogicOpts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskedLogicOpts.java
@@ -32,7 +32,7 @@ import java.util.Random;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskedLogicOpts {
     @Param({"256","512","1024"})
     private int ARRAYLEN;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
@@ -48,7 +48,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
     "--add-modules=jdk.incubator.vector",
     "--enable-preview",
     "--enable-native-access", "ALL-UNNAMED"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/RearrangeBytesBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/RearrangeBytesBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class RearrangeBytesBenchmark {
     @Param({"256", "512", "1024"})
     int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/RotateBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/RotateBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class RotateBenchmark {
     @Param({"256","512"})
     int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskTrueCount.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskTrueCount.java
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class StoreMaskTrueCount {
     private static final VectorSpecies<Short> S_SPECIES = ShortVector.SPECIES_PREFERRED;
     private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_PREFERRED;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class StoreMaskedBenchmark {
     @Param({"1024"})
     private int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedIOOBEBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedIOOBEBenchmark.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class StoreMaskedIOOBEBenchmark {
     @Param({"1024"})
     private int inSize;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
@@ -47,7 +47,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
     "--add-modules=jdk.incubator.vector",
     "--enable-preview",
     "--enable-native-access", "ALL-UNNAMED",

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
@@ -50,7 +50,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
     "--add-modules=jdk.incubator.vector",
     "--enable-preview",
     "--enable-native-access", "ALL-UNNAMED"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorFPtoIntCastOperations.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorFPtoIntCastOperations.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class VectorFPtoIntCastOperations {
     @Param({"512", "1024"})
     static int SIZE;

--- a/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
@@ -38,7 +38,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
 
-@Fork(value = 3, jvmArgsPrepend = {"-XX:-EliminateAllocations", "-XX:-DoEscapeAnalysis"})
+@Fork(value = 3, jvmArgs = {"-XX:-EliminateAllocations", "-XX:-DoEscapeAnalysis"})
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/vm/compiler/InterfacePrivateCalls.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InterfacePrivateCalls.java
@@ -64,7 +64,7 @@ public class InterfacePrivateCalls {
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    @Fork(value=3, jvmArgsAppend={"-XX:TieredStopAtLevel=1"})
+    @Fork(value=3, jvmArgs={"-XX:TieredStopAtLevel=1"})
     public void invokePrivateInterfaceMethodC1() {
         for (int i = 0; i < objs.length; ++i) {
             objs[i].foo();

--- a/test/micro/org/openjdk/bench/vm/compiler/SubIdealC0Minus_YPlusC1_.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/SubIdealC0Minus_YPlusC1_.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3 , jvmArgsAppend = {"-XX:-TieredCompilation", "-Xbatch", "-Xcomp"})
+@Fork(value = 3 , jvmArgs = {"-XX:-TieredCompilation", "-Xbatch", "-Xcomp"})
 public class SubIdealC0Minus_YPlusC1_ {
 
     private static final int I_C0 = 1234567;

--- a/test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java
@@ -367,7 +367,7 @@ public abstract class TypeVectorOperations {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
+    @Fork(jvmArgs = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
     public void cmoveD() {
         for (int i = 0; i < COUNT; i++) {
             resD[i] = resD[i] < doubles[i] ? resD[i] : doubles[i];
@@ -375,21 +375,21 @@ public abstract class TypeVectorOperations {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
+    @Fork(jvmArgs = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
     public void cmoveF() {
         for (int i = 0; i < COUNT; i++) {
             resF[i] = resF[i] < floats[i] ? resF[i] : floats[i];
         }
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:+UseSuperWord"
     })
     public static class TypeVectorOperationsSuperWord extends TypeVectorOperations {
 
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:-UseSuperWord"
     })
     public static class TypeVectorOperationsNonSuperWord extends TypeVectorOperations {

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorBitCount.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorBitCount.java
@@ -72,14 +72,14 @@ public abstract class VectorBitCount {
     }
 
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:+UseSuperWord"
     })
     public static class WithSuperword extends VectorBitCount {
 
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:-UseSuperWord"
     })
     public static class NoSuperword extends VectorBitCount {

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorReduction.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorReduction.java
@@ -176,14 +176,14 @@ public abstract class VectorReduction {
         }
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:+UseSuperWord"
     })
     public static class WithSuperword extends VectorReduction {
 
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:-UseSuperWord"
     })
     public static class NoSuperword extends VectorReduction {

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorReductionFloatingMinMax.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorReductionFloatingMinMax.java
@@ -69,7 +69,7 @@ public class VectorReductionFloatingMinMax {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:-SuperWordLoopUnrollAnalysis"})
+    @Fork(jvmArgs = {"-XX:-SuperWordLoopUnrollAnalysis"})
     public void maxRedF(Blackhole bh) {
         float max = 0.0f;
         for (int i = 0; i < COUNT_FLOAT; i++) {
@@ -79,7 +79,7 @@ public class VectorReductionFloatingMinMax {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:-SuperWordLoopUnrollAnalysis"})
+    @Fork(jvmArgs = {"-XX:-SuperWordLoopUnrollAnalysis"})
     public void minRedF(Blackhole bh) {
         float min = 0.0f;
         for (int i = 0; i < COUNT_FLOAT; i++) {

--- a/test/micro/org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.java
@@ -52,25 +52,25 @@ public class SimpleRepeatCompilation {
      = "-XX:CompileCommand=option,org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.mixHashCode,intx,RepeatCompilation,500";
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", MIXHASH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", MIXHASH_METHOD})
     public int mixHashCode_repeat() {
         return loop_hashCode();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:-TieredCompilation", MIXHASH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:-TieredCompilation", MIXHASH_METHOD})
     public int mixHashCode_repeat_c2() {
         return loop_hashCode();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:TieredStopAtLevel=1", MIXHASH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:TieredStopAtLevel=1", MIXHASH_METHOD})
     public int mixHashCode_repeat_c1() {
         return loop_hashCode();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch"})
+    @Fork(jvmArgs={"-Xbatch"})
     public int mixHashCode_baseline() {
         return loop_hashCode();
     }
@@ -95,25 +95,25 @@ public class SimpleRepeatCompilation {
      = "-XX:CompileCommand=option,org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.trivialMath,intx,RepeatCompilation,2000";
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch",TRIVIAL_MATH_METHOD})
+    @Fork(jvmArgs={"-Xbatch",TRIVIAL_MATH_METHOD})
     public int trivialMath_repeat() {
         return loop_trivialMath();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:-TieredCompilation", TRIVIAL_MATH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:-TieredCompilation", TRIVIAL_MATH_METHOD})
     public int trivialMath_repeat_c2() {
         return loop_trivialMath();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:TieredStopAtLevel=1", TRIVIAL_MATH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:TieredStopAtLevel=1", TRIVIAL_MATH_METHOD})
     public int trivialMath_repeat_c1() {
         return loop_trivialMath();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch"})
+    @Fork(jvmArgs={"-Xbatch"})
     public int trivialMath_baseline() {
         return loop_trivialMath();
     }
@@ -135,25 +135,25 @@ public class SimpleRepeatCompilation {
      = "-XX:CompileCommand=option,org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.largeMethod,intx,RepeatCompilation,100";
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch",LARGE_METHOD})
+    @Fork(jvmArgs={"-Xbatch",LARGE_METHOD})
     public int largeMethod_repeat() {
         return loop_largeMethod();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:-TieredCompilation", LARGE_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:-TieredCompilation", LARGE_METHOD})
     public int largeMethod_repeat_c2() {
         return loop_largeMethod();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:TieredStopAtLevel=1", LARGE_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:TieredStopAtLevel=1", LARGE_METHOD})
     public int largeMethod_repeat_c1() {
         return loop_largeMethod();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch"})
+    @Fork(jvmArgs={"-Xbatch"})
     public int largeMethod_baseline() {
         return loop_largeMethod();
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@Fork(value = 3, jvmArgsAppend = "-XX:-UseSuperWord")
+@Fork(value = 3, jvmArgs = "-XX:-UseSuperWord")
 @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(time = 1, timeUnit = TimeUnit.SECONDS)
 public class BasicRules {

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/ConvertF2I.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/ConvertF2I.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsAppend = {"-XX:-UseSuperWord"})
+@Fork(value = 1, jvmArgs = {"-XX:-UseSuperWord"})
 public class ConvertF2I {
     static final int LENGTH = 1000;
     static final int[] INT_ARRAY = new int[LENGTH];

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/LeaInstruction.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/LeaInstruction.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 2, jvmArgsAppend = {"-XX:LoopUnrollLimit=1"})
+@Fork(value = 2, jvmArgs = {"-XX:LoopUnrollLimit=1"})
 @Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/vm/fences/SafePublishing.java
+++ b/test/micro/org/openjdk/bench/vm/fences/SafePublishing.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-XX:+UseParallelGC", "-Xmx128m"})
+@Fork(value = 3, jvmArgs = {"-XX:+UseParallelGC", "-Xmx128m"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/vm/gc/MicroLargePages.java
+++ b/test/micro/org/openjdk/bench/vm/gc/MicroLargePages.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MINUTES)
 @State(Scope.Thread)
-@Fork(jvmArgsAppend = {"-Xmx256m", "-XX:+UseLargePages", "-XX:LargePageSizeInBytes=1g", "-Xlog:pagesize"}, value = 5)
+@Fork(jvmArgs = {"-Xmx256m", "-XX:+UseLargePages", "-XX:LargePageSizeInBytes=1g", "-Xlog:pagesize"}, value = 5)
 
 public class MicroLargePages {
 

--- a/test/micro/org/openjdk/bench/vm/gc/RawAllocationRate.java
+++ b/test/micro/org/openjdk/bench/vm/gc/RawAllocationRate.java
@@ -80,7 +80,7 @@ public class RawAllocationRate {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:TieredStopAtLevel=1"})
+    @Fork(jvmArgs={"-XX:TieredStopAtLevel=1"})
     public Object[] arrayTest_C1() {
         return arrayTest();
     }
@@ -106,7 +106,7 @@ public class RawAllocationRate {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:TieredStopAtLevel=1"})
+    @Fork(jvmArgs={"-XX:TieredStopAtLevel=1"})
     public Object[] instanceTest_C1() {
         return instanceTest();
     }


### PR DESCRIPTION
Hi all,

- This is PR contains two backport to jdk21u-dev

1. Uncleanly backport of [JDK-8342958](https://bugs.openjdk.org/browse/JDK-8342958).
2. Cleanly backport of [JDK-8343345](https://bugs.openjdk.org/browse/JDK-8343345).

- Why do we need these two backport?

1. [Suggests using jvmArgs consistently](https://github.com/openjdk/jdk/pull/21683#issue-2611685724).
2. This backport will make several JMH tests run normally after this backport. Before this backport, 'org.openjdk.bench.java.net.NetworkInterfaceLookup.bound' report fails "java.lang.IllegalAccessException: class org.openjdk.bench.java.net.NetworkInterfaceLookup cannot access a member of class java.net.NetworkInterface (in module java.base) with package access", after this backport this JMH test will run passes.

Why this backport can not backport cleanly?

1. Some JMH tests added after jdk21u, such as test/micro/org/openjdk/bench/java/lang/CallerClassBench.java was added by jdk22.
2. Some JMH tests removed after jdk21u, such as test/micro/org/openjdk/bench/java/lang/StringTemplateFMT.java wad removed by JDK-8329948
3. Some JMH tests has diffrent file name ater jdk21u, such as rename from test/micro/org/openjdk/bench/jdk/classfile/GenerateStackMaps.java to test/micro/org/openjdk/bench/jdk/classfile/CodeAttributeTools.java by JDK-8323183


Testing:

- [x] Run all the touch JMH tests locally.

Test commands:
```shell
wget https://patch-diff.githubusercontent.com/raw/openjdk/jdk21u-dev/pull/1403.diff -O JDK-8342958-21u.patch
grep "diff --git" JDK-8342958-21u.patch | awk '{print $3}' | grep "^a/test" | sed "s|^a/test/micro/||" | sed "s|/|.|g" | sed "s|\.java$||" > list.txt
rm -rf build/jmh-result/ ; mkdir -p build/jmh-result/ ; time for test in `cat list.txt` ; do time make test TEST="micro:$test" MICRO="FORK=1;WARMUP_ITER=2" CONF=release &> build/jmh-result/$test.log ; done
```

Test result:
5 tests fails, the fails unrelated to this PR, I have create a new [issue](https://bugs.openjdk.org/browse/JDK-8350051) to record this failure. All other tests passes.

[jmh-result.zip](https://github.com/user-attachments/files/18792902/jmh-result.zip)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343345](https://bugs.openjdk.org/browse/JDK-8343345) needs maintainer approval
- [x] [JDK-8342958](https://bugs.openjdk.org/browse/JDK-8342958) needs maintainer approval

### Issues
 * [JDK-8342958](https://bugs.openjdk.org/browse/JDK-8342958): Use jvmArgs consistently in microbenchmarks (**Enhancement** - P4 - Approved)
 * [JDK-8343345](https://bugs.openjdk.org/browse/JDK-8343345): Use -jvmArgsPrepend when running microbenchmarks in RunTests.gmk (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1403/head:pull/1403` \
`$ git checkout pull/1403`

Update a local copy of the PR: \
`$ git checkout pull/1403` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1403`

View PR using the GUI difftool: \
`$ git pr show -t 1403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1403.diff">https://git.openjdk.org/jdk21u-dev/pull/1403.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1403#issuecomment-2656414931)
</details>
