### PR TITLE
8350682: [JMH] vector.IndexInRangeBenchmark failed with IndexOutOfBoundsException for size=1024

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
@@ -48,7 +48,7 @@ public class IndexInRangeBenchmark {
 
     @Setup(Level.Trial)
     public void Setup() {
-        mask = new boolean[512];
+        mask = new boolean[size + 64];
     }
 
     @Benchmark


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [768b0241](https://github.com/openjdk/jdk/commit/768b02410f1b53ac95d6014f152be84c89eb33ab) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Vladimir Ivanov on 3 Mar 2025 and was reviewed by Xiaohong Gong, Derek White and Sandhya Viswanathan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350682](https://bugs.openjdk.org/browse/JDK-8350682) needs maintainer approval

### Issue
 * [JDK-8350682](https://bugs.openjdk.org/browse/JDK-8350682): [JMH] vector.IndexInRangeBenchmark failed with IndexOutOfBoundsException for size=1024 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1465/head:pull/1465` \
`$ git checkout pull/1465`

Update a local copy of the PR: \
`$ git checkout pull/1465` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1465`

View PR using the GUI difftool: \
`$ git pr show -t 1465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1465.diff">https://git.openjdk.org/jdk21u-dev/pull/1465.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1465#issuecomment-2712311425)
</details>
