### PR TITLE
8337222: gc/TestDisableExplicitGC.java fails due to unexpected CodeCache GC

### DIFF
--- a/test/hotspot/jtreg/gc/TestDisableExplicitGC.java
+++ b/test/hotspot/jtreg/gc/TestDisableExplicitGC.java
@@ -26,6 +26,7 @@ package gc;
 /*
  * @test TestDisableExplicitGC
  * @requires vm.opt.DisableExplicitGC == null
+ * @requires vm.compMode != "Xcomp"
  * @summary Verify GC behavior with DisableExplicitGC flag.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337222](https://bugs.openjdk.org/browse/JDK-8337222) needs maintainer approval

### Issue
 * [JDK-8337222](https://bugs.openjdk.org/browse/JDK-8337222): gc/TestDisableExplicitGC.java fails due to unexpected CodeCache GC (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1419/head:pull/1419` \
`$ git checkout pull/1419`

Update a local copy of the PR: \
`$ git checkout pull/1419` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1419`

View PR using the GUI difftool: \
`$ git pr show -t 1419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1419.diff">https://git.openjdk.org/jdk21u-dev/pull/1419.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1419#issuecomment-2671526219)
</details>
