### PR TITLE
8341170: Open source several Choice related tests (part 2)

### DIFF
--- a/test/jdk/java/awt/Choice/ChoiceDragEventsInside.java
+++ b/test/jdk/java/awt/Choice/ChoiceDragEventsInside.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6251983 6722236
+ * @summary MouseDragged events not triggered for Choice when dragging it with left mouse button
+ * @key headful
+ * @run main ChoiceDragEventsInside
+ */
+
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.lang.reflect.InvocationTargetException;
+
+public class ChoiceDragEventsInside extends Frame {
+    Robot robot;
+    Choice choice1;
+    Point pt;
+    Dimension size;
+    volatile boolean mouseDragged = false;
+    volatile boolean mouseDraggedOutside = false;
+
+    public void setupUI() {
+        setTitle("Choce Drag Events Inside");
+        choice1 = new Choice();
+        for (int i = 1; i < 50; i++) {
+            choice1.add("item-0" + i);
+        }
+        choice1.setForeground(Color.red);
+        choice1.setBackground(Color.red);
+        choice1.addMouseMotionListener(new MouseMotionAdapter() {
+                public void mouseMoved(MouseEvent me) {
+                    System.out.println(me);
+                }
+
+                public void mouseDragged(MouseEvent me) {
+                    System.out.println(me);
+                    mouseDragged = true;
+                    if (me.getY() < 0) {
+                        mouseDraggedOutside = true;
+                    }
+                }
+            }
+        );
+        add(choice1);
+        setLayout(new FlowLayout());
+        setSize(200, 200);
+        setLocationRelativeTo(null);
+        setVisible(true);
+        validate();
+    }
+
+    public void start() {
+        try {
+            robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+            robot.delay(100);
+            EventQueue.invokeAndWait(() -> {
+                pt = choice1.getLocationOnScreen();
+                size = choice1.getSize();
+            });
+            testDragInsideChoice(InputEvent.BUTTON1_MASK);
+            testDragInsideChoiceList(InputEvent.BUTTON1_MASK);
+            testDragOutsideChoice(InputEvent.BUTTON1_MASK);
+        } catch (Throwable e) {
+            throw new RuntimeException("Test failed. Exception thrown: " + e);
+        }
+    }
+
+    public void testDragInsideChoice(int button) {
+        robot.mouseMove(pt.x + size.width / 2, pt.y + size.height / 2);
+        robot.delay(100);
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+        robot.delay(200);
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+        robot.delay(200);
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+
+        robot.mouseMove(pt.x + size.width / 4, pt.y + size.height / 2);
+        robot.mousePress(button);
+
+        dragMouse(pt.x + size.width / 4, pt.y + size.height / 2,
+                pt.x + size.width * 3 / 4, pt.y + size.height / 2);
+        robot.mouseRelease(button);
+        robot.delay(200);
+        if (!mouseDragged) {
+            throw new RuntimeException("Test failed. Choice should generate MouseDragged events inside Choice itself");
+        } else {
+            System.out.println("Stage 1 passed. Choice generates MouseDragged events inside Choice itself");
+        }
+        mouseDragged = false;
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+    }
+
+    public void testDragInsideChoiceList(int button) {
+        robot.mouseMove(pt.x + size.width / 2, pt.y + size.height / 2);
+        robot.delay(100);
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+        robot.delay(200);
+
+        robot.mouseMove(pt.x + size.width / 2, pt.y + 5 * size.height);
+        robot.delay(200);
+        robot.mousePress(button);
+
+        dragMouse(pt.x + size.width / 2, pt.y + 5 * size.height,
+                pt.x + size.width / 2, pt.y + 8 * size.height);
+        robot.mouseRelease(button);
+        robot.delay(200);
+        if (mouseDragged) {
+            throw new RuntimeException("Test failed. Choice shouldn't generate MouseDragged events inside Choice's list");
+        } else {
+            System.out.println("Stage 2 passed. Choice doesn't generate MouseDragged events inside Choice's list");
+        }
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+        mouseDragged = false;
+    }
+
+    public void testDragOutsideChoice(int button) {
+        pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + size.width / 2, pt.y + size.height / 2);
+        robot.delay(100);
+
+        robot.mousePress(button);
+        //drag mouse outside of Choice
+        dragMouse(pt.x + size.width / 2, pt.y + size.height / 2,
+                pt.x + size.width / 2, pt.y - 3 * size.height);
+        robot.mouseRelease(button);
+        robot.delay(200);
+        if (!mouseDragged || !mouseDraggedOutside) {
+            throw new RuntimeException("Test failed. Choice should generate MouseDragged events outside Choice");
+        } else {
+            System.out.println("Stage 3 passed. Choice generates MouseDragged events outside Choice");
+        }
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+        mouseDragged = false;
+    }
+
+    public void dragMouse(int x0, int y0, int x1, int y1) {
+        int curX = x0;
+        int curY = y0;
+        int dx = x0 < x1 ? 1 : -1;
+        int dy = y0 < y1 ? 1 : -1;
+
+        while (curX != x1) {
+            curX += dx;
+            robot.mouseMove(curX, curY);
+        }
+        while (curY != y1) {
+            curY += dy;
+            robot.mouseMove(curX, curY);
+        }
+    }
+
+    public static void main(final String[] args) throws InterruptedException,
+            InvocationTargetException {
+        ChoiceDragEventsInside app = new ChoiceDragEventsInside();
+        try {
+            EventQueue.invokeAndWait(app::setupUI);
+            app.start();
+        } finally {
+            EventQueue.invokeAndWait(app::dispose);
+        }
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceMouseEventTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceMouseEventTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4319246
+ * @summary Tests that MouseReleased, MouseClicked and MouseDragged are triggered on choice
+ * @key headful
+ * @run main ChoiceMouseEventTest
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.lang.reflect.InvocationTargetException;
+
+
+public class ChoiceMouseEventTest extends Frame {
+    static volatile boolean mousePressed = false;
+    static volatile boolean mouseReleased = false;
+    static volatile boolean mouseClicked = false;
+    Choice choice = new Choice();
+    static Point location;
+    static Dimension size;
+
+    public void setupGUI() {
+        setTitle("Choice Mouse Event Test");
+        this.setLayout(new BorderLayout());
+        choice.add("item-1");
+        choice.add("item-2");
+        choice.add("item-3");
+        choice.add("item-4");
+        add("Center", choice);
+        choice.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                mouseClicked = true;
+            }
+
+            @Override
+            public void mousePressed(MouseEvent e) {
+                mousePressed = true;
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                mouseReleased = true;
+            }
+        });
+        setLocationRelativeTo(null);
+        setSize(400, 200);
+        setVisible(true);
+    }
+
+    public Point _location() {
+        return choice.getLocationOnScreen();
+    }
+
+    public Dimension _size() {
+        return choice.getSize();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        ChoiceMouseEventTest test = new ChoiceMouseEventTest();
+        try {
+            EventQueue.invokeAndWait(test::setupGUI);
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+            robot.delay(1000);
+            robot.waitForIdle();
+            EventQueue.invokeAndWait(() -> {
+                location = test._location();
+                size = test._size();
+            });
+            robot.waitForIdle();
+            robot.mouseMove(location.x + size.width - 10, location.y + (size.height / 2));
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(2000);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(2000);
+            robot.waitForIdle();
+            if (!mouseClicked || !mousePressed || !mouseReleased) {
+                throw new RuntimeException(String.format("One of the events not arrived: " +
+                        "mouseClicked = %b, mousePressed = %b, mouseReleased = %b",
+                        mouseClicked, mousePressed, mouseReleased));
+            }
+        } finally {
+            if (test != null) {
+                EventQueue.invokeAndWait(test::dispose);
+            }
+        }
+    }
+}
+

