### PR TITLE
8338010: WB_IsFrameDeoptimized miss ResourceMark

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -771,6 +771,7 @@ WB_END
 WB_ENTRY(jboolean, WB_IsFrameDeoptimized(JNIEnv* env, jobject o, jint depth))
   bool result = false;
   if (thread->has_last_Java_frame()) {
+    ResourceMark rm(THREAD);
     RegisterMap reg_map(thread,
                         RegisterMap::UpdateMap::include,
                         RegisterMap::ProcessFrames::include,


### PR DESCRIPTION
Backporting JDK-8338010: WB_IsFrameDeoptimized miss ResourceMark. Fixes bug in the `com/sun/jdi/EATests.java#id0` test, which intermittently fails with virtual thread test factory. Ran GHA Sanity Checks, and local Tier 1, and Tier 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338010](https://bugs.openjdk.org/browse/JDK-8338010) needs maintainer approval

### Issue
 * [JDK-8338010](https://bugs.openjdk.org/browse/JDK-8338010): WB_IsFrameDeoptimized miss ResourceMark (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1499/head:pull/1499` \
`$ git checkout pull/1499`

Update a local copy of the PR: \
`$ git checkout pull/1499` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1499`

View PR using the GUI difftool: \
`$ git pr show -t 1499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1499.diff">https://git.openjdk.org/jdk21u-dev/pull/1499.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1499#issuecomment-2726926738)
</details>
