### PR TITLE
8314840: 3 gc/epsilon tests ignore external vm options

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,13 +37,13 @@ import jdk.test.lib.process.ProcessTools;
 public class TestDieDefault {
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldContain("OutOfMemoryError");
     if (out.getExitValue() == 0) {
       throw new IllegalStateException("Should have failed with non-zero exit code");

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,13 @@ import jdk.test.lib.process.ProcessTools;
 public class TestDieWithHeapDump {
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(args);
+    ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(args);
     Process p = pb.start();
     OutputAnalyzer out = new OutputAnalyzer(p);
     out.shouldContain("OutOfMemoryError");

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,14 @@ public class TestDieWithOnError {
   static String ON_ERR_MSG = "Epsilon error handler message";
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.stdoutShouldNotMatch("^" + ON_ERR_MSG);
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldContain("OutOfMemoryError");
     if (out.getExitValue() == 0) {
       throw new IllegalStateException("Should have failed with non-zero exit code");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [da8abdc0](https://github.com/openjdk/jdk24u/commit/da8abdc0bf98e8afc9d56ffe25a8fe83ed1531a5) from the jdk24u [openjdk/jdk24u](https://git.openjdk.org/jdk24u) repository to jdk21u-dev repository.

The commit being backported was authored by SendaoYan on 1 Mar 2025.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314840](https://bugs.openjdk.org/browse/JDK-8314840) needs maintainer approval

### Issue
 * [JDK-8314840](https://bugs.openjdk.org/browse/JDK-8314840): 3 gc/epsilon tests ignore external vm options (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1443/head:pull/1443` \
`$ git checkout pull/1443`

Update a local copy of the PR: \
`$ git checkout pull/1443` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1443`

View PR using the GUI difftool: \
`$ git pr show -t 1443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1443.diff">https://git.openjdk.org/jdk21u-dev/pull/1443.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1443#issuecomment-2691920372)
</details>
