### PR TITLE
8315742: Open source several Swing Scroll related tests

### DIFF
--- a/test/jdk/javax/swing/JScrollBar/bug4495822.java
+++ b/test/jdk/javax/swing/JScrollBar/bug4495822.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Robot;
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
+import javax.swing.JScrollBar;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4495822
+ * @summary AdjustmentEvent.getValueIsAdjusting() always returns false
+ * @run main bug4495822
+ */
+
+public class bug4495822 {
+    public static volatile boolean isAdjusted = false;
+
+    public static void main(String[] args) throws Exception {
+
+        SwingUtilities.invokeAndWait(() -> {
+            JScrollBar scrollBar = new JScrollBar(JScrollBar.HORIZONTAL);
+            scrollBar.addAdjustmentListener(new AdjustmentListener() {
+                public void adjustmentValueChanged(AdjustmentEvent e) {
+                    if (e.getValueIsAdjusting() != scrollBar.getValueIsAdjusting()) {
+                        throw new RuntimeException("The AdjustmentEvent has incorrect \"valueIsAdjusting\" value");
+                    }
+
+                    isAdjusted = true;
+                }
+            });
+
+            scrollBar.setValueIsAdjusting(true);
+        });
+        Thread.sleep(1000);
+        if (!isAdjusted) {
+            throw new RuntimeException("adjustmentValueChanged() not invoked!");
+        }
+        System.out.println("Test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JScrollBar/bug4696826.java
+++ b/test/jdk/javax/swing/JScrollBar/bug4696826.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JComponent;
+import javax.swing.JScrollBar;
+import javax.swing.SwingUtilities;
+import javax.swing.plaf.basic.BasicScrollBarUI;
+import java.awt.Graphics;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+
+/*
+ * @test
+ * @bug 4696826
+ * @summary BasicScrollBarUI should check if it needs to paint the thumb
+ * @run main bug4696826
+ */
+
+public class bug4696826 {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JScrollBar sb = new JScrollBar();
+            sb.setBounds(new Rectangle(0, 0, 20, 20));
+
+            TestScrollBarUI ui = new TestScrollBarUI();
+            sb.setUI(ui);
+            ui.setThumbBounds(0, 0, 20, 20);
+
+            BufferedImage image = new BufferedImage(100, 100,
+                    BufferedImage.TYPE_3BYTE_BGR);
+            Graphics g = image.getGraphics();
+            g.setClip(200, 200, 100, 100);
+            sb.paint(g);
+        });
+        System.out.println("Test Passed!");
+    }
+
+    static class TestScrollBarUI extends BasicScrollBarUI {
+        protected void paintThumb(Graphics g, JComponent c, Rectangle thumbBounds) {
+            throw new RuntimeException("Thumb shouldn't be painted");
+        }
+        public void setThumbBounds(int x, int y, int width, int height) {
+            super.setThumbBounds(x, y, width, height);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JScrollBar/bug4842792.java
+++ b/test/jdk/javax/swing/JScrollBar/bug4842792.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JScrollBar;
+import javax.swing.SwingUtilities;
+import java.awt.Dimension;
+import java.awt.event.MouseEvent;
+import java.util.Date;
+
+/*
+ * @test
+ * @bug 4842792
+ * @summary JScrollBar behaves incorrectly if "Block increment" value is big enough
+ * @run main bug4842792
+ */
+
+public class bug4842792 {
+    public static TestScrollBar scrollBar;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            scrollBar = new TestScrollBar(JScrollBar.HORIZONTAL, 10, 10, 0, 100);
+            scrollBar.setPreferredSize(new Dimension(200, 20));
+            scrollBar.setBlockIncrement(Integer.MAX_VALUE);
+
+            if (scrollBar.doTest() == 0) {
+                throw new RuntimeException("The scrollbar new value should not be 0");
+            }
+        });
+        System.out.println("Test Passed!");
+    }
+
+    static class TestScrollBar extends JScrollBar {
+        public TestScrollBar(int orientation, int value, int extent,
+                             int min, int max) {
+            super(orientation, value, extent, min, max);
+        }
+
+        public int doTest() {
+            MouseEvent mouseEvent = new MouseEvent(scrollBar,
+                                           MouseEvent.MOUSE_PRESSED,
+                                           (new Date()).getTime(),
+                                           MouseEvent.BUTTON1_DOWN_MASK,
+                                           150, 10, 1, true);
+            processMouseEvent(mouseEvent);
+            return scrollBar.getValue();
+        }
+    }
+}

