### PR TITLE
8346880: [aix] java/lang/ProcessHandle/InfoTest.java still fails: "reported cputime less than expected"

### DIFF
--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -162,7 +162,24 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
 }
 
 pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid, jlong *total, jlong *start) {
-    return unix_getParentPidAndTimings(env, pid, total, start);
+    pid_t the_pid = pid;
+    struct procentry64 ProcessBuffer;
+
+    if (getprocs64(&ProcessBuffer, sizeof(ProcessBuffer), NULL, sizeof(struct fdsinfo64), &the_pid, 1) <= 0) {
+        return -1;
+    }
+
+    // Validate the pid before returning the info
+    if (kill(pid, 0) < 0) {
+        return -1;
+    }
+
+    *total = ((ProcessBuffer.pi_ru.ru_utime.tv_sec + ProcessBuffer.pi_ru.ru_stime.tv_sec) * 1000000000L) +
+             ((ProcessBuffer.pi_ru.ru_utime.tv_usec + ProcessBuffer.pi_ru.ru_stime.tv_usec));
+
+    *start = ProcessBuffer.pi_start * (jlong)1000;
+
+    return (pid_t) ProcessBuffer.pi_ppid;
 }
 
 void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [f9b11332](https://eur03.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fopenjdk%2Fjdk%2Fcommit%2Ff9b11332eccd8a8ffb4128308f442b209d07a3b1&data=05%7C02%7Cjoachim.kern%40sap.com%7Cbe715ba6412b406e359b08dd4cdd34eb%7C42f7676cf455423c82f6dc2d99791af7%7C0%7C0%7C638751235135819397%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=mvtI1vdJ41owt0%2BgXarMbCRuhHukZDrYLBdDusX4%2B3M%3D&reserved=0) from the [openjdk/jdk](https://eur03.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgit.openjdk.org%2Fjdk&data=05%7C02%7Cjoachim.kern%40sap.com%7Cbe715ba6412b406e359b08dd4cdd34eb%7C42f7676cf455423c82f6dc2d99791af7%7C0%7C0%7C638751235135832802%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=6UjioNHwX7Gmrc9OGyQBLaygd0A2kRyELgmiHtvSzUc%3D&reserved=0) repository.
The commit being backported was authored by Joachim Kern on 9 Jan 2025 and was reviewed by Martin Doerr, Christoph Langer and Matthias Baesken.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346880](https://bugs.openjdk.org/browse/JDK-8346880) needs maintainer approval

### Issue
 * [JDK-8346880](https://bugs.openjdk.org/browse/JDK-8346880): [aix] java/lang/ProcessHandle/InfoTest.java still fails: "reported cputime less than expected" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1404/head:pull/1404` \
`$ git checkout pull/1404`

Update a local copy of the PR: \
`$ git checkout pull/1404` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1404`

View PR using the GUI difftool: \
`$ git pr show -t 1404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1404.diff">https://git.openjdk.org/jdk21u-dev/pull/1404.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1404#issuecomment-2658799894)
</details>
