### PR TITLE
8346324: javax/swing/JScrollBar/4865918/bug4865918.java fails in CI

### DIFF
--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -31,10 +31,13 @@
 
 import java.awt.Dimension;
 import java.awt.Robot;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import javax.swing.JFrame;
 import javax.swing.JScrollBar;
 import javax.swing.SwingUtilities;
-import java.awt.event.MouseEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import java.util.Date;
 
@@ -42,6 +45,7 @@ public class bug4865918 {
 
     private static TestScrollBar sbar;
     private static JFrame frame;
+    private static final CountDownLatch mousePressLatch = new CountDownLatch(1);
 
     public static void main(String[] argv) throws Exception {
         try {
@@ -52,6 +56,9 @@ public class bug4865918 {
             robot.delay(1000);
 
             SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
+            if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Timed out waiting for mouse press");
+            }
 
             robot.waitForIdle();
             robot.delay(200);
@@ -81,6 +88,11 @@ public class bug4865918 {
         sbar = new TestScrollBar(JScrollBar.HORIZONTAL, -1, 10, -100, 100);
         sbar.setPreferredSize(new Dimension(200, 20));
         sbar.setBlockIncrement(10);
+        sbar.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent e) {
+                mousePressLatch.countDown();
+            }
+        });
 
         frame.getContentPane().add(sbar);
         frame.pack();


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8346324](https://bugs.openjdk.org/browse/JDK-8346324) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346324](https://bugs.openjdk.org/browse/JDK-8346324): javax/swing/JScrollBar/4865918/bug4865918.java fails in CI (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1421/head:pull/1421` \
`$ git checkout pull/1421`

Update a local copy of the PR: \
`$ git checkout pull/1421` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1421`

View PR using the GUI difftool: \
`$ git pr show -t 1421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1421.diff">https://git.openjdk.org/jdk21u-dev/pull/1421.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1421#issuecomment-2671609389)
</details>
