### PR TITLE
8340164: Open source few Component tests - Set1

### DIFF
--- a/test/jdk/java/awt/LightweightComponent/LWParentMovedTest/LWParentMovedTest.java
+++ b/test/jdk/java/awt/LightweightComponent/LWParentMovedTest/LWParentMovedTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4147246
+ * @summary Simple check for peer != null in Component.componentMoved
+ * @key headful
+ * @run main LWParentMovedTest
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+
+public class LWParentMovedTest {
+    static CMTFrame f;
+
+    // test will throw an exception and fail if lwc is null
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> f = new CMTFrame());
+        } finally {
+            if (f != null) {
+                EventQueue.invokeAndWait(() -> f.dispose());
+            }
+        }
+    }
+}
+
+class CMTFrame extends Frame {
+    Container lwc;
+    Button button;
+
+    public CMTFrame() {
+        super("Moving LWC Test");
+        setLayout(new FlowLayout());
+        lwc = new LWSquare(Color.blue, 100, 100);
+        button = new Button();
+        lwc.add(button);
+        add(lwc);
+
+        setSize(400, 300);
+        setVisible(true);
+
+        // queue up a bunch of COMPONENT_MOVED events
+        for (int i = 0; i < 1000; i++) {
+            lwc.setLocation(i, i);
+        }
+
+        // remove heavyweight from lightweight container
+        lwc.remove(button);
+    }
+}
+
+//
+// Lightweight container
+//
+class LWSquare extends Container {
+    int width;
+    int height;
+
+    public LWSquare(Color color, int w, int h) {
+        setBackground(color);
+        setLayout(new FlowLayout());
+        width = w;
+        height = h;
+        setName("LWSquare-" + color.toString());
+    }
+
+    public void paint(Graphics g) {
+        g.setColor(getBackground());
+        g.fillRect(0, 0, 1000, 1000);
+    }
+}

--- a/test/jdk/java/awt/LightweightComponent/LightWeightTabFocus/LightWeightTabFocus.java
+++ b/test/jdk/java/awt/LightweightComponent/LightWeightTabFocus/LightWeightTabFocus.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4095214
+ * @summary Test change of focus on lightweights using the tab key
+ * @key headful
+ * @run main LightWeightTabFocus
+ */
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+public class LightWeightTabFocus {
+    private static Frame f;
+    private static LightweightButton btn1;
+    private static Button btn2;
+    private static Robot robot;
+    private static volatile Point point;
+    private static Point loc;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> {
+                loc = f.getLocation();
+                point = btn2.getLocation();
+            });
+            robot.mouseMove(loc.x + point.x, loc.y + point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            // First TAB
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            if (!btn1.hasFocus()) {
+                new RuntimeException("First tab failed");
+            }
+            // Second TAB
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            if (!btn2.hasFocus()) {
+                new RuntimeException("Second tab failed");
+            }
+            // First SHIFT+TAB
+            robot.keyPress(KeyEvent.VK_SHIFT);
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.delay(100);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_SHIFT);
+            if (!btn1.hasFocus()) {
+                new RuntimeException("First shift+tab failed");
+            }
+            // Second SHIFT+TAB
+            robot.keyPress(KeyEvent.VK_SHIFT);
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.delay(100);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_SHIFT);
+            if (!btn2.hasFocus()) {
+                new RuntimeException("Second shift+tab failed");
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static Frame createUI() {
+        f = new Frame("TAB Focus Change on LW Test");
+        f.setLayout(new FlowLayout());
+        btn1 = new LightweightButton();
+        f.add(btn1);
+        btn2 = new Button("Click Me To start");
+        f.add(btn2);
+        f.pack();
+        f.setVisible(true);
+        return f;
+    }
+}
+
+class LightweightButton extends Component implements FocusListener {
+    boolean focus;
+    LightweightButton() {
+        focus = false;
+        addFocusListener(this);
+    }
+
+    public Dimension getPreferredSize()
+    {
+        return new Dimension(100, 100);
+    }
+
+    public void focusGained(FocusEvent e) {
+        focus = true;
+        repaint();
+    }
+
+    public void focusLost(FocusEvent e) {
+        focus = false;
+        repaint();
+    }
+
+    public void paint(Graphics g) {
+        if (focus) {
+            g.drawString("Has Focus", 10, 20);
+        } else {
+            g.drawString("Not Focused", 10, 20);
+        }
+    }
+
+    public boolean isFocusable() {
+        return true;
+    }
+}

