### PR TITLE
8316388: Opensource five Swing component related regression tests

### DIFF
--- a/test/jdk/javax/swing/JDesktopPane/bug4132993.java
+++ b/test/jdk/javax/swing/JDesktopPane/bug4132993.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4132993
+ * @summary JDesktopPane.getAllFramesInLayer(..) return iconified frame
+ * @run main bug4132993
+ */
+
+import javax.swing.JDesktopPane;
+import javax.swing.JInternalFrame;
+import javax.swing.JLayeredPane;
+
+
+public class bug4132993 {
+    public static void main(String[] args) throws Exception {
+        JDesktopPane mDesktop = new JDesktopPane();
+        JInternalFrame jif = new JInternalFrame("My Frame");
+        jif.setIconifiable(true);
+        mDesktop.add(jif);
+        jif.setIcon(true);
+        JInternalFrame[] ji =
+                mDesktop.getAllFramesInLayer(JLayeredPane.DEFAULT_LAYER);
+        for (int i = 0; i < ji.length; i++) {
+            if (jif == ji[i]) {
+                return;
+            }
+        }
+        throw new RuntimeException("JDesktopPane.getAllFramesInLayer() failed...");
+    }
+}

--- a/test/jdk/javax/swing/JDesktopPane/bug4773378.java
+++ b/test/jdk/javax/swing/JDesktopPane/bug4773378.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4773378
+ * @summary BasicDesktopPaneUI.desktopManager nulled after JDesktopPane.updateUI()
+ * @key headful
+ * @run main bug4773378
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.beans.PropertyVetoException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.CountDownLatch;
+import javax.swing.DefaultDesktopManager;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.event.InternalFrameAdapter;
+import javax.swing.event.InternalFrameEvent;
+
+public class bug4773378 {
+    JFrame frame;
+
+    JDesktopPane desktop;
+    DefaultDesktopManager desktopManager;
+    JInternalFrame jif;
+
+    Robot robot;
+    private final CountDownLatch frameActivated = new CountDownLatch(1);
+    public void setupGUI() {
+        frame = new JFrame("bug4773378");
+        frame.setLayout(new BorderLayout());
+        desktop = new JDesktopPane();
+        frame.add(desktop, BorderLayout.CENTER);
+
+        jif = new JInternalFrame("jif", true, false, true, true);
+        jif.setSize(150, 100);
+        jif.setVisible(true);
+        desktop.add(jif);
+
+        jif.addInternalFrameListener(new InternalFrameAdapter() {
+                public void internalFrameActivated(InternalFrameEvent e) {
+                    frameActivated.countDown();
+                }
+            });
+
+        desktopManager = new MyDesktopManager();
+        desktop.setDesktopManager(desktopManager);
+        desktop.updateUI();
+
+        frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        jif.requestFocus();
+    }
+
+    public void performTest() throws InterruptedException,
+            InvocationTargetException, AWTException {
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                jif.setSelected(true);
+            } catch (PropertyVetoException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        frameActivated.await();
+
+        robot = new Robot();
+        robot.keyPress(KeyEvent.VK_CONTROL);
+        robot.keyPress(KeyEvent.VK_F6);
+        robot.keyRelease(KeyEvent.VK_F6);
+        robot.keyRelease(KeyEvent.VK_CONTROL);
+
+        robot.waitForIdle();
+    }
+
+    public void cleanupGUI() {
+        if (frame != null) {
+            frame.setVisible(false);
+            frame.dispose();
+        }
+    }
+
+    private static class MyDesktopManager extends DefaultDesktopManager {
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        bug4773378 b = new bug4773378();
+        SwingUtilities.invokeAndWait(b::setupGUI);
+        b.performTest();
+        SwingUtilities.invokeAndWait(b::cleanupGUI);
+    }
+}

