### PR TITLE
8339906: Open source several AWT focus tests - series 4

### DIFF
--- a/test/jdk/java/awt/Focus/AltTabEventsTest.java
+++ b/test/jdk/java/awt/Focus/AltTabEventsTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4524015
+ * @summary Tests that when user switches between windows using Alt-tab then the appropriate events are generated
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AltTabEventsTest
+ */
+
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+public class AltTabEventsTest {
+
+    private static final String INSTRUCTIONS = """
+           This test verifies that when user switches between windows using Alt-tab
+           key combination then appropriate window events are generated. Also, when
+           user interacts with Menu bar, Popup menu, Choice then no excessive window
+           event is generated.
+
+           After test started you will see Frame('Test for 4524015')-F1 with some
+           components and Frame('Another frame')-F2 with no components.
+           1. Make F1 active by clicking on it.
+           2. Press Alt-tab.
+           In the messqge dialog area you should see that
+           WINDOW_DEACTIVATED, WINDOW_LOST_FOCUS event were generated.
+           If you switched to F2 then also WINDOW_ACTIVATED, WINDOW_GAINED_FOCUS
+           were generated.
+           If no events were generated the test FAILED.
+           Repeat the 2) with different circumstances.
+
+           3. Make F1 active by clicking on it.
+           4. Click on Menu bar/Button 'popup'/Choice and select some item from
+           the list shown. If any of the window events appeared in the output then
+           the test FAILED.
+
+           else the test PASSED.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("AltTabEventsTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 5)
+                .columns(35)
+                .testUI(Test::new)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+}
+
+
+class Test extends Frame {
+    PopupMenu pop;
+    Frame f;
+
+    void println(String messageIn) {
+        PassFailJFrame.log(messageIn);
+    }
+
+    public Test() {
+        super("Test for 4524015");
+        WindowAdapter wa = new WindowAdapter() {
+                public void windowActivated(WindowEvent e) {
+                    println(e.toString());
+                }
+                public void windowDeactivated(WindowEvent e) {
+                    println(e.toString());
+                }
+                public void windowGainedFocus(WindowEvent e) {
+                    println(e.toString());
+                }
+                public void windowLostFocus(WindowEvent e) {
+                    println(e.toString());
+                }
+            };
+        addWindowListener(wa);
+        addWindowFocusListener(wa);
+
+        f = new Frame("Another frame");
+        f.addWindowListener(wa);
+        f.addWindowFocusListener(wa);
+        f.setBounds(800, 300, 300, 100);
+        f.setVisible(true);
+
+        setLayout(new FlowLayout());
+        Button b = new Button("popup");
+        add(b);
+        b.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    pop.show((Component)e.getSource(), 10, 10);
+                }
+            });
+        Choice cho = new Choice();
+        add(cho);
+        cho.addItem("1");
+        cho.addItem("2");
+        cho.addItem("3");
+
+        MenuBar bar = new MenuBar();
+        Menu menu = new Menu("menu");
+        MenuItem item = new MenuItem("first");
+        menu.add(item);
+        item = new MenuItem("second");
+        menu.add(item);
+        bar.add(menu);
+        setMenuBar(bar);
+
+        pop = new PopupMenu();
+        pop.add("1");
+        pop.add("@");
+        add(pop);
+        setSize(300, 100);
+    }
+}
+

--- a/test/jdk/java/awt/Focus/ComponentLostFocusTest.java
+++ b/test/jdk/java/awt/Focus/ComponentLostFocusTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4982943
+ * @key headful
+ * @summary focus lost in text fields or text areas, unable to enter characters from keyboard
+ * @run main ComponentLostFocusTest
+ */
+
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+public class ComponentLostFocusTest {
+
+    static Frame frame;
+    static TextField tf;
+    static Robot r;
+    static Dialog dialog = null;
+    static volatile boolean passed;
+    static volatile Point loc;
+    static volatile int width;
+    static volatile int top;
+
+    private static void createTestUI() {
+
+        dialog = new Dialog(frame, "Dialog", true);
+
+        frame = new Frame("ComponentLostFocusTest Frame");
+        frame.setLayout(new FlowLayout());
+        frame.addWindowFocusListener(new WindowAdapter() {
+            public void windowGainedFocus(WindowEvent e) {
+                System.out.println("Frame gained focus: "+e);
+            }
+        });
+        tf = new TextField("Text Field");
+        frame.add(tf);
+        frame.setSize(400,300);
+        frame.setVisible(true);
+        frame.setLocationRelativeTo(null);
+        frame.validate();
+    }
+
+    public static void doTest() {
+        System.out.println("dialog.setVisible.... ");
+        new Thread(new Runnable() {
+            public void run() {
+                dialog.setVisible(true);
+            }
+        }).start();
+
+        // The bug is that this construction leads to the redundant xRequestFocus
+        // By the way, the requestFocusInWindow() works fine before the fix
+        System.out.println("requesting.... ");
+        frame.requestFocus();
+
+        r.delay(1000);
+
+        // Returning the focus to the initial frame will work correctly after the fix
+        System.out.println("disposing.... ");
+        dialog.dispose();
+
+        r.delay(1000);
+
+        // We want to track the GAIN_FOCUS from this time
+        tf.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent e) {
+                System.out.println("TextField gained focus: " + e);
+                passed = true;
+            }
+        });
+
+    }
+
+    private static void doRequestFocusToTextField() {
+        // do activation using press title
+        r.mouseMove(loc.x + width / 2, loc.y + top / 2);
+        r.waitForIdle();
+        r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        r.waitForIdle();
+
+        // request focus to the text field
+        tf.requestFocus();
+    }
+
+    public static final void main(String args[]) throws Exception {
+        r = new Robot();
+        r.setAutoDelay(100);
+
+        EventQueue.invokeAndWait(() -> createTestUI());
+        r.waitForIdle();
+        r.delay(1000);
+        try {
+            EventQueue.invokeAndWait(() -> {
+                doTest();
+                loc = frame.getLocationOnScreen();
+                width = frame.getWidth();
+                top = frame.getInsets().top;
+            });
+            doRequestFocusToTextField();
+
+            System.out.println("Focused window: " +
+                KeyboardFocusManager.getCurrentKeyboardFocusManager().
+                                     getFocusedWindow());
+            System.out.println("Focus owner: " +
+                KeyboardFocusManager.getCurrentKeyboardFocusManager().
+                                     getFocusOwner());
+
+            if (!passed) {
+                throw new RuntimeException("TextField got no focus! Test failed.");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}
+

--- a/test/jdk/java/awt/Focus/FocusKeepTest.java
+++ b/test/jdk/java/awt/Focus/FocusKeepTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4128659
+ * @summary Tests whether a focus request will work on a focus lost event.
+ * @key headful
+ * @run main FocusKeepTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.KeyboardFocusManager;
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+public class FocusKeepTest {
+
+    static JFrame frame;
+    static JTextField tf;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> createTestUI());
+            robot.waitForIdle();
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() instanceof JTextField tf1) {
+                if (!tf1.getText().equals("TextField 1")) {
+                    throw new RuntimeException("Focus on wrong textfield");
+                }
+            } else {
+                throw new RuntimeException("Focus not on correct component");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createTestUI() {
+        frame = new JFrame("FocusKeepTest");
+        tf = new JTextField("TextField 1");
+        tf.addFocusListener(new MyFocusAdapter("TextField 1"));
+        frame.add(tf, BorderLayout.NORTH);
+
+        tf = new JTextField("TextField 2");
+        tf.addFocusListener(new MyFocusAdapter("TextField 2"));
+        frame.add(tf, BorderLayout.SOUTH);
+
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    static class MyFocusAdapter extends FocusAdapter {
+        private String myName;
+
+        public MyFocusAdapter (String name) {
+            myName = name;
+        }
+
+        public void focusLost (FocusEvent e) {
+            if (myName.equals ("TextField 1")) {
+                e.getComponent().requestFocus ();
+            }
+        }
+
+        public void focusGained (FocusEvent e) {
+        }
+    }
+}

--- a/test/jdk/java/awt/Focus/KeyStrokeTest.java
+++ b/test/jdk/java/awt/Focus/KeyStrokeTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4845868
+ * @summary REGRESSION: First keystroke after JDialog is closed is lost
+ * @key headful
+ * @run main KeyStrokeTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+
+public class KeyStrokeTest {
+    static boolean keyTyped;
+    static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            KeyStrokeTest test = new KeyStrokeTest();
+            test.doTest();
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+
+    private static void doTest() throws Exception {
+        final Object monitor = new Object();
+        frame = new Frame();
+        TextField textField = new TextField() {
+                public void transferFocus() {
+                    System.err.println("transferFocus()");
+                    final Dialog dialog = new Dialog(frame, true);
+                    Button btn = new Button("Close It");
+                    btn.addActionListener(new ActionListener() {
+                            public void actionPerformed(ActionEvent e) {
+                                System.err.println("action performed");
+                                dialog.setVisible(false);
+                            }
+                        });
+                    dialog.add(btn);
+                    dialog.setSize(200, 200);
+                    dialog.setVisible(true);
+                }
+            };
+
+        textField.addKeyListener(new KeyAdapter() {
+                public void keyTyped(KeyEvent e) {
+                    System.err.println(e);
+                    if (e.getKeyChar() == 'a') {
+                        keyTyped = true;
+                    }
+
+                    synchronized (monitor) {
+                        monitor.notifyAll();
+                    }
+                }
+            });
+        frame.add(textField);
+        frame.setSize(400, 400);
+        frame.setVisible(true);
+
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        robot.delay(1000);
+        robot.keyPress(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_TAB);
+
+        robot.delay(1000);
+        robot.keyPress(KeyEvent.VK_SPACE);
+        robot.keyRelease(KeyEvent.VK_SPACE);
+
+        robot.delay(1000);
+        synchronized (monitor) {
+            robot.keyPress(KeyEvent.VK_A);
+            robot.keyRelease(KeyEvent.VK_A);
+            monitor.wait(3000);
+        }
+
+        if (!keyTyped) {
+            throw new RuntimeException("TEST FAILED");
+        }
+
+        System.out.println("Test passed");
+    }
+
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339906](https://bugs.openjdk.org/browse/JDK-8339906) needs maintainer approval

### Issue
 * [JDK-8339906](https://bugs.openjdk.org/browse/JDK-8339906): Open source several AWT focus tests - series 4 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1541/head:pull/1541` \
`$ git checkout pull/1541`

Update a local copy of the PR: \
`$ git checkout pull/1541` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1541`

View PR using the GUI difftool: \
`$ git pr show -t 1541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1541.diff">https://git.openjdk.org/jdk21u-dev/pull/1541.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1541#issuecomment-2749001028)
</details>
