### PR TITLE
8315669: Open source several Swing PopupMenu related tests

### DIFF
--- a/test/jdk/javax/swing/JPopupMenu/bug4236750.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4236750.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.Action;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.MenuElement;
+import javax.swing.SwingUtilities;
+import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeListener;
+
+/*
+ * @test
+ * @bug 4236750
+ * @summary Tests presence of JPopupMenu.insert(Action, int)
+ * @run main bug4236750
+ */
+
+public class bug4236750 {
+    private static MenuElement[] elements;
+    private static volatile boolean passed = true;
+
+    /**
+     * Auxilliary class implementing Action
+     */
+    static class NullAction implements Action {
+        public void addPropertyChangeListener(
+                PropertyChangeListener listener) {
+        }
+
+        public void removePropertyChangeListener(
+                PropertyChangeListener listener) {
+        }
+
+        public void setEnabled(boolean b) {
+        }
+
+        public boolean isEnabled() {
+            return true;
+        }
+
+        public void actionPerformed(ActionEvent e) {
+        }
+
+        private String name;
+
+        public NullAction(String s) {
+            name = s;
+        }
+
+        public void putValue(String key, Object value) {
+            if (key.equals(Action.NAME)) {
+                name = (String) value;
+            }
+        }
+
+        public Object getValue(String key) {
+            if (key.equals(Action.NAME)) {
+                return name;
+            }
+            return null;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JPopupMenu popup;
+            popup = new JPopupMenu("Test Popup");
+            JMenuItem item0 = popup.add(new NullAction("0"));
+            JMenuItem item2 = popup.add(new NullAction("2"));
+            popup.insert(new NullAction("1"), 1);
+            elements = popup.getSubElements();
+            for (int i = 0; i < 3; i++) {
+                JMenuItem mi = (JMenuItem) elements[i];
+                if (!mi.getText().equals("" + i)) {
+                    passed = false;
+                }
+            }
+        });
+
+        if (!passed) {
+            throw new RuntimeException("Failed: wrong order of menuitems");
+        }
+        System.out.println("Test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug4321273.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4321273.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import java.awt.Robot;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+
+/*
+ * @test
+ * @bug 4321273
+ * @summary NotSerializableException during the menu serialization
+ * @key headful
+ * @run main bug4321273
+*/
+
+public class bug4321273 {
+    public static JFrame frame;
+    public static JMenu menu;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                JMenuBar menuBar = new JMenuBar();
+                frame = new JFrame();
+                frame.setJMenuBar(menuBar);
+                menu = new JMenu("Menu");
+                menuBar.add(menu);
+                menu.add(new JMenuItem("item 1"));
+                menu.add(new JMenuItem("item 2"));
+                menu.add(new JMenuItem("item 3"));
+                frame.pack();
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                menu.doClick();
+                try {
+                    ByteArrayOutputStream byteArrayOutputStream =
+                            new ByteArrayOutputStream();
+                    ObjectOutputStream oos =
+                            new ObjectOutputStream(byteArrayOutputStream);
+                    oos.writeObject(menu);
+                } catch (Exception se) {
+                    throw new RuntimeException("NotSerializableException " +
+                            "during the menu serialization", se);
+                }
+            });
+
+            robot.waitForIdle();
+            robot.delay(100);
+            System.out.println("Test Passed!");
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug4711693.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4711693.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Insets;
+import java.awt.Robot;
+import java.awt.Window;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.InputEvent;
+
+/*
+ * @test
+ * @bug 4711693
+ * @summary Pop-up doesn't stay up
+ * @key headful
+ * @run main bug4711693
+ */
+
+public class bug4711693 {
+    static JFrame fr;
+    static Robot robot;
+    static volatile boolean passed = true;
+    static volatile Dimension scr;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("Test 4711693");
+                scr = new Dimension();
+                fr.setSize(600, 600);
+                GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+                GraphicsDevice[] gs = ge.getScreenDevices();
+                GraphicsConfiguration gc = null;
+
+                for (int j = 0; j < gs.length; j++) {
+                    GraphicsDevice gd = gs[j];
+                    gc = gd.getDefaultConfiguration();
+                    if (gc.getBounds().contains(100, 100)) break;
+                }
+                scr = Toolkit.getDefaultToolkit().getScreenSize();
+                Insets ins = Toolkit.getDefaultToolkit().getScreenInsets(gc);
+                scr.width -= ins.right;
+                scr.height -= ins.bottom;
+                fr.setLocation(scr.width - 400, scr.height - 400);
+                fr.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                final JPopupMenu popupMenu = new JPopupMenu();
+                final Component pane = fr.getContentPane();
+                for (int i = 1; i < 10; i++) {
+                    final String itemName = "Item " + i;
+                    JMenuItem it = popupMenu.add(new JMenuItem(itemName));
+                    it.addActionListener(new ActionListener() {
+                        public void actionPerformed(ActionEvent a) {
+                            passed = false;
+                        }
+                    });
+                }
+
+                pane.addMouseListener(new MouseAdapter() {
+                    public void mousePressed(MouseEvent e) {
+                        if ((e.isAltDown() ||
+                                ((e.getModifiersEx() &
+                                        InputEvent.BUTTON3_DOWN_MASK) != 0))) {
+                            Component parent = e.getComponent();
+                            while (parent != null && !(parent instanceof Window)) {
+                                parent = parent.getParent();
+                            }
+                            popupMenu.show(pane, e.getX(), e.getY());
+                        }
+                    }
+                });
+            });
+
+            robot.mouseMove(scr.width - 55, scr.height - 55);
+            robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+        if (!passed) {
+            throw new RuntimeException("Test failed. Popup disposed on mouse release.");
+        } else {
+            System.out.println("Test Passed!");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug4962731.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4962731.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.plaf.PopupMenuUI;
+import java.awt.BorderLayout;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4962731
+ * @summary The PopupMenu is not repainted if the LAF is changed.
+ * @key headful
+ * @run main bug4962731
+ */
+
+public class bug4962731 {
+
+    public static volatile boolean passed = false;
+    public static boolean isLafOk = true;
+    public static JFrame mainFrame;
+    public static JButton button;
+    public static MyPopup popup;
+    public static Robot robot;
+
+    public static void main(String[] args) throws Exception {
+
+        try {
+            UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        } catch (Exception ex) {
+            System.err.println("Can not initialize Motif L&F. Testing skipped.");
+            isLafOk = false;
+        }
+
+        try {
+            UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        } catch (Exception ex) {
+            System.err.println("Can not initialize Metal L&F. Testing skipped.");
+            isLafOk = false;
+        }
+
+        if (isLafOk) {
+            try {
+                robot = new Robot();
+                SwingUtilities.invokeAndWait(() -> {
+                    mainFrame = new JFrame("Bug4962731");
+                    button = new JButton("Popup!");
+                    popup = new MyPopup();
+                    popup.add("one");
+                    popup.add("two");
+                    button.setComponentPopupMenu(popup);
+                    button.addActionListener(new ActionListener() {
+                        public void actionPerformed(ActionEvent e) {
+                            popup.show(button, 300, 300);
+                            popup.engage();
+                            try {
+                                Thread.sleep(1000);
+                            } catch (InterruptedException e1) {
+                            }
+                            try {
+                                UIManager.setLookAndFeel
+                                        ("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+                            } catch (Exception ex) {
+                            }
+                            try {
+                                Thread.sleep(1000);
+                            } catch (InterruptedException e1) {
+                            }
+                            SwingUtilities.updateComponentTreeUI(mainFrame);
+                            passed = popup.check();
+                        }
+                    });
+                    mainFrame.setLayout(new BorderLayout());
+                    mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    mainFrame.add(button, BorderLayout.CENTER);
+                    mainFrame.pack();
+                    mainFrame.setVisible(true);
+                });
+
+                robot.delay(1000);
+                SwingUtilities.invokeAndWait(() -> {
+                    button.doClick();
+                });
+
+                if (!passed) {
+                    throw new RuntimeException("The UI of popup was not changed");
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(() -> {
+                    if (mainFrame != null) {
+                        mainFrame.dispose();
+                    }
+                });
+            }
+        }
+        System.out.println("test Passed!");
+    }
+
+    public static class MyPopup extends JPopupMenu {
+        PopupMenuUI thisUI;
+
+        public void engage() {
+            thisUI = getUI();
+        }
+
+        public boolean check() {
+            return getUI() != thisUI;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug4966109.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4966109.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JLabel;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4966109
+ * @summary Popup is not populated by mouse actions on lightweight components without mouse
+ * @key headful
+ * @run main bug4966109
+ */
+
+public class bug4966109 {
+    public static JFrame mainFrame;
+    public static JPopupMenu popup;
+    public static JLabel label1;
+    public static JLabel label2;
+    public static Robot robot;
+    public static volatile Point loc;
+    public static volatile Boolean passed = true;
+    public static int popupTrigger;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                mainFrame = new JFrame("Bug4966109");
+                popup = new JPopupMenu();
+                label1 = new JLabel("Label with the listener");
+                label2 = new JLabel("Label w/o listener");
+                mainFrame.setLayout(new BorderLayout());
+                mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                mainFrame.add(label1, BorderLayout.NORTH);
+                mainFrame.add(label2, BorderLayout.SOUTH);
+                mainFrame.pack();
+                mainFrame.setVisible(true);
+                popup.add("One");
+                popup.add("Two");
+                popup.add("Three");
+                label1.setComponentPopupMenu(popup);
+                label1.addMouseListener(new MouseAdapter() {
+                });
+                label2.setComponentPopupMenu(popup);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                loc = label1.getLocationOnScreen();
+                loc.x = loc.x + (int) (label1.getWidth() / 2);
+                loc.y = loc.y + (int) (label1.getHeight() / 2);
+            });
+            popupTrigger = MouseEvent.BUTTON2_DOWN_MASK;
+            robot.mouseMove(loc.x, loc.y);
+            robot.mousePress(popupTrigger);
+            robot.mouseRelease(popupTrigger);
+            robot.waitForIdle();
+            robot.delay(100);
+
+            SwingUtilities.invokeAndWait(() -> {
+                if (popup.isVisible()) {
+                    System.out.println("ZAV: Good!!! BUTTON2 is the way to go.");
+                } else {
+                    System.out.println("ZAV: Bad :( Let's try BUTTON3");
+                    popupTrigger = MouseEvent.BUTTON3_DOWN_MASK;
+                }
+            });
+
+            robot.mousePress(popupTrigger);
+            robot.mouseRelease(popupTrigger);
+            robot.waitForIdle();
+            robot.delay(100);
+
+            SwingUtilities.invokeAndWait(() -> {
+                if (popup.isVisible()) {
+                    System.out.println("ZAV: Good!!! BUTTON3 is working. At last :)");
+                    popup.setVisible(false);
+                } else {
+                    System.out.println("ZAV: Bad :( Very bad. Nothing is working...");
+                    passed = false;
+                }
+            });
+            if (!passed) {
+                throw new RuntimeException("No popup trigger mouse events found");
+            }
+            robot.waitForIdle();
+            robot.delay(100);
+
+            SwingUtilities.invokeAndWait(() -> {
+                loc = label2.getLocationOnScreen();
+                loc.x = loc.x + (int) (label2.getWidth() / 2);
+                loc.y = loc.y + (int) (label2.getHeight() / 2);
+            });
+            robot.mouseMove(loc.x, loc.y);
+            robot.mousePress(popupTrigger);
+            robot.mouseRelease(popupTrigger);
+            robot.waitForIdle();
+            robot.delay(100);
+
+            SwingUtilities.invokeAndWait(() -> {
+                if (!popup.isVisible()) {
+                    passed = false;
+                }
+            });
+            if (!passed) {
+                throw new RuntimeException("Regression: bug 4966109, popup is not visible");
+            }
+        } finally {
+            if (mainFrame != null) {
+                mainFrame.dispose();
+            }
+        }
+        System.out.println("test Passed!");
+    }
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug5091257.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug5091257.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.event.PopupMenuEvent;
+import java.awt.BorderLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 5091257
+ * @summary Application key does not display a pop-up menu in users view.
+ * @key headful
+ * @run main bug5091257
+ */
+
+public class bug5091257 {
+    public static volatile boolean passed = false;
+    public static volatile boolean isKeyOk = false;
+    public static JFrame mainFrame;
+    public static JButton button;
+    public static Robot robot;
+    public static JPopupMenu popup;
+    public static volatile Point loc;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(50);
+            SwingUtilities.invokeAndWait(() -> {
+                button = new JButton("Popup button");
+                button.addKeyListener(new KeyListener() {
+                    public void keyTyped(KeyEvent e) {
+                        if (e.getKeyCode() == KeyEvent.VK_CONTEXT_MENU) {
+                            isKeyOk = true;
+                        }
+                    }
+
+                    public void keyPressed(KeyEvent e) {
+                        if (e.getKeyCode() == KeyEvent.VK_CONTEXT_MENU) {
+                            isKeyOk = true;
+                        }
+                    }
+
+                    public void keyReleased(KeyEvent e) {
+                        if (e.getKeyCode() == KeyEvent.VK_CONTEXT_MENU) {
+                            isKeyOk = true;
+                        }
+                    }
+                });
+                mainFrame = new JFrame("Bug5091257");
+                mainFrame.setLayout(new BorderLayout());
+                mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                mainFrame.add(button, BorderLayout.CENTER);
+                mainFrame.pack();
+                mainFrame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                loc = button.getLocationOnScreen();
+                loc.x = loc.x + (int) (button.getWidth() / 2);
+                loc.y = loc.y + (int) (button.getHeight() / 2);
+            });
+            robot.mouseMove(loc.x, loc.y);
+            robot.mousePress(MouseEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON3_DOWN_MASK);
+
+            robot.waitForIdle();
+            robot.delay(100);
+
+            try {
+                robot.keyPress(KeyEvent.VK_CONTEXT_MENU);
+                robot.keyRelease(KeyEvent.VK_CONTEXT_MENU);
+            } catch (IllegalArgumentException ex) {
+                isKeyOk = false;
+            }
+
+            if (!isKeyOk) {
+                System.out.println("KeyEvent can't create or deliver " +
+                        "VK_CONTEXT_MENU event to component. Testing skipped.");
+                passed = true;
+            } else {
+                SwingUtilities.invokeAndWait(() -> {
+                    popup = new JPopupMenu();
+                    popup.add("Item to make popup not empty");
+                    popup.addPopupMenuListener(new PopupMenuListener() {
+                        public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+                            System.out.println("Popup menu became visible " +
+                                    "on context menu key press. Test passed.");
+                            passed = true;
+                        }
+
+                        public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+                        }
+
+                        public void popupMenuCanceled(PopupMenuEvent e) {
+                        }
+                    });
+                    button.setComponentPopupMenu(popup);
+                });
+                robot.keyPress(KeyEvent.VK_CONTEXT_MENU);
+                robot.keyRelease(KeyEvent.VK_CONTEXT_MENU);
+
+                robot.waitForIdle();
+                robot.delay(100);
+
+                if (!passed) {
+                    throw new RuntimeException("Popup did not open on " +
+                            "VK_CONTEXT_MENU press. Test failed.");
+                }
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (mainFrame != null) {
+                    mainFrame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315669](https://bugs.openjdk.org/browse/JDK-8315669) needs maintainer approval

### Issue
 * [JDK-8315669](https://bugs.openjdk.org/browse/JDK-8315669): Open source several Swing PopupMenu related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1514/head:pull/1514` \
`$ git checkout pull/1514`

Update a local copy of the PR: \
`$ git checkout pull/1514` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1514`

View PR using the GUI difftool: \
`$ git pr show -t 1514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1514.diff">https://git.openjdk.org/jdk21u-dev/pull/1514.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1514#issuecomment-2732554168)
</details>
