### PR TITLE
8341298: Open source more AWT window tests

### DIFF
--- a/test/jdk/java/awt/Window/LocationByPlatformWithControls/TestLocationByPlatformWithControls.java
+++ b/test/jdk/java/awt/Window/LocationByPlatformWithControls/TestLocationByPlatformWithControls.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4102292
+ * @summary Tests that location by platform works with other APIs
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestLocationByPlatformWithControls
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Checkbox;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.util.Vector;
+
+public class TestLocationByPlatformWithControls extends Frame
+    implements ActionListener, ItemListener {
+    Panel northP;
+    Panel centerP;
+    Checkbox undecoratedCB;
+    Checkbox defaultLocationCB;
+    Checkbox visibleCB;
+    Checkbox iconifiedCB;
+    Checkbox maximizedCB;
+    Button createB;
+    Button packB;
+    Button moveB;
+    Button resizeB;
+    Button reshapeB;
+    Button disposeB;
+    Vector frames;
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            This test is to check that LocationByPlatform works with other
+            controls API.
+            1) Create New Frame by clicking on "Create" Button in
+            "TestLocationByPlatformWithControls" window.
+            2) Initially this Frame will not be visible, Click on checkbox
+            "LocationByPlatform" to set default platform location for the frame
+            and then click on checkbox "Visible" to see that Frame is displayed
+            at default offsets.
+            3) Now you can play with different controls like Iconified,
+            Maximized, Pack, Move, Resize and Reshape to verify that these
+            controls work properly with the Frame.
+            4) At the end dispose the Frame by clicking on "Dispose" button.
+            5) Also we can do verify this for Undecorated Frame but for that we
+            need to follow same steps but in step 2 before we click on checkbox
+            "Visible", select "Undecorated" checkbox along with
+            "LocationByPlatform".
+            6) If everything works properly test is passed, otherwise failed.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(TestLocationByPlatformWithControls::new)
+            .logArea(4)
+            .build()
+            .awaitAndCheck();
+    }
+
+    public TestLocationByPlatformWithControls() {
+        northP = new Panel();
+        centerP = new Panel();
+
+        undecoratedCB = new Checkbox("Undecorated");
+        defaultLocationCB = new Checkbox("LocationByPlatform");
+        visibleCB = new Checkbox("Visible");
+        iconifiedCB = new Checkbox("Iconified");
+        maximizedCB = new Checkbox("Maximized");
+
+        createB = new Button("Create");
+        packB = new Button("Pack");
+        moveB = new Button("Move");
+        resizeB = new Button("Resize");
+        reshapeB = new Button("Reshape");
+        disposeB = new Button("Dispose");
+
+        frames = new Vector(10);
+        this.setTitle("TestLocationByPlatformWithControls");
+        this.setLayout(new BorderLayout());
+        this.add(northP, BorderLayout.NORTH);
+
+        northP.add(new Label("New Frame"));
+
+        createB.addActionListener(this);
+        northP.add(createB);
+
+        centerP.setEnabled(false);
+        this.add(centerP, BorderLayout.CENTER);
+
+        centerP.add(new Label("Last Frame"));
+
+        centerP.add(defaultLocationCB);
+        defaultLocationCB.addItemListener(this);
+
+        centerP.add(undecoratedCB);
+        undecoratedCB.addItemListener(this);
+
+        centerP.add(iconifiedCB);
+        iconifiedCB.addItemListener(this);
+
+        centerP.add(maximizedCB);
+        maximizedCB.addItemListener(this);
+
+        centerP.add(visibleCB);
+        visibleCB.addItemListener(this);
+
+        packB.addActionListener(this);
+        centerP.add(packB);
+
+        moveB.addActionListener(this);
+        centerP.add(moveB);
+
+        resizeB.addActionListener(this);
+        centerP.add(resizeB);
+
+        reshapeB.addActionListener(this);
+        centerP.add(reshapeB);
+
+        disposeB.addActionListener(this);
+        centerP.add(disposeB);
+        this.pack();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (e.getSource() ==  createB) {
+            Frame frame = new Frame();
+            frame.setSize(200, 200);
+            frames.add(frame);
+            updateControls(frame);
+            Panel panel = new Panel();
+            frame.add(panel);
+            panel.add(new Button ("Test Button"));
+            panel.add(new Button ("Test Button 1"));
+            panel.add(new Button ("Test Button  2"));
+            panel.add(new Button ("Test Button   3"));
+            centerP.setEnabled(true);
+            return;
+        }
+
+        if (frames.isEmpty()) {
+            return;
+        }
+
+        Frame last = (Frame)frames.lastElement();
+
+        if (e.getSource() == packB) {
+            last.pack();
+        } else
+        if (e.getSource() == moveB) {
+            int x = (int)(Math.random() * 200);
+            int y = (int)(Math.random() * 200);
+            last.setLocation(x, y);
+        } else
+        if (e.getSource() == resizeB) {
+            int w = (int)(Math.random() * 200);
+            int h = (int)(Math.random() * 200);
+            last.setSize(w, h);
+        } else
+        if (e.getSource() == reshapeB) {
+            int x = (int)(Math.random() * 200);
+            int y = (int)(Math.random() * 200);
+            int w = (int)(Math.random() * 200);
+            int h = (int)(Math.random() * 200);
+            last.setBounds(x, y, w, h);
+        } else
+        if (e.getSource() == disposeB) {
+            last.dispose();
+            frames.remove(frames.size() - 1);
+            if (frames.isEmpty()) {
+                updateControls(null);
+                centerP.setEnabled(false);
+                return;
+            }
+            last = (Frame)frames.lastElement();
+        }
+        updateControls(last);
+    }
+
+    public void updateControls(Frame f) {
+        undecoratedCB.setState(f != null ?
+            f.isUndecorated() : false);
+        defaultLocationCB.setState(f != null ?
+            f.isLocationByPlatform() : false);
+        visibleCB.setState(f != null ?
+            f.isVisible() : false);
+        iconifiedCB.setState(f != null ?
+            (f.getExtendedState() & Frame.ICONIFIED) != 0 : false);
+        maximizedCB.setState(f != null ?
+            (f.getExtendedState() & Frame.MAXIMIZED_BOTH) != 0 : false);
+    }
+
+    public void itemStateChanged(ItemEvent e) {
+        Frame last = (Frame)frames.lastElement();
+        try {
+            boolean state = e.getStateChange() == ItemEvent.SELECTED;
+            if (e.getSource() == visibleCB) {
+                last.setVisible(state);
+            } else
+            if (e.getSource() == defaultLocationCB) {
+                last.setLocationByPlatform(state);
+            } else
+            if (e.getSource() == undecoratedCB) {
+                last.setUndecorated(state);
+            } else
+            if (e.getSource() == iconifiedCB) {
+                if (state) {
+                    last.setExtendedState(last.getExtendedState() |
+                        Frame.ICONIFIED);
+                } else {
+                    last.setExtendedState(last.getExtendedState() &
+                        ~Frame.ICONIFIED);
+                }
+            } else
+            if (e.getSource() == maximizedCB) {
+                if (state) {
+                    last.setExtendedState(last.getExtendedState() |
+                        Frame.MAXIMIZED_BOTH);
+                } else {
+                    last.setExtendedState(last.getExtendedState() &
+                        ~Frame.MAXIMIZED_BOTH);
+                }
+            }
+        } catch (Throwable ex) {
+            PassFailJFrame.log(ex.getMessage());
+        } finally {
+            updateControls(last);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        while (!frames.isEmpty()) {
+            Frame last = (Frame)frames.lastElement();
+            last.dispose();
+            frames.remove(frames.size() - 1);
+        }
+    }
+}

