### PR TITLE
8340907: Open source closed frame tests # 2

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -121,6 +121,7 @@ java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java 6848406 gen
 java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java 6848407 generic-all
 java/awt/Frame/MaximizedUndecorated/MaximizedUndecorated.java 8022302 generic-all
 java/awt/Frame/RestoreToOppositeScreen/RestoreToOppositeScreen.java 8286840 linux-all
+java/awt/Frame/InitialIconifiedTest.java 8203920 macosx-all,linux-all
 java/awt/FileDialog/FileDialogIconTest/FileDialogIconTest.java 8160558 windows-all
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion.java 8060176 windows-all,macosx-all
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_1.java 8060176 windows-all,macosx-all

--- a/test/jdk/java/awt/Frame/DeiconifyClipTest.java
+++ b/test/jdk/java/awt/Frame/DeiconifyClipTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * DeiconifyClipTest.java
+ *
+ * summary:
+ *
+ * What happens is that we call AwtWindow::UpdateInsets when
+ * processing WM_NCCALCSIZE delivered on programmatic deiconification.
+ * At this point IsIconic returns false (so UpdateInsets proceeds),
+ * but the rect sizes still seems to be those weird of the iconic
+ * state.  Based on them we compute insets with top = left = 0 (and
+ * bottom and right that are completely bogus) and pass them to
+ * PaintUpdateRgn which results in incorrect clip origin.  Immediately
+ * after that we do UpdateInsets again during WM_SIZE processing and
+ * get real values.
+ */
+
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Insets;
+
+/*
+ * @test
+ * @bug 4792958
+ * @summary Incorrect clip region after programmatic restore
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DeiconifyClipTest
+*/
+
+public class DeiconifyClipTest {
+    private static final String INSTRUCTIONS = """
+            This test creates a frame that is automatically iconified/deiconified
+            in a cycle.
+
+            The test FAILS if after deiconfication the frame has a greyed-out area
+            in the lower-right corner.
+            If the frame contents is drawn completely - the test PASSES.
+
+            Press PASS or FAIL button accordingly.
+            """;
+
+    static TestFrame testFrame;
+    static volatile boolean shouldContinue = true;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .title("DeiconifyClipTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(DeiconifyClipTest::createAndShowUI)
+                .build();
+        try {
+            runThread();
+        } finally {
+            passFailJFrame.awaitAndCheck();
+            shouldContinue = false;
+        }
+    }
+
+    private static void runThread() {
+        new Thread(() -> {
+            for (int i = 0; i < 1000 && shouldContinue; ++i) {
+                try {
+                    Thread.sleep(3000);
+                    SwingUtilities.invokeAndWait(() -> {
+                        if ((testFrame.getExtendedState() & Frame.ICONIFIED)
+                                != 0) {
+                            testFrame.setExtendedState(Frame.NORMAL);
+                        } else {
+                            testFrame.setState(Frame.ICONIFIED);
+                        }
+                    });
+                } catch (Exception ignored) {
+                }
+            }
+        }).start();
+    }
+
+    static Frame createAndShowUI() {
+        testFrame = new TestFrame();
+        testFrame.getContentPane().setLayout(new BoxLayout(testFrame.getContentPane(),
+                                                   BoxLayout.Y_AXIS));
+        testFrame.getContentPane().setBackground(Color.yellow);
+        testFrame.setSize(300, 300);
+        return testFrame;
+    }
+
+    static class TestFrame extends JFrame {
+        public TestFrame() {
+            super("DeiconifyClipTest");
+        }
+
+        // make it more visible if the clip is wrong.
+        public void paint(Graphics g) {
+            Insets b = getInsets();
+            Dimension d = getSize();
+
+            int x = b.left;
+            int y = b.top;
+            int w = d.width - x - b.right;
+            int h = d.height - y - b.bottom;
+
+            g.setColor(Color.white);
+            g.fillRect(0, 0, d.width, d.height);
+
+            g.setColor(Color.green);
+            g.drawRect(x, y, w-1, h-1);
+            g.drawLine(x, y, x+w, y+h);
+            g.drawLine(x, y+h, x+w, y);
+        }
+    }
+}

