### PR TITLE
8340433: Open source closed choice tests #3

### DIFF
--- a/test/jdk/java/awt/Choice/ChoicePosTest.java
+++ b/test/jdk/java/awt/Choice/ChoicePosTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+
+/*
+ * @test
+ * @bug 4075194
+ * @summary 4075194, Choice may not be displayed at the location requested
+ * @key headful
+ */
+
+public class ChoicePosTest {
+
+    private static Robot robot;
+    private static Frame frame;
+    private static final int GAP = 10;
+    private static volatile Choice c1,c2;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(ChoicePosTest::createAndShowGUI);
+
+            robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(500);
+
+            captureAndTestChoices();
+        } finally {
+            EventQueue.invokeAndWait(frame::dispose);
+        }
+
+        System.out.println("Passed");
+    }
+
+    private static void createAndShowGUI() {
+        frame = new Frame("ChoicePosTest");
+        Insets insets = frame.getInsets();
+        frame.setSize( insets.left + 400 + insets.right, insets.top + 400 + insets.bottom );
+        frame.setBackground(Color.RED);
+        frame.setLayout(null);
+        frame.setLocationRelativeTo(null);
+
+        c1 = new Choice();
+        c1.setBackground(Color.GREEN);
+        frame.add( c1 );
+        c1.setBounds( 20, 50, 100, 100 );
+
+        c2 = new Choice();
+        c2.setBackground(Color.GREEN);
+        frame.add(c2);
+        c2.addItem("One");
+        c2.addItem("Two");
+        c2.addItem("Three");
+        c2.setBounds( 125, 50, 100, 100 );
+
+        frame.validate();
+        frame.setVisible(true);
+    }
+
+    private static void captureAndTestChoices() {
+        Point c1loc = c1.getLocationOnScreen();
+        Point c2loc = c2.getLocationOnScreen();
+
+        int startX = c1loc.x - GAP;
+        int startY = c1loc.y - GAP;
+        int captureWidth = c2loc.x + c2.getWidth() + GAP - startX;
+        int captureHeight = c2loc.y + c2.getHeight() + GAP - startY;
+
+        BufferedImage bi = robot.createScreenCapture(
+                new Rectangle(startX, startY, captureWidth, captureHeight)
+        );
+
+        int redPix = Color.RED.getRGB();
+
+        int lastNonRedCount = 0;
+
+        for (int y = 0; y < captureHeight; y++) {
+            int nonRedCount = 0;
+            for (int x = 0; x < captureWidth; x++) {
+                int pix = bi.getRGB(x, y);
+                if (pix != redPix) {
+                    nonRedCount++;
+                }
+            }
+
+            if (nonRedCount > 0 && lastNonRedCount > 0) {
+                if (lastNonRedCount - nonRedCount > 0) {
+                    System.err.printf(
+                            "Failed at %d, nonRedCount: %d lastNonRedCount: %d\n",
+                            y, nonRedCount, lastNonRedCount
+                    );
+
+                    try {
+                        ImageIO.write(bi, "png", new File("choices.png"));
+                    } catch (IOException ignored) {
+                    }
+
+                    throw new RuntimeException("Choices are not aligned");
+                }
+            }
+
+            lastNonRedCount = nonRedCount;
+        }
+    }
+}