--- a/test/jdk/java/awt/Window/NoResizeEvent/NoResizeEvent.java
+++ b/test/jdk/java/awt/Window/NoResizeEvent/NoResizeEvent.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4942457
+ * @key headful
+ * @summary Verifies that filtering of resize events on native level works.
+ * I.E.after Frame is shown no additional resize events are generated.
+ * @library /java/awt/patchlib ../../regtesthelpers
+ * @build java.desktop/java.awt.Helper
+ * @build Util
+ * @run main NoResizeEvent
+ */
+
+import test.java.awt.regtesthelpers.Util;
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+
+public class NoResizeEvent {
+    //Mutter can send window insets too late, causing additional resize events.
+    private static final boolean IS_MUTTER = Util.getWMID() == Util.MUTTER_WM;
+    private static final int RESIZE_COUNT_LIMIT = IS_MUTTER ? 5 : 3;
+    private static Frame frame;
+    static int resize_count = 0;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+            if (resize_count > RESIZE_COUNT_LIMIT) {
+                throw new RuntimeException("Resize event arrived: "
+                    + resize_count + " times.");
+            }
+        }
+    }
+
+    private static void createUI() {
+        frame = new Frame("NoResizeEvent");
+        frame.addComponentListener(new ComponentAdapter() {
+            public void componentResized(ComponentEvent e) {
+                System.out.println(e);
+                resize_count++;
+            }
+        });
+        frame.setVisible(true);
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException ie) {
+        }
+        System.out.println("Resize count: " + resize_count);
+    }
+}

