### PR TITLE
8351500: JVM crashes after task being moved to different NUMA node

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.hpp
@@ -88,9 +88,6 @@ private:
                                    size_t desired_word_size,
                                    size_t* actual_word_size);
 
-  // Node index of current thread.
-  inline uint current_node_index() const;
-
 public:
   G1Allocator(G1CollectedHeap* heap);
   ~G1Allocator();
@@ -115,13 +112,15 @@ public:
   // Attempt allocation in the current alloc region.
   inline HeapWord* attempt_allocation(size_t min_word_size,
                                       size_t desired_word_size,
-                                      size_t* actual_word_size);
+                                      size_t* actual_word_size,
+                                      uint node_index
+                                      );
 
   // This is to be called when holding an appropriate lock. It first tries in the
   // current allocation region, and then attempts an allocation using a new region.
-  inline HeapWord* attempt_allocation_locked(size_t word_size);
+  inline HeapWord* attempt_allocation_locked(size_t word_size, uint node_index);
 
-  inline HeapWord* attempt_allocation_force(size_t word_size);
+  inline HeapWord* attempt_allocation_force(size_t word_size, uint node_index);
 
   size_t unsafe_max_tlab_alloc();
   size_t used_in_alloc_regions();
@@ -139,6 +138,9 @@ public:
                                    size_t desired_word_size,
                                    size_t* actual_word_size,
                                    uint node_index);
+
+  // Node index of current thread.
+  inline uint current_node_index() const;
 };
 
 // Manages the PLABs used during garbage collection. Interface for allocation from PLABs.

