### PR TITLE
8350211: CTW: Attempt to preload all classes in constant pool

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
@@ -108,17 +108,16 @@ public class Compiler {
 
     private static void preloadClasses(String className, long id,
             ConstantPool constantPool) {
-        try {
-            for (int i = 0, n = constantPool.getSize(); i < n; ++i) {
-                try {
+        for (int i = 0, n = constantPool.getSize(); i < n; ++i) {
+            try {
+                if (constantPool.getTagAt(i) == ConstantPool.Tag.CLASS) {
                     constantPool.getClassAt(i);
-                } catch (IllegalArgumentException ignore) {
                 }
+            } catch (Throwable t) {
+                CompileTheWorld.OUT.println(String.format("[%d]\t%s\tWARNING preloading failed : %s",
+                         id, className, t));
+                t.printStackTrace(CompileTheWorld.ERR);
             }
-        } catch (Throwable t) {
-            CompileTheWorld.OUT.println(String.format("[%d]\t%s\tWARNING preloading failed : %s",
-                    id, className, t));
-            t.printStackTrace(CompileTheWorld.ERR);
         }
     }
 


### PR DESCRIPTION
Backporting JDK-8350211: CTW: Attempt to preload all classes in constant pool. Adjust CTW preloading to resolve all constant pool entries around exceptions. Ran GHA Sanity Checks, and local Tier 1, Tier 2 tests, and `applications/ctw/modules` tests (with fastdebug build). Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350211](https://bugs.openjdk.org/browse/JDK-8350211) needs maintainer approval

### Issue
 * [JDK-8350211](https://bugs.openjdk.org/browse/JDK-8350211): CTW: Attempt to preload all classes in constant pool (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1474/head:pull/1474` \
`$ git checkout pull/1474`

Update a local copy of the PR: \
`$ git checkout pull/1474` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1474`

View PR using the GUI difftool: \
`$ git pr show -t 1474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1474.diff">https://git.openjdk.org/jdk21u-dev/pull/1474.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1474#issuecomment-2715087715)
</details>
