### PR TITLE
8349200: [JMH] time.format.ZonedDateTimeFormatterBenchmark fails

### DIFF
--- a/test/micro/org/openjdk/bench/java/time/format/ZonedDateTimeFormatterBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/time/format/ZonedDateTimeFormatterBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class ZonedDateTimeFormatterBenchmark {
     private static final DateTimeFormatter df = new DateTimeFormatterBuilder()
             .appendPattern("yyyy:MM:dd:HH:mm:v")
             .toFormatter();
-    private static final String TEXT = "2015:03:10:12:13:ECT";
+    private static final String TEXT = "2015:03:10:12:13:PST";
 
     @Setup
     public void setUp() {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a51e6699](https://github.com/openjdk/jdk/commit/a51e6699b497564de65620a36dc38437ca87cb32) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 5 Feb 2025 and was reviewed by Naoto Sato and Justin Lu.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8349200](https://bugs.openjdk.org/browse/JDK-8349200) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349200](https://bugs.openjdk.org/browse/JDK-8349200): [JMH] time.format.ZonedDateTimeFormatterBenchmark fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1441/head:pull/1441` \
`$ git checkout pull/1441`

Update a local copy of the PR: \
`$ git checkout pull/1441` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1441`

View PR using the GUI difftool: \
`$ git pr show -t 1441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1441.diff">https://git.openjdk.org/jdk21u-dev/pull/1441.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1441#issuecomment-2691919227)
</details>
