### PR TITLE
8342075: HttpClient: improve HTTP/2 flow control checks

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ExchangeImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ExchangeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,10 @@ abstract class ExchangeImpl<T> {
             Utils.getDebugLogger("ExchangeImpl"::toString, Utils.DEBUG);
 
     final Exchange<T> exchange;
+
+    // this will be set to true only when the peer explicitly states (through a GOAWAY frame or
+    // a relevant error code in reset frame) that the corresponding stream (id) wasn't processed
+    private volatile boolean unprocessedByPeer;
 
     ExchangeImpl(Exchange<T> e) {
         // e == null means a http/2 pushed stream
@@ -264,4 +268,13 @@ abstract class ExchangeImpl<T> {
     // Called when server returns non 100 response to
     // an Expect-Continue
     void expectContinueFailed(int rcode) { }
+
+    final boolean isUnprocessedByPeer() {
+        return this.unprocessedByPeer;
+    }
+
+    // Marks the exchange as unprocessed by the peer
+    final void markUnprocessedByPeer() {
+        this.unprocessedByPeer = true;
+    }
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -40,6 +40,8 @@ import jdk.internal.net.http.common.Logger;
 import jdk.internal.net.http.common.MinimalFuture;
 import jdk.internal.net.http.common.Utils;
 import jdk.internal.net.http.frame.SettingsFrame;
+
+import static jdk.internal.net.http.frame.SettingsFrame.INITIAL_CONNECTION_WINDOW_SIZE;
 import static jdk.internal.net.http.frame.SettingsFrame.INITIAL_WINDOW_SIZE;
 import static jdk.internal.net.http.frame.SettingsFrame.ENABLE_PUSH;
 import static jdk.internal.net.http.frame.SettingsFrame.HEADER_TABLE_SIZE;
@@ -289,9 +291,13 @@ class Http2ClientImpl {
         // and the connection window size.
         int defaultValue = Math.max(streamWindow, K*K*32);
 
+        // The min value is the max between the streamWindow and
+        // the initial connection window size
+        int minValue = Math.max(INITIAL_CONNECTION_WINDOW_SIZE, streamWindow);
+
         return getParameter(
                 "jdk.httpclient.connectionWindowSize",
-                streamWindow, Integer.MAX_VALUE, defaultValue);
+                minValue, Integer.MAX_VALUE, defaultValue);
     }
 
     /**

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1068,6 +1068,34 @@ class Http2Connection  {
         return null;
     }
 
+    // This method is called when a DataFrame that was added
+    // to a Stream::inputQ is later dropped from the queue
+    // without being consumed.
+    //
+    // Before adding a frame to the queue, the Stream calls
+    // connection.windowUpdater.canBufferUnprocessedBytes(), which
+    // increases the count of unprocessed bytes in the connection.
+    // After consuming the frame, it calls connection.windowUpdater::processed,
+    // which decrements the count of unprocessed bytes, and possibly
+    // sends a window update to the peer.
+    //
+    // This method is called when connection.windowUpdater::processed
+    // will not be called, which can happen when consuming the frame
+    // fails, or when an empty DataFrame terminates the stream,
+    // or when the stream is cancelled while data is still
+    // sitting in its inputQ. In the later case, it is called for
+    // each frame that is dropped from the queue.
+    final void releaseUnconsumed(DataFrame df) {
+        windowUpdater.released(df.payloadLength());
+        dropDataFrame(df);
+    }
+
+    // This method can be called directly when a DataFrame is dropped
+    // before/without having been added to any Stream::inputQ.
+    // In that case, the number of unprocessed bytes hasn't been incremented
+    // by the stream, and does not need to be decremented.
+    // Otherwise, if the frame is dropped after having been added to the
+    // inputQ, releaseUnconsumed above should be called.
     final void dropDataFrame(DataFrame df) {
         if (isMarked(closedState, SHUTDOWN_REQUESTED)) return;
         if (debug.on()) {
@@ -1453,11 +1481,12 @@ class Http2Connection  {
         // Note that the default initial window size, not to be confused
         // with the initial window size, is defined by RFC 7540 as
         // 64K -1.
-        final int len = windowUpdater.initialWindowSize - DEFAULT_INITIAL_WINDOW_SIZE;
-        if (len != 0) {
+        final int len = windowUpdater.initialWindowSize - INITIAL_CONNECTION_WINDOW_SIZE;
+        assert len >= 0;
+        if (len > 0) {
             if (Log.channel()) {
                 Log.logChannel("Sending initial connection window update frame: {0} ({1} - {2})",
-                        len, windowUpdater.initialWindowSize, DEFAULT_INITIAL_WINDOW_SIZE);
+                        len, windowUpdater.initialWindowSize, INITIAL_CONNECTION_WINDOW_SIZE);
             }
             windowUpdater.sendWindowUpdate(len);
         }
@@ -1910,6 +1939,19 @@ class Http2Connection  {
         @Override
         int getStreamId() {
             return 0;
+        }
+
+        @Override
+        protected boolean windowSizeExceeded(long received) {
+            if (connection.isOpen()) {
+                try {
+                    connection.protocolError(ErrorFrame.FLOW_CONTROL_ERROR,
+                            "connection window exceeded");
+                } catch (IOException io) {
+                    connection.shutdown(io);
+                }
+            }
+            return true;
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -396,6 +397,7 @@ class Http2Connection  {
     private final String key; // for HttpClientImpl.connections map
     private final FramesDecoder framesDecoder;
     private final FramesEncoder framesEncoder = new FramesEncoder();
+    private final AtomicLong lastProcessedStreamInGoAway = new AtomicLong(-1);
 
     /**
      * Send Window controller for both connection and stream windows.
@@ -802,7 +804,9 @@ class Http2Connection  {
 
     void close() {
         if (markHalfClosedLocal()) {
-            if (connection.channel().isOpen()) {
+            // we send a GOAWAY frame only if the remote side hasn't already indicated
+            // the intention to close the connection by previously sending a GOAWAY of its own
+            if (connection.channel().isOpen() && !isMarked(closedState, HALF_CLOSED_REMOTE)) {
                 Log.logTrace("Closing HTTP/2 connection: to {0}", connection.address());
                 GoAwayFrame f = new GoAwayFrame(0,
                         ErrorFrame.NO_ERROR,
@@ -1354,13 +1358,46 @@ class Http2Connection  {
         sendUnorderedFrame(frame);
     }
 
-    private void handleGoAway(GoAwayFrame frame)
-        throws IOException
-    {
-        if (markHalfClosedLRemote()) {
-            shutdown(new IOException(
-                    connection.channel().getLocalAddress()
-                            + ": GOAWAY received"));
+    private void handleGoAway(final GoAwayFrame frame) {
+        final long lastProcessedStream = frame.getLastStream();
+        assert lastProcessedStream >= 0 : "unexpected last stream id: "
+                + lastProcessedStream + " in GOAWAY frame";
+
+        markHalfClosedRemote();
+        setFinalStream(); // don't allow any new streams on this connection
+        if (debug.on()) {
+            debug.log("processing incoming GOAWAY with last processed stream id:%s in frame %s",
+                    lastProcessedStream, frame);
+        }
+        // see if this connection has previously received a GOAWAY from the peer and if yes
+        // then check if this new last processed stream id is lesser than the previous
+        // known last processed stream id. Only update the last processed stream id if the new
+        // one is lesser than the previous one.
+        long prevLastProcessed = lastProcessedStreamInGoAway.get();
+        while (prevLastProcessed == -1 || lastProcessedStream < prevLastProcessed) {
+            if (lastProcessedStreamInGoAway.compareAndSet(prevLastProcessed,
+                    lastProcessedStream)) {
+                break;
+            }
+            prevLastProcessed = lastProcessedStreamInGoAway.get();
+        }
+        handlePeerUnprocessedStreams(lastProcessedStreamInGoAway.get());
+    }
+
+    private void handlePeerUnprocessedStreams(final long lastProcessedStream) {
+        final AtomicInteger numClosed = new AtomicInteger(); // atomic merely to allow usage within lambda
+        streams.forEach((id, exchange) -> {
+            if (id > lastProcessedStream) {
+                // any streams with an stream id higher than the last processed stream
+                // can be retried (on a new connection). we close the exchange as unprocessed
+                // to facilitate the retrying.
+                client2.client().theExecutor().ensureExecutedAsync(exchange::closeAsUnprocessed);
+                numClosed.incrementAndGet();
+            }
+        });
+        if (debug.on()) {
+            debug.log(numClosed.get() + " stream(s), with id greater than " + lastProcessedStream
+                    + ", will be closed as unprocessed");
         }
     }
 
@@ -1911,7 +1948,7 @@ class Http2Connection  {
         return markClosedState(HALF_CLOSED_LOCAL);
     }
 
-    private boolean markHalfClosedLRemote() {
+    private boolean markHalfClosedRemote() {
         return markClosedState(HALF_CLOSED_REMOTE);
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -282,23 +282,25 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         }
     }
 
-    static void registerPending(PendingRequest pending) {
+    static <T> CompletableFuture<T> registerPending(PendingRequest pending, CompletableFuture<T> res) {
         // shortcut if cf is already completed: no need to go through the trouble of
         //    registering it
-        if (pending.cf.isDone()) return;
+        if (pending.cf.isDone()) return res;
 
         var client = pending.client;
         var cf = pending.cf;
         var id = pending.id;
         boolean added = client.pendingRequests.add(pending);
         // this may immediately remove `pending` from the set is the cf is already completed
-        pending.ref = cf.whenComplete((r,t) -> client.pendingRequests.remove(pending));
+        var ref = res.whenComplete((r,t) -> client.pendingRequests.remove(pending));
+        pending.ref = ref;
         assert added : "request %d was already added".formatted(id);
         // should not happen, unless the selector manager has already
         // exited abnormally
         if (client.selmgr.isClosed()) {
             pending.abort(client.selmgr.selectorClosedException());
         }
+        return ref;
     }
 
     static void abortPendingRequests(HttpClientImpl client, Throwable reason) {
@@ -930,8 +932,9 @@ final class HttpClientImpl extends HttpClient implements Trackable {
             cf = sendAsync(req, responseHandler, null, null);
             return cf.get();
         } catch (InterruptedException ie) {
-            if (cf != null )
+            if (cf != null) {
                 cf.cancel(true);
+            }
             throw ie;
         } catch (ExecutionException e) {
             final Throwable throwable = e.getCause();
@@ -1053,19 +1056,23 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                         (b,t) -> debugCompleted("ClientImpl (async)", start, userRequest));
             }
 
-            // makes sure that any dependent actions happen in the CF default
-            // executor. This is only needed for sendAsync(...), when
-            // exchangeExecutor is non-null.
-            if (exchangeExecutor != null) {
-                res = res.whenCompleteAsync((r, t) -> { /* do nothing */}, ASYNC_POOL);
-            }
-
             // The mexCf is the Cf we need to abort if the SelectorManager thread
             // is aborted.
             PendingRequest pending = new PendingRequest(id, requestImpl, mexCf, mex, this);
-            registerPending(pending);
-            return res;
-        } catch(Throwable t) {
+            res = registerPending(pending, res);
+
+            if (exchangeExecutor != null) {
+                // makes sure that any dependent actions happen in the CF default
+                // executor. This is only needed for sendAsync(...), when
+                // exchangeExecutor is non-null.
+                return res.isDone() ? res
+                        : res.whenCompleteAsync((r, t) -> { /* do nothing */}, ASYNC_POOL);
+            } else {
+                // make a defensive copy that can be safely canceled
+                // by the caller
+                return res.isDone() ? res : res.copy();
+            }
+        } catch (Throwable t) {
             requestUnreference();
             debugCompleted("ClientImpl (async)", start, userRequest);
             throw t;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -577,8 +577,9 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                         if (debug.on()) {
                             debug.log("body subscriber registered: " + count);
                         }
+                        return true;
                     }
