### PR TITLE
8347629: Test FailOverDirectExecutionControlTest.java fails with -Xcomp

### DIFF
--- a/test/langtools/jdk/jshell/FailOverDirectExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/FailOverDirectExecutionControlTest.java
@@ -62,6 +62,7 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
 
     ClassLoader ccl;
     ExecutionControlProvider provider;
+    Logger logger;
     LogTestHandler hndlr;
     Map<Level, List<String>> logged;
 
@@ -95,7 +96,7 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
     @BeforeMethod
     @Override
     public void setUp() {
-        Logger logger = Logger.getLogger("jdk.jshell.execution");
+        logger = Logger.getLogger("jdk.jshell.execution");
         logger.setLevel(Level.ALL);
         hndlr = new LogTestHandler();
         logger.addHandler(hndlr);
@@ -137,8 +138,8 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
     @Override
     public void tearDown() {
         super.tearDown();
-        Logger logger = Logger.getLogger("jdk.jshell.execution");
         logger.removeHandler(hndlr);
+        logger = null;
         Thread.currentThread().setContextClassLoader(ccl);
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [981d3c2b](https://github.com/openjdk/jdk24u/commit/981d3c2b6edb8ee8233be07cd1ce682200019d1f) from the jdk24u [openjdk/jdk24u](https://git.openjdk.org/jdk24u) repository to jdk21u-dev repository.

The commit being backported was authored by SendaoYan on 1 Mar 2025.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8347629](https://bugs.openjdk.org/browse/JDK-8347629) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347629](https://bugs.openjdk.org/browse/JDK-8347629): Test FailOverDirectExecutionControlTest.java fails with -Xcomp (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1442/head:pull/1442` \
`$ git checkout pull/1442`

Update a local copy of the PR: \
`$ git checkout pull/1442` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1442`

View PR using the GUI difftool: \
`$ git pr show -t 1442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1442.diff">https://git.openjdk.org/jdk21u-dev/pull/1442.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1442#issuecomment-2691919827)
</details>
