### PR TITLE
8331735: UpcallLinker::on_exit races with GC when copying frame anchor

### DIFF
--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -84,16 +84,16 @@ JavaThread* UpcallLinker::on_entry(UpcallStub::FrameData* context) {
   // since it can potentially block.
   context->new_handles = JNIHandleBlock::allocate_block(thread);
 
-  // clear any pending exception in thread (native calls start with no exception pending)
-  thread->clear_pending_exception();
-
   // The call to transition_from_native below contains a safepoint check
   // which needs the code cache to be writable.
   MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   // After this, we are officially in Java Code. This needs to be done before we change any of the thread local
   // info, since we cannot find oops before the new information is set up completely.
-  ThreadStateTransition::transition_from_native(thread, _thread_in_Java, true /* check_asyncs */);
+  ThreadStateTransition::transition_from_native(thread, _thread_in_Java, false /* check_asyncs */);
+
+  // clear any pending exception in thread, in case someone forgot to check it after a JNI API call.
+  thread->clear_pending_exception();
 
   context->old_handles = thread->active_handles();
 
@@ -119,20 +119,16 @@ void UpcallLinker::on_exit(UpcallStub::FrameData* context) {
   // restore previous handle block
   thread->set_active_handles(context->old_handles);
 
-  thread->frame_anchor()->zap();
-
   debug_only(thread->dec_java_call_counter());
+
+  thread->frame_anchor()->copy(&context->jfa);
 
   // Old thread-local info. has been restored. We are now back in native code.
   ThreadStateTransition::transition_from_java(thread, _thread_in_native);
 
-  thread->frame_anchor()->copy(&context->jfa);
-
   // Release handles after we are marked as being in native code again, since this
   // operation might block
   JNIHandleBlock::release_block(context->new_handles, thread);
-
-  assert(!thread->has_pending_exception(), "Upcall can not throw an exception");
 }
 
 void UpcallLinker::handle_uncaught_exception(oop exception) {


### PR DESCRIPTION
Clean backport of a fix for a race condition in code adapted from `JavaCallWrapper` for the FFM API. This is more visible in 22 and later, where FFM is fully supported and the [OpenType implementation using HarfBuzz](https://bugs.openjdk.org/browse/JDK-8318364) has been ported to use it. However, the copy in the native state seems to have been introduced as far back as [JDK-8269240](https://bugs.openjdk.org/browse/JDK-8269240) in 17 when the `JavaCallWrapper` code was ported to what was then `universalUpcallHandler.cpp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343144](https://bugs.openjdk.org/browse/JDK-8343144) needs maintainer approval
- [x] [JDK-8286875](https://bugs.openjdk.org/browse/JDK-8286875) needs maintainer approval
- [x] [JDK-8331735](https://bugs.openjdk.org/browse/JDK-8331735) needs maintainer approval

### Issues
 * [JDK-8331735](https://bugs.openjdk.org/browse/JDK-8331735): UpcallLinker::on_exit races with GC when copying frame anchor (**Bug** - P3 - Approved)
 * [JDK-8343144](https://bugs.openjdk.org/browse/JDK-8343144): UpcallLinker::on_entry racingly clears pending exception with GC safepoints (**Bug** - P4 - Approved)
 * [JDK-8286875](https://bugs.openjdk.org/browse/JDK-8286875): ProgrammableUpcallHandler::on_entry/on_exit access thread fields from native (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1424/head:pull/1424` \
`$ git checkout pull/1424`

Update a local copy of the PR: \
`$ git checkout pull/1424` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1424`

View PR using the GUI difftool: \
`$ git pr show -t 1424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1424.diff">https://git.openjdk.org/jdk21u-dev/pull/1424.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1424#issuecomment-2672016570)
</details>