--- a/src/hotspot/share/gc/g1/g1Allocator.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.inline.hpp
@@ -51,9 +51,8 @@ inline OldGCAllocRegion* G1Allocator::old_gc_alloc_region() {
 
 inline HeapWord* G1Allocator::attempt_allocation(size_t min_word_size,
                                                  size_t desired_word_size,
-                                                 size_t* actual_word_size) {
-  uint node_index = current_node_index();
-
+                                                 size_t* actual_word_size,
+                                                 uint node_index) {
   HeapWord* result = mutator_alloc_region(node_index)->attempt_retained_allocation(min_word_size, desired_word_size, actual_word_size);
   if (result != nullptr) {
     return result;
@@ -62,8 +61,7 @@ inline HeapWord* G1Allocator::attempt_allocation(size_t min_word_size,
   return mutator_alloc_region(node_index)->attempt_allocation(min_word_size, desired_word_size, actual_word_size);
 }
 
-inline HeapWord* G1Allocator::attempt_allocation_locked(size_t word_size) {
-  uint node_index = current_node_index();
+inline HeapWord* G1Allocator::attempt_allocation_locked(size_t word_size, uint node_index) {
   HeapWord* result = mutator_alloc_region(node_index)->attempt_allocation_locked(word_size);
 
   assert(result != nullptr || mutator_alloc_region(node_index)->get() == nullptr,
@@ -71,8 +69,7 @@ inline HeapWord* G1Allocator::attempt_allocation_locked(size_t word_size) {
   return result;
 }
 
-inline HeapWord* G1Allocator::attempt_allocation_force(size_t word_size) {
-  uint node_index = current_node_index();
+inline HeapWord* G1Allocator::attempt_allocation_force(size_t word_size, uint node_index) {
   return mutator_alloc_region(node_index)->attempt_allocation_force(word_size);
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -401,7 +401,7 @@ G1CollectedHeap::mem_allocate(size_t word_size,
   return attempt_allocation(word_size, word_size, &dummy);
 }
 
-HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
+HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size, uint node_index) {
   ResourceMark rm; // For retrieving the thread names in log messages.
 
   // Make sure you read the note in attempt_allocation_humongous().
@@ -427,7 +427,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
 
       // Now that we have the lock, we first retry the allocation in case another
       // thread changed the region while we were waiting to acquire the lock.
-      result = _allocator->attempt_allocation_locked(word_size);
+      result = _allocator->attempt_allocation_locked(word_size, node_index);
       if (result != nullptr) {
         return result;
       }
@@ -438,7 +438,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
       if (GCLocker::is_active_and_needs_gc() && policy()->can_expand_young_list()) {
         // No need for an ergo message here, can_expand_young_list() does this when
         // it returns true.
-        result = _allocator->attempt_allocation_force(word_size);
+        result = _allocator->attempt_allocation_force(word_size, node_index);
         if (result != nullptr) {
           return result;
         }
@@ -495,7 +495,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
     // follow-on attempt will be at the start of the next loop
     // iteration (after taking the Heap_lock).
     size_t dummy = 0;
-    result = _allocator->attempt_allocation(word_size, word_size, &dummy);
+    result = _allocator->attempt_allocation(word_size, word_size, &dummy, node_index);
     if (result != nullptr) {
       return result;
     }
@@ -636,11 +636,13 @@ inline HeapWord* G1CollectedHeap::attempt_allocation(size_t min_word_size,
   assert(!is_humongous(desired_word_size), "attempt_allocation() should not "
          "be called for humongous allocation requests");
 
-  HeapWord* result = _allocator->attempt_allocation(min_word_size, desired_word_size, actual_word_size);
+  const uint node_index = _allocator->current_node_index();
+
+  HeapWord* result = _allocator->attempt_allocation(min_word_size, desired_word_size, actual_word_size, node_index);
 
   if (result == nullptr) {
     *actual_word_size = desired_word_size;
-    result = attempt_allocation_slow(desired_word_size);
+    result = attempt_allocation_slow(desired_word_size, node_index);
   }
 
   assert_heap_not_locked();
@@ -778,8 +780,10 @@ HeapWord* G1CollectedHeap::attempt_allocation_at_safepoint(size_t word_size,
   assert(!_allocator->has_mutator_alloc_region() || !expect_null_mutator_alloc_region,
          "the current alloc region was unexpectedly found to be non-null");
 
+  const uint node_index = _allocator->current_node_index();
+
   if (!is_humongous(word_size)) {
-    return _allocator->attempt_allocation_locked(word_size);
+    return _allocator->attempt_allocation_locked(word_size, node_index);
   } else {
     HeapWord* result = humongous_obj_allocate(word_size);
     if (result != nullptr && policy()->need_to_start_conc_mark("STW humongous allocation")) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -453,7 +453,7 @@ private:
   // Second-level mutator allocation attempt: take the Heap_lock and
   // retry the allocation attempt, potentially scheduling a GC
   // pause. This should only be used for non-humongous allocations.
-  HeapWord* attempt_allocation_slow(size_t word_size);
+  HeapWord* attempt_allocation_slow(size_t word_size, uint node_index);
 
   // Takes the Heap_lock and attempts a humongous allocation. It can
   // potentially schedule a GC pause.


### PR DESCRIPTION
(work in progress; I am not sure whether to go with this one or whether to fix it in mainline (https://github.com/openjdk/jdk/pull/23984) first, even though the error is benign in mainline)

Please see JBS issue for more details.

The problem is in `G1Allocator` and its `G1AllocRegion` objects tied to NUMA nodes. We use these structures in GC control flows, and these control flows expect the identity of `G1AllocRegion` not to change over their duration. That cannot be guaranteed since a task may be scheduled to a different NUMA node at any time. That is quite rare, but it happens.

This particular error is in JDK 21 and JDK 17. In earlier (LTS) JDKs, G1 was not yet NUMA-aware. From JDK 22 on, we have G1 Region pinning, which accidentally "solved" this particular issue.

How things go wrong on JDK 21:

- Heap region full -> `G1CollectedHeap::attempt_allocation_slow` -> `G1Allocator::attempt_allocation_locked` -> `G1AllocRegion::attempt_allocation_locked` (for Mutator Alloc Region A) -> `G1AllocRegion::attempt_allocation_using_new_region`; here we retire the old worked HeapRegion for Mutator Alloc Region A, attempt to get a new HeapRegion (if policy allows expanding Eden) and to allocate from it.

- Failing that, we now enter `G1Allocator::attempt_allocation_force` -> `G1AllocRegion::attempt_allocation_force` (but we were scheduled on different NUMA node, so this is Mutator Alloc Region B) -> `G1AllocRegion::new_alloc_region_and_allocate`, where we allocate a new region.

Here, we fail to retire the old Eden region of Mutator Alloc Region B, abandoning it, failing to add it to the collection set. This later causes the described JVM crashes.

How things go wrong on JDK 17:

In JDK 17, `G1CollectedHeap::attempt_allocation_slow` calls first `G1Allocator::attempt_allocation` (A) under lock protection, which tries to allocate in the current HeapRegion. Failing that, it calls `G1Allocator::attempt_allocation_using_new_region` (B), which first retires the HeapRegion. If NUMA node association changes between (A) and (B), we may retire a HeapRegion that is almost empty. In that case, debug JVMs will assert since it detects that we fill the remainder space in the to-be-retired region with a surprisingly large waste object.

----

Reproduction and Regression testing

Reproducing the bug was challenging, since I did not have a NUMA machine. And even if I had one, NUMA task-node migrations are very rare. 

Therefore, I built something like a `-XX:+FakeNUMA` mode which essentially interposes OS NUMA calls and fakes a NUMA system of 8 nodes. I also added a `-XX:+FakeNUMAStressMigrations` mode mimicking very frequent node migrations. With these simple tools, I could reproduce the customer problem (with `gc/TestJNICriticalStressTest`, slightly modified to increase the number of JNICritical threads).

I also saw at least one reproducible crash in ParallelGC in `FakeNUMAStressMigrations` mode which I will open a separate JBS issue for.

Having a `FakeNUMA` mode in the libjvm would be worthwhile for cases like these tests. If others agree, I will polish the `FakeNUMA` patch and bring it upstream. 

----

The fix is simple and rather low-risk. 

We simply fix the NUMA node index association for the time of a G1 allocation - at the start of `G1CollectedHeap::attempt_allocation`, we determine the NUMA node number of the current thread and use that one in all actions in the current allocation scope. 

This has the added benefit of reducing the number of calls to `sched_getcpu()`, since we don't determine the NUMA node index for every single invocation of `G1Allocator` anew; we do it just once at the beginning of a Heap allocation.

The solution has the disadvantage that we may allocate a HeapRegion from the NUMA node memory we just migrated away from. Subsequently, the OS must migrate those pages to the current NUMA node. However, I think this is absolutely acceptable since the chance of these migrations happening right in the middle of a G1 allocation is rare (about once per 4-5 hours with >5000 app threads and ~150 GC threads). The alternative would be to make the whole control flow of `G1CollectedHeap::attempt_allocation` interruptible and restartable; but that would have been a larger, more invasive patch, which I wanted to avoid.

Unfortunately, this somewhat breaks the neat encapsulation of NUMA node memory association in G1Allocator; however, one can argue that this design was wrong anyway. If you have a control flow that you expect to execute atomically for the same NUMA node, then you cannot use this approach.

(I briefly considered as an alternative patch to give `G1Allocator` an ability to temporarily freeze the NUMA node association - as in "as long as I don't tell you otherwise, use this mutator alloc region for the current thread". However, that would have been more involved since we would have to track the frozen thread-to-NUMA-node associations for all threads in G1Allocator. The simplest way, by far, is to store this association on the thread stack of the current thread as this patch does.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8351500](https://bugs.openjdk.org/browse/JDK-8351500) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8351500](https://bugs.openjdk.org/browse/JDK-8351500)

### Issue
 * [JDK-8351500](https://bugs.openjdk.org/browse/JDK-8351500): G1: NUMA migrations cause crashes in region allocation (**Bug** - P3) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1460/head:pull/1460` \
`$ git checkout pull/1460`

Update a local copy of the PR: \
`$ git checkout pull/1460` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1460`

View PR using the GUI difftool: \
`$ git pr show -t 1460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1460.diff">https://git.openjdk.org/jdk21u-dev/pull/1460.diff</a>

</details>
