### PR TITLE
8339728: [Accessibility,Windows,JAWS] Bug in the getKeyChar method of the AccessBridge class

### DIFF
--- a/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
+++ b/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3925,6 +3925,8 @@ public final class AccessBridge {
             return 0;
         int code = keyStroke.getKeyCode();
         switch (code) {
+            case KeyEvent.VK_TAB:
+            case KeyEvent.VK_SPACE:
             case KeyEvent.VK_BACK_SPACE:
             case KeyEvent.VK_DELETE:
             case KeyEvent.VK_DOWN:
@@ -3967,15 +3969,10 @@ public final class AccessBridge {
             debugString("[INFO]:   Shortcut is control character: " + Integer.toHexString(keyCode));
             return (char)keyCode;
         }
-        String keyText = KeyEvent.getKeyText(keyStroke.getKeyCode());
-        debugString("[INFO]:   Shortcut is: " + keyText);
-        if (keyText != null || keyText.length() > 0) {
-            CharSequence seq = keyText.subSequence(0, 1);
-            if (seq != null || seq.length() > 0) {
-                return seq.charAt(0);
-            }
-        }
-        return 0;
+
+        keyCode = keyStroke.getKeyCode();
+        debugString("[INFO]:   Shortcut is: " + Integer.toHexString(keyCode));
+        return (char)keyCode;
     }
 
     /*

--- a/src/jdk.accessibility/windows/native/include/bridge/AccessBridgePackages.h
+++ b/src/jdk.accessibility/windows/native/include/bridge/AccessBridgePackages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1108,6 +1108,8 @@ typedef long ABHWND64;
 #define ACCESSIBLE_CONTROLCODE_KEYSTROKE        512  // Control code key pressed, character contains control code.
 
 // The supported control code keys are:
+#define ACCESSIBLE_VK_TAB           9
+#define ACCESSIBLE_VK_SPACE         32
 #define ACCESSIBLE_VK_BACK_SPACE    8
 #define ACCESSIBLE_VK_DELETE        127
 #define ACCESSIBLE_VK_DOWN          40

--- a/test/jdk/javax/accessibility/TestJMenuItemShortcutAccessibility.java
+++ b/test/jdk/javax/accessibility/TestJMenuItemShortcutAccessibility.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+
+/*
+ * @test
+ * @bug 8339728
+ * @summary Tests that JAWS announce the shortcuts for JMenuItems.
+ * @requires os.family == "windows"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestJMenuItemShortcutAccessibility
+ */
+
+public class TestJMenuItemShortcutAccessibility {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Start the JAWS application
+                2. Press Alt + M to open application Menu
+                3. Navigate the Menu Items by using UP / DOWN arrow key
+                4. Press Pass if you are able to hear correct JAWS announcements
+                   (JAWS should read full shortcut text and not only the 1st
+                   character of shortcut text for each menu item) else Fail
+                """;
+
+        PassFailJFrame.builder()
+                .title("TestJMenuItemShortcutAccessibility Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(TestJMenuItemShortcutAccessibility::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createUI() {
+        JFrame frame = new JFrame("A Frame with Menu");
+
+        JMenuBar menuBar = new JMenuBar();
+        JMenu menu = new JMenu("Menu with shortcuts");
+        menu.setMnemonic(KeyEvent.VK_M);
+        menuBar.add(menu);
+
+        KeyStroke keyStroke1 = KeyStroke.getKeyStroke(KeyEvent.VK_F,
+                InputEvent.CTRL_DOWN_MASK);
+        KeyStroke keyStroke2 = KeyStroke.getKeyStroke(KeyEvent.VK_2,
+                InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK);
+        KeyStroke keyStroke3 = KeyStroke.getKeyStroke(KeyEvent.VK_F1,
+                InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK);
+        KeyStroke keyStroke4 = KeyStroke.getKeyStroke(KeyEvent.VK_COMMA,
+                InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK);
+        KeyStroke keyStroke5 = KeyStroke.getKeyStroke(KeyEvent.VK_PERIOD,
+                InputEvent.CTRL_DOWN_MASK | InputEvent.ALT_DOWN_MASK);
+        KeyStroke keyStroke6 = KeyStroke.getKeyStroke(KeyEvent.VK_TAB,
+                InputEvent.CTRL_DOWN_MASK);
+        KeyStroke keyStroke7 = KeyStroke.getKeyStroke(KeyEvent.VK_SPACE,
+                InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK);
+
+        JMenuItem menuItem1 = new JMenuItem("First Menu Item");
+        menuItem1.setAccelerator(keyStroke1);
+        JMenuItem menuItem2 = new JMenuItem("Second Menu Item");
+        menuItem2.setAccelerator(keyStroke2);
+        JMenuItem menuItem3 = new JMenuItem("Third Menu Item");
+        menuItem3.setAccelerator(keyStroke3);
+        JMenuItem menuItem4 = new JMenuItem("Fourth Menu Item");
+        menuItem4.setAccelerator(keyStroke4);
+        JMenuItem menuItem5 = new JMenuItem("Fifth Menu Item");
+        menuItem5.setAccelerator(keyStroke5);
+        JMenuItem menuItem6 = new JMenuItem("Sixth Menu Item");
+        menuItem6.setAccelerator(keyStroke6);
+        JMenuItem menuItem7 = new JMenuItem("Seventh Menu Item");
+        menuItem7.setAccelerator(keyStroke7);
+
+        menu.add(menuItem1);
+        menu.add(menuItem2);
+        menu.add(menuItem3);
+        menu.add(menuItem4);
+        menu.add(menuItem5);
+        menu.add(menuItem6);
+        menu.add(menuItem7);
+
+        frame.setJMenuBar(menuBar);
+        frame.setSize(300, 200);
+        return frame;
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8339728](https://bugs.openjdk.org/browse/JDK-8339728) from 24u that solves some accessibility issues on Windows, for parity with 11.0.27-oracle (and because it's marked as CPU25-critical-SQE-OK too). Low risk.

The new accessibility test passes on Windows 10 (tested with [JAWS v. 2025.2412.102 - February 2025](https://support.freedomscientific.com/Downloads/JAWS) )

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8339728](https://bugs.openjdk.org/browse/JDK-8339728) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339728](https://bugs.openjdk.org/browse/JDK-8339728): [Accessibility,Windows,JAWS] Bug in the getKeyChar method of the AccessBridge class (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1414/head:pull/1414` \
`$ git checkout pull/1414`

Update a local copy of the PR: \
`$ git checkout pull/1414` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1414`

View PR using the GUI difftool: \
`$ git pr show -t 1414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1414.diff">https://git.openjdk.org/jdk21u-dev/pull/1414.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1414#issuecomment-2668326849)
</details>
