### PR TITLE
8346828: javax/swing/JScrollBar/4865918/bug4865918.java still fails in CI

### DIFF
--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -31,10 +31,13 @@
 
 import java.awt.Dimension;
 import java.awt.Robot;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import javax.swing.JFrame;
 import javax.swing.JScrollBar;
 import javax.swing.SwingUtilities;
-import java.awt.event.MouseEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import java.util.Date;
 
@@ -42,6 +45,7 @@ public class bug4865918 {
 
     private static TestScrollBar sbar;
     private static JFrame frame;
+    private static final CountDownLatch mousePressLatch = new CountDownLatch(1);
 
     public static void main(String[] argv) throws Exception {
         try {
@@ -52,6 +56,9 @@ public class bug4865918 {
             robot.delay(1000);
 
             SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
+            if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Timed out waiting for mouse press");
+            }
 
             robot.waitForIdle();
             robot.delay(200);
@@ -81,6 +88,11 @@ public class bug4865918 {
         sbar = new TestScrollBar(JScrollBar.HORIZONTAL, -1, 10, -100, 100);
         sbar.setPreferredSize(new Dimension(200, 20));
         sbar.setBlockIncrement(10);
+        sbar.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent e) {
+                mousePressLatch.countDown();
+            }
+        });
 
         frame.getContentPane().add(sbar);
         frame.pack();

--- a/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/test/jdk/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,15 @@
 
 /*
  * @test
- * @key headful
  * @bug 4865918
+ * @requires (os.family != "mac")
  * @summary REGRESSION:JCK1.4a-runtime api/javax_swing/interactive/JScrollBarTests.html#JScrollBar
  * @run main bug4865918
  */
 
 import java.awt.Dimension;
-import java.awt.Robot;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import javax.swing.JFrame;
 import javax.swing.JScrollBar;
 import javax.swing.SwingUtilities;
 import java.util.concurrent.CountDownLatch;
@@ -44,30 +42,23 @@ import java.util.Date;
 public class bug4865918 {
 
     private static TestScrollBar sbar;
-    private static JFrame frame;
     private static final CountDownLatch mousePressLatch = new CountDownLatch(1);
 
     public static void main(String[] argv) throws Exception {
-        try {
-            Robot robot = new Robot();
-            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
+        String osName = System.getProperty("os.name");
+        if (osName.toLowerCase().contains("os x")) {
+            System.out.println("This test is not for MacOS, considered passed.");
+            return;
+        }
+        SwingUtilities.invokeAndWait(() -> setupTest());
 
-            robot.waitForIdle();
-            robot.delay(1000);
+        SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
+        if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for mouse press");
+        }
 
-            SwingUtilities.invokeAndWait(() -> sbar.pressMouse());
-            if (!mousePressLatch.await(2, TimeUnit.SECONDS)) {
-                throw new RuntimeException("Timed out waiting for mouse press");
-            }
-
-            robot.waitForIdle();
-            robot.delay(200);
-
-            if (getValue() != 9) {
-                throw new RuntimeException("The scrollbar block increment is incorrect");
-            }
-        } finally {
-            if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
+        if (getValue() != 9) {
+            throw new RuntimeException("The scrollbar block increment is incorrect");
         }
     }
 
@@ -78,12 +69,11 @@ public class bug4865918 {
             result[0] = sbar.getValue();
         });
 
+        System.out.println("value " + result[0]);
         return result[0];
     }
 
-    private static void createAndShowGUI() {
-        frame = new JFrame("bug4865918");
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    private static void setupTest() {
 
         sbar = new TestScrollBar(JScrollBar.HORIZONTAL, -1, 10, -100, 100);
         sbar.setPreferredSize(new Dimension(200, 20));
@@ -94,11 +84,6 @@ public class bug4865918 {
             }
         });
 
-        frame.getContentPane().add(sbar);
-        frame.pack();
-        frame.setLocationRelativeTo(null);
-        frame.setVisible(true);
-        frame.toFront();
     }
 
     static class TestScrollBar extends JScrollBar {


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346828](https://bugs.openjdk.org/browse/JDK-8346828) needs maintainer approval

### Issue
 * [JDK-8346828](https://bugs.openjdk.org/browse/JDK-8346828): javax/swing/JScrollBar/4865918/bug4865918.java still fails in CI (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1422/head:pull/1422` \
`$ git checkout pull/1422`

Update a local copy of the PR: \
`$ git checkout pull/1422` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1422`

View PR using the GUI difftool: \
`$ git pr show -t 1422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1422.diff">https://git.openjdk.org/jdk21u-dev/pull/1422.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1422#issuecomment-2671644089)
</details>
