### PR TITLE
8330936: [ubsan] exclude function BilinearInterp and ShapeSINextSpan in libawt java2d from ubsan checks

### DIFF
--- a/src/java.desktop/share/native/libawt/java2d/loops/TransformHelper.c
+++ b/src/java.desktop/share/native/libawt/java2d/loops/TransformHelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@
 
 #include "sun_java2d_loops_TransformHelper.h"
 #include "java_awt_image_AffineTransformOp.h"
+
+#include "ub.h"
 
 /*
  * The stub functions replace the bilinear and bicubic interpolation
@@ -661,6 +663,7 @@ Transform_SafeHelper(JNIEnv *env,
         ((jubyte *)pRes)[comp] = (jubyte) ((cR + (1<<15)) >> 16); \
     } while (0)
 
+ATTRIBUTE_NO_UBSAN
 static void
 BilinearInterp(jint *pRGB, jint numpix,
                jint xfract, jint dxfract,

--- a/src/java.desktop/share/native/libawt/java2d/pipe/ShapeSpanIterator.c
+++ b/src/java.desktop/share/native/libawt/java2d/pipe/ShapeSpanIterator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@
 
 #include "sun_java2d_pipe_ShapeSpanIterator.h"
 #include "java_awt_geom_PathIterator.h"
+
+#include "ub.h"
 
 /*
  * This structure holds all of the information needed to trace and
@@ -1243,6 +1245,7 @@ ShapeSIIntersectClipBox(JNIEnv *env, void *private,
     }
 }
 
+ATTRIBUTE_NO_UBSAN
 static jboolean
 ShapeSINextSpan(void *state, jint spanbox[])
 {


### PR DESCRIPTION
had to adjust year in ShapeSpanIterator.c

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330936](https://bugs.openjdk.org/browse/JDK-8330936) needs maintainer approval

### Issue
 * [JDK-8330936](https://bugs.openjdk.org/browse/JDK-8330936): [ubsan] exclude function BilinearInterp and ShapeSINextSpan in libawt java2d from ubsan checks (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1591/head:pull/1591` \
`$ git checkout pull/1591`

Update a local copy of the PR: \
`$ git checkout pull/1591` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1591`

View PR using the GUI difftool: \
`$ git pr show -t 1591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1591.diff">https://git.openjdk.org/jdk21u-dev/pull/1591.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1591#issuecomment-2778513037)
</details>
