### PR TITLE
Backport 56387a09810a3204ed820885e0ff0b26408be59d

### DIFF
--- a/src/java.base/share/classes/java/security/SecureRandom.java
+++ b/src/java.base/share/classes/java/security/SecureRandom.java
@@ -230,8 +230,8 @@ public class SecureRandom extends java.util.Random {
         if (provider == null || algorithm == null) {
             return false;
         } else {
-            return Boolean.parseBoolean(provider.getProperty(
-                    "SecureRandom." + algorithm + " ThreadSafe", "false"));
+            Service service = provider.getService("SecureRandom", algorithm);
+            return Boolean.parseBoolean(service.getAttribute("ThreadSafe"));
         }
     }
 


### PR DESCRIPTION
Backporting JDK-8329754: The ThreadSafe attribute is ignored for SecureRandom algorithm aliases. Fixes a bug that occurs when a provider registers an alias for the `SecureRandom` algorithm with "ThreadSafe=true" and where the `SecureRandom` instances using the alias do not honor the `ThreadSafe` attribute. 