### PR TITLE
8343936: Adjust timeout in test javax/management/monitor/DerivedGaugeMonitorTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -529,8 +529,6 @@ sun/management/jdp/JdpOffTest.java                              8308807 aix-ppc6
 
 javax/management/MBeanServer/OldMBeanServerTest.java            8030957 aix-all
 
-javax/management/monitor/DerivedGaugeMonitorTest.java           8042211 generic-all
-
 javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 generic-all
 
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8262312 linux-all

--- a/test/jdk/javax/management/monitor/DerivedGaugeMonitorTest.java
+++ b/test/jdk/javax/management/monitor/DerivedGaugeMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@
  * @summary Test that the initial derived gauge is (Integer)0
  * @author Daniel Fuchs
  *
+ * @library /test/lib
+ *
  * @run clean DerivedGaugeMonitorTest
  * @run build DerivedGaugeMonitorTest
  * @run main DerivedGaugeMonitorTest
@@ -40,8 +42,11 @@ import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
 import javax.management.monitor.CounterMonitor;
 import javax.management.monitor.GaugeMonitor;
+import jdk.test.lib.Utils;
 
 public class DerivedGaugeMonitorTest {
+
+    public static final int WAIT_TIME = 1000;
 
     public static interface Things {
         public long getALong();
@@ -239,7 +244,7 @@ public class DerivedGaugeMonitorTest {
             mon1.setGranularityPeriod(5);
             mon2.setGranularityPeriod(5);
 
-            my.cdl.await(1000, TimeUnit.MILLISECONDS);
+            my.cdl.await(Utils.adjustTimeout(WAIT_TIME), TimeUnit.MILLISECONDS);
             if (my.cdl.getCount() > 0)
                 throw new Exception(attr+": Count down not reached!");
 


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

Resolved ProblemList, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343936](https://bugs.openjdk.org/browse/JDK-8343936) needs maintainer approval

### Issue
 * [JDK-8343936](https://bugs.openjdk.org/browse/JDK-8343936): Adjust timeout in test javax/management/monitor/DerivedGaugeMonitorTest.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1518/head:pull/1518` \
`$ git checkout pull/1518`

Update a local copy of the PR: \
`$ git checkout pull/1518` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1518`

View PR using the GUI difftool: \
`$ git pr show -t 1518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1518.diff">https://git.openjdk.org/jdk21u-dev/pull/1518.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1518#issuecomment-2732950366)
</details>
