### PR TITLE
8350786: Some java/lang jtreg tests miss requires vm.hasJFR

### DIFF
--- a/test/jdk/java/lang/Thread/ThreadSleepEvent.java
+++ b/test/jdk/java/lang/Thread/ThreadSleepEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /**
  * @test
  * @summary Test that Thread.sleep emits a JFR jdk.ThreadSleep event
+ * @requires vm.hasJFR
  * @modules jdk.jfr
  * @run junit ThreadSleepEvent
  */

--- a/test/jdk/java/lang/Thread/virtual/JfrEvents.java
+++ b/test/jdk/java/lang/Thread/virtual/JfrEvents.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @summary Basic test for JFR jdk.VirtualThreadXXX events
- * @requires vm.continuations
+ * @requires vm.continuations & vm.hasJFR
  * @modules jdk.jfr java.base/java.lang:+open
  * @library /test/lib
  * @run junit/othervm --enable-native-access=ALL-UNNAMED JfrEvents


### PR DESCRIPTION
backport has only 2 files not 3 (test/jdk/java/lang/Thread/virtual/MonitorPinnedEvents.java not there)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350786](https://bugs.openjdk.org/browse/JDK-8350786) needs maintainer approval

### Issue
 * [JDK-8350786](https://bugs.openjdk.org/browse/JDK-8350786): Some java/lang jtreg tests miss requires vm.hasJFR (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1530/head:pull/1530` \
`$ git checkout pull/1530`

Update a local copy of the PR: \
`$ git checkout pull/1530` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1530`

View PR using the GUI difftool: \
`$ git pr show -t 1530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1530.diff">https://git.openjdk.org/jdk21u-dev/pull/1530.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1530#issuecomment-2736846053)
</details>
