### PR TITLE
Backport dff5719e6f95f9ce50a5d49adf13541e22f7b5b1

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressG1Uncommit.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Uncommit.java
@@ -57,6 +57,7 @@ public class TestStressG1Uncommit {
         Collections.addAll(options,
             "-Xlog:gc,gc+heap+region=debug",
             "-XX:+UseG1GC",
+            "-Xmx1g",
             StressUncommit.class.getName()
         );
         OutputAnalyzer output = ProcessTools.executeLimitedTestJava(options);
@@ -79,9 +80,9 @@ class StressUncommit {
         // Leave 20% head room to try to avoid Full GCs.
         long allocationSize = (long) (Runtime.getRuntime().maxMemory() * 0.8);
 
-        // Figure out suitable number of workers (~1 per gig).
-        int gigsOfAllocation = (int) Math.ceil((double) allocationSize / G);
-        int numWorkers = Math.min(gigsOfAllocation, Runtime.getRuntime().availableProcessors());
+        // Figure out suitable number of workers (~1 per 100M).
+        int allocationChunks = (int) Math.ceil((double) allocationSize / (100 * M));
+        int numWorkers = Math.min(allocationChunks, Runtime.getRuntime().availableProcessors());
         long workerAllocation = allocationSize / numWorkers;
 
         log("Using " + numWorkers + " workers, each allocating: ~" + (workerAllocation / M) + "M");


### PR DESCRIPTION
Backporting JDK-8347126: gc/stress/TestStressG1Uncommit.java gets OOM-killed. Minor change that reduces the memory usage in the gc/stress/TestStressG1Uncommit.java test. Ran GHA Sanity Checks, local Tier 1 and Tier 2 tests, and `gc/stress/TestStressG1Uncommit.java`. Patch is clean.