### PR TITLE
8335860: compiler/vectorization/TestFloat16VectorConvChain.java fails with non-standard AVX/SSE settings

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -83,6 +83,7 @@ public class IREncodingPrinter {
     private static final List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
         // x86
         "fma",
+        "f16c",
         // Intel SSE
         "sse",
         "sse2",

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -24,7 +24,6 @@
 /**
 * @test
 * @summary Test Float16 vector conversion chain.
-* @requires vm.compiler2.enabled
 * @library /test/lib /
 * @run driver compiler.vectorization.TestFloat16VectorConvChain
 */
@@ -39,7 +38,7 @@ import java.util.Arrays;
 public class TestFloat16VectorConvChain {
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE_ANY, ">= 1", IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE_ANY, " >= 1"})
+    @IR(applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true"}, counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE_ANY, ">= 1", IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE_ANY, " >= 1"})
     public static void test(short [] res, short [] src1, short [] src2) {
         for (int i = 0; i < res.length; i++) {
             res[i] = (short)Float.float16ToFloat(Float.floatToFloat16(Float.float16ToFloat(src1[i]) + Float.float16ToFloat(src2[i])));


### PR DESCRIPTION
I backport this to fix test failures caused by backport of JDK-8333890.

Omitted change to ProblemList as test is not ProblemListed in 21.

Further I add an additon to the IR framework from https://bugs.openjdk.org/browse/JDK-8318683 that is required by this change. 
JDK-8318683 is not a candidate for backport, as the change causing this is an enhancement in 22.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335860](https://bugs.openjdk.org/browse/JDK-8335860) needs maintainer approval

### Issue
 * [JDK-8335860](https://bugs.openjdk.org/browse/JDK-8335860): compiler/vectorization/TestFloat16VectorConvChain.java fails with non-standard AVX/SSE settings (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1588/head:pull/1588` \
`$ git checkout pull/1588`

Update a local copy of the PR: \
`$ git checkout pull/1588` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1588`

View PR using the GUI difftool: \
`$ git pr show -t 1588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1588.diff">https://git.openjdk.org/jdk21u-dev/pull/1588.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1588#issuecomment-2777897019)
</details>