-                    return true;
+                    return false;
                 }
             } finally {
                 selmgr.unlock();

--- a/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ class MultiExchange<T> implements Cancelable {
     Exchange<T> exchange; // the current exchange
     Exchange<T> previous;
     volatile Throwable retryCause;
-    volatile boolean expiredOnce;
+    volatile boolean retriedOnce;
     volatile HttpResponse<T> response;
 
     // Maximum number of times a request will be retried/redirected
@@ -459,7 +459,7 @@ class MultiExchange<T> implements Cancelable {
                             return exch.ignoreBody().handle((r,t) -> {
                                 previousreq = currentreq;
                                 currentreq = newrequest;
-                                expiredOnce = false;
+                                retriedOnce = false;
                                 setExchange(new Exchange<>(currentreq, this, acc));
                                 return responseAsyncImpl();
                             }).thenCompose(Function.identity());
@@ -472,7 +472,7 @@ class MultiExchange<T> implements Cancelable {
                             return completedFuture(response);
                         }
                         // all exceptions thrown are handled here
-                        CompletableFuture<Response> errorCF = getExceptionalCF(ex);
+                        CompletableFuture<Response> errorCF = getExceptionalCF(ex, exch.exchImpl);
                         if (errorCF == null) {
                             return responseAsyncImpl();
                         } else {
@@ -544,34 +544,38 @@ class MultiExchange<T> implements Cancelable {
      * Takes a Throwable and returns a suitable CompletableFuture that is
      * completed exceptionally, or null.
      */
-    private CompletableFuture<Response> getExceptionalCF(Throwable t) {
+    private CompletableFuture<Response> getExceptionalCF(Throwable t, ExchangeImpl<?> exchImpl) {
         if ((t instanceof CompletionException) || (t instanceof ExecutionException)) {
             if (t.getCause() != null) {
                 t = t.getCause();
             }
         }
+        final boolean retryAsUnprocessed = exchImpl != null && exchImpl.isUnprocessedByPeer();
         if (cancelled && !requestCancelled() && t instanceof IOException) {
             if (!(t instanceof HttpTimeoutException)) {
                 t = toTimeoutException((IOException)t);
             }
-        } else if (retryOnFailure(t)) {
+        } else if (retryAsUnprocessed || retryOnFailure(t)) {
             Throwable cause = retryCause(t);
 
             if (!(t instanceof ConnectException)) {
                 // we may need to start a new connection, and if so
                 // we want to start with a fresh connect timeout again.
                 if (connectTimeout != null) connectTimeout.reset();
-                if (!canRetryRequest(currentreq)) {
-                    return failedFuture(cause); // fails with original cause
+                if (!retryAsUnprocessed && !canRetryRequest(currentreq)) {
+                    // a (peer) processed request which cannot be retried, fail with
+                    // the original cause
+                    return failedFuture(cause);
                 }
             } // ConnectException: retry, but don't reset the connectTimeout.
 
             // allow the retry mechanism to do its work
             retryCause = cause;
-            if (!expiredOnce) {
+            if (!retriedOnce) {
                 if (debug.on())
-                    debug.log(t.getClass().getSimpleName() + " (async): retrying...", t);
-                expiredOnce = true;
+                    debug.log(t.getClass().getSimpleName()
+                            + " (async): retrying " + currentreq + " due to: ", t);
+                retriedOnce = true;
                 // The connection was abruptly closed.
                 // We return null to retry the same request a second time.
                 // The request filters have already been applied to the
@@ -582,7 +586,7 @@ class MultiExchange<T> implements Cancelable {
             } else {
                 if (debug.on()) {
                     debug.log(t.getClass().getSimpleName()
-                            + " (async): already retried once.", t);
+                            + " (async): already retried once " + currentreq, t);
                 }
                 t = cause;
             }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/MultiExchange.java
@@ -91,7 +91,7 @@ class MultiExchange<T> implements Cancelable {
     Exchange<T> previous;
     volatile Throwable retryCause;
     volatile boolean expiredOnce;
-    volatile HttpResponse<T> response = null;
+    volatile HttpResponse<T> response;
 
     // Maximum number of times a request will be retried/redirected
     // for any reason
@@ -279,10 +279,18 @@ class MultiExchange<T> implements Cancelable {
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         boolean cancelled = this.cancelled;
+        boolean firstCancel = false;
         if (!cancelled && mayInterruptIfRunning) {
             if (interrupted.get() == null) {
-                interrupted.compareAndSet(null,
+                firstCancel = interrupted.compareAndSet(null,
                         new CancellationException("Request cancelled"));
+            }
+            if (debug.on()) {
+                if (firstCancel) {
+                    debug.log("multi exchange recording: " + interrupted.get());
+                } else {
+                    debug.log("multi exchange recorded: " + interrupted.get());
+                }
             }
             this.cancelled = true;
             var exchange = getExchange();
@@ -365,17 +373,30 @@ class MultiExchange<T> implements Cancelable {
                     }).exceptionallyCompose(this::whenCancelled);
     }
 
+    // returns a CancellationExcpetion that wraps the given cause
+    // if cancel(boolean) was called, the given cause otherwise
+    private Throwable wrapIfCancelled(Throwable cause) {
+        CancellationException interrupt = interrupted.get();
+        if (interrupt == null) return cause;
+
+        var cancel = new CancellationException(interrupt.getMessage());
+        // preserve the stack trace of the original exception to
+        // show where the call to cancel(boolean) came from
+        cancel.setStackTrace(interrupt.getStackTrace());
+        cancel.initCause(Utils.getCancelCause(cause));
+        return cancel;
+    }
+
+    // if the request failed because the multi exchange was cancelled,
+    // make sure the reported exception is wrapped in CancellationException
     private CompletableFuture<HttpResponse<T>> whenCancelled(Throwable t) {
-        CancellationException x = interrupted.get();
-        if (x != null) {
-            // make sure to fail with CancellationException if cancel(true)
-            // was called.
-            t = x.initCause(Utils.getCancelCause(t));
+        var x = wrapIfCancelled(t);
+        if (x instanceof CancellationException) {
             if (debug.on()) {
-                debug.log("MultiExchange interrupted with: " + t.getCause());
+                debug.log("MultiExchange interrupted with: " + x.getCause());
             }
         }
-        return MinimalFuture.failedFuture(t);
+        return MinimalFuture.failedFuture(x);
     }
 
     static class NullSubscription implements Flow.Subscription {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -191,7 +191,7 @@ class Stream<T> extends ExchangeImpl<T> {
                 if (debug.on()) debug.log("subscribing user subscriber");
                 subscriber.onSubscribe(userSubscription);
             }
-            while (!inputQ.isEmpty()) {
+            while (!inputQ.isEmpty() && errorRef.get() == null) {
                 Http2Frame frame = inputQ.peek();
                 if (frame instanceof ResetFrame rf) {
                     inputQ.remove();
@@ -425,6 +425,10 @@ class Stream<T> extends ExchangeImpl<T> {
     // pushes entire response body into response subscriber
     // blocking when required by local or remote flow control
     CompletableFuture<T> receiveData(BodySubscriber<T> bodySubscriber, Executor executor) {
+        // ensure that the body subscriber will be subscribed and onError() is
+        // invoked
+        pendingResponseSubscriber = bodySubscriber;
+
         // We want to allow the subscriber's getBody() method to block so it
         // can work with InputStreams. So, we offload execution.
         responseBodyCF = ResponseSubscribers.getBodyAsync(executor, bodySubscriber,
@@ -435,9 +439,6 @@ class Stream<T> extends ExchangeImpl<T> {
             responseBodyCF.completeExceptionally(t);
         }
 
-        // ensure that the body subscriber will be subscribed and onError() is
-        // invoked
-        pendingResponseSubscriber = bodySubscriber;
         sched.runOrSchedule(); // in case data waiting already to be processed, or error
 
         return responseBodyCF;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -160,14 +160,13 @@ class Stream<T> extends ExchangeImpl<T> {
     // send lock: prevent sending DataFrames after reset occurred.
     private final Lock sendLock = new ReentrantLock();
     private final Lock stateLock = new ReentrantLock();
-
     /**
      * A reference to this Stream's connection Send Window controller. The
      * stream MUST acquire the appropriate amount of Send Window before
      * sending any data. Will be null for PushStreams, as they cannot send data.
      */
     private final WindowController windowController;
-    private final WindowUpdateSender windowUpdater;
+    private final WindowUpdateSender streamWindowUpdater;
 
     @Override
     HttpConnection connection() {
@@ -206,7 +205,8 @@ class Stream<T> extends ExchangeImpl<T> {
                 int size = Utils.remaining(dsts, Integer.MAX_VALUE);
                 if (size == 0 && finished) {
                     inputQ.remove();
-                    connection.ensureWindowUpdated(df); // must update connection window
+                    // consumed will not be called
+                    connection.releaseUnconsumed(df); // must update connection window
                     Log.logTrace("responseSubscriber.onComplete");
                     if (debug.on()) debug.log("incoming: onComplete");
                     sched.stop();
@@ -222,7 +222,11 @@ class Stream<T> extends ExchangeImpl<T> {
                     try {
                         subscriber.onNext(dsts);
                     } catch (Throwable t) {
-                        connection.dropDataFrame(df); // must update connection window
+                        // Data frames that have been added to the inputQ
+                        // must be released using releaseUnconsumed() to
+                        // account for the amount of unprocessed bytes
+                        // tracked by the connection.windowUpdater.
+                        connection.releaseUnconsumed(df);
                         throw t;
                     }
                     if (consumed(df)) {
@@ -274,8 +278,12 @@ class Stream<T> extends ExchangeImpl<T> {
     private void drainInputQueue() {
         Http2Frame frame;
         while ((frame = inputQ.poll()) != null) {
-            if (frame instanceof DataFrame) {
-                connection.dropDataFrame((DataFrame)frame);
+            if (frame instanceof DataFrame df) {
+                // Data frames that have been added to the inputQ
+                // must be released using releaseUnconsumed() to
+                // account for the amount of unprocessed bytes
+                // tracked by the connection.windowUpdater.
+                connection.releaseUnconsumed(df);
             }
         }
     }
@@ -301,12 +309,13 @@ class Stream<T> extends ExchangeImpl<T> {
         boolean endStream = df.getFlag(DataFrame.END_STREAM);
         if (len == 0) return endStream;
 
-        connection.windowUpdater.update(len);
-
+        connection.windowUpdater.processed(len);
         if (!endStream) {
+            streamWindowUpdater.processed(len);
+        } else {
             // Don't send window update on a stream which is
             // closed or half closed.
-            windowUpdater.update(len);
+            streamWindowUpdater.released(len);
         }
 
         // true: end of stream; false: more data coming
@@ -376,8 +385,21 @@ class Stream<T> extends ExchangeImpl<T> {
     }
 
     private void receiveDataFrame(DataFrame df) {
-        inputQ.add(df);
-        sched.runOrSchedule();
+        try {
+            int len = df.payloadLength();
+            if (len > 0) {
+                // we return from here if the connection is being closed.
+                if (!connection.windowUpdater.canBufferUnprocessedBytes(len)) return;
+                // we return from here if the stream is being closed.
+                if (closed || !streamWindowUpdater.canBufferUnprocessedBytes(len)) {
+                    connection.releaseUnconsumed(df);
+                    return;
+                }
+            }
+            inputQ.add(df);
+        } finally {
+            sched.runOrSchedule();
+        }
     }
 
     /** Handles a RESET frame. RESET is always handled inline in the queue. */
@@ -461,7 +483,7 @@ class Stream<T> extends ExchangeImpl<T> {
         this.responseHeadersBuilder = new HttpHeadersBuilder();
         this.rspHeadersConsumer = new HeadersConsumer();
         this.requestPseudoHeaders = createPseudoHeaders(request);
-        this.windowUpdater = new StreamWindowUpdateSender(connection);
+        this.streamWindowUpdater = new StreamWindowUpdateSender(connection);
     }
 
     private boolean checkRequestCancelled() {
@@ -495,6 +517,8 @@ class Stream<T> extends ExchangeImpl<T> {
                 if (debug.on()) {
                     debug.log("request cancelled or stream closed: dropping data frame");
                 }
+                // Data frames that have not been added to the inputQ
+                // can be released using dropDataFrame
                 connection.dropDataFrame(df);
             } else {
                 receiveDataFrame(df);
@@ -1397,12 +1421,18 @@ class Stream<T> extends ExchangeImpl<T> {
 
     @Override
     void onProtocolError(final IOException cause) {
+        onProtocolError(cause, ResetFrame.PROTOCOL_ERROR);
+    }
+
+    void onProtocolError(final IOException cause, int code) {
         if (debug.on()) {
-            debug.log("cancelling exchange on stream %d due to protocol error: %s", streamid, cause.getMessage());
+            debug.log("cancelling exchange on stream %d due to protocol error [%s]: %s",
+                    streamid, ErrorFrame.stringForCode(code),
+                    cause.getMessage());
         }
         Log.logError("cancelling exchange on stream {0} due to protocol error: {1}\n", streamid, cause);
         // send a RESET frame and close the stream
-        cancelImpl(cause, ResetFrame.PROTOCOL_ERROR);
+        cancelImpl(cause, code);
     }
 
     void connectionClosing(Throwable cause) {
@@ -1698,6 +1728,13 @@ class Stream<T> extends ExchangeImpl<T> {
                 dbg = connection.dbgString() + ":WindowUpdateSender(stream: " + streamid + ")";
                 return dbgString = dbg;
             }
+        }
+
+        @Override
+        protected boolean windowSizeExceeded(long received) {
+            onProtocolError(new ProtocolException("stream %s flow control window exceeded"
+                            .formatted(streamid)), ResetFrame.FLOW_CONTROL_ERROR);
+            return true;
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -672,20 +672,39 @@ class Stream<T> extends ExchangeImpl<T> {
                 stateLock.unlock();
             }
             try {
-                int error = frame.getErrorCode();
-                IOException e = new IOException("Received RST_STREAM: "
-                        + ErrorFrame.stringForCode(error));
-                if (errorRef.compareAndSet(null, e)) {
-                    if (subscriber != null) {
-                        subscriber.onError(e);
+                final int error = frame.getErrorCode();
+                // A REFUSED_STREAM error code implies that the stream wasn't processed by the
+                // peer and the client is free to retry the request afresh.
+                if (error == ErrorFrame.REFUSED_STREAM) {
+                    // Here we arrange for the request to be retried. Note that we don't call
+                    // closeAsUnprocessed() method here because the "closed" state is already set
+                    // to true a few lines above and calling close() from within
+                    // closeAsUnprocessed() will end up being a no-op. We instead do the additional
+                    // bookkeeping here.
+                    markUnprocessedByPeer();
+                    errorRef.compareAndSet(null, new IOException("request not processed by peer"));
+                    if (debug.on()) {
+                        debug.log("request unprocessed by peer (REFUSED_STREAM) " + this.request);
+                    }
+                } else {
+                    final String reason = ErrorFrame.stringForCode(error);
+                    final IOException failureCause = new IOException("Received RST_STREAM: " + reason);
+                    if (debug.on()) {
+                        debug.log(streamid + " received RST_STREAM with code: " + reason);
+                    }
+                    if (errorRef.compareAndSet(null, failureCause)) {
+                        if (subscriber != null) {
+                            subscriber.onError(failureCause);
+                        }
                     }
                 }
-                completeResponseExceptionally(e);
+                final Throwable failureCause = errorRef.get();
+                completeResponseExceptionally(failureCause);
                 if (!requestBodyCF.isDone()) {
-                    requestBodyCF.completeExceptionally(errorRef.get()); // we may be sending the body..
+                    requestBodyCF.completeExceptionally(failureCause); // we may be sending the body..
                 }
                 if (responseBodyCF != null) {
-                    responseBodyCF.completeExceptionally(errorRef.get());
+                    responseBodyCF.completeExceptionally(failureCause);
                 }
             } finally {
                 connection.decrementStreamsCount(streamid);
@@ -1698,7 +1717,35 @@ class Stream<T> extends ExchangeImpl<T> {
     }
 
     final String dbgString() {
-        return connection.dbgString() + "/Stream("+streamid+")";
+        final int id = streamid;
+        final String sid = id == 0 ? "?" : String.valueOf(id);
+        return connection.dbgString() + "/Stream(" + sid + ")";
+    }
+
+    /**
+     * An unprocessed exchange is one that hasn't been processed by a peer. The local end of the
+     * connection would be notified about such exchanges when it receives a GOAWAY frame with
+     * a stream id that tells which exchanges have been unprocessed.
+     * This method is called on such unprocessed exchanges and the implementation of this method
+     * will arrange for the request, corresponding to this exchange, to be retried afresh on a
+     * new connection.
+     */
+    void closeAsUnprocessed() {
+        try {
+            // We arrange for the request to be retried on a new connection as allowed by the RFC-9113
+            markUnprocessedByPeer();
+            this.errorRef.compareAndSet(null, new IOException("request not processed by peer"));
+            if (debug.on()) {
+                debug.log("closing " + this.request + " as unprocessed by peer");
+            }
+            // close the exchange and complete the response CF exceptionally
+            close();
+            completeResponseExceptionally(this.errorRef.get());
+        } finally {
+            // decrementStreamsCount isn't really needed but we do it to make sure
+            // the log messages, where these counts/states get reported, show the accurate state.
+            connection.decrementStreamsCount(streamid);
+        }
     }
 
     private class HeadersConsumer extends ValidatingHeadersConsumer implements DecodingCallback {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/WindowUpdateSender.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/WindowUpdateSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,16 +31,31 @@ import jdk.internal.net.http.frame.SettingsFrame;
 import jdk.internal.net.http.frame.WindowUpdateFrame;
 import jdk.internal.net.http.common.Utils;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
+/**
+ * A class that tracks the amount of flow controlled
+ * data received on an HTTP/2 connection
+ */
 abstract class WindowUpdateSender {
 
     final Logger debug =
             Utils.getDebugLogger(this::dbgString, Utils.DEBUG);
 
+    // The threshold at which window updates are sent in bytes
     final int limit;
+    // The flow control window in bytes
+    final int windowSize;
     final Http2Connection connection;
-    final AtomicInteger received = new AtomicInteger();
+    // The amount of flow controlled data received and processed, in bytes,
+    // since the start of the window.
+    // The window is exhausted when received + unprocessed >= windowSize
+    final AtomicLong received = new AtomicLong();
+    // The amount of flow controlled data received and unprocessed, in bytes,
+    // since the start of the window.
+    // The window is exhausted when received + unprocessed >= windowSize
+    final AtomicLong unprocessed = new AtomicLong();
     final ReentrantLock sendLock = new ReentrantLock();
 
     WindowUpdateSender(Http2Connection connection) {
@@ -53,6 +68,7 @@ abstract class WindowUpdateSender {
 
     WindowUpdateSender(Http2Connection connection, int maxFrameSize, int initWindowSize) {
         this.connection = connection;
+        this.windowSize = initWindowSize;
         int v0 = Math.max(0, initWindowSize - maxFrameSize);
         int v1 = (initWindowSize + (maxFrameSize - 1)) / maxFrameSize;
         v1 = v1 * maxFrameSize / 2;
@@ -66,16 +82,119 @@ abstract class WindowUpdateSender {
                       maxFrameSize, initWindowSize, limit);
     }
 
+    // O for the connection window, > 0 for a stream window
     abstract int getStreamId();
 
+
+    /**
+     * {@return {@code true} if buffering the given amount of
+     * flow controlled data would not exceed the flow control
+     * window}
+     * <p>
+     * This method is called before buffering and processing
+     * a DataFrame. The count of unprocessed bytes is incremented
+     * by the given amount, and checked against the number of
+     * available bytes in the flow control window.
+     * <p>
+     * This method returns {@code true} if the bytes can be buffered
+     * without exceeding the flow control window, {@code false}
+     * if the flow control window is exceeded and corrective
+     * action (close/reset) has been taken.
+     * <p>
+     * When this method returns true, either {@link #processed(int)}
+     * or {@link #released(int)} must eventually be called to release
+     * the bytes from the flow control window.
+     *
+     * @implSpec
+     * an HTTP/2 endpoint may disable its own flow control
+     * (see <a href="https://www.rfc-editor.org/rfc/rfc9113.html#section-5.2.1">
+     *     RFC 9113, section 5.2.1</a>), in which case this
+     * method may return true even if the flow control window would
+     * be exceeded: that is, the flow control window is exceeded but
+     * the endpoint decided to take no corrective action.
+     *
+     * @param  len a number of unprocessed bytes, which
+     *             the caller wants to buffer.
+     */
+    boolean canBufferUnprocessedBytes(int len) {
+        return !checkWindowSizeExceeded(unprocessed.addAndGet(len));
+    }
+
+    // adds the provided amount to the amount of already
+    // received and processed bytes and checks whether the
+    // flow control window is exceeded. If so, take
+    // corrective actions and return true.
+    private boolean checkWindowSizeExceeded(long len) {
+        // because windowSize is bound by Integer.MAX_VALUE
+        // we will never reach the point where received.get() + len
+        // could overflow
+        long rcv = received.get() + len;
+        return rcv > windowSize && windowSizeExceeded(rcv);
+    }
+
+    /**
+     * Called after unprocessed buffered bytes have been
+     * processed, to release part of the flow control window
+     *
+     * @apiNote this method is called only when releasing bytes
+     * that where buffered after calling
+     * {@link #canBufferUnprocessedBytes(int)}.
+     *
+     * @param delta the amount of processed bytes to release
+     */
+    void processed(int delta) {
+        long rest = unprocessed.addAndGet(-delta);
+        assert rest >= 0;
+        update(delta);
+    }
+
+    /**
+     * Called when it is desired to release unprocessed bytes
+     * without processing them, or without triggering the
+     * sending of a window update. This method can be called
+     * instead of calling {@link #processed(int)}.
+     * When this method is called instead of calling {@link #processed(int)},
+     * it should generally be followed by a call to {@link #update(int)},
+     * unless the stream or connection is being closed.
+     *
+     * @apiNote this method should only be called to release bytes that
+     * have been buffered after calling {@link
+     * #canBufferUnprocessedBytes(int)}.
+     *
+     * @param delta the amount of bytes to release from the window
+     *
+     * @return the amount of remaining unprocessed bytes
+     */
+    long released(int delta) {
+        long rest = unprocessed.addAndGet(-delta);
+        assert rest >= 0;
+        return rest;
+    }
+
+    /**
+     * This method is called to update the flow control window,
+     * and possibly send a window update
+     *
+     * @apiNote this method can be called directly if a frame is
+     * dropped before calling {@link #canBufferUnprocessedBytes(int)}.
+     * Otherwise, either {@link #processed(int)} or {@link #released(int)}
+     * should be called, depending on whether sending a window update
+     * is desired or not. It is typically not desired to send an update
+     * if the stream or connection is being closed.
+     *
+     * @param delta the amount of bytes released from the window.
+     */
     void update(int delta) {
-        int rcv = received.addAndGet(delta);
+        long rcv = received.addAndGet(delta);
         if (debug.on()) debug.log("update: %d, received: %d, limit: %d", delta, rcv, limit);
+        if (rcv > windowSize && windowSizeExceeded(rcv)) {
+            return;
+        }
         if (rcv > limit) {
             sendLock.lock();
             try {
-                int tosend = received.get();
-                if( tosend > limit) {
+                int tosend = (int)Math.min(received.get(), Integer.MAX_VALUE);
+                if (tosend > limit) {
                     received.getAndAdd(-tosend);
                     sendWindowUpdate(tosend);
                 }
@@ -87,6 +206,7 @@ abstract class WindowUpdateSender {
 
     void sendWindowUpdate(int delta) {
         if (debug.on()) debug.log("sending window update: %d", delta);
+        assert delta > 0 : "illegal window update delta: " + delta;
         connection.sendUnorderedFrame(new WindowUpdateFrame(getStreamId(), delta));
     }
 
@@ -103,5 +223,17 @@ abstract class WindowUpdateSender {
             return streamId == 0 ? dbg : (dbgString = dbg);
         }
     }
+
+    /**
+     * Called when the flow control window size is exceeded
+     * This method may return false if flow control is disabled
+     * in this endpoint.
+     *
+     * @param received the amount of data received, which is greater
+     *                 than {@code windowSize}
+     * @return {@code true} if the error was reported to the peer
+     *         and no further window update should be sent.
+     */
+    protected abstract boolean windowSizeExceeded(long received);
 
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/GoAwayFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/GoAwayFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,9 @@ public class GoAwayFrame extends ErrorFrame {
 
     @Override
     public String toString() {
-        return super.toString() + " Debugdata: " + new String(debugData, UTF_8);
+        return super.toString()
+                + " lastStreamId=" + lastStream
+                + ", Debugdata: " + new String(debugData, UTF_8);
     }
 
     public int getLastStream() {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/SettingsFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,6 +165,11 @@ public class SettingsFrame extends Http2Frame {
     public static final int DEFAULT_INITIAL_WINDOW_SIZE = 64 * K -1;
     // The initial value is 2^14 (16,384) octets.
     public static final int DEFAULT_MAX_FRAME_SIZE = 16 * K;
+
+    // Initial connection window size. This cannot be updated using the
+    // SETTINGS frame.
+    public static final int INITIAL_CONNECTION_WINDOW_SIZE = DEFAULT_INITIAL_WINDOW_SIZE;
+
 
     public static SettingsFrame defaultRFCSettings() {
         SettingsFrame f = new SettingsFrame();

--- a/src/java.net.http/share/classes/module-info.java
+++ b/src/java.net.http/share/classes/module-info.java
@@ -57,9 +57,11 @@
  * means that the cache is unbounded.
  * </li>
  * <li><p><b>{@systemProperty jdk.httpclient.connectionWindowSize}</b> (default: 2^26)<br>
- * The HTTP/2 client connection window size in bytes. The maximum size is 2^31-1. This value
- * cannot be smaller than the stream window size, which can be configured through the
- * {@code jdk.httpclient.windowsize} system property.
+ * The HTTP/2 client connection window size in bytes. Valid values are in the range
+ * [2^16-1, 2^31-1]. If an invalid value is provided, the default value is used.
+ * The implementation guarantees that the actual value will be no smaller than the stream
+ * window size, which can be configured through the {@code jdk.httpclient.windowsize}
+ * system property.
  * </li>
  * <li><p><b>{@systemProperty jdk.httpclient.disableRetryConnect}</b> (default: false)<br>
  * Whether automatic retry of connection failures is disabled. If false, then retries are
@@ -150,7 +152,8 @@
  * or 16kB)<br>The buffer size used by the web socket implementation for socket writes.
  * </li>
  * <li><p><b>{@systemProperty jdk.httpclient.windowsize}</b> (default: 16777216 or 16 MB)<br>
- * The HTTP/2 client stream window size in bytes.
+ * The HTTP/2 client stream window size in bytes. Valid values are in the range [2^14, 2^31-1].
+ * If an invalid value is provided, the default value is used.
  * </li>
  * <li><p><b>{@systemProperty jdk.httpclient.auth.retrylimit}</b> (default: 3)<br>
  * The number of attempts the Basic authentication filter will attempt to retry a failed

--- a/test/jdk/java/net/httpclient/GZIPInputStreamTest.java
+++ b/test/jdk/java/net/httpclient/GZIPInputStreamTest.java
@@ -26,7 +26,7 @@
  * @bug 8217264
  * @summary Tests that you can map an InputStream to a GZIPInputStream
  * @library /test/lib /test/jdk/java/net/httpclient/lib
- * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.common.HttpServerAdapters
+ * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.common.HttpServerAdapters ReferenceTracker
  * @run testng/othervm GZIPInputStreamTest
  */
 

--- a/test/jdk/java/net/httpclient/HttpGetInCancelledFuture.java
+++ b/test/jdk/java/net/httpclient/HttpGetInCancelledFuture.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jdk.internal.net.http.common.OperationTrackers.Tracker;
+import jdk.test.lib.net.SimpleSSLContext;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @bug 8316580
+ * @library /test/lib
+ * @run junit/othervm -Djdk.tracePinnedThreads=full
+ *                   -DuseReferenceTracker=false
+ *                   HttpGetInCancelledFuture
+ * @run junit/othervm -Djdk.tracePinnedThreads=full
+ *                   -DuseReferenceTracker=true
+ *                   HttpGetInCancelledFuture
+ * @summary This test verifies that cancelling a future that
+ * does an HTTP request using the HttpClient doesn't cause
+ * HttpClient::close to block forever.
+ */
+public class HttpGetInCancelledFuture {
+
+    static final boolean useTracker = Boolean.getBoolean("useReferenceTracker");
+
+    static final class TestException extends RuntimeException {
+        public TestException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    static ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
+
+    HttpClient makeClient(URI uri, Version version, Executor executor) {
+        var builder = HttpClient.newBuilder();
+        if (uri.getScheme().equalsIgnoreCase("https")) {
+            try {
+                builder.sslContext(new SimpleSSLContext().get());
+            } catch (IOException io) {
+                throw new UncheckedIOException(io);
+            }
+        }
+        return builder.connectTimeout(Duration.ofSeconds(1))
+                .executor(executor)
+                .version(version)
+                .build();
+    }
+
+    record TestCase(String url, int reqCount, Version version) {}
+    // A server that doesn't accept
+    static volatile ServerSocket NOT_ACCEPTING;
+
+    static List<TestCase> parameters() {
+        ServerSocket ss = NOT_ACCEPTING;
+        if (ss == null) {
+            synchronized (HttpGetInCancelledFuture.class) {
+                if ((ss = NOT_ACCEPTING) == null) {
+                    try {
+                        ss = new ServerSocket();
+                        var loopback = InetAddress.getLoopbackAddress();
+                        ss.bind(new InetSocketAddress(loopback, 0), 10);
+                        NOT_ACCEPTING = ss;
+                    } catch (IOException io) {
+                        throw new UncheckedIOException(io);
+                    }
+                }
+            }
+        }
+        URI http = URIBuilder.newBuilder()
+                .loopback()
+                .scheme("http")
+                .port(ss.getLocalPort())
+                .path("/not-accepting/")
+                .buildUnchecked();
+        URI https = URIBuilder.newBuilder()
+                .loopback()
+                .scheme("https")
+                .port(ss.getLocalPort())
+                .path("/not-accepting/")
+                .buildUnchecked();
+        // use all HTTP versions, without and with TLS
+        return List.of(
+                new TestCase(http.toString(), 200, Version.HTTP_2),
+                new TestCase(http.toString(), 200, Version.HTTP_1_1),
+                new TestCase(https.toString(), 200, Version.HTTP_2),
+                new TestCase(https.toString(), 200, Version.HTTP_1_1)
+                );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void runTest(TestCase test) {
+        System.out.println("Testing with: " + test);
+        runTest(test.url, test.reqCount, test.version);
+    }
+
+    static class TestTaskScope implements AutoCloseable {
+        final ExecutorService pool = new ForkJoinPool();
+        final Map<Task<?>, Future<?>> tasks = new ConcurrentHashMap<>();
+        final AtomicReference<ExecutionException> failed = new AtomicReference<>();
+
+        class Task<T> implements Callable<T> {
+            final Callable<T> task;
+            final CompletableFuture<T> cf = new CompletableFuture<>();
+            Task(Callable<T> task) {
+                this.task = task;
+            }
+            @Override
+            public T call() throws Exception {
+                try {
+                    var res = task.call();
+                    cf.complete(res);
+                    return res;
+                } catch (Throwable t) {
+                    cf.completeExceptionally(t);
+                    throw t;
+                }
+            }
+            CompletableFuture<T> cf() {
+                return cf;
+            }
+        }
+
+
+        static class ShutdownOnFailure extends TestTaskScope {
+            public ShutdownOnFailure() {}
+
+            @Override
+            protected <T> void completed(Task<T> task, T result, Throwable throwable) {
+                super.completed(task, result, throwable);
+                if (throwable != null) {
+                    if (failed.get() == null) {
+                        ExecutionException ex = throwable instanceof ExecutionException x
+                                ? x : new ExecutionException(throwable);
+                        failed.compareAndSet(null, ex);
+                    }
+                    tasks.entrySet().forEach(this::cancel);
+                }
+            }
+
+            void cancel(Map.Entry<Task<?>, Future<?>> entry) {
+                entry.getValue().cancel(true);
+                entry.getKey().cf().cancel(true);
+                tasks.remove(entry.getKey(), entry.getValue());
+            }
+
+            @Override
+            public <T> CompletableFuture<T> fork(Callable<T> callable) {
+                var ex = failed.get();
+                if (ex == null) {
+                    return super.fork(callable);
+                } // otherwise do nothing
+                return CompletableFuture.failedFuture(new RejectedExecutionException());
+            }
+        }
+
+        public <T> CompletableFuture<T> fork(Callable<T> callable) {
+            var task = new Task<>(callable);
+            var res = pool.submit(task);
+            tasks.put(task, res);
+            task.cf.whenComplete((r,t) -> completed(task, r, t));
+            return task.cf;
+        }
+
+        protected <T> void completed(Task<T> task, T result, Throwable throwable) {
+            tasks.remove(task);
+        }
+
+        public void join() throws InterruptedException {
+            try {
+                var cfs = tasks.keySet().stream()
+                        .map(Task::cf).toArray(CompletableFuture[]::new);
+                CompletableFuture.allOf(cfs).get();
+            } catch (InterruptedException it) {
+                throw it;
+            } catch (ExecutionException ex) {
+                failed.compareAndSet(null, ex);
+            }
+        }
+
+        public void throwIfFailed() throws ExecutionException {
+            ExecutionException x = failed.get();
+            if (x != null) throw x;
+        }
+
+        public void close() {
+            pool.close();
+        }
+    }
+
+    ExecutorService testExecutor() {
+        return Executors.newCachedThreadPool();
+    }
+
+    void runTest(String url, int reqCount, Version version) {
+        final var dest = URI.create(url);
+        try (final var executor = testExecutor()) {
+            var httpClient = makeClient(dest, version, executor);
+            TRACKER.track(httpClient);
+            Tracker tracker = TRACKER.getTracker(httpClient);
+            Throwable failed = null;
+            try {
+                try (final var scope = new TestTaskScope.ShutdownOnFailure()) {
+                    launchAndProcessRequests(scope, httpClient, reqCount, dest);
+                } finally {
+                    System.out.printf("StructuredTaskScope closed: STARTED=%s, SUCCESS=%s, INTERRUPT=%s, FAILED=%s%n",
+                            STARTED.get(), SUCCESS.get(), INTERRUPT.get(), FAILED.get());
+                }
+                System.out.println("ERROR: Expected TestException not thrown");
+                throw new AssertionError("Expected TestException not thrown");
+            } catch (TestException x) {
+                System.out.println("Got expected exception: " + x);
+            } catch (Throwable t) {
+                System.out.println("ERROR: Unexpected exception: " + t);
+                failed = t;
+                throw t;
+            } finally {
+                // we can either use the tracker or call HttpClient::close
+                if (useTracker) {
+                    // using the tracker depends on GC but will give us some diagnostic
+                    // if some operations are not properly cancelled and prevent the client
+                    // from terminating
+                    httpClient = null;
+                    System.gc();
+                    System.out.println(TRACKER.diagnose(tracker));
+                    var error = TRACKER.check(tracker, 10000);
+                    if (error != null) {
+                        if (failed != null) error.addSuppressed(failed);
+                        EXCEPTIONS.forEach(x -> {
+                            System.out.println("FAILED: " + x);
+                        });
+                        EXCEPTIONS.forEach(x -> {
+                            x.printStackTrace(System.out);
+                        });
+                        throw error;
+                    }
+                } else {
+                    // if not all operations terminate, close() will block
+                    // forever and the test will fail in jtreg timeout.
+                    // there will be no diagnostic.
+                    httpClient.close();
+                }
+                System.out.println("HttpClient closed");
+            }
+        } finally {
+            System.out.println("ThreadExecutor closed");
+        }
+        // not all tasks may have been started before the scope was cancelled
+        // due to the first connect/timeout exception, but all tasks that started
+        // must have either succeeded, be interrupted, or failed
+        assertTrue(STARTED.get() > 0);
+        assertEquals(STARTED.get(), SUCCESS.get() + INTERRUPT.get() + FAILED.get());
+        if (SUCCESS.get() > 0) {
+            // we don't expect any server to be listening and responding
+            System.out.println("WARNING: got some unexpected successful responses from "
+                    + "\"" + NOT_ACCEPTING.getLocalSocketAddress() + "\": " + SUCCESS.get());
+        }
+    }
+
+    private void launchAndProcessRequests(
+            TestTaskScope.ShutdownOnFailure scope,
+            HttpClient httpClient,
+            int reqCount,
+            URI dest) {
+        for (int counter = 0; counter < reqCount; counter++) {
+            scope.fork(() ->
+                    getAndCheck(httpClient, dest)
+            );
+        }
+        try {
+            scope.join();
+        } catch (InterruptedException e) {
+            throw new AssertionError("scope.join() was interrupted", e);
+        }
+        try {
+            scope.throwIfFailed();
+        } catch (ExecutionException e) {
+            throw new TestException("something threw an exception in StructuredTaskScope", e);
+        }
+    }
+
+    final static AtomicLong ID = new AtomicLong();
+    final AtomicLong SUCCESS = new AtomicLong();
+    final AtomicLong INTERRUPT = new AtomicLong();
+    final AtomicLong FAILED = new AtomicLong();
+    final AtomicLong STARTED = new AtomicLong();
+    final CopyOnWriteArrayList<Exception> EXCEPTIONS = new CopyOnWriteArrayList<>();
+    private String getAndCheck(HttpClient httpClient, URI url) {
+        STARTED.incrementAndGet();
+        final var response = sendRequest(httpClient, url);
+        String res = response.body();
+        int statusCode = response.statusCode();
+        assertEquals(200, statusCode);
+        return res;
+    }
+
+    private HttpResponse<String> sendRequest(HttpClient httpClient, URI url) {
+        var id = ID.incrementAndGet();
+        try {
+            var request = HttpRequest.newBuilder(url).GET().build();
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            // System.out.println("Got response for " + id + ": " + response);
+            SUCCESS.incrementAndGet();
+            return response;
+        } catch (InterruptedException e) {
+            INTERRUPT.incrementAndGet();
+            // System.out.println("Got interrupted for " + id + ": " + e);
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            FAILED.incrementAndGet();
+            EXCEPTIONS.add(e);
+            //System.out.println("Got exception for " + id + ": " + e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        try {
+            System.gc();
+            var error = TRACKER.check(5000);
+            if (error != null) throw error;
+        } finally {
+            ServerSocket ss;
+            synchronized (HttpGetInCancelledFuture.class) {
+                ss = NOT_ACCEPTING;
+                NOT_ACCEPTING = null;
+            }
+            if (ss != null) {
+                try {
+                    ss.close();
+                } catch (IOException io) {
+                    throw new UncheckedIOException(io);
+                }
+            }
+        }
+    }
+}
+

--- a/test/jdk/java/net/httpclient/ProxySelectorTest.java
+++ b/test/jdk/java/net/httpclient/ProxySelectorTest.java
@@ -376,7 +376,7 @@ public class ProxySelectorTest implements HttpServerAdapters {
     public void teardown() throws Exception {
         client = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(1500);
         try {
             proxy.stop();
             authproxy.stop();

--- a/test/jdk/java/net/httpclient/ReferenceTracker.java
+++ b/test/jdk/java/net/httpclient/ReferenceTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,6 +246,11 @@ public class ReferenceTracker {
         }
         long duration = Duration.ofNanos(System.nanoTime() - waitStart).toMillis();
         if (hasOutstanding.test(tracker)) {
+            if (i == 0 && waited == 0) {
+                // we found nothing and didn't wait expecting success, but then found
+                // something. Respin to make sure we wait.
+                return check(tracker, graceDelayMs, hasOutstanding, description, printThreads);
+            }
             StringBuilder warnings = diagnose(tracker, new StringBuilder(), hasOutstanding);
             if (hasOutstanding.test(tracker)) {
                 fail = new AssertionError(warnings.toString());
@@ -302,6 +307,11 @@ public class ReferenceTracker {
         }
         long duration = Duration.ofNanos(System.nanoTime() - waitStart).toMillis();
         if (TRACKERS.stream().anyMatch(hasOutstanding)) {
+            if (i == 0 && waited == 0) {
+                // we found nothing and didn't wait expecting success, but then found
+                // something. Respin to make sure we wait.
+                return check(graceDelayMs, hasOutstanding, description, printThreads);
+            }
             StringBuilder warnings = diagnose(new StringBuilder(), hasOutstanding);
             addSummary(warnings);
             if (TRACKERS.stream().anyMatch(hasOutstanding)) {

--- a/test/jdk/java/net/httpclient/ReferenceTracker.java
+++ b/test/jdk/java/net/httpclient/ReferenceTracker.java
@@ -115,6 +115,14 @@ public class ReferenceTracker {
                 "outstanding operations or unreleased resources", true);
     }
 
+    public AssertionError checkFinished(Tracker tracker, long graceDelayMs) {
+        Predicate<Tracker> hasOperations = (t) -> t.getOutstandingOperations() > 0;
+        Predicate<Tracker> hasSubscribers = (t) -> t.getOutstandingSubscribers() > 0;
+        return check(tracker, graceDelayMs,
+                hasOperations.or(hasSubscribers),
+                "outstanding operations or unreleased resources", false);
+    }
+
     public AssertionError check(long graceDelayMs) {
         Predicate<Tracker> hasOperations = (t) -> t.getOutstandingOperations() > 0;
         Predicate<Tracker> hasSubscribers = (t) -> t.getOutstandingSubscribers() > 0;

--- a/test/jdk/java/net/httpclient/http2/ConnectionFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/ConnectionFlowControlTest.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8342075
+ * @summary checks connection flow control
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
+ * @run testng/othervm  -Djdk.internal.httpclient.debug=true
+ *                      -Djdk.httpclient.connectionWindowSize=65535
+ *                      -Djdk.httpclient.windowsize=16384
+ *                      ConnectionFlowControlTest
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ProtocolException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.ResponseInfo;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestServer;
+import jdk.httpclient.test.lib.http2.BodyOutputStream;
+import jdk.httpclient.test.lib.http2.Http2Handler;
+import jdk.httpclient.test.lib.http2.Http2TestExchange;
+import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
+import jdk.httpclient.test.lib.http2.Http2TestServer;
+import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
+import jdk.internal.net.http.common.HttpHeadersBuilder;
+import jdk.internal.net.http.frame.ContinuationFrame;
+import jdk.internal.net.http.frame.HeaderFrame;
+import jdk.internal.net.http.frame.HeadersFrame;
+import jdk.internal.net.http.frame.Http2Frame;
+import jdk.internal.net.http.frame.SettingsFrame;
+import jdk.test.lib.Utils;
+import jdk.test.lib.net.SimpleSSLContext;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static java.util.List.of;
+import static java.util.Map.entry;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class ConnectionFlowControlTest {
+
+    SSLContext sslContext;
+    HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
+    HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
+    String http2URI;
+    String https2URI;
+    final AtomicInteger reqid = new AtomicInteger();
+
+
+    @DataProvider(name = "variants")
+    public Object[][] variants() {
+        return new Object[][] {
+                { http2URI },
+                { https2URI },
+        };
+    }
+
+    @Test(dataProvider = "variants")
+    void test(String uri) throws Exception {
+        System.out.printf("%ntesting %s%n", uri);
+        ConcurrentHashMap<String, CompletableFuture<String>> responseSent = new ConcurrentHashMap<>();
+        ConcurrentHashMap<String, HttpResponse<InputStream>> responses = new ConcurrentHashMap<>();
+        FCHttp2TestExchange.setResponseSentCB((s) -> responseSent.get(s).complete(s));
+        int connectionWindowSize = Math.max(Integer.getInteger(
+                "jdk.httpclient.connectionWindowSize", 65535), 65535);
+        int windowSize = Math.max(Integer.getInteger(
+                "jdk.httpclient.windowsize", 65535), 16384);
+        int max = connectionWindowSize / windowSize + 2;
+        System.out.printf("connection window: %s, stream window: %s, will make %s requests%n",
+                connectionWindowSize, windowSize, max);
+
+        try (HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build()) {
+            String label = null;
+
+            Throwable t = null;
+            try {
+                String[] keys = new String[max];
+                for (int i = 0; i < max; i++) {
+                    String query = "reqId=" + reqid.incrementAndGet();
+                    keys[i] = query;
+                    URI uriWithQuery = URI.create(uri + "?" + query);
+                    CompletableFuture<String> sent = new CompletableFuture<>();
+                    responseSent.put(query, sent);
+                    HttpRequest request = HttpRequest.newBuilder(uriWithQuery)
+                            .POST(BodyPublishers.ofString("Hello there!"))
+                            .build();
+                    System.out.println("\nSending request:" + uriWithQuery);
+                    final HttpClient cc = client;
+                    var response = cc.send(request, BodyHandlers.ofInputStream());
+                    responses.put(query, response);
+                    String ckey = response.headers().firstValue("X-Connection-Key").get();
+                    if (label == null) label = ckey;
+                    try {
+                        if (i < max - 1) {
+                            // the connection window might be exceeded at i == max - 2, which
+                            // means that the last request could go on a new connection.
+                            assertEquals(ckey, label, "Unexpected key for " + query);
+                        }
+                    } catch (AssertionError ass) {
+                        // since we won't pull all responses, the client
+                        // will not exit unless we ask it to shutdown now.
+                        client.shutdownNow();
+                        throw ass;
+                    }
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ie) {
+                    // ignore
+                }
+                CompletableFuture<?> allsent = CompletableFuture.allOf(responseSent.values().stream()
+                        .toArray(CompletableFuture<?>[]::new));
+                allsent.get();
+                for (int i = 0; i < max; i++) {
+                    try {
+                        String query = keys[i];
+                        var response = responses.get(keys[i]);
+                        String ckey = response.headers().firstValue("X-Connection-Key").get();
+                        if (label == null) label = ckey;
+                        assertEquals(ckey, label, "Unexpected key for " + query);
+                        int wait = uri.startsWith("https://") ? 500 : 250;
+                        try (InputStream is = response.body()) {
+                            Thread.sleep(Utils.adjustTimeout(wait));
+                            is.readAllBytes();
+                        }
+                        System.out.printf("%s did not fail: %s%n", query, response.statusCode());
+                    } catch (AssertionError t1) {
+                        // since we won't pull all responses, the client
+                        // will not exit unless we ask it to shutdown now.
+                        client.shutdownNow();
+                        throw t1;
+                    } catch (Throwable t0) {
+                        System.out.println("Got EXPECTED: " + t0);
+                        if (t0 instanceof ExecutionException) {
+                            t0 = t0.getCause();
+                        }
+                        t = t0;
+                        try {
+                            assertDetailMessage(t0, i);
+                        } catch (AssertionError e) {
+                            // since we won't pull all responses, the client
+                            // will not exit unless we ask it to shutdown now.
+                            client.shutdownNow();
+                            throw e;
+                        }
+                    }
+                }
+            } catch (Throwable t0) {
+                System.out.println("Got EXPECTED: " + t0);
+                if (t0 instanceof ExecutionException) {
+                    t0 = t0.getCause();
+                }
+                t = t0;
+            }
+            if (t == null) {
+                // we could fail here if we haven't waited long enough
+                fail("Expected exception, got all responses, should sleep time be raised?");
+            } else {
+                assertDetailMessage(t, max);
+            }
+            String query = "reqId=" + reqid.incrementAndGet();
+            URI uriWithQuery = URI.create(uri + "?" + query);
+            CompletableFuture<String> sent = new CompletableFuture<>();
+            responseSent.put(query, sent);
+            HttpRequest request = HttpRequest.newBuilder(uriWithQuery)
+                    .POST(BodyPublishers.ofString("Hello there!"))
+                    .build();
+            System.out.println("\nSending last request:" + uriWithQuery);
+            var response = client.send(request, BodyHandlers.ofString());
+            if (label != null) {
+                String ckey = response.headers().firstValue("X-Connection-Key").get();
+                assertNotEquals(ckey, label);
+                System.out.printf("last request %s sent on different connection as expected:" +
+                        "\n\tlast: %s\n\tprevious: %s%n", query, ckey, label);
+            }
+        }
+    }
+
+    // Assertions based on implementation specific detail messages. Keep in
+    // sync with implementation.
+    static void assertDetailMessage(Throwable throwable, int iterationIndex) {
+        try {
+            Throwable cause = throwable;
+            while (cause != null) {
+                if (cause instanceof ProtocolException) {
+                    if (cause.getMessage().contains("connection window exceeded")) {
+                       System.out.println("Found expected exception: " + cause);
+                       return;
+                    }
+                }
+                cause = cause.getCause();
+            }
+            throw new AssertionError(
+                    "ProtocolException(\"protocol error: connection window exceeded\") not found",
+                             throwable);
+        } catch (AssertionError e) {
+            System.out.println("Exception does not match expectation: " + throwable);
+            throwable.printStackTrace(System.out);
+            throw e;
+        }
+    }
+
+    @BeforeTest
+    public void setup() throws Exception {
+        sslContext = new SimpleSSLContext().get();
+        if (sslContext == null)
+            throw new AssertionError("Unexpected null sslContext");
+
+        var http2TestServer = new Http2TestServer("localhost", false, 0);
+        http2TestServer.addHandler(new Http2TestHandler(), "/http2/");
+        this.http2TestServer = HttpTestServer.of(http2TestServer);
+        http2URI = "http://" + this.http2TestServer.serverAuthority() + "/http2/x";
+
+        var https2TestServer = new Http2TestServer("localhost", true, sslContext);
+        https2TestServer.addHandler(new Http2TestHandler(), "/https2/");
+        this.https2TestServer = HttpTestServer.of(https2TestServer);
+        https2URI = "https://" + this.https2TestServer.serverAuthority() + "/https2/x";
+
+        // Override the default exchange supplier with a custom one to enable
+        // particular test scenarios
+        http2TestServer.setExchangeSupplier(FCHttp2TestExchange::new);
+        https2TestServer.setExchangeSupplier(FCHttp2TestExchange::new);
+
+        this.http2TestServer.start();
+        this.https2TestServer.start();
+    }
+
+    @AfterTest
+    public void teardown() throws Exception {
+        http2TestServer.stop();
+        https2TestServer.stop();
+    }
+
+    static class Http2TestHandler implements Http2Handler {
+
+        @Override
+        public void handle(Http2TestExchange t) throws IOException {
+            String query = t.getRequestURI().getRawQuery();
+
+            try (InputStream is = t.getRequestBody();
+                 OutputStream os = t.getResponseBody()) {
+
+                byte[] bytes = is.readAllBytes();
+                System.out.println("Server " + t.getLocalAddress() + " received:\n"
+                        + t.getRequestURI() + ": " + new String(bytes, StandardCharsets.UTF_8));
+                t.getResponseHeaders().setHeader("X-Connection-Key", t.getConnectionKey());
+
+                if (bytes.length == 0) bytes = "no request body!".getBytes(StandardCharsets.UTF_8);
+                int window = Math.max(16384, Integer.getInteger("jdk.httpclient.windowsize", 2*16*1024));
+                 final int maxChunkSize;
+                if (t instanceof FCHttp2TestExchange fct) {
+                    maxChunkSize = Math.min(window, fct.conn.getMaxFrameSize());
+                } else {
+                    maxChunkSize = Math.min(window, SettingsFrame.MAX_FRAME_SIZE);
+                }
+                byte[] resp = bytes.length < maxChunkSize
+                        ? bytes
+                        : Arrays.copyOfRange(bytes, 0, maxChunkSize);
+                int max = (window / resp.length);
+                // send in chunks
+                t.sendResponseHeaders(200, 0);
+                int sent = 0;
+                for (int i=0; i<=max; i++) {
+                    int len = Math.min(resp.length, window - sent);
+                    if (len <= 0) break;
+                    if (os instanceof BodyOutputStream bos) {
+                        try {
+                            // we don't wait for the stream window, but we want
+                            // to wait for the connection window
+                            bos.waitForStreamWindow(len);
+                        } catch (InterruptedException ie) {
+                            // ignore and continue...
+                        }
+                    }
+                    ((BodyOutputStream) os).writeUncontrolled(resp, 0, len);
+                    sent += len;
+                }
+                if (sent != window) fail("should have sent %s, sent %s".formatted(window, sent));
+            }
+            if (t instanceof FCHttp2TestExchange fct) {
+                fct.responseSent(query);
+            } else {
+                fail("Exchange is not %s but %s"
+                        .formatted(FCHttp2TestExchange.class.getName(), t.getClass().getName()));
+            }
+        }
+    }
+
+    // A custom Http2TestExchangeImpl that overrides sendResponseHeaders to
+    // allow headers to be sent with a number of CONTINUATION frames.
+    static class FCHttp2TestExchange extends Http2TestExchangeImpl {
+        static volatile Consumer<String> responseSentCB;
+        static void setResponseSentCB(Consumer<String> responseSentCB) {
+            FCHttp2TestExchange.responseSentCB = responseSentCB;
+        }
+
+        final Http2TestServerConnection conn;
+        FCHttp2TestExchange(int streamid, String method, HttpHeaders reqheaders,
+                             HttpHeadersBuilder rspheadersBuilder, URI uri, InputStream is,
+                             SSLSession sslSession, BodyOutputStream os,
+                             Http2TestServerConnection conn, boolean pushAllowed) {
+            super(streamid, method, reqheaders, rspheadersBuilder, uri, is, sslSession, os, conn, pushAllowed);
+            this.conn = conn;
+        }
+        public void responseSent(String query) {
+            System.out.println("Server: response sent for " + query);
+            responseSentCB.accept(query);
+        }
+
+    }
+}

--- a/test/jdk/java/net/httpclient/http2/H2GoAwayTest.java
+++ b/test/jdk/java/net/httpclient/http2/H2GoAwayTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.net.ssl.SSLContext;
+
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestExchange;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestHandler;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestServer;
+import jdk.test.lib.net.SimpleSSLContext;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static java.net.http.HttpClient.Version.HTTP_2;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/*
+ * @test
+ * @bug 8335181
+ * @summary verify that the HttpClient correctly handles incoming GOAWAY frames and
+ *          retries any unprocessed requests on a new connection
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.common.HttpServerAdapters
+ *        jdk.test.lib.net.SimpleSSLContext
+ * @run junit H2GoAwayTest
+ */
+public class H2GoAwayTest {
+    private static final String REQ_PATH = "/test";
+    private static HttpTestServer server;
+    private static String REQ_URI_BASE;
+    private static SSLContext sslCtx;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        sslCtx = new SimpleSSLContext().get();
+        assertNotNull(sslCtx, "SSLContext couldn't be created");
+        server = HttpTestServer.create(HTTP_2, sslCtx);
+        server.addHandler(new Handler(), REQ_PATH);
+        server.start();
+        System.out.println("Server started at " + server.getAddress());
+        REQ_URI_BASE = URIBuilder.newBuilder().scheme("https")
+                .loopback()
+                .port(server.getAddress().getPort())
+                .path(REQ_PATH)
+                .build().toString();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (server != null) {
+            System.out.println("Stopping server at " + server.getAddress());
+            server.stop();
+        }
+    }
+
+    /**
+     * Verifies that when several requests are sent using send() and the server
+     * connection is configured to send a GOAWAY after processing only a few requests, then
+     * the remaining requests are retried on a different connection
+     */
+    @Test
+    public void testSequential() throws Exception {
+        final LimitedPerConnRequestApprover reqApprover = new LimitedPerConnRequestApprover();
+        server.setRequestApprover(reqApprover::allowNewRequest);
+        try (final HttpClient client = HttpClient.newBuilder().version(HTTP_2)
+                .sslContext(sslCtx).build()) {
+            final String[] reqMethods = {"HEAD", "GET", "POST"};
+            for (final String reqMethod : reqMethods) {
+                final int numReqs = LimitedPerConnRequestApprover.MAX_REQS_PER_CONN + 3;
+                final Set<String> connectionKeys = new LinkedHashSet<>();
+                for (int i = 1; i <= numReqs; i++) {
+                    final URI reqURI = new URI(REQ_URI_BASE + "?seq&" + reqMethod + "=" + i);
+                    final HttpRequest req = HttpRequest.newBuilder()
+                            .uri(reqURI)
+                            .method(reqMethod, HttpRequest.BodyPublishers.noBody())
+                            .build();
+                    System.out.println("initiating request " + req);
+                    final HttpResponse<String> resp = client.send(req, BodyHandlers.ofString());
+                    final String respBody = resp.body();
+                    System.out.println("received response: " + respBody);
+                    assertEquals(200, resp.statusCode(),
+                            "unexpected status code for request " + resp.request());
+                    // response body is the logical key of the connection on which the
+                    // request was handled
+                    connectionKeys.add(respBody);
+                }
+                System.out.println("connections involved in handling the requests: "
+                        + connectionKeys);
+                // all requests have finished, we now just do a basic check that
+                // more than one connection was involved in processing these requests
+                assertEquals(2, connectionKeys.size(),
+                        "unexpected number of connections " + connectionKeys);
+            }
+        } finally {
+            server.setRequestApprover(null); // reset
+        }
+    }
+
+    /**
+     * Verifies that when a server responds with a GOAWAY and then never processes the new retried
+     * requests on a new connection too, then the application code receives the request failure.
+     * This tests the send() API of the HttpClient.
+     */
+    @Test
+    public void testUnprocessedRaisesException() throws Exception {
+        try (final HttpClient client = HttpClient.newBuilder().version(HTTP_2)
+                .sslContext(sslCtx).build()) {
+            final Random random = new Random();
+            final String[] reqMethods = {"HEAD", "GET", "POST"};
+            for (final String reqMethod : reqMethods) {
+                final int maxAllowedReqs = 2;
+                final int numReqs = maxAllowedReqs + 3; // 3 more requests than max allowed
+                // configure the approver
+                final LimitedRequestApprover reqApprover = new LimitedRequestApprover(maxAllowedReqs);
+                server.setRequestApprover(reqApprover::allowNewRequest);
+                try {
+                    int numSuccess = 0;
+                    int numFailed = 0;
+                    for (int i = 1; i <= numReqs; i++) {
+                        final String reqQueryPart = "?sync&" + reqMethod + "=" + i;
+                        final URI reqURI = new URI(REQ_URI_BASE + reqQueryPart);
+                        final HttpRequest req = HttpRequest.newBuilder()
+                                .uri(reqURI)
+                                .method(reqMethod, HttpRequest.BodyPublishers.noBody())
+                                .build();
+                        System.out.println("initiating request " + req);
+                        if (i <= maxAllowedReqs) {
+                            // expected to successfully complete
+                            numSuccess++;
+                            final HttpResponse<String> resp = client.send(req, BodyHandlers.ofString());
+                            final String respBody = resp.body();
+                            System.out.println("received response: " + respBody);
+                            assertEquals(200, resp.statusCode(),
+                                    "unexpected status code for request " + resp.request());
+                        } else {
+                            // expected to fail as unprocessed
+                            try {
+                                final HttpResponse<String> resp = client.send(req, BodyHandlers.ofString());
+                                fail("Request was expected to fail as unprocessed,"
+                                        + " but got response: " + resp.body() + ", status code: "
+                                        + resp.statusCode());
+                            } catch (IOException ioe) {
+                                // verify it failed for the right reason
+                                if (ioe.getMessage() == null
+                                        || !ioe.getMessage().contains("request not processed by peer")) {
+                                    // propagate the original failure
+                                    throw ioe;
+                                }
+                                numFailed++; // failed due to right reason
+                                System.out.println("received expected failure: " + ioe
+                                        + ", for request " + reqURI);
+                            }
+                        }
+                    }
+                    // verify the correct number of requests succeeded/failed
+                    assertEquals(maxAllowedReqs, numSuccess, "unexpected number of requests succeeded");
+                    assertEquals((numReqs - maxAllowedReqs), numFailed, "unexpected number of requests failed");
+                } finally {
+                    server.setRequestApprover(null); // reset
+                }
+            }
+        }
+    }
+
+    /**
+     * Verifies that when a server responds with a GOAWAY and then never processes the new retried
+     * requests on a new connection too, then the application code receives the request failure.
+     * This tests the sendAsync() API of the HttpClient.
+     */
+    @Test
+    public void testUnprocessedRaisesExceptionAsync() throws Throwable {
+        try (final HttpClient client = HttpClient.newBuilder().version(HTTP_2)
+                .sslContext(sslCtx).build()) {
+            final Random random = new Random();
+            final String[] reqMethods = {"HEAD", "GET", "POST"};
+            for (final String reqMethod : reqMethods) {
+                final int maxAllowedReqs = 2;
+                final int numReqs = maxAllowedReqs + 3; // 3 more requests than max allowed
+                // configure the approver
+                final LimitedRequestApprover reqApprover = new LimitedRequestApprover(maxAllowedReqs);
+                server.setRequestApprover(reqApprover::allowNewRequest);
+                try {
+                    final List<Future<HttpResponse<String>>> futures = new ArrayList<>();
+                    for (int i = 1; i <= numReqs; i++) {
+                        final URI reqURI = new URI(REQ_URI_BASE + "?async&" + reqMethod + "=" + i);
+                        final HttpRequest req = HttpRequest.newBuilder()
+                                .uri(reqURI)
+                                .method(reqMethod, HttpRequest.BodyPublishers.noBody())
+                                .build();
+                        System.out.println("initiating request " + req);
+                        final Future<HttpResponse<String>> f = client.sendAsync(req, BodyHandlers.ofString());
+                        futures.add(f);
+                    }
+                    // wait for responses
+                    int numFailed = 0;
+                    int numSuccess = 0;
+                    for (int i = 1; i <= numReqs; i++) {
+                        final String reqQueryPart = "?async&" + reqMethod + "=" + i;
+                        try {
+                            System.out.println("waiting response of request "
+                                    + REQ_URI_BASE + reqQueryPart);
+                            final HttpResponse<String> resp = futures.get(i - 1).get();
+                            numSuccess++;
+                            final String respBody = resp.body();
+                            System.out.println("request: " + resp.request()
+                                    + ", received response: " + respBody);
+                            assertEquals(200, resp.statusCode(),
+                                    "unexpected status code for request " + resp.request());
+                        } catch (ExecutionException ee) {
+                            final Throwable cause = ee.getCause();
+                            if (!(cause instanceof IOException ioe)) {
+                                throw cause;
+                            }
+                            // verify it failed for the right reason
+                            if (ioe.getMessage() == null
+                                    || !ioe.getMessage().contains("request not processed by peer")) {
+                                // propagate the original failure
+                                throw ioe;
+                            }
+                            numFailed++; // failed due to the right reason
+                            System.out.println("received expected failure: " + ioe
+                                    + ", for request " + REQ_URI_BASE + reqQueryPart);
+                        }
+                    }
+                    // verify the correct number of requests succeeded/failed
+                    assertEquals(maxAllowedReqs, numSuccess, "unexpected number of requests succeeded");
+                    assertEquals((numReqs - maxAllowedReqs), numFailed, "unexpected number of requests failed");
+                } finally {
+                    server.setRequestApprover(null); // reset
+                }
+            }
+        }
+    }
+
+    // only allows fixed number of requests, irrespective of which server connection handles
+    // it. requests that are rejected will either be sent a GOAWAY on the connection
+    // or a RST_FRAME with a REFUSED_STREAM on the stream
+    private static final class LimitedRequestApprover {
+        private final int maxAllowedReqs;
+        private final AtomicInteger numApproved = new AtomicInteger();
+
+        private LimitedRequestApprover(final int maxAllowedReqs) {
+            this.maxAllowedReqs = maxAllowedReqs;
+        }
+
+        public boolean allowNewRequest(final String serverConnKey) {
+            final int approved = numApproved.incrementAndGet();
+            return approved <= maxAllowedReqs;
+        }
+    }
+
+    // allows a certain number of requests per server connection.
+    // requests that are rejected will either be sent a GOAWAY on the connection
+    // or a RST_FRAME with a REFUSED_STREAM on the stream
+    private static final class LimitedPerConnRequestApprover {
+        private static final int MAX_REQS_PER_CONN = 6;
+        private final Map<String, AtomicInteger> numApproved =
+                new ConcurrentHashMap<>();
+        private final Map<String, AtomicInteger> numDisapproved =
+                new ConcurrentHashMap<>();
+
+        public boolean allowNewRequest(final String serverConnKey) {
+            final AtomicInteger approved = numApproved.computeIfAbsent(serverConnKey,
+                    (k) -> new AtomicInteger());
+            int curr = approved.get();
+            while (curr < MAX_REQS_PER_CONN) {
+                if (approved.compareAndSet(curr, curr + 1)) {
+                    return true; // new request allowed
+                }
+                curr = approved.get();
+            }
+            final AtomicInteger disapproved = numDisapproved.computeIfAbsent(serverConnKey,
+                    (k) -> new AtomicInteger());
+            final int numUnprocessed = disapproved.incrementAndGet();
+            System.out.println(approved.get() + " processed, "
+                    + numUnprocessed + " unprocessed requests on connection " + serverConnKey);
+            return false;
+        }
+    }
+
+    private static final class Handler implements HttpTestHandler {
+
+        @Override
+        public void handle(final HttpTestExchange exchange) throws IOException {
+            final String connectionKey = exchange.getConnectionKey();
+            System.out.println("responding to request: " + exchange.getRequestURI()
+                    + " on connection " + connectionKey);
+            final byte[] response = connectionKey.getBytes(UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (final OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        }
+    }
+}

--- a/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8342075
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
+ * @run testng/othervm  -Djdk.internal.httpclient.debug=true
+ *                      -Djdk.httpclient.connectionWindowSize=65535
+ *                      -Djdk.httpclient.windowsize=16384
+ *                      StreamFlowControlTest
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ProtocolException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestServer;
+import jdk.httpclient.test.lib.http2.BodyOutputStream;
+import jdk.httpclient.test.lib.http2.Http2Handler;
+import jdk.httpclient.test.lib.http2.Http2TestExchange;
+import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
+import jdk.httpclient.test.lib.http2.Http2TestServer;
+import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
+import jdk.internal.net.http.common.HttpHeadersBuilder;
+import jdk.internal.net.http.frame.SettingsFrame;
+import jdk.test.lib.Utils;
+import jdk.test.lib.net.SimpleSSLContext;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class StreamFlowControlTest {
+
+    SSLContext sslContext;
+    HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
+    HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
+    String http2URI;
+    String https2URI;
+    final AtomicInteger reqid = new AtomicInteger();
+
+
+    @DataProvider(name = "variants")
+    public Object[][] variants() {
+        return new Object[][] {
+                { http2URI,  false },
+                { https2URI, false },
+                { http2URI,  true },
+                { https2URI, true },
+        };
+    }
+
+
+    @Test(dataProvider = "variants")
+    void test(String uri,
+              boolean sameClient)
+        throws Exception
+    {
+        System.out.printf("%ntesting test(%s, %s)%n", uri, sameClient);
+        ConcurrentHashMap<String, CompletableFuture<String>>  responseSent = new ConcurrentHashMap<>();
+        FCHttp2TestExchange.setResponseSentCB((s) -> responseSent.get(s).complete(s));
+
+        HttpClient client = null;
+        try {
+            int max = sameClient ? 10 : 3;
+            String label = null;
+            for (int i = 0; i < max; i++) {
+                if (!sameClient || client == null)
+                    client = HttpClient.newBuilder().sslContext(sslContext).build();
+
+                String query = "reqId=" + reqid.incrementAndGet();
+                URI uriWithQuery = URI.create(uri + "?" + query);
+                CompletableFuture<String> sent = new CompletableFuture<>();
+                responseSent.put(query, sent);
+                HttpRequest request = HttpRequest.newBuilder(uriWithQuery)
+                        .POST(BodyPublishers.ofString("Hello there!"))
+                        .build();
+                System.out.println("\nSending request:" + uriWithQuery);
+                final HttpClient cc = client;
+                try {
+                    HttpResponse<InputStream> response = cc.send(request, BodyHandlers.ofInputStream());
+                    if (sameClient) {
+                        String key = response.headers().firstValue("X-Connection-Key").get();
+                        if (label == null) label = key;
+                        assertEquals(key, label, "Unexpected key for " + query);
+                    }
+                    sent.join();
+                    // we have to pull to get the exception, but slow enough
+                    // so that DataFrames are buffered up to the point that
+                    // the window is exceeded...
+                    int wait = uri.startsWith("https://") ? 500 : 350;
+                    try (InputStream is = response.body()) {
+                        Thread.sleep(Utils.adjustTimeout(wait));
+                        is.readAllBytes();
+                    }
+                    // we could fail here if we haven't waited long enough
+                    fail("Expected exception, got :" + response + ", should sleep time be raised?");
+                } catch (IOException ioe) {
+                    System.out.println("Got EXPECTED: " + ioe);
+                    assertDetailMessage(ioe, i);
+                } finally {
+                    if (!sameClient && client != null) {
+                        client.close();
+                        client = null;
+                    }
+                }
+            }
+        } finally {
+            if (sameClient && client != null) client.close();
+        }
+
+    }
+
+    @Test(dataProvider = "variants")
+    void testAsync(String uri,
+                   boolean sameClient)
+    {
+        System.out.printf("%ntesting testAsync(%s, %s)%n", uri, sameClient);
+        ConcurrentHashMap<String, CompletableFuture<String>> responseSent = new ConcurrentHashMap<>();
+        FCHttp2TestExchange.setResponseSentCB((s) -> responseSent.get(s).complete(s));
+
+        HttpClient client = null;
+        try {
+            int max = sameClient ? 5 : 3;
+            String label = null;
+            for (int i = 0; i < max; i++) {
+                if (!sameClient || client == null)
+                    client = HttpClient.newBuilder().sslContext(sslContext).build();
+
+                String query = "reqId=" + reqid.incrementAndGet();
+                URI uriWithQuery = URI.create(uri + "?" + query);
+                CompletableFuture<String> sent = new CompletableFuture<>();
+                responseSent.put(query, sent);
+                HttpRequest request = HttpRequest.newBuilder(uriWithQuery)
+                        .POST(BodyPublishers.ofString("Hello there!"))
+                        .build();
+                System.out.println("\nSending request:" + uriWithQuery);
+                final HttpClient cc = client;
+
+                Throwable t = null;
+                try {
+                    HttpResponse<InputStream> response = cc.sendAsync(request, BodyHandlers.ofInputStream()).get();
+                    if (sameClient) {
+                        String key = response.headers().firstValue("X-Connection-Key").get();
+                        if (label == null) label = key;
+                        assertEquals(key, label, "Unexpected key for " + query);
+                    }
+                    sent.join();
+                    int wait = uri.startsWith("https://") ? 600 : 300;
+                    try (InputStream is = response.body()) {
+                        Thread.sleep(Utils.adjustTimeout(wait));
+                        is.readAllBytes();
+                    }
+                    // we could fail here if we haven't waited long enough
+                    fail("Expected exception, got :" + response + ", should sleep time be raised?");
+                } catch (Throwable t0) {
+                    System.out.println("Got EXPECTED: " + t0);
+                    if (t0 instanceof ExecutionException) {
+                        t0 = t0.getCause();
+                    }
+                    t = t0;
+                } finally {
+                    if (!sameClient && client != null) {
+                        client.close();
+                        client = null;
+                    }
+                }
+                assertDetailMessage(t, i);
+            }
+        } finally {
+            if (sameClient && client != null) client.close();
+        }
+    }
+
+    // Assertions based on implementation specific detail messages. Keep in
+    // sync with implementation.
+    static void assertDetailMessage(Throwable throwable, int iterationIndex) {
+        try {
+            Throwable cause = throwable;
+            while (cause != null) {
+                if (cause instanceof ProtocolException) {
+                    if (cause.getMessage().matches("stream [0-9]+ flow control window exceeded")) {
+                       System.out.println("Found expected exception: " + cause);
+                       return;
+                    }
+                }
+                cause = cause.getCause();
+            }
+            throw new AssertionError(
+                    "ProtocolException(\"stream X flow control window exceeded\") not found",
+                             throwable);
+        } catch (AssertionError e) {
+            System.out.println("Exception does not match expectation: " + throwable);
+            throwable.printStackTrace(System.out);
+            throw e;
+        }
+    }
+
+    @BeforeTest
+    public void setup() throws Exception {
+        sslContext = new SimpleSSLContext().get();
+        if (sslContext == null)
+            throw new AssertionError("Unexpected null sslContext");
+
+        var http2TestServer = new Http2TestServer("localhost", false, 0);
+        http2TestServer.addHandler(new Http2TestHandler(), "/http2/");
+        this.http2TestServer = HttpTestServer.of(http2TestServer);
+        http2URI = "http://" + this.http2TestServer.serverAuthority() + "/http2/x";
+
+        var https2TestServer = new Http2TestServer("localhost", true, sslContext);
+        https2TestServer.addHandler(new Http2TestHandler(), "/https2/");
+        this.https2TestServer = HttpTestServer.of(https2TestServer);
+        https2URI = "https://" + this.https2TestServer.serverAuthority() + "/https2/x";
+
+        // Override the default exchange supplier with a custom one to enable
+        // particular test scenarios
+        http2TestServer.setExchangeSupplier(FCHttp2TestExchange::new);
+        https2TestServer.setExchangeSupplier(FCHttp2TestExchange::new);
+
+        this.http2TestServer.start();
+        this.https2TestServer.start();
+    }
+
+    @AfterTest
+    public void teardown() throws Exception {
+        http2TestServer.stop();
+        https2TestServer.stop();
+    }
+
+    static class Http2TestHandler implements Http2Handler {
+
+        @Override
+        public void handle(Http2TestExchange t) throws IOException {
+            String query = t.getRequestURI().getRawQuery();
+
+            try (InputStream is = t.getRequestBody();
+                 OutputStream os = t.getResponseBody()) {
+
+                byte[] bytes = is.readAllBytes();
+                System.out.println("Server " + t.getLocalAddress() + " received:\n"
+                        + t.getRequestURI() + ": " + new String(bytes, StandardCharsets.UTF_8));
+                t.getResponseHeaders().setHeader("X-Connection-Key", t.getConnectionKey());
+
+                if (bytes.length == 0) bytes = "no request body!".getBytes(StandardCharsets.UTF_8);
+                int window = Integer.getInteger("jdk.httpclient.windowsize", 2 * 16 * 1024);
+                final int maxChunkSize;
+                if (t instanceof FCHttp2TestExchange fct) {
+                    maxChunkSize = Math.min(window, fct.conn.getMaxFrameSize());
+                } else {
+                    maxChunkSize = Math.min(window, SettingsFrame.MAX_FRAME_SIZE);
+                }
+                byte[] resp = bytes.length <= maxChunkSize
+                        ? bytes
+                        : Arrays.copyOfRange(bytes, 0, maxChunkSize);
+                int max = (window / resp.length) + 2;
+                // send in chunks
+                t.sendResponseHeaders(200, 0);
+                for (int i = 0; i <= max; i++) {
+                    if (t instanceof FCHttp2TestExchange fct) {
+                        try {
+                            // we don't wait for the stream window, but we want
+                            // to wait for the connection window
+                            fct.conn.obtainConnectionWindow(resp.length);
+                        } catch (InterruptedException ie) {
+                            // ignore and continue...
+                        }
+                    }
+                    ((BodyOutputStream) os).writeUncontrolled(resp, 0, resp.length);
+                }
+            }
+            if (t instanceof FCHttp2TestExchange fct) {
+                fct.responseSent(query);
+            } else fail("Exchange is not %s but %s"
+                    .formatted(FCHttp2TestExchange.class.getName(), t.getClass().getName()));
+        }
+    }
+
+    // A custom Http2TestExchangeImpl that overrides sendResponseHeaders to
+    // allow headers to be sent with a number of CONTINUATION frames.
+    static class FCHttp2TestExchange extends Http2TestExchangeImpl {
+        static volatile Consumer<String> responseSentCB;
+        static void setResponseSentCB(Consumer<String> responseSentCB) {
+            FCHttp2TestExchange.responseSentCB = responseSentCB;
+        }
+
+        final Http2TestServerConnection conn;
+        FCHttp2TestExchange(int streamid, String method, HttpHeaders reqheaders,
+                             HttpHeadersBuilder rspheadersBuilder, URI uri, InputStream is,
+                             SSLSession sslSession, BodyOutputStream os,
+                             Http2TestServerConnection conn, boolean pushAllowed) {
+            super(streamid, method, reqheaders, rspheadersBuilder, uri, is, sslSession, os, conn, pushAllowed);
+            this.conn = conn;
+        }
+        public void responseSent(String query) {
+            System.out.println("Server: response sent for " + query);
+            responseSentCB.accept(query);
+        }
+
+    }
+}

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -58,6 +58,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -240,6 +241,7 @@ public interface HttpServerAdapters {
         public abstract void close();
         public abstract InetSocketAddress getRemoteAddress();
         public abstract InetSocketAddress getLocalAddress();
+        public abstract String getConnectionKey();
         public void serverPush(URI uri, HttpHeaders headers, byte[] body) {
             ByteArrayInputStream bais = new ByteArrayInputStream(body);
             serverPush(uri, headers, bais);
@@ -254,7 +256,7 @@ public interface HttpServerAdapters {
             return new Http1TestExchange(exchange);
         }
         public static HttpTestExchange of(Http2TestExchange exchange) {
-            return new Http2TestExchangeImpl(exchange);
+            return new H2ExchangeImpl(exchange);
         }
 
         abstract void doFilter(Filter.Chain chain) throws IOException;
@@ -310,15 +312,21 @@ public interface HttpServerAdapters {
             public URI getRequestURI() { return exchange.getRequestURI(); }
             @Override
             public String getRequestMethod() { return exchange.getRequestMethod(); }
+
+            @Override
+            public String getConnectionKey() {
+                return exchange.getLocalAddress() + "->" + exchange.getRemoteAddress();
+            }
+
             @Override
             public String toString() {
                 return this.getClass().getSimpleName() + ": " + exchange.toString();
             }
         }
 
-        private static final class Http2TestExchangeImpl extends HttpTestExchange {
+        private static final class H2ExchangeImpl extends HttpTestExchange {
             private final Http2TestExchange exchange;
-            Http2TestExchangeImpl(Http2TestExchange exch) {
+            H2ExchangeImpl(Http2TestExchange exch) {
                 this.exchange = exch;
             }
             @Override
@@ -369,6 +377,11 @@ public interface HttpServerAdapters {
             @Override
             public InetSocketAddress getLocalAddress() {
                 return exchange.getLocalAddress();
+            }
+
+            @Override
+            public String getConnectionKey() {
+                return exchange.getConnectionKey();
             }
 
             @Override
@@ -716,6 +729,7 @@ public interface HttpServerAdapters {
         public abstract HttpTestContext addHandler(HttpTestHandler handler, String root);
         public abstract InetSocketAddress getAddress();
         public abstract Version getVersion();
+        public abstract void setRequestApprover(final Predicate<String> approver);
 
         public String serverAuthority() {
             InetSocketAddress address = getAddress();
@@ -864,6 +878,11 @@ public interface HttpServerAdapters {
                         impl.getAddress().getPort());
             }
             public Version getVersion() { return Version.HTTP_1_1; }
+
+            @Override
+            public void setRequestApprover(final Predicate<String> approver) {
+                throw new UnsupportedOperationException("not supported");
+            }
         }
 
         private static class Http1TestContext extends HttpTestContext {
@@ -915,6 +934,11 @@ public interface HttpServerAdapters {
                         impl.getAddress().getPort());
             }
             public Version getVersion() { return Version.HTTP_2; }
+
+            @Override
+            public void setRequestApprover(final Predicate<String> approver) {
+                this.impl.setRequestApprover(approver);
+            }
         }
 
         private static class Http2TestContext

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/BodyOutputStream.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/BodyOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package jdk.httpclient.test.lib.http2;
 
 import java.io.*;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import jdk.internal.net.http.frame.DataFrame;
 import jdk.internal.net.http.frame.ResetFrame;
@@ -65,6 +66,10 @@ public class BodyOutputStream extends OutputStream {
         // first wait for the connection window
         conn.obtainConnectionWindow(demand);
         // now wait for the stream window
+        waitForStreamWindow(demand);
+    }
+
+    public void waitForStreamWindow(int demand) throws InterruptedException {
         synchronized (this) {
             while (demand > 0) {
                 int n = Math.min(demand, window);
@@ -83,6 +88,7 @@ public class BodyOutputStream extends OutputStream {
 
     @Override
     public void write(byte[] buf, int offset, int len) throws IOException {
+        Objects.checkFromIndexSize(offset, len, buf.length);
         if (closed) {
             throw new IOException("closed");
         }
@@ -101,6 +107,34 @@ public class BodyOutputStream extends OutputStream {
             }
         } catch (InterruptedException ex) {
             throw new IOException(ex);
+        }
+    }
+
+    /**
+     * This method pushes frames onto the stack without checking
+     * for flow control, allowing the sender to bypass flow
+     * control for testing purposes
+     * @param buf     data to send
+     * @param offset  offset at which the data starts
+     * @param len     length of the data to send
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeUncontrolled(byte[] buf, int offset, int len)
+            throws IOException {
+        Objects.checkFromIndexSize(offset, len, buf.length);
+        if (closed) {
+            throw new IOException("closed");
+        }
+
+        if (!goodToGo) {
+            throw new IllegalStateException("sendResponseHeaders must be called first");
+        }
+        int max = conn.getMaxFrameSize();
+        while (len > 0) {
+            int n = len > max ? max : len;
+            send(buf, offset, n, 0);
+            offset += n;
+            len -= n;
         }
     }
 

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchange.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,4 +84,10 @@ public interface Http2TestExchange {
      * It may also complete exceptionally
      */
     CompletableFuture<Long> sendPing();
+
+    /**
+     * {@return the identification of the connection on which this exchange is being
+     * processed}
+     */
+    String getConnectionKey();
 }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
@@ -227,6 +227,11 @@ public class Http2TestExchangeImpl implements Http2TestExchange {
         }
     }
 
+    @Override
+    public String getConnectionKey() {
+        return conn.connectionKey();
+    }
+
     private boolean isHeadRequest() {
         return HEAD.equalsIgnoreCase(getRequestMethod());
     }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+
 import javax.net.ServerSocketFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
@@ -59,6 +61,8 @@ public class Http2TestServer implements AutoCloseable {
     final Set<Http2TestServerConnection> connections;
     final Properties properties;
     final String name;
+    // request approver which takes the server connection key as the input
+    private volatile Predicate<String> newRequestApprover;
 
     private static ThreadFactory defaultThreadFac =
         (Runnable r) -> {
@@ -283,6 +287,14 @@ public class Http2TestServer implements AutoCloseable {
 
     public String serverName() {
         return serverName;
+    }
+
+    public void setRequestApprover(final Predicate<String> approver) {
+        this.newRequestApprover = approver;
+    }
+
+    Predicate<String> getRequestApprover() {
+        return this.newRequestApprover;
     }
 
     private synchronized void putConnection(InetSocketAddress addr, Http2TestServerConnection c) {

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -1374,7 +1374,7 @@ public class Http2TestServerConnection {
      *
      * @param amount
      */
-    synchronized void obtainConnectionWindow(int amount) throws InterruptedException {
+    public synchronized void obtainConnectionWindow(int amount) throws InterruptedException {
         while (amount > 0) {
             int n = Math.min(amount, sendWindow);
             amount -= n;
@@ -1384,9 +1384,13 @@ public class Http2TestServerConnection {
         }
     }
 
-    synchronized void updateConnectionWindow(int amount) {
-        sendWindow += amount;
-        notifyAll();
+    void updateConnectionWindow(int amount) {
+        System.out.printf("sendWindow (window=%s, amount=%s) is now: %s%n",
+                sendWindow, amount, sendWindow + amount);
+        synchronized (this) {
+            sendWindow += amount;
+            notifyAll();
+        }
     }
 
     // simplified output headers class. really just a type safe container

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -77,15 +77,20 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static jdk.internal.net.http.frame.ErrorFrame.REFUSED_STREAM;
 import static jdk.internal.net.http.frame.SettingsFrame.DEFAULT_MAX_FRAME_SIZE;
 import static jdk.internal.net.http.frame.SettingsFrame.HEADER_TABLE_SIZE;
 
@@ -115,6 +120,10 @@ public class Http2TestServerConnection {
     volatile boolean stopping;
     volatile int nextPushStreamId = 2;
     ConcurrentLinkedQueue<PingRequest> pings = new ConcurrentLinkedQueue<>();
+    // the max stream id of a processed H2 request. -1 implies none were processed.
+    private final AtomicInteger maxProcessedRequestStreamId = new AtomicInteger(-1);
+    // the stream id that was sent in a GOAWAY frame. -1 implies no GOAWAY frame was sent.
+    private final AtomicInteger goAwayRequestStreamId = new AtomicInteger(-1);
 
     final static ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
     final static byte[] EMPTY_BARRAY = new byte[0];
@@ -239,11 +248,29 @@ public class Http2TestServerConnection {
         return ping.response();
     }
 
-    void goAway(int error) throws IOException {
-        int laststream = nextstream >= 3 ? nextstream - 2 : 1;
-
-        GoAwayFrame go = new GoAwayFrame(laststream, error);
-        outputQ.put(go);
+    private void sendGoAway(final int error) throws IOException {
+        int maxProcessedStreamId = maxProcessedRequestStreamId.get();
+        if (maxProcessedStreamId == -1) {
+            maxProcessedStreamId = 0;
+        }
+        boolean send = false;
+        int currentGoAwayReqStrmId = goAwayRequestStreamId.get();
+        // update the last processed stream id and send a goaway frame if the new last processed
+        // stream id is lesser than the last processed stream id sent in
+        // a previous goaway frame (if any)
+        while (currentGoAwayReqStrmId == -1 || maxProcessedStreamId < currentGoAwayReqStrmId) {
+            if (goAwayRequestStreamId.compareAndSet(currentGoAwayReqStrmId, maxProcessedStreamId)) {
+                send = true;
+                break;
+            }
+            currentGoAwayReqStrmId = goAwayRequestStreamId.get();
+        }
+        if (!send) {
+            return;
+        }
+        final GoAwayFrame frame = new GoAwayFrame(maxProcessedStreamId, error);
+        outputQ.put(frame);
+        System.err.println("Sending GOAWAY frame " + frame + " from server connection " + this);
     }
 
     /**
@@ -336,8 +363,9 @@ public class Http2TestServerConnection {
             q.orderlyClose();
         });
         try {
-            if (error != -1)
-                goAway(error);
+            if (error != -1) {
+                sendGoAway(error);
+            }
             outputQ.orderlyClose();
             socket.close();
         } catch (Exception e) {
@@ -619,6 +647,14 @@ public class Http2TestServerConnection {
             path = path + "?" + uri.getRawQuery();
         headersBuilder.setHeader(":path", path);
 
+        // skip processing the request if configured to do so
+        final String connKey = connectionKey();
+        if (!shouldProcessNewHTTPRequest(connKey)) {
+            System.err.println("Rejecting primordial stream 1 and sending GOAWAY" +
+                    " on server connection " + connKey + ", for request: " + path);
+            sendGoAway(ErrorFrame.NO_ERROR);
+            return;
+        }
         Queue q = new Queue(sentinel);
         byte[] body = getRequestBody(request);
         addHeaders(getHeaders(request.headers), headersBuilder);
@@ -627,9 +663,22 @@ public class Http2TestServerConnection {
 
         addRequestBodyToQueue(body, q);
         streams.put(1, q);
+        maxProcessedRequestStreamId.set(1);
         exec.submit(() -> {
             handleRequest(headers, q, 1, true /*complete request has been read*/);
         });
+    }
+
+    private boolean shouldProcessNewHTTPRequest(final String serverConnKey) {
+        final Predicate<String> approver = this.server.getRequestApprover();
+        if (approver == null) {
+            return true; // process the request
+        }
+        return approver.test(serverConnKey);
+    }
+
+    final String connectionKey() {
+        return this.server.getAddress() + "->" + this.socket.getRemoteSocketAddress();
     }
 
     // all other streams created here
@@ -639,7 +688,7 @@ public class Http2TestServerConnection {
         frames.add(frame);
         int streamid = frame.streamid();
         if (streamid != nextstream) {
-            throw new IOException("unexpected stream id");
+            throw new IOException("unexpected stream id: " + streamid);
         }
         nextstream += 2;
 
@@ -670,12 +719,30 @@ public class Http2TestServerConnection {
             throw new IOException("Unexpected Upgrade in headers:" + headers);
         }
         disallowedHeader = headers.firstValue("HTTP2-Settings");
-        if (disallowedHeader.isPresent())
+        if (disallowedHeader.isPresent()) {
             throw new IOException("Unexpected HTTP2-Settings in headers:" + headers);
+        }
 
-
+        // skip processing the request if the server is configured to do so
+        final String connKey = connectionKey();
+        final String path = headers.firstValue(":path").orElse("");
+        if (!shouldProcessNewHTTPRequest(connKey)) {
+            System.err.println("Rejecting stream " + streamid
+                    + " and sending GOAWAY on server connection "
+                    + connKey + ", for request: " + path);
+            sendGoAway(ErrorFrame.NO_ERROR);
+            return;
+        }
         Queue q = new Queue(sentinel);
         streams.put(streamid, q);
+        // keep track of the largest request id that we have processed
+        int currentLargest = maxProcessedRequestStreamId.get();
+        while (streamid > currentLargest) {
+            if (maxProcessedRequestStreamId.compareAndSet(currentLargest, streamid)) {
+                break;
+            }
+            currentLargest = maxProcessedRequestStreamId.get();
+        }
         exec.submit(() -> {
             handleRequest(headers, q, streamid, endStreamReceived);
         });
@@ -778,6 +845,8 @@ public class Http2TestServerConnection {
             while (!stopping) {
                 Http2Frame frame = readFrameImpl();
                 if (frame == null) {
+                    System.err.println("EOF reached on connection " + connectionKey()
+                            + ", will no longer accept incoming frames");
                     closeIncoming();
                     return;
                 }
@@ -801,6 +870,17 @@ public class Http2TestServerConnection {
                             // TODO: close connection
                             continue;
                         } else {
+                            final int streamId = frame.streamid();
+                            final int finalProcessedStreamId = goAwayRequestStreamId.get();
+                            // if we already sent a goaway, then don't create new streams with
+                            // higher stream ids.
+                            if (finalProcessedStreamId != -1 && streamId > finalProcessedStreamId) {
+                                System.err.println(connectionKey() + " resetting stream " + streamId
+                                        + " as REFUSED_STREAM");
+                                final ResetFrame rst = new ResetFrame(streamId, REFUSED_STREAM);
+                                outputQ.put(rst);
+                                continue;
+                            }
                             createStream((HeadersFrame) frame);
                         }
                     } else {

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -82,7 +82,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiPredicate;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;


### PR DESCRIPTION
Please review the backport of JDK-8342075

Almost clean backport except for the import section of src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java

All jtreg tests for java.net.httpclient are passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8342075](https://bugs.openjdk.org/browse/JDK-8342075) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 21.0.7 to be approved (needs to be created)

### Integration blocker
&nbsp;⚠️ Dependency #1426 must be integrated first

### Issue
 * [JDK-8342075](https://bugs.openjdk.org/browse/JDK-8342075): HttpClient: improve HTTP/2 flow control checks (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1427/head:pull/1427` \
`$ git checkout pull/1427`

Update a local copy of the PR: \
`$ git checkout pull/1427` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1427`

View PR using the GUI difftool: \
`$ git pr show -t 1427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1427.diff">https://git.openjdk.org/jdk21u-dev/pull/1427.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1427#issuecomment-2673156787)
</details>
