### PR TITLE
8339794: Open source closed choice tests #1

### DIFF
--- a/test/jdk/java/awt/Choice/ChoiceInsertTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceInsertTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Robot;
+
+/*
+ * @test
+ * @bug 4082078
+ * @summary Test for bug(s): 4082078, Multiple calls to Choice.insert cause core dump
+ * @key headful
+ * @run main ChoiceInsertTest
+ */
+
+public class ChoiceInsertTest extends Frame {
+    Choice c;
+    Label  l;
+
+    private static ChoiceInsertTest choiceInsertTest;
+
+    public ChoiceInsertTest() {
+        c = new Choice();
+        l = new Label("If you see this, the choice insert bug is fixed!");
+        c.add("Initial choice");
+        add(c);
+    }
+
+    public void testInsertion() {
+        // inserting 30 or so items aborts Solaris VM
+        // in JDK's before 1.1.5
+        for (int nchoice = 0; nchoice < 30; nchoice++) {
+            c.insert("new choice", 0);
+        }
+        // if you made it to here the bug is not there anymore...
+        remove(l);
+        add(l);
+        validate();
+    }
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            EventQueue.invokeAndWait(() ->{
+                choiceInsertTest = new ChoiceInsertTest();
+                choiceInsertTest.setTitle("ChoiceInsertTest");
+                choiceInsertTest.setLocationRelativeTo(null);
+                choiceInsertTest.setSize(500, 300);
+                choiceInsertTest.setLayout(new GridLayout());
+                choiceInsertTest.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(500);
+            EventQueue.invokeAndWait(choiceInsertTest::testInsertion);
+            robot.delay(1000);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (choiceInsertTest != null) {
+                    choiceInsertTest.dispose();
+                }
+            });
+        }
+
+        System.err.println("ChoiceInsertTest: Didn't abort VM inserting 30 items, so we passed!");
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceMouseDragTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceMouseDragTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4328557
+ * @summary Tests that MouseDragged and MouseReleased are triggered on choice
+ * @library /lib/client
+ * @build ExtendedRobot
+ * @key headful
+ * @run main ChoiceMouseDragTest
+ */
+
+
+public class ChoiceMouseDragTest extends Frame {
+    private static final Choice choice = new Choice();
+
+    private static ExtendedRobot robot;
+    private volatile boolean isDragged;
+    private volatile boolean isReleased;
+
+    private static volatile ChoiceMouseDragTest choiceMouseDragTest;
+
+    public ChoiceMouseDragTest() {
+        super("ChoiceMouseDragTest");
+        this.setLayout(new BorderLayout());
+        choice.add("item-1");
+        choice.add("item-2");
+        choice.add("item-3");
+        choice.add("item-4");
+        add("Center", choice);
+        choice.addMouseListener(new MouseEventHandler());
+        choice.addMouseMotionListener(new MouseMotionEventHandler());
+        setSize(400, 200);
+        setLocationRelativeTo(null);
+        setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() ->
+                    choiceMouseDragTest = new ChoiceMouseDragTest());
+
+            robot = new ExtendedRobot();
+            robot.waitForIdle();
+            robot.delay(500);
+
+            Point pointToDrag = choice.getLocationOnScreen();
+            pointToDrag.x += choice.getWidth() - 10;
+            pointToDrag.y += choice.getHeight() / 2 ;
+
+            choiceMouseDragTest.test(InputEvent.BUTTON3_DOWN_MASK, pointToDrag);
+            choiceMouseDragTest.test(InputEvent.BUTTON1_DOWN_MASK, pointToDrag);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (choiceMouseDragTest != null) {
+                    choiceMouseDragTest.dispose();
+                }
+            });
+        }
+    }
+
+    void test(int buttonToTest, Point pointToDrag) {
+        isDragged = false;
+        isReleased = false;
+
+        robot.mouseMove(pointToDrag.x, pointToDrag.y);
+        robot.waitForIdle();
+
+        robot.mousePress(buttonToTest);
+
+        robot.glide(pointToDrag.x + 100, pointToDrag.y);
+        robot.waitForIdle();
+
+        robot.mouseRelease(buttonToTest);
+        robot.waitForIdle();
+
+        if (!isReleased || !isDragged) {
+            throw new RuntimeException(("Test failed: button %d dragged(received %b) or " +
+                    "released(received %b)")
+                    .formatted(buttonToTest, isDragged, isReleased));
+        }
+
+        robot.delay(500);
+    }
+
+    class MouseEventHandler extends MouseAdapter {
+        public void mousePressed(MouseEvent me) {
+            System.out.println(me.paramString());
+        }
+
+        public void mouseReleased(MouseEvent me) {
+            System.out.println(me.paramString());
+            isReleased = true;
+        }
+
+        public void mouseClicked(MouseEvent me) {
+            System.out.println(me.paramString());
+        }
+    }
+
+    class MouseMotionEventHandler extends MouseAdapter {
+        public void mouseDragged(MouseEvent me) {
+            System.out.println(me.paramString());
+            isDragged = true;
+        }
+    }
+}