--- a/test/jdk/java/awt/Choice/DeadlockTest.java
+++ b/test/jdk/java/awt/Choice/DeadlockTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Frame;
+import jdk.test.lib.Platform;
+
+/*
+ * @test
+ * @bug 4134619
+ * @summary    Tests that the EventDispatchThread doesn't deadlock with
+ *             user threads which are modifying a Choice component.
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jdk.test.lib.Platform
+ * @run main/manual DeadlockTest
+ */
+
+public class DeadlockTest extends Thread {
+
+    static volatile Choice choice1;
+    static volatile Choice choice2;
+    static volatile Choice choice3;
+    static volatile Frame frame;
+    static int itemCount = 0;
+
+    private static final boolean isWindows = Platform.isWindows();
+
+    private static final String INSTRUCTIONS = """
+            Click on the top Choice component and hold the mouse still briefly.
+            Then, without releasing the mouse button, move the cursor to a menu
+            item and then again hold the mouse still briefly.
+            %s
+            Release the button and repeat this process.
+
+            Verify that this does not cause a deadlock
+            or crash within a reasonable amount of time.
+            """.formatted(
+                isWindows
+                    ? "(menu can automatically collapse sometimes, this is ok)\n"
+                    : ""
+
+    )       ;
+
+    public static void main(String[] args) throws Exception {
+        DeadlockTest deadlockTest = new DeadlockTest();
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .title("DeadlockTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(deadlockTest::createAndShowUI)
+                .build();
+
+        deadlockTest.start();
+
+        passFailJFrame.awaitAndCheck();
+    }
+
+   public Frame createAndShowUI() {
+       frame = new Frame("Check Choice");
+       frame.setLayout(new BorderLayout());
+       choice1 = new Choice();
+       choice2 = new Choice();
+       choice3 = new Choice();
+       frame.add(choice1, BorderLayout.NORTH);
+       frame.add(choice3, BorderLayout.CENTER);
+       frame.add(choice2, BorderLayout.SOUTH);
+       frame.pack();
+       return frame;
+   }
+
+    public void run() {
+        while (true) {
+            if (choice1 != null && itemCount < 40) {
+                choice1.add("I am Choice, yes I am : " + itemCount * itemCount);
+                choice2.add("I am the same, yes I am : " + itemCount * itemCount);
+                choice3.add("I am the same, yes I am : " + itemCount * itemCount);
+                itemCount++;
+            }
+            if (itemCount >= 20 && choice1 != null &&
+                    choice1.getItemCount() > 0) {
+                choice1.removeAll();
+                choice2.removeAll();
+                choice3.removeAll();
+                itemCount = 0;
+            }
+            frame.validate();
+            try {
+                Thread.sleep(1000);
+            } catch (Exception ignored) {}
+        }
+    }
+}

--- a/test/jdk/java/awt/Choice/SetFontTest.java
+++ b/test/jdk/java/awt/Choice/SetFontTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Panel;
+
+/*
+ * @test
+ * @bug 4293346
+ * @summary Checks that Choice does update its dimensions on font change
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetFontTest
+ */
+
+public class SetFontTest {
+
+    private static final String INSTRUCTIONS = """
+            Choice component used to not update its dimension on font change.
+            Select one of fonts on the choice pull down list.
+            Pull down the list after the font change; if items in the list are
+            shown correctly the test is passed, otherwise it failed.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("SetFontTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(SetFontTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Frame frame = new Frame("SetFontTest");
+        Choice choice = new Choice();
+        frame.setBounds(100, 400, 400, 100);
+        choice.addItem("dummy");
+        choice.addItem("Set LARGE Font");
+        choice.addItem("Set small Font");
+        choice.addItem("addNewItem");
+        choice.addItem("deleteItem");
+
+        choice.addItemListener(e -> {
+            if (e.getItem().toString().equals("addNewItem")) {
+                choice.addItem("very very very very long item");
+                frame.validate();
+            } else if (e.getItem().toString().equals("deleteItem")) {
+                if (choice.getItemCount() > 4) {
+                    choice.remove(4);
+                    frame.validate();
+                }
+            } else if (e.getItem().toString().equals("Set LARGE Font")) {
+                choice.setFont(new Font("Dialog", Font.PLAIN, 24));
+                frame.validate();
+            } else if (e.getItem().toString().equals("Set small Font")) {
+                choice.setFont(new Font("Dialog", Font.PLAIN, 10));
+                frame.validate();
+            }
+        });
+        Panel panel = new Panel();
+        panel.add(choice);
+        frame.add(panel, BorderLayout.CENTER);
+        return frame;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

One test fails, but I could reproduce this in head. So this is not a 21u specific issue and thus not 
a blocker for this test-only backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340433](https://bugs.openjdk.org/browse/JDK-8340433) needs maintainer approval

### Issue
 * [JDK-8340433](https://bugs.openjdk.org/browse/JDK-8340433): Open source closed choice tests #3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1515/head:pull/1515` \
`$ git checkout pull/1515`

Update a local copy of the PR: \
`$ git checkout pull/1515` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1515`

View PR using the GUI difftool: \
`$ git pr show -t 1515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1515.diff">https://git.openjdk.org/jdk21u-dev/pull/1515.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1515#issuecomment-2732723517)
</details>
