### PR TITLE
8316061: Open source several Swing RootPane and Slider related tests

### DIFF
--- a/test/jdk/javax/swing/JRootPane/bug4207333.java
+++ b/test/jdk/javax/swing/JRootPane/bug4207333.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JRootPane;
+import java.lang.reflect.Field;
+
+/*
+ * @test
+ * @bug 4207333
+ * @summary Inadvertant API regression in JRootPane
+ * @run main bug4207333
+ */
+
+public class bug4207333 {
+    public static void main(String[] argv) {
+        TestableRootPane rp = new TestableRootPane();
+        rp.setDefaultButton(new JButton("Default, eh?"));
+
+        if (!rp.test("defaultPressAction")) {
+            throw new RuntimeException("Failed test for bug 4207333");
+        }
+        if (!rp.test("defaultReleaseAction")) {
+            throw new RuntimeException("Failed test for bug 4207333");
+        }
+        System.out.println("Test Passed!");
+    }
+
+    private static class TestableRootPane extends JRootPane {
+        public boolean test(String fieldName) {
+            boolean result = false;
+            try {
+                Class superClass = getClass().getSuperclass();
+                Field field = superClass.getDeclaredField(fieldName);
+                Class fieldClass = field.getType();
+                Class actionClass = Class.forName("javax.swing.Action");
+
+                // Is the Field an Action?
+                result = actionClass.isAssignableFrom(fieldClass);
+            } catch (NoSuchFieldException pe) {
+                // Not a bug if the fields are removed since their
+                // type was a package private class!
+                result = true;
+            } catch (Exception iae) {
+                System.out.println("Exception " + iae);
+            }
+            return result;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JRootPane/bug4224113.java
+++ b/test/jdk/javax/swing/JRootPane/bug4224113.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.plaf.RootPaneUI;
+
+/*
+ * @test
+ * @bug 4224113
+ * @summary Tests the presence of RootPaneUI
+ * @run main bug4224113
+ */
+
+public class bug4224113 {
+    public static class TestRootPaneUI extends RootPaneUI {
+    }
+
+    public static void main(String[] args) {
+        TestRootPaneUI r = new TestRootPaneUI();
+        System.out.println("Test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JRootPane/bug4627806.java
+++ b/test/jdk/javax/swing/JRootPane/bug4627806.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JRootPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+/*
+ * @test
+ * @bug 4627806
+ * @key headful
+ * @summary MetalRootPaneUI calls validate() instead of revalidate()
+ * @run main bug4627806
+ */
+
+public class bug4627806 {
+    private static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("Test");
+                JPanel p = new JPanel();
+                JMenuItem c = new JMenuItem();
+                p.add(c);
+                frame.getContentPane().add(p);
+                frame.pack();
+                c.getUI().uninstallUI(c);
+                JRootPane rootPane = frame.getRootPane();
+                rootPane.getUI().uninstallUI(rootPane);
+                System.out.println("Test Passed!");
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JSlider/bug4200901.java
+++ b/test/jdk/javax/swing/JSlider/bug4200901.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JSlider;
+
+/*
+ * @test
+ * @bug 4200901
+ * @summary Test to check if JSlider.createStandardLabels() throws Exception
+ * @run main bug4200901
+ */
+
+public class bug4200901 {
+    public static void main(String[] args) {
+        try {
+            JSlider slider = new JSlider();
+            slider.createStandardLabels( -1 );
+        } catch ( IllegalArgumentException e ) {
+            System.out.println("Test Passed!");
+            return;
+        }
+        throw new RuntimeException( "TEST FAILED!");
+    }
+}

--- a/test/jdk/javax/swing/JSlider/bug4203754.java
+++ b/test/jdk/javax/swing/JSlider/bug4203754.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JSlider;
+import javax.swing.SwingUtilities;
+import java.awt.FlowLayout;
+import java.awt.Robot;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+/*
+ * @test
+ * @bug 4203754
+ * @key headful
+ * @summary Labels in a JSlider don't disable or enable with the slider
+ * @run main bug4203754
+ */
+
+public class bug4203754 {
+    private static JFrame frame;
+    private static Robot robot;
+    private static JLabel label;
+
+    public static void main(String[] argv) throws Exception {
+        try {
+            robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("Test");
+                frame.getContentPane().setLayout(new FlowLayout());
+                JSlider slider = new JSlider(0, 100, 25);
+                frame.getContentPane().add(slider);
+
+                label = new JLabel("0", JLabel.CENTER) {
+                    public void setEnabled(boolean b) {
+                        super.setEnabled(b);
+                    }
+                };
+
+                Dictionary labels = new Hashtable();
+                labels.put(Integer.valueOf(0), label);
+                slider.setLabelTable(labels);
+                slider.setPaintLabels(true);
+                slider.setEnabled(false);
+                frame.setSize(250, 150);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            if (label.isEnabled()) {
+                throw new RuntimeException("Label should be disabled");
+            }
+            System.out.println("Test Passed!");
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8316061](https://bugs.openjdk.org/browse/JDK-8316061) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316061](https://bugs.openjdk.org/browse/JDK-8316061): Open source several Swing RootPane and Slider related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1483/head:pull/1483` \
`$ git checkout pull/1483`

Update a local copy of the PR: \
`$ git checkout pull/1483` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1483`

View PR using the GUI difftool: \
`$ git pr show -t 1483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1483.diff">https://git.openjdk.org/jdk21u-dev/pull/1483.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1483#issuecomment-2721209564)
</details>
