### PR TITLE
8294155: Exception thrown before awaitAndCheck hangs PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1787,8 +1787,20 @@ public final class PassFailJFrame {
 
         public PassFailJFrame build() throws InterruptedException,
                 InvocationTargetException {
-            validate();
-            return new PassFailJFrame(this);
+            try {
+                validate();
+                return new PassFailJFrame(this);
+            } catch (final Throwable t) {
+                // Dispose of all the windows, including those that may not
+                // be registered with PassFailJFrame to allow AWT to shut down
+                try {
+                    invokeOnEDT(() -> Arrays.stream(Window.getWindows())
+                                            .forEach(Window::dispose));
+                } catch (Throwable edt) {
+                    t.addSuppressed(edt);
+                }
+                throw t;
+            }
         }
 
         /**


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8294155](https://bugs.openjdk.org/browse/JDK-8294155) needs maintainer approval

### Issue
 * [JDK-8294155](https://bugs.openjdk.org/browse/JDK-8294155): Exception thrown before awaitAndCheck hangs PassFailJFrame (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1522/head:pull/1522` \
`$ git checkout pull/1522`

Update a local copy of the PR: \
`$ git checkout pull/1522` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1522`

View PR using the GUI difftool: \
`$ git pr show -t 1522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1522.diff">https://git.openjdk.org/jdk21u-dev/pull/1522.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1522#issuecomment-2734617572)
</details>
