### PR TITLE
8345134: Test sun/security/tools/jarsigner/ConciseJarsigner.java failed: unable to find valid certification path to requested target

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
+++ b/test/jdk/sun/security/tools/jarsigner/ConciseJarsigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,8 +43,15 @@ public class ConciseJarsigner {
     static OutputAnalyzer kt(String cmd) throws Exception {
         // Choose 2048-bit RSA to make sure it runs fine and fast. In
         // fact, every keyalg/keysize combination is OK for this test.
-        return SecurityTools.keytool("-storepass changeit -keypass changeit "
-                + "-keystore ks -keyalg rsa -keysize 2048 " + cmd);
+        // The start date is set to -1M to prevent the certificate not yet valid during fast enough execution.
+        // If -startdate is specified in cmd, cmd version will be used.
+        if (cmd.contains("-startdate")) {
+            return SecurityTools.keytool("-storepass changeit -keypass changeit "
+                    + "-keystore ks -keyalg rsa -keysize 2048 " + cmd);
+        } else {
+            return SecurityTools.keytool("-storepass changeit -keypass changeit "
+                    + "-keystore ks -keyalg rsa -keysize 2048 -startdate -1M " + cmd);
+        }
     }
 
     static void gencert(String owner, String cmd) throws Exception {


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345134](https://bugs.openjdk.org/browse/JDK-8345134) needs maintainer approval

### Issue
 * [JDK-8345134](https://bugs.openjdk.org/browse/JDK-8345134): Test sun/security/tools/jarsigner/ConciseJarsigner.java failed: unable to find valid certification path to requested target (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1534/head:pull/1534` \
`$ git checkout pull/1534`

Update a local copy of the PR: \
`$ git checkout pull/1534` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1534`

View PR using the GUI difftool: \
`$ git pr show -t 1534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1534.diff">https://git.openjdk.org/jdk21u-dev/pull/1534.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1534#issuecomment-2741623163)
</details>
