### PR TITLE
8309978: [x64] Fix useless padding

### DIFF
--- a/src/hotspot/cpu/x86/c2_intelJccErratum_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_intelJccErratum_x86.cpp
@@ -100,7 +100,7 @@ int IntelJccErratum::compute_padding(uintptr_t current_offset, const MachNode* m
   if (index_in_block < block->number_of_nodes() - 1) {
     Node* next = block->get_node(index_in_block + 1);
     if (next->is_Mach() && (next->as_Mach()->flags() & Node::PD::Flag_intel_jcc_erratum)) {
-      jcc_size += mach->size(regalloc);
+      jcc_size += next->size(regalloc);
     }
   }
   if (jcc_size > largest_jcc_size()) {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2998,9 +2998,8 @@ void Compile::Code_Gen() {
     output.Output();
     if (failing())  return;
     output.install();
+    print_method(PHASE_FINAL_CODE, 1); // Compile::_output is not null here
   }
-
-  print_method(PHASE_FINAL_CODE, 1);
 
   // He's dead, Jim.
   _cfg     = (PhaseCFG*)((intptr_t)0xdeadbeef);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPadding.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPadding.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8309978
+ * @summary [x64] Fix useless padding
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @requires (os.simpleArch == "x64")
+ * @run driver compiler.c2.irTests.TestPadding
+ */
+
+public class TestPadding {
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:+IntelJccErratumMitigation");
+    }
+
+    @Run(test = "test")
+    public static void test_runner() {
+        test(42);
+        tpf.b1++; // to take both branches in test()
+    }
+
+    @Test
+    @IR(counts = { IRNode.NOP, "1" })
+    static int test(int i) {
+        TestPadding tp = tpf;
+        if (tp.b1 > 42) { // Big 'cmpb' instruction at offset 0x30
+          tp.i1 = i;
+        }
+        return i;
+    }
+
+    static TestPadding t1;
+    static TestPadding t2;
+    static TestPadding t3;
+    static TestPadding t4;
+
+    static TestPadding tpf = new TestPadding(); // Static field offset > 128
+
+    int i1;
+
+    long l1;
+    long l2;
+    long l3;
+    long l4;
+    long l5;
+    long l6;
+    long l7;
+    long l8;
+    long l9;
+    long l10;
+    long l11;
+    long l12;
+    long l13;
+    long l14;
+    long l15;
+    long l16;
+
+    byte b1 = 1; // Field offset > 128
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1002,6 +1002,11 @@ public class IRNode {
         vectorNode(NEG_VD, "NegVD", TYPE_DOUBLE);
     }
 
+    public static final String NOP = PREFIX + "NOP" + POSTFIX;
+    static {
+        machOnlyNameRegex(NOP, "Nop");
+    }
+
     public static final String NULL_ASSERT_TRAP = PREFIX + "NULL_ASSERT_TRAP" + POSTFIX;
     static {
         trapNodes(NULL_ASSERT_TRAP,"null_assert");


### PR DESCRIPTION
Backporting JDK-8309978: [x64] Fix useless padding. Adjusting code to remove possibility to useless padding in code generation and adding test. Ran GHA Sanity Checks, and local Tier 1, and Tier 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309978](https://bugs.openjdk.org/browse/JDK-8309978) needs maintainer approval

### Issue
 * [JDK-8309978](https://bugs.openjdk.org/browse/JDK-8309978): [x64] Fix useless padding (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1491/head:pull/1491` \
`$ git checkout pull/1491`

Update a local copy of the PR: \
`$ git checkout pull/1491` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1491`

View PR using the GUI difftool: \
`$ git pr show -t 1491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1491.diff">https://git.openjdk.org/jdk21u-dev/pull/1491.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1491#issuecomment-2723164755)
</details>