--- a/test/jdk/javax/swing/JScrollPane/bug4247092.java
+++ b/test/jdk/javax/swing/JScrollPane/bug4247092.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JScrollPane;
+
+/*
+ * @test
+ * @bug 4247092
+ * @summary JScrollPane.setCorner(corner,null) causes NPE, but defolt getCorner() rtns null
+ * @run main bug4247092
+ */
+
+public class bug4247092 {
+    public static void main(String[] args) {
+        JScrollPane sp = new JScrollPane();
+        sp.setCorner(JScrollPane.LOWER_RIGHT_CORNER, null);
+        if (sp.getCorner(JScrollPane.LOWER_RIGHT_CORNER) != null) {
+            throw new RuntimeException("The corner component should be null");
+        }
+        System.out.println("Test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JScrollPane/bug4264640.java
+++ b/test/jdk/javax/swing/JScrollPane/bug4264640.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Robot;
+
+/*
+ * @test
+ * @bug 4264640
+ * @summary Tests that JScrollPane sets correct position of its column header view
+ * @key headful
+ * @run main bug4264640
+ */
+
+public class bug4264640 {
+    public static JFrame frame;
+    public static JButton b;
+    public static Robot robot;
+    public static volatile int yPos;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("Scroll Pane test");
+                JScrollPane scroller = new JScrollPane();
+                b = new JButton("This is BUG !");
+                b.setBounds(12, 12, 169, 133);
+                scroller.setColumnHeaderView(b);
+
+                Container pane = frame.getContentPane();
+                pane.setLayout(new BorderLayout());
+                pane.add(scroller);
+                frame.setSize(200,200);
+                frame.setVisible(true);
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+               yPos = b.getY();
+            });
+            if (yPos != 0) {
+                throw new RuntimeException("Failed: Y = " + yPos + " (should be 0)");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+        System.out.println("Test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JScrollPane/bug4467063.java
+++ b/test/jdk/javax/swing/JScrollPane/bug4467063.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import java.awt.ComponentOrientation;
+
+/*
+ * @test
+ * @bug 4467063
+ * @summary JScrollPane.setCorner() causes IllegalArgumentException. (invalid corner key)
+ * @run main bug4467063
+ */
+
+public class bug4467063 {
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JScrollPane sp = new JScrollPane();
+
+            //Test corners for left-to-right orientation
+            sp.setComponentOrientation(ComponentOrientation.LEFT_TO_RIGHT);
+            sp.setCorner(JScrollPane.LOWER_LEADING_CORNER, new JButton("0"));
+            sp.setCorner(JScrollPane.LOWER_TRAILING_CORNER, new JButton("1"));
+            sp.setCorner(JScrollPane.UPPER_LEADING_CORNER, new JButton("2"));
+            sp.setCorner(JScrollPane.UPPER_TRAILING_CORNER, new JButton("3"));
+
+            if (!sp.getCorner(JScrollPane.LOWER_LEADING_CORNER).equals(
+                    sp.getCorner(JScrollPane.LOWER_LEFT_CORNER))) {
+                throw new RuntimeException("Incorrect LOWER_LEADING_CORNER value");
+            }
+
+            if (!sp.getCorner(JScrollPane.LOWER_TRAILING_CORNER).equals(
+                    sp.getCorner(JScrollPane.LOWER_RIGHT_CORNER))) {
+                throw new RuntimeException("Incorrect LOWER_TRAILING_CORNER value");
+            }
+
+            if (!sp.getCorner(JScrollPane.UPPER_LEADING_CORNER).equals(
+                    sp.getCorner(JScrollPane.UPPER_LEFT_CORNER))) {
+                throw new RuntimeException("Incorrect UPPER_LEADING_CORNER value");
+            }
+
+            if (!sp.getCorner(JScrollPane.UPPER_TRAILING_CORNER).equals(
+                    sp.getCorner(JScrollPane.UPPER_RIGHT_CORNER))) {
+                throw new RuntimeException("Incorrect UPPER_TRAILING_CORNER value");
+            }
+
+            //Test corners for right-to-left orientation
+            sp.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+            sp.setCorner(JScrollPane.LOWER_LEADING_CORNER, new JButton("0"));
+            sp.setCorner(JScrollPane.LOWER_TRAILING_CORNER, new JButton("1"));
+            sp.setCorner(JScrollPane.UPPER_LEADING_CORNER, new JButton("2"));
+            sp.setCorner(JScrollPane.UPPER_TRAILING_CORNER, new JButton("3"));
+
+            if (!sp.getCorner(JScrollPane.LOWER_LEADING_CORNER).equals(
+                    sp.getCorner(JScrollPane.LOWER_RIGHT_CORNER))) {
+                throw new RuntimeException("Incorrect LOWER_LEADING_CORNER value");
+            }
+
+            if (!sp.getCorner(JScrollPane.LOWER_TRAILING_CORNER).equals(
+                    sp.getCorner(JScrollPane.LOWER_LEFT_CORNER))) {
+                throw new RuntimeException("Incorrect LOWER_TRAILING_CORNER value");
+            }
+
+            if (!sp.getCorner(JScrollPane.UPPER_LEADING_CORNER).equals(
+                    sp.getCorner(JScrollPane.UPPER_RIGHT_CORNER))) {
+                throw new RuntimeException("Incorrect UPPER_LEADING_CORNER value");
+            }
+
+            if (!sp.getCorner(JScrollPane.UPPER_TRAILING_CORNER).equals(
+                    sp.getCorner(JScrollPane.UPPER_LEFT_CORNER))) {
+                throw new RuntimeException("Incorrect UPPER_TRAILING_CORNER value");
+            }
+        });
+        System.out.println("Test Passed!");
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315742](https://bugs.openjdk.org/browse/JDK-8315742) needs maintainer approval

### Issue
 * [JDK-8315742](https://bugs.openjdk.org/browse/JDK-8315742): Open source several Swing Scroll related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1469/head:pull/1469` \
`$ git checkout pull/1469`

Update a local copy of the PR: \
`$ git checkout pull/1469` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1469`

View PR using the GUI difftool: \
`$ git pr show -t 1469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1469.diff">https://git.openjdk.org/jdk21u-dev/pull/1469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1469#issuecomment-2714766290)
</details>
