### PR TITLE
8349623: [ASAN] Gtest os_linux.glibc_mallinfo_wrapper_vm fails

### DIFF
--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -522,26 +522,28 @@ TEST_VM(os_linux, decoder_get_source_info_valid_overflow_minimal) {
 #endif // clang
 
 #ifdef __GLIBC__
+#ifndef ADDRESS_SANITIZER
 TEST_VM(os_linux, glibc_mallinfo_wrapper) {
   // Very basic test. Call it. That proves that resolution and invocation works.
   os::Linux::glibc_mallinfo mi;
   bool did_wrap = false;
 
-  os::Linux::get_mallinfo(&mi, &did_wrap);
-
   void* p = os::malloc(2 * K, mtTest);
   ASSERT_NOT_NULL(p);
+
+  os::Linux::get_mallinfo(&mi, &did_wrap);
 
   // We should see total allocation values > 0
   ASSERT_GE((mi.uordblks + mi.hblkhd), 2 * K);
 
-  // These values also should exceed some reasonable size.
+  // These values also should less than some reasonable size.
   ASSERT_LT(mi.fordblks, 2 * G);
   ASSERT_LT(mi.uordblks, 2 * G);
   ASSERT_LT(mi.hblkhd, 2 * G);
 
   os::free(p);
 }
+#endif // ADDRESS_SANITIZER
 #endif // __GLIBC__
 
 #endif // LINUX


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [155697fc](https://github.com/openjdk/jdk/commit/155697fc0ed69f1b4f871b00fe67685177bad59a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 7 Mar 2025 and was reviewed by Thomas Stuefe.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349623](https://bugs.openjdk.org/browse/JDK-8349623) needs maintainer approval

### Issue
 * [JDK-8349623](https://bugs.openjdk.org/browse/JDK-8349623): [ASAN] Gtest os_linux.glibc_mallinfo_wrapper_vm fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1463/head:pull/1463` \
`$ git checkout pull/1463`

Update a local copy of the PR: \
`$ git checkout pull/1463` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1463`

View PR using the GUI difftool: \
`$ git pr show -t 1463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1463.diff">https://git.openjdk.org/jdk21u-dev/pull/1463.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1463#issuecomment-2712267743)
</details>
