### PR TITLE
8350260: Improve HTML instruction formatting in PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -633,6 +633,8 @@ public final class PassFailJFrame {
                               ? configureHTML(instructions, rows, columns)
                               : configurePlainText(instructions, rows, columns);
         text.setEditable(false);
+        text.setBorder(createTextBorder());
+        text.setCaretPosition(0);
 
         JPanel textPanel = new JPanel(new BorderLayout());
         textPanel.setBorder(createEmptyBorder(GAP, 0, GAP, 0));
@@ -687,7 +689,6 @@ public final class PassFailJFrame {
         JTextArea text = new JTextArea(instructions, rows, columns);
         text.setLineWrap(true);
         text.setWrapStyleWord(true);
-        text.setBorder(createTextBorder());
         return text;
     }
 
@@ -701,10 +702,10 @@ public final class PassFailJFrame {
 
         HTMLEditorKit kit = (HTMLEditorKit) text.getEditorKit();
         StyleSheet styles = kit.getStyleSheet();
-        // Reduce the default margins
-        styles.addRule("ol, ul { margin-left-ltr: 20; margin-left-rtl: 20 }");
-        // Make the size of code blocks the same as other text
-        styles.addRule("code { font-size: inherit }");
+        // Reduce the list default margins
+        styles.addRule("ol, ul { margin-left-ltr: 30; margin-left-rtl: 30 }");
+        // Make the size of code (and other elements) the same as other text
+        styles.addRule("code, kbd, samp, pre { font-size: inherit }");
 
         return text;
     }


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350260](https://bugs.openjdk.org/browse/JDK-8350260) needs maintainer approval

### Issue
 * [JDK-8350260](https://bugs.openjdk.org/browse/JDK-8350260): Improve HTML instruction formatting in PassFailJFrame (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1520/head:pull/1520` \
`$ git checkout pull/1520`

Update a local copy of the PR: \
`$ git checkout pull/1520` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1520`

View PR using the GUI difftool: \
`$ git pr show -t 1520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1520.diff">https://git.openjdk.org/jdk21u-dev/pull/1520.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1520#issuecomment-2734515748)
</details>
