### PR TITLE
8346264: "Total compile time" counter should include time spent in failing/bailout compiles

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2501,6 +2501,11 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
   // C1 and C2 counters are counting both successful and unsuccessful compiles
   _t_total_compilation.add(time);
 
+  // Update compilation times. Used by the implementation of JFR CompilerStatistics
+  // and java.lang.management.CompilationMXBean.
+  _perf_total_compilation->inc(time.ticks());
+  _peak_compilation_time = MAX2(time.milliseconds(), _peak_compilation_time);
+
   if (!success) {
     _total_bailout_count++;
     if (UsePerfData) {
@@ -2519,12 +2524,6 @@ void CompileBroker::collect_statistics(CompilerThread* thread, elapsedTimer time
     _t_invalidated_compilation.add(time);
   } else {
     // Compilation succeeded
-
-    // update compilation ticks - used by the implementation of
-    // java.lang.management.CompilationMXBean
-    _perf_total_compilation->inc(time.ticks());
-    _peak_compilation_time = time.milliseconds() > _peak_compilation_time ? time.milliseconds() : _peak_compilation_time;
-
     if (CITime) {
       int bytes_compiled = method->code_size() + task->num_inlined_bytecodes();
       if (is_osr) {


### PR DESCRIPTION
Backporting JDK-8346264: "Total compile time" counter should include time spent in failing/bailout compiles. Adjusting compilation time to include failed compilations. Ran GHA Sanity Checks, local Tier 1 and Tier 2 tests, and `jdk/jfr` and `java/lang/management` explicitly. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346264](https://bugs.openjdk.org/browse/JDK-8346264) needs maintainer approval

### Issue
 * [JDK-8346264](https://bugs.openjdk.org/browse/JDK-8346264): "Total compile time" counter should include time spent in failing/bailout compiles (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1457/head:pull/1457` \
`$ git checkout pull/1457`

Update a local copy of the PR: \
`$ git checkout pull/1457` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1457`

View PR using the GUI difftool: \
`$ git pr show -t 1457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1457.diff">https://git.openjdk.org/jdk21u-dev/pull/1457.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1457#issuecomment-2705204295)
</details>
