### PR TITLE
8336827: compiler/vectorization/TestFloat16VectorConvChain.java  timeouts on ppc64 platforms after JDK-8335860

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -24,7 +24,6 @@
 /**
 * @test
 * @summary Test Float16 vector conversion chain.
-* @requires vm.compiler2.enabled
 * @library /test/lib /
 * @run driver compiler.vectorization.TestFloat16VectorConvChain
 */
@@ -39,7 +38,7 @@ import java.util.Arrays;
 public class TestFloat16VectorConvChain {
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE_ANY, ">= 1", IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE_ANY, " >= 1"})
+    @IR(applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true"}, counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE_ANY, ">= 1", IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE_ANY, " >= 1"})
     public static void test(short [] res, short [] src1, short [] src2) {
         for (int i = 0; i < res.length; i++) {
             res[i] = (short)Float.float16ToFloat(Float.floatToFloat16(Float.float16ToFloat(src1[i]) + Float.float16ToFloat(src2[i])));

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -24,6 +24,8 @@
 /**
 * @test
 * @summary Test Float16 vector conversion chain.
+* @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch == "aarch64"
+*           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh.*")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestFloat16VectorConvChain
 */

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -26,6 +26,7 @@
 * @summary Test Float16 vector conversion chain.
 * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch == "aarch64"
 *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh.*")
+*           | ((os.arch == "ppc64" | os.arch == "ppc64le") & vm.cpu.features ~= ".*darn.*")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestFloat16VectorConvChain
 */


### PR DESCRIPTION
I backport this to fix test failures caused by backport of JDK-8333890.

I include parts of JDK-8345146 that enable the test again. 
JDK-8345146 implements the needed features for this test on PPC and was backported already.
The test adaption for TestFloat16VectorConvChain was omitted as the test was not in 21 at that time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336827](https://bugs.openjdk.org/browse/JDK-8336827) needs maintainer approval

### Issue
 * [JDK-8336827](https://bugs.openjdk.org/browse/JDK-8336827): compiler/vectorization/TestFloat16VectorConvChain.java  timeouts on ppc64 platforms after JDK-8335860 (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1589/head:pull/1589` \
`$ git checkout pull/1589`

Update a local copy of the PR: \
`$ git checkout pull/1589` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1589`

View PR using the GUI difftool: \
`$ git pr show -t 1589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1589.diff">https://git.openjdk.org/jdk21u-dev/pull/1589.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1589#issuecomment-2777916858)
</details>
