### PR TITLE
8347286: (fs) Remove some extensions from java/nio/file/Files/probeContentType/Basic.java

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import jdk.internal.util.OperatingSystem;
-import jdk.internal.util.OSVersion;
 import jdk.internal.util.StaticProperty;
 
 /**
@@ -189,18 +188,8 @@ public class Basic {
         exTypes.add(new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")));
         exTypes.add(new ExType("wasm", List.of("application/wasm")));
 
-        // extensions with content type that differs on Windows 11+ and
-        // Windows Server 2025
-        if (OperatingSystem.isWindows() &&
-            (StaticProperty.osName().matches("^.*[11|2025]$") ||
-                new OSVersion(10, 0).compareTo(OSVersion.current()) > 0)) {
-            System.out.println("Windows 11+ detected: using different types");
-            exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip", "application/x-compressed")));
-            exTypes.add(new ExType("csv", List.of("text/csv", "application/vnd.ms-excel")));
-            exTypes.add(new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed", "application/x-compressed")));
-            exTypes.add(new ExType("rtf", List.of("application/rtf", "text/rtf", "application/msword")));
-            exTypes.add(new ExType("7z", List.of("application/x-7z-compressed", "application/x-compressed")));
-        } else {
+        // extensions with consistent content type on Unix (but not on Windows)
+        if (!OperatingSystem.isWindows()) {
             exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip")));
             exTypes.add(new ExType("csv", List.of("text/csv")));
             exTypes.add(new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed")));


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347286](https://bugs.openjdk.org/browse/JDK-8347286) needs maintainer approval

### Issue
 * [JDK-8347286](https://bugs.openjdk.org/browse/JDK-8347286): (fs) Remove some extensions from java/nio/file/Files/probeContentType/Basic.java (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1504/head:pull/1504` \
`$ git checkout pull/1504`

Update a local copy of the PR: \
`$ git checkout pull/1504` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1504`

View PR using the GUI difftool: \
`$ git pr show -t 1504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1504.diff">https://git.openjdk.org/jdk21u-dev/pull/1504.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1504#issuecomment-2727011202)
</details>