--- a/test/jdk/javax/swing/JEditorPane/bug4325606.java
+++ b/test/jdk/javax/swing/JEditorPane/bug4325606.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4325606
+ * @summary Tests getting row start
+ * @key headful
+ * @run main bug4325606
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Utilities;
+
+public class bug4325606 {
+
+    public volatile boolean passed = true;
+    private JFrame frame;
+    private JEditorPane pane;
+
+    public void setupGUI() {
+        frame = new JFrame("Click Bug");
+        frame.setLayout(new BorderLayout());
+
+        pane = new JEditorPane();
+        pane.addMouseListener(new ClickListener());
+        pane.setContentType("text/html");
+        pane.setText("<html><body>" +
+                "<p>Here is line one</p>" +
+                "<p>Here is line two</p>" +
+                "</body></html>");
+
+        frame.add(new JScrollPane(pane), BorderLayout.CENTER);
+
+        frame.addWindowListener(new TestStateListener());
+        frame.setLocation(50, 50);
+        frame.setSize(400, 300);
+        frame.setVisible(true);
+    }
+
+    class TestStateListener extends WindowAdapter {
+        public void windowOpened(WindowEvent ev) {
+            Robot robo;
+            try {
+                robo = new Robot();
+            } catch (AWTException e) {
+                throw new RuntimeException("Robot could not be created", e);
+            }
+            robo.setAutoDelay(100);
+            robo.delay(1000);
+            Point p = frame.getLocationOnScreen();
+            robo.mouseMove(p.x + 50, p.y + 50);
+            robo.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robo.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robo.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robo.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robo.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robo.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        }
+    }
+
+    class ClickListener extends MouseAdapter {
+        public void mouseClicked(MouseEvent event) {
+            try {
+                Utilities.getRowStart(pane, pane.getCaretPosition());
+            } catch (BadLocationException blex) {
+                throw new RuntimeException("Test failed.", blex);
+            }
+        }
+    }
+
+    public void cleanupGUI() {
+        if (frame != null) {
+            frame.setVisible(false);
+            frame.dispose();
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        bug4325606 b = new bug4325606();
+        try {
+            Robot robot = new Robot();
+            SwingUtilities.invokeAndWait(b::setupGUI);
+            robot.waitForIdle();
+        } finally {
+            SwingUtilities.invokeAndWait(b::cleanupGUI);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JEditorPane/bug4330998.java
+++ b/test/jdk/javax/swing/JEditorPane/bug4330998.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4330998
+ * @summary JEditorPane.setText(null) throws NullPointerException.
+ * @run main bug4330998
+ */
+
+import javax.swing.JEditorPane;
+
+public class bug4330998 {
+    public static void main(String[] args) {
+        JEditorPane jep = new JEditorPane();
+        jep.setText(null);
+    }
+}

--- a/test/jdk/javax/swing/JEditorPane/bug4694598.java
+++ b/test/jdk/javax/swing/JEditorPane/bug4694598.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4694598
+ * @key headful
+ * @summary JEditor pane throws NullPointerException on mouse movement.
+ * @run main bug4694598
+ */
+
+import java.awt.AWTException;
+import java.awt.Robot;
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4694598 {
+    JFrame frame;
+    volatile int bottom;
+    final Path frameContentFile = Path.of("FrameContent.html");
+
+    public void setupGUI() {
+        frame = new JFrame("Test 4694598");
+        JEditorPane jep = new JEditorPane();
+        jep.setEditable(false);
+        frame.getContentPane().add(jep);
+        frame.setLocation(50, 50);
+        frame.setSize(400, 400);
+
+        String frameContentString = "<HTML><BODY>\n" +
+                "    Frame content.\n" +
+                "</BODY></HTML>";
+        try (Writer writer = Files.newBufferedWriter(frameContentFile)) {
+            writer.write(frameContentString);
+        } catch (IOException ioe){
+            throw new RuntimeException("Could not create html file to embed", ioe);
+        }
+        URL frameContentUrl;
+        try {
+            frameContentUrl = frameContentFile.toUri().toURL();
+        } catch (MalformedURLException mue) {
+            throw new RuntimeException("Can not convert path to URL", mue);
+        }
+        jep.setContentType("text/html");
+        String html = "<HTML> <BODY>" +
+                "<FRAMESET cols=\"100%\">" +
+                "<FRAME src=\"" + frameContentUrl + "\">" +
+                "</FRAMESET>" +
+                // ! Without <noframes> bug is not reproducable
+                "<NOFRAMES>" +
+                "</NOFRAMES>" +
+                "</BODY> </HTML>";
+        jep.setText(html);
+
+        frame.setVisible(true);
+    }
+
+    public void performTest() throws InterruptedException,
+            InvocationTargetException, AWTException {
+        Robot robo = new Robot();
+        robo.waitForIdle();
+
+        final int range = 20;
+        SwingUtilities.invokeAndWait(() -> {
+            bottom = frame.getLocationOnScreen().y
+                    + frame.getSize().height - range;
+        });
+        for (int i = 0; i < range; i++) {
+            robo.mouseMove(300, bottom + i);
+            robo.waitForIdle();
+            robo.delay(50);
+        }
+    }
+
+    public void cleanupGUI() {
+        if (frame != null) {
+            frame.setVisible(false);
+            frame.dispose();
+        }
+        try {
+            Files.deleteIfExists(frameContentFile);
+        } catch (IOException ignore) {}
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        bug4694598 app = new bug4694598();
+        SwingUtilities.invokeAndWait(app::setupGUI);
+        app.performTest();
+        SwingUtilities.invokeAndWait(app::cleanupGUI);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316388](https://bugs.openjdk.org/browse/JDK-8316388) needs maintainer approval

### Issue
 * [JDK-8316388](https://bugs.openjdk.org/browse/JDK-8316388): Opensource five Swing component related regression tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1540/head:pull/1540` \
`$ git checkout pull/1540`

Update a local copy of the PR: \
`$ git checkout pull/1540` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1540`

View PR using the GUI difftool: \
`$ git pr show -t 1540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1540.diff">https://git.openjdk.org/jdk21u-dev/pull/1540.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1540#issuecomment-2748992057)
</details>
