### PR TITLE
Backport 030149fec4f175e5571e053fa56d2921d95c6b13

### DIFF
--- a/test/jdk/javax/print/attribute/PageRangesException.java
+++ b/test/jdk/javax/print/attribute/PageRangesException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.print.attribute.standard.PageRanges;
+
+/*
+ * @test
+ * @bug 4433126 4433096
+ * @key printer
+ * @summary  The line "ERROR: <message>" should NOT appear.
+ * @run main PageRangesException
+ */
+
+public class PageRangesException {
+    public static void main(String[] args) throws Exception {
+        // test 4433126
+        try {
+            PageRanges pr = new PageRanges("0:22");
+            throw new RuntimeException("ERROR: no exceptions");
+        } catch (IllegalArgumentException ie) {
+            System.out.println("OKAY: IllegalArgumentException " + ie);
+        }
+
+        // test 4433096
+        try {
+            int[][] m = null;
+            PageRanges pr = new PageRanges(m);
+            throw new RuntimeException("ERROR: NullPointerException expected");
+        } catch (IllegalArgumentException ie) {
+            throw new RuntimeException("ERROR: IllegalArgumentException", ie);
+        } catch (NullPointerException e) {
+            System.out.println("OKAY: NullPointerException");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.