### PR TITLE
8352076: [21u] Problem list tests that fail in 21 and would be fixed by 8309622

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,9 +92,12 @@ gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#iu-aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
+gc/shenandoah/TestAllocIntArrays.java#aggressive 8309622 generic-all
+gc/shenandoah/TestAllocIntArrays.java#iu-aggressive 8309622 generic-all
 gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
 gc/stress/gclocker/TestGCLockerWithParallel.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
+gc/stress/gcold/TestGCOldWithShenandoah.java#iu-aggressive 8309622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 


### PR DESCRIPTION
I want to problem list these as they fail in our CI and we don't want to backport the fix as it is too large.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352076](https://bugs.openjdk.org/browse/JDK-8352076) needs maintainer approval

### Issue
 * [JDK-8352076](https://bugs.openjdk.org/browse/JDK-8352076): [21u] Problem list tests that fail in 21 and would be fixed by 8309622 (**Sub-task** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1493/head:pull/1493` \
`$ git checkout pull/1493`

Update a local copy of the PR: \
`$ git checkout pull/1493` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1493`

View PR using the GUI difftool: \
`$ git pr show -t 1493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1493.diff">https://git.openjdk.org/jdk21u-dev/pull/1493.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1493#issuecomment-2725074092)
</details>