--- a/test/jdk/java/awt/LightweightComponent/LightweightFontTest/LightweightFontTest.java
+++ b/test/jdk/java/awt/LightweightComponent/LightweightFontTest/LightweightFontTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4077709 4153989
+ * @summary Lightweight component font settable test
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual LightweightFontTest
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Frame;
+import java.awt.Graphics;
+
+
+public class LightweightFontTest {
+    static Font desiredFont = null;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                [ There are 7 steps to this test ]
+                1. The 2 bordered labels (Emacs vs. vi) should be in a LARGE font
+                   (approximately 1/2 inch tall)
+                2. The labels should not overlap.
+                3. Each button should be large enough to contain the entire label.
+                4. The labels should have red backgrounds
+                5. The text in the left label should be blue and the right yellow
+                6. Resize the window to make it much smaller and larger
+                7. The buttons should never overlap, and they should be large
+                   enough to contain the entire label.
+                   (although the button may disappear if there is not enough
+                   room in the window)"
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(LightweightFontTest::createUI)
+                .logArea(5)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("Lightweight Font Test");
+        f.setLayout(new FlowLayout());
+
+        desiredFont = new Font(Font.DIALOG, Font.PLAIN, 36);
+        Component component;
+        component = new BorderedLabel("Emacs or vi?");
+        component.setFont(desiredFont);
+        component.setBackground(Color.red);
+        component.setForeground(Color.blue);
+        f.add(component);
+        component = new BorderedLabel("Vi or Emacs???");
+        component.setFont(desiredFont);
+        component.setBackground(Color.red);
+        component.setForeground(Color.yellow);
+        f.add(component);
+        f.pack();
+        return f;
+    }
+}
+
+/**
+ * Lightweight component
+ */
+class BorderedLabel extends Component {
+    boolean superIsButton;
+    String labelString;
+
+    BorderedLabel(String labelString) {
+        this.labelString = labelString;
+
+        Component thisComponent = this;
+        superIsButton = (thisComponent instanceof Button);
+        if(superIsButton) {
+            ((Button)thisComponent).setLabel(labelString);
+        }
+    }
+
+    public Dimension getMinimumSize() {
+        Dimension minSize = new Dimension();
+
+        if (superIsButton) {
+            minSize = super.getMinimumSize();
+        } else {
+
+            Graphics g = getGraphics();
+            verifyFont(g);
+            FontMetrics metrics = g.getFontMetrics();
+
+            minSize.width = metrics.stringWidth(labelString) + 14;
+            minSize.height = metrics.getMaxAscent() + metrics.getMaxDescent() + 9;
+
+            g.dispose();
+        }
+        return minSize;
+    }
+
+    public Dimension getPreferredSize() {
+        Dimension prefSize = new Dimension();
+        if (superIsButton) {
+            prefSize = super.getPreferredSize();
+        } else {
+            prefSize = getMinimumSize();
+        }
+        return prefSize;
+    }
+
+    public void paint(Graphics g) {
+        verifyFont(g);
+        super.paint(g);
+        if (superIsButton) {
+            return;
+        }
+        Dimension size = getSize();
+        Color oldColor = g.getColor();
+
+        // draw border
+        g.setColor(getBackground());
+        g.fill3DRect(0, 0, size.width, size.height, false);
+        g.fill3DRect(3, 3, size.width - 6, size.height - 6, true);
+
+        // draw text
+        FontMetrics metrics = g.getFontMetrics();
+        int centerX = size.width / 2;
+        int centerY = size.height / 2;
+        int textX = centerX - (metrics.stringWidth(labelString) / 2);
+        int textY = centerY + ((metrics.getMaxAscent()
+                + metrics.getMaxDescent()) / 2);
+        g.setColor(getForeground());
+        g.drawString(labelString, textX, textY);
+
+        g.setColor(oldColor);
+    }
+
+    /**
+     * Verifies that the font is correct and prints a warning
+     * message and/or throws a RuntimeException if it is not.
+     */
+    private void verifyFont(Graphics g) {
+        Font desiredFont = LightweightFontTest.desiredFont;
+        Font actualFont = g.getFont();
+        if (!actualFont.equals(desiredFont)) {
+            PassFailJFrame.log("AWT BUG: FONT INFORMATION LOST!");
+            PassFailJFrame.log("         Desired font: " + desiredFont);
+            PassFailJFrame.log("          Actual font: " + actualFont);
+            PassFailJFrame.forceFail();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340164](https://bugs.openjdk.org/browse/JDK-8340164) needs maintainer approval

### Issue
 * [JDK-8340164](https://bugs.openjdk.org/browse/JDK-8340164): Open source few Component tests - Set1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1510/head:pull/1510` \
`$ git checkout pull/1510`

Update a local copy of the PR: \
`$ git checkout pull/1510` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1510`

View PR using the GUI difftool: \
`$ git pr show -t 1510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1510.diff">https://git.openjdk.org/jdk21u-dev/pull/1510.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1510#issuecomment-2729875330)
</details>
