### PR TITLE
8338314: JFR: Split JFRCheckpoint VM operation

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -392,14 +392,22 @@ static u4 write_metadata(JfrChunkWriter& chunkwriter) {
   return invoke(wm);
 }
 
-template <typename Instance, void(Instance::*func)()>
-class JfrVMOperation : public VM_Operation {
+class JfrSafepointClearVMOperation : public VM_Operation {
  private:
-  Instance& _instance;
+  JfrRecorderService& _instance;
  public:
-  JfrVMOperation(Instance& instance) : _instance(instance) {}
-  void doit() { (_instance.*func)(); }
-  VMOp_Type type() const { return VMOp_JFRCheckpoint; }
+  JfrSafepointClearVMOperation(JfrRecorderService& instance) : _instance(instance) {}
+  void doit() { _instance.safepoint_clear(); }
+  VMOp_Type type() const { return VMOp_JFRSafepointClear; }
+};
+
+class JfrSafepointWriteVMOperation : public VM_Operation {
+ private:
+  JfrRecorderService& _instance;
+ public:
+  JfrSafepointWriteVMOperation(JfrRecorderService& instance) : _instance(instance) {}
+  void doit() { _instance.safepoint_write(); }
+  VMOp_Type type() const { return VMOp_JFRSafepointWrite; }
 };
 
 JfrRecorderService::JfrRecorderService() :
@@ -468,9 +476,9 @@ void JfrRecorderService::pre_safepoint_clear() {
 }
 
 void JfrRecorderService::invoke_safepoint_clear() {
-  JfrVMOperation<JfrRecorderService, &JfrRecorderService::safepoint_clear> safepoint_task(*this);
+  JfrSafepointClearVMOperation op(*this);
   ThreadInVMfromNative transition(JavaThread::current());
-  VMThread::execute(&safepoint_task);
+  VMThread::execute(&op);
 }
 
 void JfrRecorderService::safepoint_clear() {
@@ -573,10 +581,10 @@ void JfrRecorderService::pre_safepoint_write() {
 }
 
 void JfrRecorderService::invoke_safepoint_write() {
-  JfrVMOperation<JfrRecorderService, &JfrRecorderService::safepoint_write> safepoint_task(*this);
+  JfrSafepointWriteVMOperation op(*this);
   // can safepoint here
   ThreadInVMfromNative transition(JavaThread::current());
-  VMThread::execute(&safepoint_task);
+  VMThread::execute(&op);
 }
 
 void JfrRecorderService::safepoint_write() {

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.hpp
@@ -35,6 +35,8 @@ class JfrStorage;
 class JfrStringPool;
 
 class JfrRecorderService : public StackObj {
+  friend class JfrSafepointClearVMOperation;
+  friend class JfrSafepointWriteVMOperation;
  private:
   JfrCheckpointManager& _checkpoint_manager;
   JfrChunkWriter& _chunkwriter;

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -91,7 +91,8 @@
   template(HeapWalkOperation)                     \
   template(HeapIterateOperation)                  \
   template(ReportJavaOutOfMemory)                 \
-  template(JFRCheckpoint)                         \
+  template(JFRSafepointClear)                     \
+  template(JFRSafepointWrite)                     \
   template(ShenandoahFullGC)                      \
   template(ShenandoahInitMark)                    \
   template(ShenandoahFinalMarkStartEvac)          \


### PR DESCRIPTION
Backporting JDK-8338314: JFR: Split JFRCheckpoint VM operation. This change adds more detail to JFR logging in the hs_err to help with debugging. Ran GHA Sanity Checks, and local Tier 1, and Tier 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8338314](https://bugs.openjdk.org/browse/JDK-8338314) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338314](https://bugs.openjdk.org/browse/JDK-8338314): JFR: Split JFRCheckpoint VM operation (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1494/head:pull/1494` \
`$ git checkout pull/1494`

Update a local copy of the PR: \
`$ git checkout pull/1494` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1494`

View PR using the GUI difftool: \
`$ git pr show -t 1494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1494.diff">https://git.openjdk.org/jdk21u-dev/pull/1494.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1494#issuecomment-2725677738)
</details>
