### PR TITLE
JDK-8351934

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -1760,7 +1760,7 @@ public class ForkJoinPool extends AbstractExecutorService {
             int sp = (int)c & ~INACTIVE;
             if ((sp & SMASK) == (cfg & SMASK) &&
                 compareAndSetCtl(c, ((pred & SP_MASK) |
-                                     (UC_MASK & (c - TC_UNIT))))) {
+                                     (c & RC_MASK) | ((c - TC_UNIT) & TC_MASK)))) {
                 w.config = cfg;  // add sentinel for deregisterWorker
                 w.phase = sp;
                 return true;


### PR DESCRIPTION
This a backport of JDK-8351933 [0] (PR [1]) for 21u. At one of code paths the TC subfield of ctl field is decremented and the result is not masked correctly. The target code is also in tryTrim() but the surrounding is different from the current master, as well as the original mask name. The core change is the same, candidate for compareAndSetCtl() is constructed using '(c & RC_MASK) | ((c - TC_UNIT) & TC_MASK' instead of '(UC_MASK & (c - TC_UNIT))' to correctly preserve the RC subfield.

[0] https://bugs.openjdk.org/browse/JDK-8351933
[1] https://github.com/openjdk/jdk/pull/24034