### PR TITLE
8315871: Opensource five more Swing regression tests

### DIFF
--- a/test/jdk/javax/swing/AncestorNotifier/4817630/bug4817630.java
+++ b/test/jdk/javax/swing/AncestorNotifier/4817630/bug4817630.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ *  @test
+ *  @bug 4817630
+ *  @summary AncestorEvent ancestorAdded thrown at JFrame creation, not at show()
+ *  @key headful
+ *  @run main bug4817630
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
+
+public class bug4817630 {
+
+    JFrame fr;
+
+    volatile boolean ancestorAdded = false;
+    volatile boolean passed = true;
+
+    public void init() {
+        fr = new JFrame("bug4817630");
+        JLabel label = new JLabel("Label");
+
+        label.addAncestorListener(new AncestorListener() {
+                public void ancestorAdded(AncestorEvent e) {
+                    if (!fr.isVisible()) {
+                        setPassed(false);
+                    }
+                    synchronized (bug4817630.this) {
+                        ancestorAdded = true;
+                        bug4817630.this.notifyAll();
+                    }
+                }
+                public void ancestorRemoved(AncestorEvent e) {
+                }
+                public void ancestorMoved(AncestorEvent e) {
+                }
+            });
+
+        fr.setLocationRelativeTo(null);
+        fr.getContentPane().add(label);
+        fr.pack();
+        fr.setVisible(true);
+    }
+
+    public void start() {
+        try {
+            synchronized (bug4817630.this) {
+                while (!ancestorAdded) {
+                    bug4817630.this.wait();
+                }
+            }
+        } catch(Exception e) {
+            throw new RuntimeException("Test failed because of "
+                    + e.getLocalizedMessage());
+        }
+    }
+
+    public void destroy() {
+        if (fr != null) {
+            fr.setVisible(false);
+            fr.dispose();
+        }
+        if (!isPassed()) {
+            throw new RuntimeException("ancestorAdded() method shouldn't be "
+                    + "called before the frame is shown.");
+        }
+    }
+
+    synchronized void setPassed(boolean passed) {
+        this.passed = passed;
+    }
+
+    synchronized boolean isPassed() {
+        return passed;
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        bug4817630 test = new bug4817630();
+        try {
+            SwingUtilities.invokeAndWait(test::init);
+            test.start();
+        } finally {
+            SwingUtilities.invokeAndWait(test::destroy);
+        }
+    }
+}

--- a/test/jdk/javax/swing/BoxLayout/4191948/bug4191948.java
+++ b/test/jdk/javax/swing/BoxLayout/4191948/bug4191948.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4191948
+ * @summary BoxLayout doesn't ignore invisible components
+ * @key headful
+ * @run main bug4191948
+ */
+
+import java.awt.BorderLayout;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+public class bug4191948 {
+    JFrame frame;
+    JPanel p;
+    JButton foo1;
+    JButton foo2;
+    JButton foo3;
+
+    public void init() {
+        frame = new JFrame("bug4191948");
+        p = new JPanel();
+        p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
+        foo1 = (JButton)p.add(new JButton("Foo1"));
+        foo2 = (JButton)p.add(new JButton("Foo2"));
+        foo3 = (JButton)p.add(new JButton("Foo3"));
+
+        foo2.setVisible(false);
+        frame.setLocationRelativeTo(null);
+        frame.setLayout(new BorderLayout());
+        frame.add(p, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public void start() {
+        try {
+            int totalWidth = p.getPreferredSize().width;
+            int foo1Width = foo1.getPreferredSize().width;
+            int foo2Width = foo2.getPreferredSize().width;
+            int foo3Width = foo3.getPreferredSize().width;
+            if (totalWidth >= (foo1Width + foo2Width + foo3Width)) {
+                throw new RuntimeException("Panel is too wide");
+            }
+        } finally {
+            if (frame != null) {
+                frame.setVisible(false);
+                frame.dispose();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        bug4191948 test = new bug4191948();
+        SwingUtilities.invokeAndWait(test::init);
+        SwingUtilities.invokeAndWait(test::start);
+    }
+}

--- a/test/jdk/javax/swing/ComponentInputMap/4248723/bug4248723.java
+++ b/test/jdk/javax/swing/ComponentInputMap/4248723/bug4248723.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4248723
+ * @summary Tests that ComponentInputMap doesn't throw NPE when deserializing
+ * @run main bug4248723
+ */
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import javax.swing.ComponentInputMap;
+import javax.swing.JButton;
+import javax.swing.KeyStroke;
+
+public class bug4248723 {
+    public static Object serializeAndDeserialize(Object toWrite)
+            throws ClassNotFoundException, IOException {
+        ByteArrayOutputStream ostream = new ByteArrayOutputStream();
+        ObjectOutputStream p = new ObjectOutputStream(ostream);
+        p.writeObject(toWrite);
+        p.flush();
+        byte[] data = ostream.toByteArray();
+        ostream.close();
+
+        ByteArrayInputStream istream = new ByteArrayInputStream(data);
+        ObjectInputStream q = new ObjectInputStream(istream);
+        Object retValue = q.readObject();
+        istream.close();
+        return retValue;
+    }
+
+    public static void main(String[] argv) {
+        ComponentInputMap cim = new ComponentInputMap(new JButton());
+        cim.put(KeyStroke.getKeyStroke(
+                KeyEvent.VK_B, InputEvent.CTRL_DOWN_MASK), "A");
+        try {
+            cim = (ComponentInputMap)serializeAndDeserialize(cim);
+        } catch (ClassNotFoundException|IOException ignore) {
+            // Should not cause test to fail so silently ignore these
+        }
+    }
+}

--- a/test/jdk/javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
+++ b/test/jdk/javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4297953
+ * @summary Tests that DefaultBoundedRangeModel doesn't zero out the
+ *          extent value when maximum changes
+ * @run main bug4297953
+ */
+
+import javax.swing.JScrollBar;
+
+public class bug4297953 {
+    public static void main(String[] args)  {
+        JScrollBar sb = new JScrollBar(JScrollBar.HORIZONTAL, 90, 10, 0, 100);
+        sb.setMaximum(80);
+        if (sb.getVisibleAmount() != 10) {
+            throw new RuntimeException("Failed: extent is " + sb.getVisibleAmount());
+        }
+    }
+}

--- a/test/jdk/javax/swing/DefaultButtonModel/4097723/bug4097723.java
+++ b/test/jdk/javax/swing/DefaultButtonModel/4097723/bug4097723.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4097723
+ * @summary Tests that method DefaultButtonModel.getGroup() exists
+ * @run main bug4097723
+ */
+
+import javax.swing.ButtonGroup;
+import javax.swing.DefaultButtonModel;
+
+public class bug4097723 {
+    public static void main(String[] argv) {
+        DefaultButtonModel dbm = new DefaultButtonModel();
+        ButtonGroup group = new ButtonGroup();
+        dbm.setGroup(group);
+        ButtonGroup g = dbm.getGroup();
+        if (g != group) {
+            throw new RuntimeException("Failure: getGroup() returned wrong thing");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315871](https://bugs.openjdk.org/browse/JDK-8315871) needs maintainer approval

### Issue
 * [JDK-8315871](https://bugs.openjdk.org/browse/JDK-8315871): Opensource five more Swing regression tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1590/head:pull/1590` \
`$ git checkout pull/1590`

Update a local copy of the PR: \
`$ git checkout pull/1590` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1590`

View PR using the GUI difftool: \
`$ git pr show -t 1590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1590.diff">https://git.openjdk.org/jdk21u-dev/pull/1590.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1590#issuecomment-2778301704)
</details>
