### PR TITLE
Backport 7c36fa7e175c01dd994cd8f1ef9fd942dbddbce0

### DIFF
--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -118,7 +118,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
 
             // Load and use the archived cache if it exists
             CDS.initializeFromArchive(ByteCache.class);
-            if (archivedCache == null || archivedCache.length != size) {
+            if (archivedCache == null) {
                 Byte[] c = new Byte[size];
                 byte value = (byte)-128;
                 for(int i = 0; i < size; i++) {
@@ -127,6 +127,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
                 archivedCache = c;
             }
             cache = archivedCache;
+            assert cache.length == size;
         }
     }
 

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -8969,7 +8969,7 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
 
             // Load and use the archived cache if it exists
             CDS.initializeFromArchive(CharacterCache.class);
-            if (archivedCache == null || archivedCache.length != size) {
+            if (archivedCache == null) {
                 Character[] c = new Character[size];
                 for (int i = 0; i < size; i++) {
                     c[i] = new Character((char) i);
@@ -8977,6 +8977,7 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
                 archivedCache = c;
             }
             cache = archivedCache;
+            assert cache.length == size;
         }
     }
 

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -1038,7 +1038,17 @@ public final class Integer extends Number
             if (archivedCache == null || size > archivedCache.length) {
                 Integer[] c = new Integer[size];
                 int j = low;
-                for(int i = 0; i < c.length; i++) {
+                // If archive has Integer cache, we must use all instances from it.
+                // Otherwise, the identity checks between archived Integers and
+                // runtime-cached Integers would fail.
+                int archivedSize = (archivedCache == null) ? 0 : archivedCache.length;
+                for (int i = 0; i < archivedSize; i++) {
+                    c[i] = archivedCache[i];
+                    assert j == archivedCache[i];
+                    j++;
+                }
+                // Fill the rest of the cache.
+                for (int i = archivedSize; i < size; i++) {
                     c[i] = new Integer(j++);
                 }
                 archivedCache = c;

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -1169,7 +1169,7 @@ public final class Long extends Number
 
             // Load and use the archived cache if it exists
             CDS.initializeFromArchive(LongCache.class);
-            if (archivedCache == null || archivedCache.length != size) {
+            if (archivedCache == null) {
                 Long[] c = new Long[size];
                 long value = -128;
                 for(int i = 0; i < size; i++) {
@@ -1178,6 +1178,7 @@ public final class Long extends Number
                 archivedCache = c;
             }
             cache = archivedCache;
+            assert cache.length == size;
         }
     }
 

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -244,7 +244,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
 
             // Load and use the archived cache if it exists
             CDS.initializeFromArchive(ShortCache.class);
-            if (archivedCache == null || archivedCache.length != size) {
+            if (archivedCache == null) {
                 Short[] c = new Short[size];
                 short value = -128;
                 for(int i = 0; i < size; i++) {
@@ -253,6 +253,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
                 archivedCache = c;
             }
             cache = archivedCache;
+            assert cache.length == size;
         }
     }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedIntegerHolder.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedIntegerHolder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import jdk.internal.misc.CDS;
+
+public class ArchivedIntegerHolder {
+    public static Object[] archivedObjects;
+    static {
+        CDS.initializeFromArchive(ArchivedIntegerHolder.class);
+        if (archivedObjects == null) {
+            archivedObjects = new Object[256];
+            for (int i = -128; i <= 127; i++) {
+                archivedObjects[i + 128] = Integer.valueOf(i);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckIntegerCacheApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckIntegerCacheApp.java
@@ -62,6 +62,14 @@ public class CheckIntegerCacheApp {
             }
         }
 
+        // Check that archived integer cache agrees with runtime integer cache.
+        for (int i = -128; i <= 127; i++) {
+            if (ArchivedIntegerHolder.archivedObjects[i + 128] != Integer.valueOf(i)) {
+                throw new RuntimeException(
+                        "FAILED. Archived and runtime caches disagree for " + i);
+            }
+        }
+
         int high = Integer.parseInt(args[0]);
         if (Integer.valueOf(high) != Integer.valueOf(high)) {
             throw new RuntimeException(


### PR DESCRIPTION
Backporting JDK-8343019: Primitive caches must use boxed instances from the archive. Fixes bug with code that uses CDS archived cache instances, since the boxed equality can break when comparing the CDS-archived value and the Integer cached value recreated at runtime, in cases when the primitive cache is dropped. Ran GHA Sanity Checks, and local Tier 1, and Tier 2 tests. Patch is clean.