### PR TITLE
8279016: JFR Leak Profiler is broken with Shenandoah

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -848,6 +848,10 @@ define SetupRunJtregTestBody
     endif
   endif
 
+  ifneq ($$(findstring -XX:+UseShenandoahGC, $$(JTREG_ALL_OPTIONS)), )
+    JTREG_AUTO_PROBLEM_LISTS += ProblemList-shenandoah.txt
+  endif
+
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \

--- a/src/hotspot/share/jfr/leakprofiler/leakProfiler.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/leakProfiler.hpp
@@ -35,6 +35,7 @@ class LeakProfiler : public AllStatic {
   static bool start(int sample_count);
   static bool stop();
   static bool is_running();
+  static bool is_supported();
 
   static void emit_events(int64_t cutoff_ticks, bool emit_all, bool skip_bfs);
   static void sample(HeapWord* object, size_t size, JavaThread* thread);

--- a/test/jdk/ProblemList-shenandoah.txt
+++ b/test/jdk/ProblemList-shenandoah.txt
@@ -1,0 +1,60 @@
+#
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#############################################################################
+#
+# List of quarantined tests for testing with Shenandoah.
+#
+#############################################################################
+
+# Quiet all LeakProfiler tests
+
+jdk/jfr/api/consumer/TestRecordingFileWrite.java        8342951     generic-all
+jdk/jfr/event/oldobject/TestAllocationTime.java         8342951     generic-all
+jdk/jfr/event/oldobject/TestArrayInformation.java       8342951     generic-all
+jdk/jfr/event/oldobject/TestCircularReference.java      8342951     generic-all
+jdk/jfr/event/oldobject/TestClassLoaderLeak.java        8342951     generic-all
+jdk/jfr/event/oldobject/TestFieldInformation.java       8342951     generic-all
+jdk/jfr/event/oldobject/TestG1.java                     8342951     generic-all
+jdk/jfr/event/oldobject/TestHeapDeep.java               8342951     generic-all
+jdk/jfr/event/oldobject/TestHeapShallow.java            8342951     generic-all
+jdk/jfr/event/oldobject/TestLargeRootSet.java           8342951     generic-all
+jdk/jfr/event/oldobject/TestLastKnownHeapUsage.java     8342951     generic-all
+jdk/jfr/event/oldobject/TestListenerLeak.java           8342951     generic-all
+jdk/jfr/event/oldobject/TestMetadataRetention.java      8342951     generic-all
+jdk/jfr/event/oldobject/TestObjectAge.java              8342951     generic-all
+jdk/jfr/event/oldobject/TestObjectDescription.java      8342951     generic-all
+jdk/jfr/event/oldobject/TestObjectSize.java             8342951     generic-all
+jdk/jfr/event/oldobject/TestParallel.java               8342951     generic-all
+jdk/jfr/event/oldobject/TestReferenceChainLimit.java    8342951     generic-all
+jdk/jfr/event/oldobject/TestSanityDefault.java          8342951     generic-all
+jdk/jfr/event/oldobject/TestSerial.java                 8342951     generic-all
+jdk/jfr/event/oldobject/TestShenandoah.java             8342951     generic-all
+jdk/jfr/event/oldobject/TestThreadLocalLeak.java        8342951     generic-all
+jdk/jfr/event/oldobject/TestZ.java                      8342951     generic-all
+jdk/jfr/jcmd/TestJcmdDump.java                          8342951     generic-all
+jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java             8342951     generic-all
+jdk/jfr/jcmd/TestJcmdStartPathToGCRoots.java            8342951     generic-all
+jdk/jfr/jvm/TestWaste.java                              8342951     generic-all
+jdk/jfr/startupargs/TestOldObjectQueueSize.java         8342951     generic-all
+

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -752,6 +752,7 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 # jdk_jfr
 
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-all
+jdk/jfr/event/oldobject/TestShenandoah.java                     8342951 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64


### PR DESCRIPTION
Plugs the bug opportunity with Shenandoah and JFR. Both changes apply cleanly, and both are need at the same time to keep the tests clean.

Additional testing:
 - [x] MacOS AArch64 fastdebug, `jdk_jfr`
 - [x] MacOS AArch64 fastdebug, `jdk_jfr` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8279016](https://bugs.openjdk.org/browse/JDK-8279016) needs maintainer approval
- [x] [JDK-8343754](https://bugs.openjdk.org/browse/JDK-8343754) needs maintainer approval

### Issues
 * [JDK-8279016](https://bugs.openjdk.org/browse/JDK-8279016): JFR Leak Profiler is broken with Shenandoah (**Enhancement** - P3 - Approved)
 * [JDK-8343754](https://bugs.openjdk.org/browse/JDK-8343754): Problemlist jdk/jfr/event/oldobject/TestShenandoah.java after JDK-8279016 (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1439/head:pull/1439` \
`$ git checkout pull/1439`

Update a local copy of the PR: \
`$ git checkout pull/1439` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1439`

View PR using the GUI difftool: \
`$ git pr show -t 1439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1439.diff">https://git.openjdk.org/jdk21u-dev/pull/1439.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1439#issuecomment-2688423850)
</details>
