### PR TITLE
8350616: Skip ValidateHazardPtrsClosure in non-debug builds

### DIFF
--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -367,6 +367,7 @@ class ScanHazardPtrPrintMatchingThreadsClosure : public ThreadClosure {
   }
 };
 
+#ifdef ASSERT
 // Closure to validate hazard ptrs.
 //
 class ValidateHazardPtrsClosure : public ThreadClosure {
@@ -387,6 +388,7 @@ class ValidateHazardPtrsClosure : public ThreadClosure {
            p2i(thread));
   }
 };
+#endif
 
 // Closure to determine if the specified JavaThread is found by
 // threads_do().
@@ -951,8 +953,10 @@ void ThreadsSMRSupport::free_list(ThreadsList* threads) {
     log_debug(thread, smr)("tid=" UINTX_FORMAT ": ThreadsSMRSupport::free_list: threads=" INTPTR_FORMAT " is not freed.", os::current_thread_id(), p2i(threads));
   }
 
+#ifdef ASSERT
   ValidateHazardPtrsClosure validate_cl;
   threads_do(&validate_cl);
+#endif
 
   delete scan_table;
 }


### PR DESCRIPTION
Backporting JDK-8350616: Skip ValidateHazardPtrsClosure in non-debug builds. Simple cleanup to skip debug code in non-debug builds, removing some overhead when working with very large numbers of threads. Ran GHA Sanity Checks, and local Tier 1 and Tier 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350616](https://bugs.openjdk.org/browse/JDK-8350616) needs maintainer approval

### Issue
 * [JDK-8350616](https://bugs.openjdk.org/browse/JDK-8350616): Skip ValidateHazardPtrsClosure in non-debug builds (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1473/head:pull/1473` \
`$ git checkout pull/1473`

Update a local copy of the PR: \
`$ git checkout pull/1473` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1473`

View PR using the GUI difftool: \
`$ git pr show -t 1473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1473.diff">https://git.openjdk.org/jdk21u-dev/pull/1473.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1473#issuecomment-2715056670)
</details>
