### PR TITLE
8276995: Bug in jdk.jfr.event.gc.collection.TestSystemGC

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/collection/TestSystemGC.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestSystemGC.java
@@ -68,12 +68,12 @@ public class TestSystemGC {
             RecordedEvent event2 = events.get(1);
             Events.assertFrame(event2, Runtime.class, "gc");
             Events.assertEventThread(event2, Thread.currentThread());
-            Events.assertField(event1, "invokedConcurrent").isEqual(concurrent);
+            Events.assertField(event2, "invokedConcurrent").isEqual(concurrent);
 
             RecordedEvent event3 = events.get(2);
             // MemoryMXBean.class is an interface so can't assertFrame on it
             Events.assertEventThread(event3, Thread.currentThread());
-            Events.assertField(event1, "invokedConcurrent").isEqual(concurrent);
+            Events.assertField(event3, "invokedConcurrent").isEqual(concurrent);
         }
      }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e80b76b6](https://github.com/openjdk/jdk/commit/e80b76b663c6b82a353665fd68819cc9295ec429) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Robert Toyonaga on 27 Feb 2025 and was reviewed by Erik Gahlin and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276995](https://bugs.openjdk.org/browse/JDK-8276995) needs maintainer approval

### Issue
 * [JDK-8276995](https://bugs.openjdk.org/browse/JDK-8276995): Bug in jdk.jfr.event.gc.collection.TestSystemGC (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1444/head:pull/1444` \
`$ git checkout pull/1444`

Update a local copy of the PR: \
`$ git checkout pull/1444` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1444`

View PR using the GUI difftool: \
`$ git pr show -t 1444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1444.diff">https://git.openjdk.org/jdk21u-dev/pull/1444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1444#issuecomment-2696325807)
</details>
