### PR TITLE
8345676: [ubsan] ProcessImpl_md.c:561:40: runtime error: applying zero offset to null pointer on macOS aarch64

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -558,7 +558,9 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
         return -1;
     }
     offset = copystrings(buf, 0, &c->argv[0]);
-    offset = copystrings(buf, offset, &c->envv[0]);
+    if (c->envv != NULL) {
+        offset = copystrings(buf, offset, &c->envv[0]);
+    }
     if (c->pdir != NULL) {
         if (sp.dirlen > 0) {
             memcpy(buf+offset, c->pdir, sp.dirlen);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345676](https://bugs.openjdk.org/browse/JDK-8345676) needs maintainer approval

### Issue
 * [JDK-8345676](https://bugs.openjdk.org/browse/JDK-8345676): [ubsan] ProcessImpl_md.c:561:40: runtime error: applying zero offset to null pointer on macOS aarch64 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1405/head:pull/1405` \
`$ git checkout pull/1405`

Update a local copy of the PR: \
`$ git checkout pull/1405` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1405`

View PR using the GUI difftool: \
`$ git pr show -t 1405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1405.diff">https://git.openjdk.org/jdk21u-dev/pull/1405.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1405#issuecomment-2662963343)
</details>
