### PR TITLE
8340809: Open source few more AWT PopupMenu tests

### DIFF
--- a/test/jdk/java/awt/PopupMenu/ActivePopupCrashTest.java
+++ b/test/jdk/java/awt/PopupMenu/ActivePopupCrashTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.Robot;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import java.util.Hashtable;
+
+/*
+ * @test
+ * @bug 4214550
+ * @summary Tests that there is no seg fault on repeatedly showing
+ *          PopupMenu by right-clicking Label, Panel or Button
+ * @key headful
+ * @run main ActivePopupCrashTest
+ */
+
+public class ActivePopupCrashTest {
+    private static Frame f;
+    private static Label l;
+    private static Button b;
+    private static Panel p;
+
+    private static volatile Point labelCenter;
+    private static volatile Point buttonCenter;
+    private static volatile Point panelCenter;
+
+    public static void main(String[] args) throws Exception {
+        final int REPEAT_COUNT = 5;
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+            EventQueue.invokeAndWait(ActivePopupCrashTest::createAndShowUI);
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                labelCenter = getCenterPoint(l);
+                buttonCenter = getCenterPoint(b);
+                panelCenter = getCenterPoint(p);
+            });
+
+            for (int i = 0; i < REPEAT_COUNT; i++) {
+                robot.mouseMove(labelCenter.x, labelCenter.y);
+                robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+
+                robot.mouseMove(buttonCenter.x, buttonCenter.y);
+                robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+
+                robot.mouseMove(panelCenter.x, panelCenter.y);
+                robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+            }
+
+            // To close the popup, otherwise test fails on windows with timeout error
+            robot.mouseMove(panelCenter.x - 5, panelCenter.y - 5);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static Point getCenterPoint(Component component) {
+        Point p = component.getLocationOnScreen();
+        Dimension size = component.getSize();
+        return new Point(p.x + size.width / 2, p.y + size.height / 2);
+    }
+
+    public static void createAndShowUI() {
+        f = new Frame("ActivePopupCrashTest Test");
+        MenuItem item = new MenuItem("file-1");
+        item.addActionListener(ActivePopupCrashTest::logActionEvent);
+        Menu m = new Menu("file");
+        m.add(item);
+        item = new MenuItem("file-2");
+        m.add(item);
+        MenuBar mb = new MenuBar();
+        mb.add(m);
+
+        f.setMenuBar(mb);
+        f.setSize(200, 200);
+        f.setLayout(new BorderLayout());
+
+        l = new Label("label");
+        addPopup(l, "label");
+        f.add(l, BorderLayout.NORTH);
+
+        p = new Panel();
+        addPopup(p, "panel");
+        f.add(p, BorderLayout.CENTER);
+
+        b = new Button("button");
+        addPopup(b, "button");
+        f.add(b, BorderLayout.SOUTH);
+
+        f.setSize(400, 300);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+    static void addPopup(Component c, String name) {
+        PopupMenu pm = new PopupMenu();
+        MenuItem mi = new MenuItem(name + "-1");
+        mi.addActionListener(ActivePopupCrashTest::logActionEvent);
+        pm.add(mi);
+
+        mi = new MenuItem(name + "-2");
+        pm.add(mi);
+
+        setHash(c, pm);
+        c.add(pm);
+        c.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                mouseAction("mouseClicked", e);
+            }
+
+            @Override
+            public void mousePressed(MouseEvent e) {
+                mouseAction("mousePressed", e);
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                mouseAction("mouseReleased", e);
+            }
+        });
+    }
+
+    static void logActionEvent(ActionEvent e) {
+        System.out.println("actionPerformed, event=" + e + ", mod=" + getMods(e));
+        System.out.println("command=" + e.getActionCommand());
+        System.out.println("param=" + e.paramString());
+        System.out.println("source=" + e.getSource());
+    }
+
+    static String getMods(ActionEvent e) { return getMods(e.getModifiers()); }
+
+    static String getMods(MouseEvent e) { return getMods(e.getModifiers()); }
+
+    static String getMods(int mods) {
+        String modstr = "";
+        if ((mods & ActionEvent.SHIFT_MASK) == ActionEvent.SHIFT_MASK) {
+            modstr += (" SHIFT");
+        } else if ((mods & ActionEvent.ALT_MASK) == ActionEvent.ALT_MASK) {
+            modstr += (" ALT");
+        } else if ((mods & ActionEvent.CTRL_MASK) == ActionEvent.CTRL_MASK) {
+            modstr += (" CTRL");
+        } else if ((mods & ActionEvent.META_MASK) == ActionEvent.META_MASK) {
+            modstr += (" META");
+        }
+        return modstr;
+    }
+
+    static void mouseAction(String which, MouseEvent e) {
+        Component c = e.getComponent();
+        System.out.println(which + " e = " + e + " , mods = " + getMods(e) +
+                " , component = " + c);
+        if (e.isPopupTrigger()) {
+            System.out.println("isPopup");
+            PopupMenu pm = getHash(c);
+            pm.show(c, c.getWidth() / 2, c.getHeight() / 2);
+        }
+    }
+
+    static Hashtable<Component, PopupMenu> popupTable = new Hashtable<>();
+
+    static void setHash(Component c, PopupMenu p) {
+        popupTable.put(c, p);
+    }
+
+    static PopupMenu getHash(Component c) {
+        return popupTable.get(c);
+    }
+
+}

