### PR TITLE
8331088: Incorrect TraceLoopPredicate output

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -1456,7 +1456,7 @@ bool PhaseIdealLoop::loop_predication_impl_helper(IdealLoopTree* loop, IfProjNod
     IfNode* upper_bound_iff = upper_bound_proj->in(0)->as_If();
     _igvn.hash_delete(upper_bound_iff);
     upper_bound_iff->set_req(1, upper_bound_bol);
-    if (TraceLoopPredicate) tty->print_cr("upper bound check if: %d", lower_bound_iff->_idx);
+    if (TraceLoopPredicate) tty->print_cr("upper bound check if: %d", upper_bound_iff->_idx);
 
     // Fall through into rest of the cleanup code which will move any dependent nodes to the skeleton predicates of the
     // upper bound test. We always need to create skeleton predicates in order to properly remove dead loops when later


### PR DESCRIPTION
Backporting JDK-8331088: Incorrect TraceLoopPredicate output. The PhaseIdealLoop::loop_predication_impl_helper prints the node index of the lower bounds check, rather than the upper bounds check (introduced by https://bugs.openjdk.org/browse/JDK-8203197).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331088](https://bugs.openjdk.org/browse/JDK-8331088) needs maintainer approval

### Issue
 * [JDK-8331088](https://bugs.openjdk.org/browse/JDK-8331088): Incorrect TraceLoopPredicate output (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1577/head:pull/1577` \
`$ git checkout pull/1577`

Update a local copy of the PR: \
`$ git checkout pull/1577` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1577`

View PR using the GUI difftool: \
`$ git pr show -t 1577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1577.diff">https://git.openjdk.org/jdk21u-dev/pull/1577.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1577#issuecomment-2773288118)
</details>