--- a/test/jdk/java/awt/Choice/WheelEventsConsumed.java
+++ b/test/jdk/java/awt/Choice/WheelEventsConsumed.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
+
+/*
+ * @test
+ * @bug 6253211
+ * @summary PIT: MouseWheel events not triggered for Choice drop down in XAWT
+ * @requires (os.family == "linux")
+ * @key headful
+ * @run main WheelEventsConsumed
+ */
+
+public class WheelEventsConsumed extends Frame implements MouseWheelListener
+{
+    Robot robot;
+    Choice choice1 = new Choice();
+    Point pt;
+    final static int delay = 100;
+    boolean mouseWheeled = false;
+    final static int OUTSIDE_CHOICE = 1;
+    final static int INSIDE_LIST_OF_CHOICE = 2;
+    final static int INSIDE_CHOICE_COMPONENT = 3;
+    static String toolkit;
+
+    private static volatile WheelEventsConsumed frame = null;
+
+    public static void main(String[] args) throws Exception {
+        toolkit = Toolkit.getDefaultToolkit().getClass().getName();
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new WheelEventsConsumed();
+                frame.initAndShow();
+            });
+            frame.test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void mouseWheelMoved(MouseWheelEvent me) {
+        mouseWheeled = true;
+        System.out.println(me);
+    }
+
+    public void initAndShow() {
+        setTitle("WheelEventsConsumed test");
+        for (int i = 1; i < 10; i++) {
+            choice1.add("item-0" + i);
+        }
+
+        choice1.addMouseWheelListener(this);
+        add(choice1);
+        setLayout(new FlowLayout());
+        setSize(200, 200);
+        setLocationRelativeTo(null);
+        setVisible(true);
+        validate();
+    }
+
+    public void test() {
+        try {
+            robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+            robot.waitForIdle();
+            robot.delay(delay * 5);
+            testMouseWheel(1, OUTSIDE_CHOICE);
+            robot.delay(delay);
+            testMouseWheel(-1, INSIDE_LIST_OF_CHOICE);
+            robot.delay(delay);
+            testMouseWheel(1, INSIDE_CHOICE_COMPONENT);
+            robot.delay(delay);
+        } catch (Throwable e) {
+            throw new RuntimeException("Test failed. Exception thrown: " + e);
+        }
+    }
+
+    public void testMouseWheel(int amt, int mousePosition) {
+        pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth() / 2, pt.y + choice1.getHeight() / 2);
+
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(50);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(50);
+
+        switch (mousePosition) {
+            case OUTSIDE_CHOICE:
+                robot.mouseMove(pt.x + choice1.getWidth() * 3 / 2, pt.y + choice1.getHeight() / 2);
+                break;
+            case INSIDE_LIST_OF_CHOICE:
+                robot.mouseMove(pt.x + choice1.getWidth() / 2, pt.y + choice1.getHeight() * 4);
+                break;
+            case INSIDE_CHOICE_COMPONENT:
+                robot.mouseMove(pt.x + choice1.getWidth() / 2, pt.y + choice1.getHeight() / 2);
+                break;
+        }
+
+        robot.delay(delay);
+        for (int i = 0; i < 10; i++) {
+            robot.mouseWheel(amt);
+            robot.delay(delay);
+        }
+
+        if (!mouseWheeled) {
+            if (toolkit.equals("sun.awt.windows.WToolkit") && mousePosition == OUTSIDE_CHOICE) {
+                System.out.println("Passed. Separate case on Win32. Choice generated MouseWheel events" + mousePosition);
+            } else {
+                throw new RuntimeException("Test failed. Choice should generate MOUSE_WHEEL events." + mousePosition);
+            }
+        } else {
+            System.out.println("Passed. Choice generated MouseWheel events" + mousePosition);
+        }
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.delay(10);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+        mouseWheeled = false;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8339794](https://bugs.openjdk.org/browse/JDK-8339794) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339794](https://bugs.openjdk.org/browse/JDK-8339794): Open source closed choice tests #1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1532/head:pull/1532` \
`$ git checkout pull/1532`

Update a local copy of the PR: \
`$ git checkout pull/1532` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1532`

View PR using the GUI difftool: \
`$ git pr show -t 1532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1532.diff">https://git.openjdk.org/jdk21u-dev/pull/1532.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1532#issuecomment-2741563626)
</details>
