### PR TITLE
8328484: Convert and Opensource few JFileChooser applet test to main

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/EnterEmptyDirectory.java
+++ b/test/jdk/javax/swing/JFileChooser/EnterEmptyDirectory.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+
+/*
+ * @test
+ * @bug 4913368
+ * @requires (os.family == "linux")
+ * @summary Test repainting when entering an empty directory w/ GTK LAF
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual EnterEmptyDirectory
+ */
+
+public class EnterEmptyDirectory {
+
+    private static final String INSTRUCTIONS = """
+        This test is only for the GTK Look & Feel.
+
+        Step 1:
+        Find or create an empty directory. This directory should
+        be in a directory with other files and directories, such that
+        there are items in both the Folders and Files lists of the
+        JFileChooser.
+
+        Step 2:
+        Click the "Show JFileChooser" button and enter the empty directory.
+        If both lists are correctly repainted such that they are both empty
+        (except for the ./ and ../) then the test passes.
+
+        If the contents of the Folders or Files lists are unchanged, test FAILS. """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        PassFailJFrame.builder()
+                .title("JFileChooser Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(15)
+                .columns(40)
+                .splitUI(EnterEmptyDirectory::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JPanel createAndShowUI() {
+        JButton button = new JButton("Show JFileChooser");
+        button.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                JFileChooser jfc = new JFileChooser();
+                jfc.setMultiSelectionEnabled(true);
+                jfc.showOpenDialog(null);
+            }
+        });
+        JPanel p = new JPanel();
+        p.setLayout(new BorderLayout());
+        p.setSize(200, 200);
+        p.add(button);
+        return p;
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/FileSelectionTests.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSelectionTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+
+/*
+ * @test
+ * @bug 4835633
+ * @requires (os.family == "windows")
+ * @summary Test various file selection scenarios
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FileSelectionTests
+ */
+
+public class FileSelectionTests {
+    private static final String INSTRUCTIONS = """
+        This test is only for the Windows Look & Feel.
+        This is a test of file selection/deselection using the mouse.
+        There are quite a few steps. If any step doesn't behave as
+        expected, press Fail else press Pass.
+
+        Make sure that you are in a directory with at least a few files.
+        Note that if you don't wait long enough between mouse buttons presses
+         that the action will be interpreted as a double-click and will dismiss
+         the dialog. Just re-show the dialog in this case.
+
+        Press "Show Windows JFileChooser" button to show the JFileChooser.
+
+        TEST 1:
+            Click on a filename.  The file should become selected.
+        TEST 2:
+            Clear any selection. Click to right of a filename,
+             in the space between the filename and the file's icon in the next column.
+             The file should NOT be selected.  If it becomes selected, press Fail.
+        TEST 3:
+            Select a filename. As in TEST 2, click in the empty space to the right of
+             the filename. The file should be deselected.
+        TEST 4:
+            Clear any selection. If necessary, resize the file dialog and/or change to
+             a directory with only a couple files, so that there is some space between
+             the list of files and the bottom of the file pane.
+            Click below the file list, in the empty space between the last file and
+             bottom of the file pane. The last file in the column above the cursor
+             should NOT become selected. If any file becomes selected, press Fail.
+        TEST 5:
+            Select a file. As in TEST 4, click in the empty space below the file list.
+            The selected file should become deselected.
+        TEST 6:
+            Clear any selection. As in TEST 4, click below the file list.
+            Then click on the last filename in the list. It should NOT go into edit mode.
+        TEST 7:
+            Clear any selection. Double-click below file list. The dialog should not be
+             dismissed, and no exception should be thrown.
+        TEST 8:
+            Clear any selection. As in TEST 2, press the mouse button in the empty space
+             to the right of a filename, but this time drag the mouse onto the filename.
+            The file should NOT become selected.
+        TEST 9:
+            Clear any selection. As in TEST 4, press the mouse button in the empty space
+             below the file list, but this time drag onto the last filename in the column.
+            The file should NOT become selected.
+        TEST 10:
+            Click on a filename, and then click again to go into rename mode.
+            Modify the filename, and then click to the right of the edit box.
+            The filename should be the new filename.
+        TEST 11:
+            As in TEST 10, rename a file, but this time end the editing by clicking below
+             the file list.  Again, the file should retain the new name.
+        TEST 12:
+            Use shift-click to select several files.  Hold "shift down" and click in
+             (1) the empty space to the right of a file name and
+             (2) in the empty space below the list of files.
+            The files should remain selected. If the selection is cleared press Fail.
+        TEST 13:
+            Switch to Details view. Repeat TESTS 1-11.
+        TEST 14:
+            Details view. Clear any selection. Click in the Size column.
+            No file should become selected.
+        TEST 15:
+            Details view. Select a file. Click in the Size column.
+            The file should be deselected.
+        TEST 16:
+            Details view. Shift-click to select several files. Shift-click in
+             (1) the empty space to the right of a filename
+             (2) in the Size column and
+             (3) below the list of files.
+            The files should remain selected. If the selection is cleared, press Fail. """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        PassFailJFrame.builder()
+                .title("JFileChooser Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(25)
+                .columns(50)
+                .testTimeOut(10)
+                .splitUI(FileSelectionTests::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JPanel createAndShowUI() {
+        JButton button = new JButton("Show Windows JFileChooser");
+        button.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                JFileChooser jfc = new JFileChooser();
+                jfc.setMultiSelectionEnabled(true);
+                jfc.showOpenDialog(null);
+            }
+        });
+        JPanel p = new JPanel();
+        p.setLayout(new BorderLayout());
+        p.setSize(200, 200);
+        p.add(button);
+        return p;
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/ShowHiddenFiles.java
+++ b/test/jdk/javax/swing/JFileChooser/ShowHiddenFiles.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeEvent;
+import javax.swing.JComponent;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+/*
+ * @test
+ * @bug 4835479
+ * @requires (os.family == "windows")
+ * @summary JFileChooser should respect native setting for showing hidden files
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ShowHiddenFiles
+ */
+
+public class ShowHiddenFiles
+{
+    private static final String INSTRUCTIONS = """
+        This tests JFileChooser's ability to track the native setting for
+        displaying of hidden files.
+        This test has four parts. If any portion of any of the tests don't
+        behave as specified, press FAIL else press PASS.
+        Before beginning the tests, you'll want to find the Folder Options
+        dialog on your Windows platform. Open an Explorer window for c:/
+        and select Tools->Folder Options. Under the View tab, locate
+        the option to show hidden files. You will need this for the tests.
+
+        TEST 1:
+            This tests that JFileChooser tracks the native platform setting.
+            Configure windows to Show Hidden Files, and in an Explorer window
+            locate a hidden file that is now shown (there are usually hidden
+            files in c:/).
+            Click on the TEST 1 button to display a JFileChooser.
+            Confirm that the hidden files are shown in the JFileChooser.
+            On Windows 98, TEST 1 is now complete.
+            On Windows 2000 and later, configure Folder Options to hide hidden
+            files. Confirm that
+                (1) the files are hidden in the JFileChooser and
+                (2) "PropertyChangeEvent for FILE_HIDING_CHANGED_PROPERTY"
+            appears in the accessory text field.
+            Re-enable showing of hidden files and confirm that
+                (1) the hidden files are again shown and
+                (2) you get another PropertyChangeEvent.
+            Press "Cancel" button to close JFileChooser window.
+
+        TEST 2:
+            This tests that JFileChooser.setFileHidingEnabled(true) overrides the
+            native platform setting.
+            Make sure Windows is configured to Show Hidden Files.
+            Click on the TEST 2 button.
+            Confirm that hidden files are NOT displayed in the JFileChooser.
+            Press "Cancel" button to close JFileChooser window.
+
+        TEST 3:
+            This tests that JFileChooser.setFileHidingEnabled(false) overrides the
+            Make sure Windows is configured to NOT show hidden files.
+            Click on the TEST 3 button.
+            Confirm that hidden files ARE displayed in the JFileChooser.
+            Press "Cancel" button to close JFileChooser window.
+
+        TEST 4:
+            This tests that calling setFileHidingEnabled() on a showing
+            JFileChooser will cause it to ignore further changes in the
+            native platform setting.
+            Click on the TEST 4 button. As in TEST 1, confirm that the
+            JFileChooser tracks the native setting.
+            Click on the "Show Hidden Files" button.
+            Confirm that hidden files remain visible, even when you change
+            the native setting.
+            Repeat the test for the "Hide Hidden Files" button.
+            Press "Cancel" button to close JFileChooser window.
+        """;
+    private static JButton test1, test2, test3, test4;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("JFileChooser Instructions")
+            .instructions(INSTRUCTIONS)
+            .rows(25)
+            .columns(50)
+            .splitUI(ShowHiddenFiles::createAndShowUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    public static JPanel createAndShowUI() {
+        test1 = new JButton("TEST 1: Track native setting");
+        test2 = new JButton("TEST 2: setFileHidingEnabled(true)");
+        test3 = new JButton("TEST 3: setFileHidingEnabled(false)");
+        test4 = new JButton("TEST 4: setFileHidingEnabled() on showing JFC");
+
+        ButtonListener bl = new ButtonListener();
+        test1.addActionListener(bl);
+        test2.addActionListener(bl);
+        test3.addActionListener(bl);
+        test4.addActionListener(bl);
+
+        JPanel p = new JPanel();
+        p.setLayout(new GridLayout(4,1));
+        p.setSize(200, 200);
+        p.add(test1);
+        p.add(test2);
+        p.add(test3);
+        p.add(test4);
+        return p;
+    }
+
+    private static class ButtonListener implements ActionListener {
+        public void actionPerformed(ActionEvent e) {
+            JFileChooser jfc = new JFileChooser("c:/");
+            if (e.getSource() == test1) {
+                jfc.setAccessory(createTest1Acc(jfc));
+            }
+            else if (e.getSource() == test2) {
+                jfc.setAccessory(null);
+                jfc.setFileHidingEnabled(true);
+            }
+            else if (e.getSource() == test3) {
+                jfc.setAccessory(null);
+                jfc.setFileHidingEnabled(false);
+            }
+            else if (e.getSource() == test4) {
+                jfc.setAccessory(createTest4Acc(jfc));
+            }
+            else {
+                return;
+            }
+            jfc.showOpenDialog(new JFrame());
+        }
+    }
+
+    private static class JFCHideButton extends JButton implements ActionListener {
+        JFileChooser jfc;
+        boolean setVal;
+
+        public JFCHideButton(String label, JFileChooser jfc, boolean setVal) {
+            super(label);
+            this.jfc = jfc;
+            this.setVal = setVal;
+            addActionListener(this);
+        }
+        public void actionPerformed(ActionEvent e) {
+            jfc.setFileHidingEnabled(setVal);
+        }
+    }
+
+    private static JPanel createTest1Acc(JFileChooser jfc) {
+        JPanel jpl = new JPanel();
+        jpl.add(createTAListener(jfc));
+        return jpl;
+    }
+
+    private static JPanel createTest4Acc(JFileChooser jfc) {
+        JPanel jpl = new JPanel();
+        jpl.setLayout(new BorderLayout());
+
+        JPanel north = new JPanel();
+        north.setLayout(new GridLayout(2,1));
+        north.add(new JFCHideButton("Show Hidden Files", jfc, false));
+        north.add(new JFCHideButton("Hide Hidden Files", jfc, true));
+        jpl.add(BorderLayout.NORTH, north);
+        jpl.add(BorderLayout.CENTER, createTAListener(jfc));
+        return jpl;
+    }
+
+    private static JComponent createTAListener(JFileChooser jfc) {
+        final JTextArea jta = new JTextArea(10,20);
+        PropertyChangeListener pcl = new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent e) {
+                jta.append("PropertyChangeEvent for FILE_HIDING_CHANGED_PROPERTY\n");
+            }
+        };
+        jfc.addPropertyChangeListener(JFileChooser.FILE_HIDING_CHANGED_PROPERTY, pcl);
+        JScrollPane jsp = new JScrollPane(jta);
+        return jsp;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8328484](https://bugs.openjdk.org/browse/JDK-8328484) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328484](https://bugs.openjdk.org/browse/JDK-8328484): Convert and Opensource few JFileChooser applet test to main (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1559/head:pull/1559` \
`$ git checkout pull/1559`

Update a local copy of the PR: \
`$ git checkout pull/1559` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1559`

View PR using the GUI difftool: \
`$ git pr show -t 1559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1559.diff">https://git.openjdk.org/jdk21u-dev/pull/1559.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1559#issuecomment-2768311932)
</details>
