### PR TITLE
8343529: serviceability/sa/ClhsdbWhere.java fails AssertionFailure: Corrupted constant pool

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSJstackPrintAll.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSJstackPrintAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,10 @@ public class ClhsdbCDSJstackPrintAll {
             CDSTestUtils.createArchiveAndCheck(opts);
 
             ClhsdbLauncher test = new ClhsdbLauncher();
+            // This test could possibly cause some unexpected SA exceptions because one
+            // or more threads are active during the stack trace. Ignore them. The threads
+            // we care about should still be present in the output.
+            test.ignoreExceptions();
             theApp = LingeredApp.startApp(
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:SharedArchiveFile=" + sharedArchiveName,

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,9 +41,15 @@ import jdk.test.lib.SA.SATestUtils;
 public class ClhsdbLauncher {
 
     private Process toolProcess;
+    private boolean ignoreExceptions;
 
     public ClhsdbLauncher() {
         toolProcess = null;
+        ignoreExceptions = false;
+    }
+
+    public void ignoreExceptions() {
+        ignoreExceptions = true;
     }
 
     /**
@@ -147,11 +153,13 @@ public class ClhsdbLauncher {
         // -Xcheck:jni might be set via TEST_VM_OPTS. Make sure there are no warnings.
         oa.shouldNotMatch("^WARNING: JNI local refs:.*$");
         oa.shouldNotMatch("^WARNING in native method:.*$");
-        // This will detect most SA failures, including during the attach.
-        oa.shouldNotMatch("^sun.jvm.hotspot.debugger.DebuggerException:.*$");
-        // This will detect unexpected exceptions, like NPEs and asserts, that are caught
-        // by sun.jvm.hotspot.CommandProcessor.
-        oa.shouldNotMatch("^Error: .*$");
+        if (!ignoreExceptions) {
+            // This will detect most SA failures, including during the attach.
+            oa.shouldNotMatch("^sun.jvm.hotspot.debugger.DebuggerException:.*$");
+            // This will detect unexpected exceptions, like NPEs and asserts, that are caught
+            // by sun.jvm.hotspot.CommandProcessor.
+            oa.shouldNotMatch("^Error: .*$");
+        }
 
         String[] parts = output.split("hsdb>");
         for (String cmd : commands) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbWhere.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbWhere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,10 @@ public class ClhsdbWhere {
         LingeredApp theApp = null;
         try {
             ClhsdbLauncher test = new ClhsdbLauncher();
+            // This test could possibly cause some unexpected SA exceptions because one
+            // or more threads are active during the stack trace. Ignore them. The threads
+            // we care about should still be present in the output.
+            test.ignoreExceptions();
             theApp = LingeredApp.startApp();
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

I had to resolve as https://github.com/openjdk/jdk/commit/831868271656a60074b478e8124da82bde39cfc5: SA decoding of scalar replaced objects is broken
is not in 21.  This added one more line ClhsdbLauncher.java:158 that needs to be indented.  Trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307318](https://bugs.openjdk.org/browse/JDK-8307318) needs maintainer approval
- [x] [JDK-8343529](https://bugs.openjdk.org/browse/JDK-8343529) needs maintainer approval

### Issues
 * [JDK-8343529](https://bugs.openjdk.org/browse/JDK-8343529): serviceability/sa/ClhsdbWhere.java fails AssertionFailure: Corrupted constant pool (**Bug** - P4 - Approved)
 * [JDK-8307318](https://bugs.openjdk.org/browse/JDK-8307318): Test serviceability/sa/ClhsdbCDSJstackPrintAll.java failed: ArrayIndexOutOfBoundsException (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1519/head:pull/1519` \
`$ git checkout pull/1519`

Update a local copy of the PR: \
`$ git checkout pull/1519` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1519`

View PR using the GUI difftool: \
`$ git pr show -t 1519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1519.diff">https://git.openjdk.org/jdk21u-dev/pull/1519.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1519#issuecomment-2733365754)
</details>
