### PR TITLE
8343978: Update the default value of CodeEntryAlignment for Ampere-1A and 1B

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -158,6 +158,10 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
       FLAG_SET_DEFAULT(OnSpinWaitInstCount, 2);
     }
+    if (FLAG_IS_DEFAULT(CodeEntryAlignment) &&
+        (_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
+      FLAG_SET_DEFAULT(CodeEntryAlignment, 32);
+    }
   }
 
   // ThunderX


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8343978](https://bugs.openjdk.org/browse/JDK-8343978) needs maintainer approval

### Issue
 * [JDK-8343978](https://bugs.openjdk.org/browse/JDK-8343978): Update the default value of CodeEntryAlignment for Ampere-1A and 1B (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1411/head:pull/1411` \
`$ git checkout pull/1411`

Update a local copy of the PR: \
`$ git checkout pull/1411` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1411`

View PR using the GUI difftool: \
`$ git pr show -t 1411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1411.diff">https://git.openjdk.org/jdk21u-dev/pull/1411.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1411#issuecomment-2667559730)
</details>
