### PR TITLE
8334780: Crash: assert(h_array_list.not_null()) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
@@ -136,7 +136,9 @@ jobject JdkJfrEvent::get_all_klasses(TRAPS) {
   transform_klasses_to_local_jni_handles(event_subklasses, THREAD);
 
   Handle h_array_list(THREAD, new_java_util_arraylist(THREAD));
-  assert(h_array_list.not_null(), "invariant");
+  if (h_array_list.is_null()) {
+    return empty_java_util_arraylist;
+  }
 
   static const char add_method_name[] = "add";
   static const char add_method_signature[] = "(Ljava/lang/Object;)Z";


### PR DESCRIPTION
Backporting JDK-8334780: Crash: assert(h_array_list.not_null()) failed: invariant. Fixes an incorrect assertion, since new_java_util_arraylist() function uses CHECK_NULL constructs on exceptions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334780](https://bugs.openjdk.org/browse/JDK-8334780) needs maintainer approval

### Issue
 * [JDK-8334780](https://bugs.openjdk.org/browse/JDK-8334780): Crash: assert(h_array_list.not_null()) failed: invariant (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1537/head:pull/1537` \
`$ git checkout pull/1537`

Update a local copy of the PR: \
`$ git checkout pull/1537` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1537`

View PR using the GUI difftool: \
`$ git pr show -t 1537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1537.diff">https://git.openjdk.org/jdk21u-dev/pull/1537.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1537#issuecomment-2743862083)
</details>
