### PR TITLE
Backport 12d060a255b9b783488714c6c2cb73a899d3f708

### DIFF
--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -30,9 +30,7 @@
 // os::Linux defines the interface to Linux operating systems
 
 class os::Linux {
-  friend class CgroupSubsystem;
   friend class os;
-  friend class OSContainer;
   friend class TestReserveMemorySpecial;
 
   static int (*_pthread_getcpuclockid)(pthread_t, clockid_t *);
@@ -59,7 +57,6 @@ class os::Linux {
   static julong available_memory();
   static julong free_memory();
 
-  static int active_processor_count();
 
   static void initialize_system_info();
 
@@ -109,6 +106,7 @@ class os::Linux {
     bool     has_steal_ticks;
   };
 
+  static int active_processor_count();
   static void kernel_version(long* major, long* minor);
 
   // which_logical_cpu=-1 returns accumulated ticks for all cpus.


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

Trivial resolve, probably clean anyways.