--- a/test/jdk/java/awt/Frame/FrameSetCursorTest.java
+++ b/test/jdk/java/awt/Frame/FrameSetCursorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.event.ActionListener;
+import java.lang.Exception;
+import java.lang.InterruptedException;
+import java.lang.Object;
+import java.lang.String;
+import java.lang.Thread;
+
+/*
+ * @test
+ * @bug 4097226
+ * @summary Frame.setCursor() sometimes doesn't update the cursor until user moves the mouse
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FrameSetCursorTest
+ */
+
+public class FrameSetCursorTest {
+    private static final String INSTRUCTIONS = """
+            1. Keep the instruction dialog and TestFrame side by side so that
+               you can read the instructions while doing the test
+            2. Click on the 'Start Busy' button on the frame titled 'TestFrame'
+               and DO NOT MOVE THE MOUSE ANYWHERE till you complete the steps below
+            3. The cursor on the TestFrame changes to busy cursor
+            4. If you don't see the busy cursor press 'Fail' after
+               the `done sleeping` message
+            5. If the busy cursor is seen, after 5 seconds the message
+               'done sleeping' is displayed in the message window
+            6. Check for the cursor type after the display of 'done sleeping'
+            7. If the cursor on the TestFrame has changed back to default cursor
+               (without you touching or moving the mouse), then press 'Pass'
+               else if the frame still shows the busy cursor press 'Fail'
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("FrameSetCursorTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(FrameSetCursorTest::createAndShowUI)
+                .logArea(5)
+                .build()
+                .awaitAndCheck();
+
+    }
+
+    static Frame createAndShowUI() {
+        Frame frame = new Frame("TestFrame");
+        Panel panel = new Panel();
+        Button busyButton = new Button("Start Busy");
+
+        ActionListener actionListener = event -> {
+            Object source = event.getSource();
+            if (source == busyButton) {
+                frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException ignored) {}
+                PassFailJFrame.log("done sleeping");
+                frame.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+            }
+        };
+
+        busyButton.addActionListener(actionListener);
+        panel.setLayout(new BorderLayout());
+        panel.add("North", busyButton);
+
+        frame.add(panel);
+        frame.pack();
+        frame.setSize(200, 200);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Frame/InitialIconifiedTest.java
+++ b/test/jdk/java/awt/Frame/InitialIconifiedTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4851435
+ * @summary Frame is not shown initially iconified after pack
+ */
+
+public class InitialIconifiedTest {
+
+    private static Frame backgroundFrame;
+    private static Frame testedFrame;
+
+    private static final Rectangle backgroundFrameBounds =
+            new Rectangle(100, 100, 200, 200);
+    private static final Rectangle testedFrameBounds =
+            new Rectangle(150, 150, 100, 100);
+
+    private static Robot robot;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+
+        try {
+            EventQueue.invokeAndWait(InitialIconifiedTest::initAndShowGui);
+            robot.waitForIdle();
+            robot.delay(500);
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                backgroundFrame.dispose();
+                testedFrame.dispose();
+            });
+        }
+    }
+
+    private static void initAndShowGui() {
+        backgroundFrame = new Frame("DisposeTest background");
+        backgroundFrame.setUndecorated(true);
+        backgroundFrame.setBackground(Color.RED);
+        backgroundFrame.setBounds(backgroundFrameBounds);
+        backgroundFrame.setVisible(true);
+
+        testedFrame = new Frame("Should have started ICONIC");
+        testedFrame.setExtendedState(Frame.ICONIFIED);
+        testedFrame.setBounds(testedFrameBounds);
+        testedFrame.setVisible(true);
+    }
+
+    private static void test() {
+        BufferedImage bi = robot.createScreenCapture(backgroundFrameBounds);
+        int redPix = Color.RED.getRGB();
+
+        for (int x = 0; x < bi.getWidth(); x++) {
+            for (int y = 0; y < bi.getHeight(); y++) {
+                if (bi.getRGB(x, y) != redPix) {
+                    try {
+                        ImageIO.write(bi, "png",
+                                new File("failure.png"));
+                    } catch (IOException ignored) {}
+                    throw new RuntimeException("Test failed");
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/Frame/InsetCorrectionTest.java
+++ b/test/jdk/java/awt/Frame/InsetCorrectionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4091426
+ * @key headful
+ * @summary Test inset correction when setVisible(true) BEFORE setSize(), setLocation()
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual InsetCorrectionTest
+ */
+
+public class InsetCorrectionTest {
+    private static final String INSTRUCTIONS = """
+            There is a frame of size 300x300 at location (100,100).
+            It has a menubar with one menu, 'File', but the frame
+            is otherwise empty.  In particular, there should be no
+            part of the frame that is not shown in the background color.
+            Upon test completion, click Pass or Fail appropriately.
+            """;
+
+    private static InsetCorrection testFrame;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> testFrame = new InsetCorrection());
+
+        try {
+            PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                    .title("InsetCorrectionTest Instructions")
+                    .instructions(INSTRUCTIONS)
+                    .columns(45)
+                    .logArea(3)
+                    .build();
+            EventQueue.invokeAndWait(() ->
+                    PassFailJFrame.log("frame location: " + testFrame.getBounds()));
+            passFailJFrame.awaitAndCheck();
+        } finally {
+            EventQueue.invokeAndWait(testFrame::dispose);
+        }
+    }
+
+    static class InsetCorrection extends Frame
+            implements ActionListener {
+        MenuBar mb;
+        Menu file;
+        MenuItem cause_bug_b;
+
+        public InsetCorrection() {
+            super("InsetCorrection");
+            mb = new MenuBar();
+            file = new Menu("File");
+            mb.add(file);
+            cause_bug_b = new MenuItem("cause bug");
+            file.add(cause_bug_b);
+            setMenuBar(mb);
+            cause_bug_b.addActionListener(this);
+
+            // Making the frame visible before setSize and setLocation()
+            // are being called causes sometimes strange behaviour with
+            // JDK1.1.5G. The frame is then sometimes to large and the
+            // excess areas are drawn in black. This only happens
+            // sometimes.
+            setVisible(true);
+            setSize(300, 300);
+            setLocation(100, 100);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            setVisible(false);
+            setVisible(true);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

One test is failing, but that one is added to the ProblemList by this change, so I assume this is expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340907](https://bugs.openjdk.org/browse/JDK-8340907) needs maintainer approval

### Issue
 * [JDK-8340907](https://bugs.openjdk.org/browse/JDK-8340907): Open source closed frame tests # 2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1484/head:pull/1484` \
`$ git checkout pull/1484`

Update a local copy of the PR: \
`$ git checkout pull/1484` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1484`

View PR using the GUI difftool: \
`$ git pr show -t 1484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1484.diff">https://git.openjdk.org/jdk21u-dev/pull/1484.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1484#issuecomment-2721400811)
</details>