--- a/test/jdk/java/awt/Choice/ChoiceRemoveTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceRemoveTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4079027
+ * @summary Removing an item dynamically from a Choice object breaks lower items.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ChoiceRemoveTest
+ */
+
+import java.awt.Choice;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.event.ItemEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.lang.reflect.InvocationTargetException;
+
+public class ChoiceRemoveTest extends Frame {
+    Choice selector;
+    static final String INSTRUCTIONS = """
+            After window 'Choice Remove Test' appears wait for three seconds
+            and then click on the choice. In popup there should be no
+            'Choice A' variant. Try selecting each variant with mouse
+            and verify by the log that the correct variant gets selected.
+            If after selecting item in the list the correct item gets selected
+            and correct item name appears in the log press Pass otherwise press Fail.
+            """;
+
+    public static void main(String[] argv) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .testUI(ChoiceRemoveTest::new)
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    public ChoiceRemoveTest() {
+        super("Choice Remove Test");
+        Panel p;
+        Label prompt;
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowOpened(WindowEvent e) {
+                super.windowOpened(e);
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(2000);
+                    } catch (InterruptedException ignore) {
+                    }
+                    removeFirst();
+                }).start();
+            }
+        });
+
+        setLayout(new GridLayout());
+        p = new Panel();
+
+        prompt = new Label("Select different items including the last one");
+        p.add(prompt);
+
+        selector = new Choice();
+        selector.add("Choice A");
+        selector.add("Choice B");
+        selector.add("Choice C");
+        selector.add("Choice D");
+        selector.add("Choice E");
+        selector.addItemListener(e -> {
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+                Object selected = e.getItem();
+                PassFailJFrame.log(selected.toString());
+            }
+        });
+        p.add(selector);
+        add(p);
+        pack();
+    }
+
+    public void removeFirst() {
+        selector.remove("Choice A");
+    }
+}

