### PR TITLE
8211400: nsk.share.gc.Memory::getArrayLength returns wrong value

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/Memory.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/Memory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,12 +150,9 @@ public final class Memory {
          *  @return length of array
          */
         public static int getArrayLength(long memory, long objectSize) {
-                int referenceSize = getReferenceSize();
                 int arrayExtraSize = getArrayExtraSize();
-                return (int) Math.min(
-                                (memory - arrayExtraSize) / (objectSize + referenceSize),
-                                Integer.MAX_VALUE
-                                );
+                return (int) Math.min((memory - arrayExtraSize) / objectSize,
+                        Integer.MAX_VALUE);
         }
 
         /**
@@ -166,7 +163,7 @@ public final class Memory {
          *  @return size of array
          */
         public static long getArraySize(int length, long objectSize) {
-                return getObjectExtraSize() + length * (objectSize + getReferenceSize());
+                return getArrayExtraSize() + length * objectSize;
         }
 
         /**


### PR DESCRIPTION
Backport for parity with Oracle 21.0.8. Clean, low risk: fixes an nsk test, nsk passes with modified test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8211400](https://bugs.openjdk.org/browse/JDK-8211400) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211400](https://bugs.openjdk.org/browse/JDK-8211400): nsk.share.gc.Memory::getArrayLength returns wrong value (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1595/head:pull/1595` \
`$ git checkout pull/1595`

Update a local copy of the PR: \
`$ git checkout pull/1595` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1595`

View PR using the GUI difftool: \
`$ git pr show -t 1595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1595.diff">https://git.openjdk.org/jdk21u-dev/pull/1595.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1595#issuecomment-2779469042)
</details>