--- a/test/jdk/java/awt/PopupMenu/KeyTraversalCrash.java
+++ b/test/jdk/java/awt/PopupMenu/KeyTraversalCrash.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Menu;
+import java.awt.MenuItem;
+import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.Robot;
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 5021183
+ * @summary Tests Key Traversal doesn't crash PopupMenu
+ * @key headful
+ * @run main KeyTraversalCrash
+ */
+
+public class KeyTraversalCrash {
+    private static Frame f;
+    private static Label label;
+
+    private static volatile Point loc;
+    private static volatile Dimension dim;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            EventQueue.invokeAndWait(KeyTraversalCrash::createAndShowUI);
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                loc = label.getLocationOnScreen();
+                dim = label.getSize();
+            });
+
+            robot.mouseMove(loc.x + 20, loc.y + 20);
+            robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+
+            robot.mouseMove(loc.x + 25, loc.y + 25);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            robot.keyPress(KeyEvent.VK_LEFT);
+            robot.keyRelease(KeyEvent.VK_LEFT);
+
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
+
+            // To close the popup, otherwise test fails on windows with timeout error
+            robot.mouseMove(loc.x + dim.width - 20, loc.y + dim.height - 20);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    public static void createAndShowUI() {
+        f = new Frame("KeyTraversalCrash Test");
+        final PopupMenu popup = new PopupMenu();
+        for (int i = 0; i < 10; i++) {
+            Menu menu = new Menu("Menu " + i);
+            for(int j = 0; j < 10; j++) {
+                MenuItem menuItem = new MenuItem("MenuItem " + j);
+                menu.add(menuItem);
+            }
+            popup.add(menu);
+        }
+        label = new Label("Label");
+        f.add(label);
+        f.add(popup);
+        label.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent me) {
+                if (me.isPopupTrigger()) {
+                    popup.show(me.getComponent(), me.getX(), me.getY());
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent me) {
+                if (me.isPopupTrigger()) {
+                    popup.show(me.getComponent(), me.getX(), me.getY());
+                }
+            }
+        });
+        f.setSize(200, 200);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/PopupMenu/MultiplePopupMenusTest.java
+++ b/test/jdk/java/awt/PopupMenu/MultiplePopupMenusTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4186663 4265525
+ * @summary Tests that multiple PopupMenus cannot appear at the same time
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MultiplePopupMenusTest
+ */
+
+public class MultiplePopupMenusTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Click the right mouse button on the button
+                If multiple popups appear at the same time the
+                test fails else passes.
+                """;
+
+        PassFailJFrame.builder()
+                .title("MultiplePopupMenusTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(30)
+                .testUI(MultiplePopupMenusTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame fr = new Frame("MultiplePopupMenusTest Test");
+        TestButton button = new TestButton("button");
+        fr.add(button);
+        fr.setSize(200, 200);
+        return fr;
+    }
+
+    static class TestButton extends Button {
+        public TestButton(String title) {
+            super(title);
+            enableEvents(AWTEvent.MOUSE_EVENT_MASK);
+        }
+
+        @Override
+        public void processMouseEvent(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                for (int i = 0; i < 10; i++) {
+                    PopupMenu pm = new PopupMenu("Popup " + i);
+                    pm.add(new MenuItem("item 1"));
+                    pm.add(new MenuItem("item 2"));
+                    add(pm);
+                    pm.show(this, e.getX() + i * 5, e.getY() + i * 5);
+                }
+            }
+            super.processMouseEvent(e);
+        }
+    }
+}

--- a/test/jdk/java/awt/PopupMenu/PopupMenuCrash.java
+++ b/test/jdk/java/awt/PopupMenu/PopupMenuCrash.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4281273
+ * @summary PopupMenu crashed in Java. Simplified testcase.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "windows")
+ * @run main/manual PopupMenuCrash
+ */
+
+public class PopupMenuCrash {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This tests a windows specific problem.
+                When you see a frame titled "PopupMenuCrash Test", right-click on it
+                several times for a few seconds. Then wait about 10 seconds before the
+                PopupMenus start to appear. Then dispose them one by one by clicking on them.
+                When PopupMenus do not appear anymore, press Pass.
+                In case of a failure, you'll see a crash.
+                """;
+
+        PassFailJFrame.builder()
+                .title("PopupMenuCrash Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(PopupMenuCrash::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        final Frame f = new Frame("PopupMenuCrash Test");
+        f.setLayout(new FlowLayout());
+        f.add(new Label("Press right mouse button inside this frame."));
+        f.add(new Label("A pop-up menu should appear."));
+        f.addMouseListener(new MouseAdapter() {
+            PopupMenu popup;
+            boolean firstPress = true;
+
+            @Override
+            public void mousePressed(MouseEvent evt) {
+                if (firstPress) {
+                    firstPress = false;
+                    try {
+                        Thread.sleep(10000);
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+
+                if ((evt.getModifiers() & InputEvent.BUTTON3_MASK) != 0) {
+                    popup = new PopupMenu("Popup Menu Title");
+                    MenuItem mi = new MenuItem("MenuItem");
+                    popup.add(mi);
+                    f.add(popup);
+                    popup.show(evt.getComponent(), evt.getX(), evt.getY());
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent evt) {
+                if ((evt.getModifiers() & InputEvent.BUTTON3_MASK) != 0) {
+                    if (popup != null) {
+                        f.remove(popup);
+                        popup = null;
+                    }
+                }
+            }
+        });
+
+        f.setSize(400, 350);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/PopupMenu/StressTest.java
+++ b/test/jdk/java/awt/PopupMenu/StressTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.MenuItem;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.Robot;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4083400
+ * @key headful
+ * @summary Tests that excessive popping up and down does not crash or
+ *          throw an exception.
+ * @run main StressTest
+ */
+
+public class StressTest {
+    private static Frame fr;
+    private static PopupTestPanel panel;
+
+    private static volatile Point panelCenter;
+
+    public static void main(String[] args) throws Exception {
+        final int REPEAT_COUNT = 5;
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+            EventQueue.invokeAndWait(StressTest::createAndShowUI);
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                Point loc = panel.getLocationOnScreen();
+                Dimension dim = panel.getSize();
+                panelCenter = new Point(loc.x + dim.width / 2, loc.y + dim.height / 2);
+            });
+
+            for (int i = 0; i < REPEAT_COUNT; i++) {
+                robot.mouseMove(panelCenter.x + i * 2, panelCenter.y + i * 2);
+
+                robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+
+                robot.mouseMove(panelCenter.x - i * 2, panelCenter.y - i * 2);
+
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    public static void createAndShowUI() {
+        fr = new Frame("PopupMenu Test");
+        panel = new PopupTestPanel();
+        fr.add(panel);
+        fr.setSize(300, 200);
+        fr.setVisible(true);
+    }
+
+    static class PopupTestPanel extends Panel {
+
+        static class Item extends MenuItem {
+            public Item(String text) {
+                super(text);
+            }
+
+            public boolean isEnabled() {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ignored) {
+                }
+                return super.isEnabled();
+            }
+        }
+
+        final PopupMenu popup;
+
+        public PopupTestPanel() {
+            popup = new PopupMenu();
+            popup.add(new Item("Soap"));
+            popup.add(new Item("Sponge"));
+            popup.add(new Item("Flannel"));
+            popup.add(new Item("Mat"));
+            popup.add(new Item("Towel"));
+            add(popup);
+            addMouseListener(new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    if (e.isPopupTrigger()) {
+                        showPopup(e);
+                    }
+                }
+
+                @Override
+                public void mouseReleased(MouseEvent e) {
+                    if (e.isPopupTrigger()) {
+                        showPopup(e);
+                    }
+                }
+
+                private void showPopup(MouseEvent e) {
+                    popup.show((Component) e.getSource(), e.getX(), e.getY());
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340809](https://bugs.openjdk.org/browse/JDK-8340809) needs maintainer approval

### Issue
 * [JDK-8340809](https://bugs.openjdk.org/browse/JDK-8340809): Open source few more AWT PopupMenu tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1517/head:pull/1517` \
`$ git checkout pull/1517`

Update a local copy of the PR: \
`$ git checkout pull/1517` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1517`

View PR using the GUI difftool: \
`$ git pr show -t 1517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1517.diff">https://git.openjdk.org/jdk21u-dev/pull/1517.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1517#issuecomment-2732859702)
</details>
