### PR TITLE
8328264: AArch64: remove UseNeon condition in CRC32 intrinsic

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -3897,7 +3897,7 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
     add(table2, table0, 2*256*sizeof(juint));
     add(table3, table0, 3*256*sizeof(juint));
 
-  if (UseNeon) {
+    { // Neon code start
       cmp(len, (u1)64);
       br(Assembler::LT, L_by16);
       eor(v16, T16B, v16, v16);
@@ -4029,7 +4029,7 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
       update_word_crc32(crc, tmp, tmp2, table0, table1, table2, table3, true);
 
       add(len, len, 32);
-  }
+    } // Neon code end
 
   BIND(L_by16);
     subs(len, len, 16);


### PR DESCRIPTION
This is a clean backport of a tiny enhancement in one of aarch64 crc32 implementations. Similar to JDK 23 -UseNeon makes no sense in update releases either https://github.com/openjdk/jdk/pull/18294#issuecomment-1997727704

Benchmarking results for jdk21u on Graviton 2, `-XX:-UseCRC32 -XX:-UseCryptoPmullForCRC32`:

```
Benchmark                  (count)   Mode  Cnt      Score    Error   Units
TestCRC32.testCRC32Update       64  thrpt    4  15263.125 ± 20.681  ops/ms
TestCRC32.testCRC32Update      128  thrpt    4   7746.327 ±  7.583  ops/ms
TestCRC32.testCRC32Update      256  thrpt    4   3904.416 ±  3.398  ops/ms
TestCRC32.testCRC32Update      512  thrpt    4   1959.262 ±  1.617  ops/ms
TestCRC32.testCRC32Update     2048  thrpt    4    489.607 ±  0.286  ops/ms
TestCRC32.testCRC32Update    16384  thrpt    4     61.355 ±  0.991  ops/ms
TestCRC32.testCRC32Update    65536  thrpt    4     15.318 ±  0.270  ops/ms
-->
TestCRC32.testCRC32Update       64  thrpt    4  18649.642 ± 40.169  ops/ms
TestCRC32.testCRC32Update      128  thrpt    4  11265.168 ± 13.246  ops/ms
TestCRC32.testCRC32Update      256  thrpt    4   6188.989 ±  4.609  ops/ms
TestCRC32.testCRC32Update      512  thrpt    4   3254.121 ±  3.669  ops/ms
TestCRC32.testCRC32Update     2048  thrpt    4    846.038 ±  0.861  ops/ms
TestCRC32.testCRC32Update    16384  thrpt    4    107.056 ±  0.116  ops/ms
TestCRC32.testCRC32Update    65536  thrpt    4     26.780 ±  0.041  ops/ms
```

JDK-8329749 is an optional follow-up for this backport.

Testing: tier1,2 on linux-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8328264](https://bugs.openjdk.org/browse/JDK-8328264) needs maintainer approval

### Issue
 * [JDK-8328264](https://bugs.openjdk.org/browse/JDK-8328264): AArch64: remove UseNeon condition in CRC32 intrinsic (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1462/head:pull/1462` \
`$ git checkout pull/1462`

Update a local copy of the PR: \
`$ git checkout pull/1462` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1462`

View PR using the GUI difftool: \
`$ git pr show -t 1462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1462.diff">https://git.openjdk.org/jdk21u-dev/pull/1462.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1462#issuecomment-2711115235)
</details>
