### PR TITLE
8328864: NullPointerException in sun.security.jca.ProviderList.getService()

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/ProviderList.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderList.java
@@ -369,17 +369,19 @@ public final class ProviderList {
         int i;
 
         // Preferred provider list
-        if (preferredPropList != null &&
-                (pList = preferredPropList.getAll(type, name)) != null) {
+        if (preferredPropList != null) {
+            pList = preferredPropList.getAll(type, name);
             for (i = 0; i < pList.size(); i++) {
                 Provider p = getProvider(pList.get(i).provider);
+                if (p == null) {
+                    continue;
+                }
                 Service s = p.getService(type, name);
                 if (s != null) {
                     return s;
                 }
             }
         }
-
         for (i = 0; i < configs.length; i++) {
             Provider p = getProvider(i);
             Service s = p.getService(type, name);

--- a/test/jdk/sun/security/jca/NullPreferredList.java
+++ b/test/jdk/sun/security/jca/NullPreferredList.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.*;
+
+/**
+ * @test
+ * @bug 8328864
+ * @summary Test that ProviderList.getService checks configs when
+ * ProviderList.getProvider fails for preferred providers.
+ * @run main/othervm
+ *  -Djava.security.properties=${test.src}/app-security.properties NullPreferredList
+ */
+
+public class NullPreferredList {
+
+    public static void main(final String[] args) throws Exception {
+        final KeyStore ks = KeyStore.getInstance("PKCS12");
+        System.out.println("Got keystore " + ks);
+    }
+}

--- a/test/jdk/sun/security/jca/app-security.properties
+++ b/test/jdk/sun/security/jca/app-security.properties
@@ -1,0 +1,1 @@
+jdk.security.provider.preferred=KeyStore.PKCS12:NonExistingProvider


### PR DESCRIPTION
Backporting JDK-8328864: NullPointerException in sun.security.jca.ProviderList.getService(). Updated `getService` to check whether `getProvider` returns null when checking for preferred providers, continuing the loop if so. Added NullPreferredList test. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328864](https://bugs.openjdk.org/browse/JDK-8328864) needs maintainer approval

### Issue
 * [JDK-8328864](https://bugs.openjdk.org/browse/JDK-8328864): NullPointerException in sun.security.jca.ProviderList.getService() (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1598/head:pull/1598` \
`$ git checkout pull/1598`

Update a local copy of the PR: \
`$ git checkout pull/1598` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1598`

View PR using the GUI difftool: \
`$ git pr show -t 1598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1598.diff">https://git.openjdk.org/jdk21u-dev/pull/1598.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1598#issuecomment-2779537375)
</details>
