### PR TITLE
8341893: AArch64: Micro-optimize compressed ptr decoding

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4836,8 +4836,10 @@ void  MacroAssembler::decode_heap_oop(Register d, Register s) {
   verify_heapbase("MacroAssembler::decode_heap_oop: heap base corrupted?");
 #endif
   if (CompressedOops::base() == nullptr) {
-    if (CompressedOops::shift() != 0 || d != s) {
+    if (CompressedOops::shift() != 0) {
       lsl(d, s, CompressedOops::shift());
+    } else if (d != s) {
+      mov(d, s);
     }
   } else {
     Label done;


### PR DESCRIPTION
This is a small clean backport to fix compressed ptr decoding inefficiency. 

Testing: tier 1,2 on linux-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8341893](https://bugs.openjdk.org/browse/JDK-8341893) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341893](https://bugs.openjdk.org/browse/JDK-8341893): AArch64: Micro-optimize compressed ptr decoding (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1551/head:pull/1551` \
`$ git checkout pull/1551`

Update a local copy of the PR: \
`$ git checkout pull/1551` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1551`

View PR using the GUI difftool: \
`$ git pr show -t 1551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1551.diff">https://git.openjdk.org/jdk21u-dev/pull/1551.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1551#issuecomment-2761277224)
</details>
