### PR TITLE
8333890: Fatal error in auto-vectorizer with float16 kernel.

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3802,6 +3802,12 @@ const Type* SuperWord::container_type(Node* n) {
   }
   const Type* t = _igvn.type(n);
   if (t->basic_type() == T_INT) {
+    // Float to half float conversion may be succeeded by a conversion from
+    // half float to float, in such a case back propagation of narrow type (SHORT)
+    // may not be possible.
+    if (n->Opcode() == Op_ConvF2HF) {
+      return TypeInt::SHORT;
+    }
     // A narrow type of arithmetic operations will be determined by
     // propagating the type of memory operations.
     return TypeInt::INT;

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @summary Test Float16 vector conversion chain.
+* @requires vm.compiler2.enabled
+* @library /test/lib /
+* @run driver compiler.vectorization.TestFloat16VectorConvChain
+*/
+
+package compiler.vectorization;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import java.util.Arrays;
+
+
+public class TestFloat16VectorConvChain {
+
+    @Test
+    @IR(counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE_ANY, ">= 1", IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE_ANY, " >= 1"})
+    public static void test(short [] res, short [] src1, short [] src2) {
+        for (int i = 0; i < res.length; i++) {
+            res[i] = (short)Float.float16ToFloat(Float.floatToFloat16(Float.float16ToFloat(src1[i]) + Float.float16ToFloat(src2[i])));
+        }
+    }
+
+    @Run(test = {"test"})
+    @Warmup(1000)
+    public static void micro() {
+        short [] res = new short[1024];
+        short [] src1 = new short[1024];
+        short [] src2 = new short[1024];
+        Arrays.fill(src1, (short)Float.floatToFloat16(1.0f));
+        Arrays.fill(src2, (short)Float.floatToFloat16(2.0f));
+        for (int i = 0; i < 1000; i++) {
+            test(res, src1, src2);
+        }
+    }
+
+    public static void main(String [] args) {
+        TestFramework.run(TestFloat16VectorConvChain.class);
+    }
+}


### PR DESCRIPTION
Backporting JDK-8333890: Fatal error in auto-vectorizer with float16 kernel. Fixes an assertion failure seen while auto-vectorizing conversion chain involving float16 type by constraining the container type for ConvF2HF IR to short type upfront. Adds test to confirm.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333890](https://bugs.openjdk.org/browse/JDK-8333890) needs maintainer approval

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8333890: Fatal error in auto-vectorizer with float16 kernel.`

### Issue
 * [JDK-8333890](https://bugs.openjdk.org/browse/JDK-8333890): Fatal error in auto-vectorizer with float16 kernel. (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1549/head:pull/1549` \
`$ git checkout pull/1549`

Update a local copy of the PR: \
`$ git checkout pull/1549` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1549`

View PR using the GUI difftool: \
`$ git pr show -t 1549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1549.diff">https://git.openjdk.org/jdk21u-dev/pull/1549.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1549#issuecomment-2755353285)
</details>
