### PR TITLE
6956385: URLConnection.getLastModified() leaks file handles for jar:file and file: URLs

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/file/FileURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/file/FileURLConnection.java
@@ -90,6 +90,12 @@ public class FileURLConnection extends URLConnection {
         }
     }
 
+    public synchronized void closeInputStream() throws IOException {
+        if (is != null) {
+            is.close();
+        }
+    }
+
     private boolean initializedHeaders = false;
 
     private void initializeHeaders() {

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/JarURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/JarURLConnection.java
@@ -25,6 +25,7 @@
 
 package sun.net.www.protocol.jar;
 
+import sun.net.www.protocol.file.FileURLConnection;
 import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -88,8 +89,14 @@ public class JarURLConnection extends java.net.JarURLConnection {
             try {
                 super.close();
             } finally {
-                if (!getUseCaches()) {
-                    jarFile.close();
+                try {
+                    if (!getUseCaches()) {
+                        jarFile.close();
+                    }
+                } finally {
+                    if (jarFileURLConnection instanceof FileURLConnection fileURLConnection) {
+                        fileURLConnection.closeInputStream();
+                    }
                 }
             }
         }

--- a/test/jdk/sun/net/www/protocol/jar/FileURLConnectionLeak.java
+++ b/test/jdk/sun/net/www/protocol/jar/FileURLConnectionLeak.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6956385
+ * @summary JarURLConnection may fail to close its underlying FileURLConnection
+ * @run main/othervm FileURLConnectionLeak
+ */
+
+import java.net.URI;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+public class FileURLConnectionLeak {
+    public static void main(String[] args) throws Exception {
+        URLConnection.setDefaultUseCaches("file", false);
+        URLConnection.setDefaultUseCaches("jar", false);
+        var jar = Path.of("x.jar").toAbsolutePath();
+        var mani = new Manifest();
+        mani.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        try (var os = Files.newOutputStream(jar); var jos = new JarOutputStream(os, mani)) {}
+        var u = URI.create("jar:" + jar.toUri() + "!/META-INF/MANIFEST.MF").toURL();
+        // FileURLConnection.is not used, so was always fine:
+        try (var is = u.openStream()) {
+            is.transferTo(System.out);
+        }
+        // FileURLConnection.is opened implicitly:
+        var conn = u.openConnection();
+        conn.getLastModified();
+        // Idiom to close URLConnection (cf. JDK-8224095), which must also close the other stream:
+        conn.getInputStream().close();
+        var fds = Path.of("/proc/" + ProcessHandle.current().pid() + "/fd");
+        if (Files.isDirectory(fds)) {
+            // Linux: verify that x.jar is not open
+            for (var fd : (Iterable<Path>) Files.list(fds)::iterator) {
+                if (Files.isSymbolicLink(fd)) {
+                    var file = Files.readSymbolicLink(fd);
+                    if (file.equals(jar)) {
+                        throw new IllegalStateException("Still held open " + jar + " from " + fd);
+                    }
+                }
+            }
+        }
+        // Windows: verify that mandatory file locks do not prevent deletion
+        Files.delete(jar);
+    }
+}


### PR DESCRIPTION
Clean backport. Fixes file handle leak if `FileURLConnection` used for `JarURLConnection`. Passes tier1 jtreg and the new test/jdk/sun/net/www/protocol/jar/FileURLConnectionLeak.java on linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-6956385](https://bugs.openjdk.org/browse/JDK-6956385) needs maintainer approval

### Issue
 * [JDK-6956385](https://bugs.openjdk.org/browse/JDK-6956385): URLConnection.getLastModified() leaks file handles for jar:file and file: URLs (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1546/head:pull/1546` \
`$ git checkout pull/1546`

Update a local copy of the PR: \
`$ git checkout pull/1546` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1546`

View PR using the GUI difftool: \
`$ git pr show -t 1546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1546.diff">https://git.openjdk.org/jdk21u-dev/pull/1546.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1546#issuecomment-2755396350)
</details>
