### PR TITLE
8339678: Update runtime/condy tests to be executed with VM flags

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -50,3 +50,5 @@ vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 83
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64
 
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
+
+runtime/condy/escapeAnalysis/TestEscapeCondy.java 8339694 generic-all

--- a/test/hotspot/jtreg/runtime/condy/BadBSMUseTest.java
+++ b/test/hotspot/jtreg/runtime/condy/BadBSMUseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8186211
  * @summary CONSTANT_Dynamic_info structure's tries to use a BSM index whose signature is for an invokedynamic and vice versa.
- * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile CondyUsesIndyBSM.jcod
@@ -42,7 +41,7 @@ public class BadBSMUseTest {
     public static void main(String args[]) throws Throwable {
         // 1. Test a CONSTANT_Dynamic_info's bootstrap_method_attr_index points
         //    at a BSM meant for a CONSTANT_InvokeDynamic_info
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("CondyUsesIndyBSM");
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("CondyUsesIndyBSM");
         OutputAnalyzer oa = new OutputAnalyzer(pb.start());
         oa.shouldContain("In Indybsm target CallSite method foo");
         oa.shouldContain("BootstrapMethodError: bootstrap method initialization exception");
@@ -50,7 +49,7 @@ public class BadBSMUseTest {
 
         // 2. Test a CONSTANT_InvokeDynamic_info's bootstrap_method_attr_index points
         //    at a BSM meant for a CONSTANT_Dynamic_info
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("IndyUsesCondyBSM");
+        pb = ProcessTools.createTestJavaProcessBuilder("IndyUsesCondyBSM");
         oa = new OutputAnalyzer(pb.start());
         oa.shouldContain("In Condybsm");
         oa.shouldContain("BootstrapMethodError: bootstrap method initialization exception");

--- a/test/hotspot/jtreg/runtime/condy/CondyLDCTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyLDCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8186211
  * @summary Tests various ldc, ldc_w, ldc2_w instructions of CONSTANT_Dynamic.
- * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile CondyUseLDC_W.jasm
@@ -42,7 +41,7 @@ public class CondyLDCTest {
     public static void main(String args[]) throws Throwable {
         // 1. Test a ldc_w instruction can be used with condy's which generate
         //    loadable constants of the following types: byte, char, short, float, integer, boolean.
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xverify:all",
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Xverify:all",
                                                                              "CondyUseLDC_W");
         OutputAnalyzer oa = new OutputAnalyzer(pb.start());
         oa.shouldNotContain("VerifyError");
@@ -50,7 +49,7 @@ public class CondyLDCTest {
 
         // 2. Test ldc2_w of a condy which returns a dynamically generated
         //    float constant, generates a VerifyError.
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xverify:all",
+        pb = ProcessTools.createTestJavaProcessBuilder("-Xverify:all",
                                                               "CondyBadLDC2_W");
         oa = new OutputAnalyzer(pb.start());
         oa.shouldContain("java.lang.VerifyError: Illegal type at constant pool entry");
@@ -59,7 +58,7 @@ public class CondyLDCTest {
 
         // 3. Test a ldc of a condy which returns a dynamically generated
         //    double constant, generates a VerifyError.
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xverify:all",
+        pb = ProcessTools.createTestJavaProcessBuilder("-Xverify:all",
                                                               "CondyBadLDC");
         oa = new OutputAnalyzer(pb.start());
         oa.shouldContain("java.lang.VerifyError: Illegal type at constant pool entry");

--- a/test/hotspot/jtreg/runtime/condy/CondyNewInvokeSpecialTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyNewInvokeSpecialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8186211
  * @summary Test CONSTANT_Dynamic where the BSM is invoked via a REF_newInvokeSpecial.
- * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile CondyNewInvokeSpecial.jasm
@@ -38,7 +37,7 @@ import jdk.test.lib.compiler.InMemoryJavaCompiler;
 
 public class CondyNewInvokeSpecialTest {
     public static void main(String args[]) throws Throwable {
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xverify:all",
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Xverify:all",
                                                                              "CondyNewInvokeSpecial");
         OutputAnalyzer oa = new OutputAnalyzer(pb.start());
         oa.shouldContain("In CondyNewInvokeSpecial <init> method");

--- a/test/hotspot/jtreg/runtime/condy/escapeAnalysis/TestEscapeCondy.java
+++ b/test/hotspot/jtreg/runtime/condy/escapeAnalysis/TestEscapeCondy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  * @bug 8216970
  * @summary Ensure escape analysis can handle an ldc of a dynamic
  *          constant whose return type is an array of boolean.
- * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile TestEscapeThroughInvokeWithCondy$A.jasm
@@ -43,7 +42,7 @@ public class TestEscapeCondy {
     public static void main(String args[]) throws Throwable {
         // 1. Test escape analysis of a method that contains
         //    a ldc instruction of a condy whose return type is an array of boolean
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
              "-XX:CompileCommand=dontinline,runtime.condy.TestEscapeThroughInvokeWithCondy::create",
              "runtime.condy.TestEscapeThroughInvokeWithCondy");
         OutputAnalyzer oa = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/condy/staticInit/TestInitException.java
+++ b/test/hotspot/jtreg/runtime/condy/staticInit/TestInitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8228485
  * @summary Correctly handle initialization error for Condy BSM.
- * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile Example.jasm
@@ -38,7 +37,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class TestInitException {
     public static void main(java.lang.String[] unused) throws Exception {
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("Example");
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("Example");
         OutputAnalyzer oa = new OutputAnalyzer(pb.start());
         // First call stack trace
         // shouldMatch is used to workaround CODETOOLS-7902686
@@ -52,4 +51,3 @@ public class TestInitException {
         oa.shouldHaveExitValue(1);
     }
 }
-


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339678](https://bugs.openjdk.org/browse/JDK-8339678) needs maintainer approval

### Issue
 * [JDK-8339678](https://bugs.openjdk.org/browse/JDK-8339678): Update runtime/condy tests to be executed with VM flags (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1525/head:pull/1525` \
`$ git checkout pull/1525`

Update a local copy of the PR: \
`$ git checkout pull/1525` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1525`

View PR using the GUI difftool: \
`$ git pr show -t 1525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1525.diff">https://git.openjdk.org/jdk21u-dev/pull/1525.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1525#issuecomment-2736241976)
</details>