--- a/test/jdk/java/awt/Window/ProxyCrash/PopupProxyCrash.java
+++ b/test/jdk/java/awt/Window/ProxyCrash/PopupProxyCrash.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4381561
+ * @key headful
+ * @summary Tests that when we show the popup window AWT doesn't crash due to
+ * the problems with focus proxy window code
+ * @run main PopupProxyCrash
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+
+import javax.swing.Box;
+import javax.swing.JComboBox;
+import javax.swing.JTextField;
+import javax.swing.plaf.basic.BasicComboBoxUI;
+import javax.swing.plaf.basic.BasicComboPopup;
+import javax.swing.plaf.basic.ComboPopup;
+
+public class PopupProxyCrash implements ActionListener {
+    private static JTextField jtf;
+    private static Button tf;
+    private static Panel panel;
+    private static Font[] fonts;
+    private static Robot robot;
+
+    private static JComboBox cb;
+
+    private static MyComboBoxUI comboBoxUI;
+    private static Frame frame;
+    private static int TEST_COUNT = 10;
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            EventQueue.invokeAndWait(() -> createUI());
+            robot.waitForIdle();
+            runTest();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createUI() {
+        frame = new Frame("PopupProxyCrash");
+        Font dialog = new Font("Dialog", Font.PLAIN, 12);
+        Font serif = new Font("Serif", Font.PLAIN, 12);
+        Font monospaced = new Font("Monospaced", Font.PLAIN, 12);
+
+        fonts = new Font[] { dialog, serif, monospaced };
+
+        cb = new JComboBox(fonts);
+
+        cb.setLightWeightPopupEnabled(false);
+        comboBoxUI = new MyComboBoxUI();
+        cb.setUI(comboBoxUI);
+        jtf = new JTextField("JTextField");
+        jtf.setFont(fonts[1]);
+        tf = new Button("TextField");
+        tf.setFont(fonts[1]);
+        cb.addActionListener(new PopupProxyCrash());
+
+        panel = new Panel() {
+            public Dimension getPreferredSize() {
+                return new Dimension(100, 20);
+            }
+            public void paint(Graphics g) {
+                System.out.println("Painting with font " + getFont());
+                g.setColor(Color.white);
+                g.fillRect(0, 0, getWidth(), getHeight());
+                g.setColor(Color.black);
+                g.setFont(getFont());
+                g.drawString("LightWeight", 10, 10);
+            }
+        };
+        panel.setFont(fonts[1]);
+
+        Container parent = Box.createVerticalBox();
+        parent.add(jtf);
+        parent.add(tf);
+        parent.add(panel);
+        parent.add(cb);
+
+        frame.add(parent, BorderLayout.CENTER);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static Point getComboBoxLocation() throws Exception {
+        final Point[] result = new Point[1];
+
+        EventQueue.invokeAndWait(() -> {
+            Point point = cb.getLocationOnScreen();
+            Dimension size = cb.getSize();
+
+            point.x += size.width / 2;
+            point.y += size.height / 2;
+            result[0] = point;
+        });
+        return result[0];
+    }
+
+    private static Point getItemPointToClick(final int item) throws Exception {
+        final Point[] result = new Point[1];
+
+        EventQueue.invokeAndWait(() -> {
+            BasicComboPopup popup = (BasicComboPopup)comboBoxUI.getComboPopup();
+            Point point = popup.getLocationOnScreen();
+            Dimension size = popup.getSize();
+
+            int step = size.height / fonts.length;
+            point.x += size.width / 2;
+            point.y += step / 2 + step * item;
+            result[0] = point;
+        });
+        return result[0];
+    }
+
+    static void runTest() throws Exception {
+        for (int i = 0; i < TEST_COUNT; i++) {
+            Point point = getComboBoxLocation();
+            robot.mouseMove(point.x, point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(500);
+
+            point = getItemPointToClick(i % fonts.length);
+            robot.mouseMove(point.x, point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(500);
+        }
+    }
+    public void actionPerformed(ActionEvent ae) {
+        System.out.println("Font selected");
+        Font font = fonts[((JComboBox)ae.getSource()).getSelectedIndex()];
+
+        tf.setFont(font);
+        jtf.setFont(font);
+        panel.setFont(font);
+        panel.repaint();
+    }
+
+    private static class MyComboBoxUI extends BasicComboBoxUI {
+        public ComboPopup getComboPopup() {
+            return popup;
+        }
+    }
+}

--- a/test/jdk/java/awt/Window/WindowToFrontTest/WindowToFrontTest.java
+++ b/test/jdk/java/awt/Window/WindowToFrontTest/WindowToFrontTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4488209
+ * @summary JFrame toFront causes the entire frame to be repainted, causes UI
+ * to flash
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual WindowToFrontTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class WindowToFrontTest implements ActionListener {
+    static Frame frame;
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            1) Click the "toFront" button, this causes the
+            "WindowToFrontTest" frame to move front and gets repainted
+            completely.
+            2) Move "WindowToFrontTest" window and continue to click on "toFront
+            multiple times. If the "WindowToFrontTest" Frame content is not
+            drawn properly and continues to blink, test is failed
+            otherwise passed.
+            """;
+
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .rows(13)
+            .columns(40)
+            .build();
+        EventQueue.invokeAndWait(() -> createUI());
+        passFailJFrame.awaitAndCheck();
+    }
+
+    private static void createUI() {
+        frame = new Frame("WindowToFrontTest");
+        frame.setLayout(new BorderLayout());
+        frame.setSize(512, 512);
+        PassFailJFrame.addTestWindow(frame);
+        frame.setVisible(true);
+
+        Frame buttonFrame = new Frame("Test Button");
+        Button push = new Button("toFront");
+        push.addActionListener(new WindowToFrontTest());
+        buttonFrame.add(push);
+        buttonFrame.pack();
+        PassFailJFrame.addTestWindow(buttonFrame);
+        buttonFrame.setVisible(true);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        frame.toFront();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341298](https://bugs.openjdk.org/browse/JDK-8341298) needs maintainer approval

### Issue
 * [JDK-8341298](https://bugs.openjdk.org/browse/JDK-8341298): Open source more AWT window tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1527/head:pull/1527` \
`$ git checkout pull/1527`

Update a local copy of the PR: \
`$ git checkout pull/1527` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1527`

View PR using the GUI difftool: \
`$ git pr show -t 1527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1527.diff">https://git.openjdk.org/jdk21u-dev/pull/1527.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1527#issuecomment-2736306270)
</details>