--- a/test/jdk/java/awt/Choice/PopupMenuOnChoiceArea.java
+++ b/test/jdk/java/awt/Choice/PopupMenuOnChoiceArea.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6240046
+ * @summary REG:Choice's Drop-down does not disappear when clicking somewhere, after popup menu is disposed-XTkt
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PopupMenuOnChoiceArea
+ */
+
+
+import java.awt.CheckboxMenuItem;
+import java.awt.Choice;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.PopupMenu;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.lang.reflect.InvocationTargetException;
+
+public class PopupMenuOnChoiceArea extends Frame {
+    static final String INSTRUCTIONS = """
+            You would see a window named 'Popup menu on choice area'
+            with Choice in it. Move the mouse pointer to the choice.
+            Click right mouse button on it.
+            You should see a popup menu with 'File' in it.
+            Close this popup menu by pressing Esc.
+            Click the left mouse button on the Choice.
+            You should see a Choice drop-down menu.
+            Move mouse pointer into drop-down menu.
+            Click right mouse button on any item in it.
+            If you see a 'File' popup menu press Fail.
+            If Choice drop-down closes instead press Pass.
+            """;
+
+    public PopupMenuOnChoiceArea() {
+        super("Popup menu on choice area");
+        this.setLayout(new FlowLayout());
+        Choice choice = new Choice();
+        choice.add("item-1");
+        choice.add("item-2");
+        choice.add("item-3");
+        choice.add("item-4");
+        add("Center", choice);
+        Menu fileMenu = new Menu("File");
+        Menu open = new Menu("Open");
+        Menu save = new Menu("save");
+        CheckboxMenuItem exit = new CheckboxMenuItem("Exit");
+        fileMenu.add(open);
+        fileMenu.add(save);
+        fileMenu.add(exit);
+        final PopupMenu pop = new PopupMenu();
+        pop.setLabel("This is a popup menu");
+        pop.setName("a menu");
+        pop.add(fileMenu);
+        choice.add(pop);
+        choice.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent me) {
+                if (me.isPopupTrigger()) {
+                    pop.show(me.getComponent(), me.getX(), me.getY());
+                }
+            }
+
+            public void mouseReleased(MouseEvent me) {
+                if (me.isPopupTrigger()) {
+                    pop.show(me.getComponent(), me.getX(), me.getY());
+                }
+            }
+        });
+        setSize(200, 200);
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .testUI(PopupMenuOnChoiceArea::new)
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/Choice/ScrollbarFlickers.java
+++ b/test/jdk/java/awt/Choice/ScrollbarFlickers.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6405707
+ * @summary Choice popup & scrollbar gets Flickering when mouse is pressed & drag on the scrollbar
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollbarFlickers
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Frame;
+import java.lang.reflect.InvocationTargetException;
+
+public class ScrollbarFlickers extends Frame {
+    static final String INSTRUCTIONS = """
+            Open the choice popup. Select any item in it and
+            drag it with the mouse above or below the choice.
+            Keep the choice opened.
+            Continue dragging the mouse outside of the choice
+            making content of the popup scroll.
+            If you see that scrollbar flickers press Fail.
+            Otherwise press Pass.
+            """;
+
+    public ScrollbarFlickers() {
+        super("Scrollbar Flickering Test");
+        Choice ch = new Choice();
+        setLayout(new BorderLayout());
+        ch.add("Praveen");
+        ch.add("Mohan");
+        ch.add("Rakesh");
+        ch.add("Menon");
+        ch.add("Girish");
+        ch.add("Ramachandran");
+        ch.add("Elancheran");
+        ch.add("Subramanian");
+        ch.add("Raju");
+        ch.add("Pallath");
+        ch.add("Mayank");
+        ch.add("Joshi");
+        ch.add("Sundar");
+        ch.add("Srinivas");
+        ch.add("Mandalika");
+        ch.add("Suresh");
+        ch.add("Chandar");
+        add(ch);
+        setSize(200, 200);
+        validate();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .testUI(ScrollbarFlickers::new)
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341170](https://bugs.openjdk.org/browse/JDK-8341170) needs maintainer approval

### Issue
 * [JDK-8341170](https://bugs.openjdk.org/browse/JDK-8341170): Open source several Choice related tests (part 2) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1447/head:pull/1447` \
`$ git checkout pull/1447`

Update a local copy of the PR: \
`$ git checkout pull/1447` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1447`

View PR using the GUI difftool: \
`$ git pr show -t 1447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1447.diff">https://git.openjdk.org/jdk21u-dev/pull/1447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1447#issuecomment-2698423405)
</details>
