### PR TITLE
8344346: java/net/httpclient/ShutdownNow.java fails with java.lang.AssertionError: client was still running, but exited after further delay: timeout should be adjusted

### DIFF
--- a/test/jdk/java/net/httpclient/ShutdownNow.java
+++ b/test/jdk/java/net/httpclient/ShutdownNow.java
@@ -30,6 +30,7 @@
  *          isTerminated.
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
+ *        jdk.test.lib.RandomFactory jdk.test.lib.Utils
  *        ReferenceTracker
  * @run testng/othervm
  *       -Djdk.internal.httpclient.debug=true
@@ -41,8 +42,6 @@
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
@@ -58,20 +57,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
 
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
 import jdk.test.lib.RandomFactory;
+import jdk.test.lib.Utils;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -211,7 +202,7 @@ public class ShutdownNow implements HttpServerAdapters {
             }
             CompletableFuture.allOf(responses.toArray(new CompletableFuture<?>[0])).get();
         } finally {
-            if (client.awaitTermination(Duration.ofMillis(2000))) {
+            if (client.awaitTermination(Duration.ofMillis(Utils.adjustTimeout(1000)))) {
                 out.println("Client terminated within expected delay");
             } else {
                 throw new AssertionError("client still running");
@@ -273,7 +264,7 @@ public class ShutdownNow implements HttpServerAdapters {
                 }).thenCompose((c) -> c).get();
             }
        } finally {
-            if (client.awaitTermination(Duration.ofMillis(2000))) {
+            if (client.awaitTermination(Duration.ofMillis(Utils.adjustTimeout(1000)))) {
                 out.println("Client terminated within expected delay");
             } else {
                 throw new AssertionError("client still running");


### PR DESCRIPTION
Backport for parity with Oracle 21.0.8. The modified test passes. Low risk: the patch modifies only a test timeout.

Clean except that the replaced fixed timeout in 21u was 2000ms, but 2500ms in 24. Apparently, a previous fix attempt just increased the timeout from 2000 to 2500.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8344346](https://bugs.openjdk.org/browse/JDK-8344346) needs maintainer approval

### Issue
 * [JDK-8344346](https://bugs.openjdk.org/browse/JDK-8344346): java/net/httpclient/ShutdownNow.java fails with java.lang.AssertionError: client was still running, but exited after further delay: timeout should be adjusted (**Bug** - P4 - Approved)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1586/head:pull/1586` \
`$ git checkout pull/1586`

Update a local copy of the PR: \
`$ git checkout pull/1586` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1586`

View PR using the GUI difftool: \
`$ git pr show -t 1586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1586.diff">https://git.openjdk.org/jdk21u-dev/pull/1586.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1586#issuecomment-2776948536)
</details>
