### PR TITLE
8340555: Open source DnD tests - Set4

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -468,6 +468,9 @@ java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
 java/awt/Dialog/ChoiceModalDialogTest.java 8161475 macosx-all
 java/awt/dnd/BadSerializationTest/BadSerializationTest.java 8277817 linux-x64,windows-x64
+java/awt/dnd/DragSourceMotionListenerTest.java 8225131 windows-all
+java/awt/dnd/RejectDragTest.java 7124259 macosx-all
+java/awt/dnd/DnDHTMLToOutlookTest/DnDHTMLToOutlookTest.java 8027424 generic-all
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
 java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java 8305061 macosx-x64

--- a/test/jdk/java/awt/dnd/DnDHTMLToOutlookTest/DnDHTMLToOutlookTest.java
+++ b/test/jdk/java/awt/dnd/DnDHTMLToOutlookTest/DnDHTMLToOutlookTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.Panel;
+
+
+/*
+ * @test
+ * @bug 6392086
+ * @summary Tests dnd to another screen
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DnDHTMLToOutlookTest
+ */
+
+public class DnDHTMLToOutlookTest {
+
+    private static final String INSTRUCTIONS = """
+            The window contains a yellow button. Click on the button
+            to copy HTML from DnDSource.html file into the clipboard or drag
+            HTML context. Paste into or drop over the HTML capable editor in
+            external application such as Outlook, Word.
+
+            When the mouse enters the editor, cursor should change to indicate
+            that copy operation is about to happen and then release the mouse
+            button. HTML text without tags should appear inside the document.
+
+            You should be able to repeat this operation multiple times.
+            If the above is true Press PASS else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .title("Test Instructions")
+                      .instructions(INSTRUCTIONS)
+                      .columns(40)
+                      .testUI(DnDHTMLToOutlookTest::createAndShowUI)
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Frame frame = new Frame("DnDHTMLToOutlookTest");
+        Panel mainPanel;
+        Component dragSource;
+
+        mainPanel = new Panel();
+        mainPanel.setLayout(new BorderLayout());
+
+        mainPanel.setBackground(Color.YELLOW);
+        dragSource = new DnDSource("Drag ME (HTML)!");
+
+        mainPanel.add(dragSource, BorderLayout.CENTER);
+        frame.add(mainPanel);
+        frame.setSize(200, 200);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/dnd/DnDHTMLToOutlookTest/DnDSource.html
+++ b/test/jdk/java/awt/dnd/DnDHTMLToOutlookTest/DnDSource.html
@@ -1,0 +1,25 @@
+<!--
+ Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+ This code is free software; you can redistribute it and/or modify it
+ under the terms of the GNU General Public License version 2 only, as
+ published by the Free Software Foundation.
+
+ This code is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ version 2 for more details (a copy is included in the LICENSE file that
+ accompanied this code).
+
+ You should have received a copy of the GNU General Public License version
+ 2 along with this work; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ or visit www.oracle.com if you need additional information or have any
+ questions.
+-->
+
+<h1>DnDHTMLToOutlookTest<br>HTML Drag & Paste problem</h1>
+<p>if you see the bold header above without HTML tags and without StartHTML as the first word, press PASS</p>

--- a/test/jdk/java/awt/dnd/DnDHTMLToOutlookTest/DnDSource.java
+++ b/test/jdk/java/awt/dnd/DnDHTMLToOutlookTest/DnDSource.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.InvalidDnDOperationException;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+class DnDSource extends Button implements Transferable,
+                                          DragGestureListener,
+                                          DragSourceListener {
+    private DataFlavor m_df;
+    private transient int m_dropAction;
+    private ByteArrayInputStream m_data = null;
+
+    DnDSource(String label) {
+        super(label);
+        setBackground(Color.yellow);
+        setForeground(Color.blue);
+        setSize(200, 120);
+
+        try {
+            m_df = new DataFlavor("text/html; Class=" + InputStream.class.getName() + "; charset=UTF-8");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        DragSource dragSource = new DragSource();
+        dragSource.createDefaultDragGestureRecognizer(
+                this,
+                DnDConstants.ACTION_COPY_OR_MOVE,
+                this
+        );
+        dragSource.addDragSourceListener(this);
+
+        String dir = System.getProperty("test.src", ".");
+
+        try {
+            m_data = new ByteArrayInputStream(Files.readAllBytes(
+                    Paths.get(dir, "DnDSource.html")));
+            m_data.mark(m_data.available());
+            addActionListener(
+                new ActionListener(){
+                    public void actionPerformed(ActionEvent ae){
+                        Toolkit.getDefaultToolkit().getSystemClipboard()
+                               .setContents( DnDSource.this, null);
+                    }
+                }
+            );
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        System.err.println("starting Drag");
+        try {
+            dge.startDrag(null, this, this);
+        } catch (InvalidDnDOperationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void dragEnter(DragSourceDragEvent dsde) {
+        System.err.println("[Source] dragEnter");
+    }
+
+    public void dragOver(DragSourceDragEvent dsde) {
+        System.err.println("[Source] dragOver");
+        m_dropAction = dsde.getDropAction();
+        System.out.println("m_dropAction = " + m_dropAction);
+    }
+
+    public void dragExit(DragSourceEvent dsde) {
+        System.err.println("[Source] dragExit");
+    }
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {
+        System.err.println("[Source] dragDropEnd");
+    }
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {
+        System.err.println("[Source] dropActionChanged");
+        m_dropAction = dsde.getDropAction();
+        System.out.println("m_dropAction = " + m_dropAction);
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[] {m_df};
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor sdf) {
+        System.err.println("[Source] isDataFlavorSupported" + m_df.equals(sdf));
+        return m_df.equals(sdf);
+    }
+
+    public Object getTransferData(DataFlavor tdf) throws UnsupportedFlavorException {
+        if (!m_df.equals(tdf)) {
+            throw new UnsupportedFlavorException(tdf);
+        }
+        System.err.println("[Source] Ok");
+        m_data.reset();
+        return m_data;
+    }
+}

--- a/test/jdk/java/awt/dnd/DragSourceMotionListenerTest.java
+++ b/test/jdk/java/awt/dnd/DragSourceMotionListenerTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.AWTEventListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4422345
+ * @summary tests that DragSourceMotionListeners work correctly and
+           DragSourceEvents position is correct
+ */
+
+public class DragSourceMotionListenerTest implements AWTEventListener {
+    static class TestPanel extends Panel {
+        final Dimension preferredDimension = new Dimension(200, 200);
+        public Dimension getPreferredSize() {
+            return preferredDimension;
+        }
+    }
+
+    private static Frame frame;
+    private static final Panel source = new TestPanel();
+    private static final Panel target = new TestPanel();
+    private static final DragSource ds = DragSource.getDefaultDragSource();
+    private static volatile CountDownLatch mouseReleaseEvent;
+
+    static volatile boolean passedTest1 = false;
+    static volatile boolean passedTest2 = false;
+
+    private static final Point testPoint1 = new Point();
+    private static final Point testPoint2 = new Point();
+    private static volatile Point srcPoint;
+    private static volatile Point dstOutsidePoint;
+    private static volatile Point dstInsidePoint;
+
+    private static final Transferable t = new StringSelection("TEXT");
+    private static final DragGestureListener gestureListener = e -> e.startDrag(null, t);
+
+    private static final DragSourceAdapter sourceAdapter = new DragSourceAdapter() {
+        public void dragMouseMoved(DragSourceDragEvent dsde) {
+            if (Math.abs(dsde.getX() - testPoint1.getX()) < 5) {
+                passedTest1 = true;
+            }
+        }
+
+        public void dragDropEnd(DragSourceDropEvent dsde) {
+            if (Math.abs(dsde.getX() - testPoint2.getX()) < 5) {
+                passedTest2 = true;
+            }
+        }
+    };
+
+    private static final DropTargetListener targetAdapter = new DropTargetAdapter() {
+        public void drop(DropTargetDropEvent e) {
+            e.acceptDrop(DnDConstants.ACTION_COPY);
+            try {
+                final Transferable t = e.getTransferable();
+                final String str =
+                        (String) t.getTransferData(DataFlavor.stringFlavor);
+                e.dropComplete(true);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                e.dropComplete(false);
+            }
+        }
+    };
+
+    private static final DropTarget dropTarget = new DropTarget(target, targetAdapter);
+    Component clickedComponent = null;
+
+    private void createAndShowUI() {
+        frame = new Frame("DragSourceMotionListenerTest");
+        ds.addDragSourceListener(sourceAdapter);
+        ds.addDragSourceMotionListener(sourceAdapter);
+        ds.createDefaultDragGestureRecognizer(source, DnDConstants.ACTION_COPY, gestureListener);
+        target.setDropTarget(dropTarget);
+
+        frame.setLayout(new GridLayout(1, 2));
+
+        frame.add(source);
+        frame.add(target);
+
+        Toolkit.getDefaultToolkit()
+               .addAWTEventListener(this, AWTEvent.MOUSE_EVENT_MASK);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(10);
+
+            DragSourceMotionListenerTest dsmObj = new DragSourceMotionListenerTest();
+            EventQueue.invokeAndWait(dsmObj::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                srcPoint = getPoint(source, 1);
+
+                dstOutsidePoint = getPoint(frame, 3);
+                testPoint1.setLocation(dstOutsidePoint);
+
+                dstInsidePoint = getPoint(target, 1);
+                testPoint2.setLocation(dstInsidePoint);
+            });
+            robot.waitForIdle();
+
+            if (!dsmObj.pointInComponent(robot, srcPoint, source)) {
+                throw new RuntimeException("WARNING: Couldn't locate source panel.");
+            }
+
+            if (!dsmObj.pointInComponent(robot, dstInsidePoint, target)) {
+                throw new RuntimeException("WARNING: Couldn't locate target panel.");
+            }
+
+            robot.mouseMove(srcPoint.x, srcPoint.y);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (; !srcPoint.equals(dstOutsidePoint);
+                 srcPoint.translate(sign(dstOutsidePoint.x - srcPoint.x),
+                                    sign(dstOutsidePoint.y - srcPoint.y))) {
+                robot.mouseMove(srcPoint.x, srcPoint.y);
+            }
+
+            for (int i = 0; i < 10; i++) {
+                robot.mouseMove(srcPoint.x, srcPoint.y++);
+            }
+
+            for (;!srcPoint.equals(dstInsidePoint);
+                 srcPoint.translate(sign(dstInsidePoint.x - srcPoint.x),
+                                    sign(dstInsidePoint.y - srcPoint.y))) {
+                robot.mouseMove(srcPoint.x, srcPoint.y);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            if (!passedTest1) {
+                throw new RuntimeException("Failed first test.");
+            }
+
+            if (!passedTest2) {
+                throw new RuntimeException("Failed second test.");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static Point getPoint(Container container, int multiple) {
+        Point p = container.getLocationOnScreen();
+        Dimension d = container.getSize();
+        p.translate(multiple * d.width / 2, d.height / 2);
+        return p;
+    }
+
+    public static int sign(int n) {
+        return Integer.compare(n, 0);
+    }
+
+    public void eventDispatched(AWTEvent e) {
+        if (e.getID() == MouseEvent.MOUSE_RELEASED) {
+            clickedComponent = (Component)e.getSource();
+            mouseReleaseEvent.countDown();
+        }
+    }
+
+    boolean pointInComponent(Robot robot, Point p, Component comp) throws Exception {
+        robot.waitForIdle();
+        clickedComponent = null;
+        mouseReleaseEvent = new CountDownLatch(1);
+        robot.mouseMove(p.x, p.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        if (!mouseReleaseEvent.await(2, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Mouse Release Event not received");
+        }
+
+        Component c = clickedComponent;
+        while (c != null && c != comp) {
+            c = c.getParent();
+        }
+        return c == comp;
+    }
+}

--- a/test/jdk/java/awt/dnd/DragToAnotherScreenTest.java
+++ b/test/jdk/java/awt/dnd/DragToAnotherScreenTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Label;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+import java.util.List;
+
+import javax.swing.JOptionPane;
+
+/*
+ * @test
+ * @bug 6179157
+ * @key multimon
+ * @summary Tests dnd to another screen
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DragToAnotherScreenTest
+ */
+
+public class DragToAnotherScreenTest {
+    private static Label label0;
+    private static Label label1;
+    private static final int HGAP = 20;
+
+    private static final String INSTRUCTIONS = """
+                The following test is applicable for Single as well
+                as Multi-monitor screens.
+
+                It is a semi-automated test, the test will prompt
+                the user whether the drag and drop action was successful or not
+                and automatically PASS/FAIL the test.
+
+                If on multi-monitor screens then please position
+                the drag and drop windows on different screens.
+
+                If you can not move the mouse from the frame "Drag Source"
+                to the frame "Drop Target" press PASS,
+                else proceed to the next step.
+
+                Drag the label "Drag me" and drop it on the
+                label "Drop on me".
+
+                If you can not drag to the second label (for example
+                if you can not drag across screens) press FAIL.
+
+                After the drag and drop action, the test displays
+                Success/Failure msg in JOptionPane.
+                Click on OK button and the test is configured to
+                automatically PASS/FAIL.
+                """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .title("Test Instructions")
+                      .instructions(INSTRUCTIONS)
+                      .columns(35)
+                      .testUI(DragToAnotherScreenTest::createAndShowUI)
+                      .positionTestUI(DragToAnotherScreenTest::positionMultiTestUI)
+                      .logArea(10)
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static List<Frame> createAndShowUI() {
+        PassFailJFrame.log("----- System Configuration ----");
+        PassFailJFrame.log("Toolkit:" + Toolkit.getDefaultToolkit()
+                                               .getClass()
+                                               .getName());
+
+        GraphicsDevice[] gd = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                                                 .getScreenDevices();
+        if (gd.length == 1) {
+            PassFailJFrame.log("Single Monitor");
+        } else {
+            PassFailJFrame.log("Multi-Monitor");
+        }
+        PassFailJFrame.log("--------------");
+        PassFailJFrame.log("Test logs:\n");
+        Frame frame0 = new Frame("Drag Source", gd[0].getDefaultConfiguration());
+        frame0.setSize(300, 300);
+        label0 = new Label("Drag me");
+        frame0.add(label0);
+
+        Frame frame1 = new Frame("Drop Target", gd[(gd.length > 1 ? 1 : 0)].getDefaultConfiguration());
+        frame1.setSize(300, 300);
+        label1 = new Label("Drop on me");
+        frame1.add(label1);
+
+        DragGestureListener dragGestureListener = dge -> dge.startDrag(null, new StringSelection(label0.getText()), null);
+        new DragSource().createDefaultDragGestureRecognizer(label0,
+                                                            DnDConstants.ACTION_COPY, dragGestureListener);
+
+        DropTargetAdapter dropTargetAdapter = new DropTargetAdapter() {
+            public void drop(DropTargetDropEvent dtde) {
+                Transferable t = dtde.getTransferable();
+                if (t.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+                    dtde.acceptDrop(DnDConstants.ACTION_COPY);
+                    try {
+                        String str = (String) t.getTransferData(DataFlavor.stringFlavor);
+                        label1.setText(str);
+                        JOptionPane.showMessageDialog(frame0,
+                                                      "getTransferData was successful",
+                                                      "Test Passed", JOptionPane.PLAIN_MESSAGE);
+                    } catch (Exception e) {
+                        dtde.dropComplete(false);
+                        e.printStackTrace();
+                        PassFailJFrame.log("getTransferData() Failed");
+                        JOptionPane.showMessageDialog(frame0,
+                                                      "getTransferData() Failed",
+                                                      "Test Failed", JOptionPane.ERROR_MESSAGE);
+                        PassFailJFrame.forceFail("getTransferData() Failed");
+                    }
+                    dtde.dropComplete(true);
+                } else {
+                    dtde.rejectDrop();
+                    PassFailJFrame.log("stringFlavor is not supported by Transferable");
+                    JOptionPane.showMessageDialog(frame0,
+                                                  "stringFlavor is not supported by Transferable",
+                                                  "Test Failed", JOptionPane.ERROR_MESSAGE);
+                    PassFailJFrame.forceFail("stringFlavor is not supported by Transferable");
+                }
+            }
+        };
+        new DropTarget(label1, dropTargetAdapter);
+        return List.of(frame0, frame1);
+    }
+
+    private static void positionMultiTestUI(List<? extends Window> windows,
+                                            PassFailJFrame.InstructionUI instructionUI) {
+        int x = instructionUI.getLocation().x + instructionUI.getSize().width + HGAP;
+        for (Window w : windows) {
+            w.setLocation(x, instructionUI.getLocation().y);
+            x += w.getWidth() + HGAP;
+        }
+    }
+}

--- a/test/jdk/java/awt/dnd/RejectDragTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.StringSelection;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.event.InputEvent;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4407521
+ * @summary Tests that DragSourceListener.dragEnter() and
+            DragSourceListener.dragOver() are not called after
+            drag rejecting, but DragSourceListener.dragExit() is.
+ */
+
+public class RejectDragTest {
+    private static Frame frame;
+    private static Robot robot;
+    private static volatile boolean dragEnterCalled;
+    private static volatile boolean dragOverCalled;
+    private static volatile boolean dragExitCalledAtFirst;
+    private static volatile Point startPoint;
+    private static volatile Point endPoint;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+
+            EventQueue.invokeAndWait(RejectDragTest::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(RejectDragTest::addDnDListeners);
+            robot.waitForIdle();
+
+            testDnD();
+            robot.waitForIdle();
+            robot.delay(200);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void addDnDListeners() {
+        final DragSourceListener dragSourceListener = new DragSourceAdapter() {
+            private boolean first = true;
+
+            public void dragEnter(DragSourceDragEvent dsde) {
+                first = false;
+                dragEnterCalled = true;
+            }
+
+            public void dragExit(DragSourceEvent dse) {
+                if (first) {
+                    dragExitCalledAtFirst = true;
+                    first = false;
+                }
+            }
+
+            public void dragDropEnd(DragSourceDropEvent dsde) {
+                first = false;
+            }
+
+            public void dragOver(DragSourceDragEvent dsde) {
+                first = false;
+                dragOverCalled = true;
+            }
+
+            public void dropActionChanged(DragSourceDragEvent dsde) {
+                first = false;
+            }
+        };
+
+        DragGestureListener dragGestureListener =
+                dge -> dge.startDrag(null, new StringSelection("OKAY"),
+                                     dragSourceListener);
+        new DragSource().createDefaultDragGestureRecognizer(frame,
+                                                            DnDConstants.ACTION_COPY,
+                                                            dragGestureListener);
+
+        DropTargetAdapter dropTargetListener = new DropTargetAdapter() {
+            public void dragEnter(DropTargetDragEvent dtde) {
+               dtde.rejectDrag();
+            }
+
+            public void drop(DropTargetDropEvent dtde) {
+               dtde.rejectDrop();
+            }
+        };
+
+        new DropTarget(frame, dropTargetListener);
+    }
+
+    private static void createAndShowUI() {
+        frame = new Frame("RejectDragTest");
+        frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void testDnD() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            Point start = frame.getLocationOnScreen();
+            start.translate(50, 50);
+            startPoint = start;
+
+            Point end = new Point(start);
+            end.translate(150, 150);
+            endPoint = end;
+        });
+
+        robot.mouseMove(startPoint.x, startPoint.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        for (Point p = new Point(startPoint); !p.equals(endPoint);
+             p.translate(sign(endPoint.x - p.x),
+                         sign(endPoint.y - p.y))) {
+            robot.mouseMove(p.x, p.y);
+            robot.delay(30);
+        }
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        if (dragEnterCalled || dragOverCalled) {
+            throw new RuntimeException("Test failed: " +
+                                       (dragEnterCalled ? "DragSourceListener.dragEnter() was called; " : "") +
+                                       (dragOverCalled ? "DragSourceListener.dragOver() was called; " : "") +
+                                       (!dragExitCalledAtFirst ? "DragSourceListener.dragExit() was not " +
+                                                                 "called immediately after rejectDrag() " : ""));
+        }
+    }
+
+    public static int sign(int n) {
+        return Integer.compare(n, 0);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340555](https://bugs.openjdk.org/browse/JDK-8340555) needs maintainer approval

### Issue
 * [JDK-8340555](https://bugs.openjdk.org/browse/JDK-8340555): Open source DnD tests - Set4 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1572/head:pull/1572` \
`$ git checkout pull/1572`

Update a local copy of the PR: \
`$ git checkout pull/1572` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1572`

View PR using the GUI difftool: \
`$ git pr show -t 1572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1572.diff">https://git.openjdk.org/jdk21u-dev/pull/1572.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1572#issuecomment-2772696406)
</details>
