### PR TITLE
Backport 1131bb77ec94dd131a10df4ba0f3fab32c65c0f2

### DIFF
--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -269,8 +269,6 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
                                                   Register thread,
                                                   Register tmp,
                                                   Register tmp2) {
-  // Generated code assumes that buffer index is pointer sized.
-  STATIC_ASSERT(in_bytes(SATBMarkQueue::byte_width_of_index()) == sizeof(intptr_t));
 #ifdef _LP64
   assert(thread == r15_thread, "must be");
 #endif // _LP64
@@ -320,6 +318,9 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
   // dirty card and log.
 
   __ movb(Address(card_addr, 0), G1CardTable::dirty_card_val());
+
+  // The code below assumes that buffer index is pointer sized.
+  STATIC_ASSERT(in_bytes(G1DirtyCardQueue::byte_width_of_index()) == sizeof(intptr_t));
 
   __ movptr(tmp2, queue_index);
   __ testptr(tmp2, tmp2);


### PR DESCRIPTION
Backporting JDK-8329261: G1: interpreter post-barrier x86 code asserts index size of wrong buffer. This changeset updates an assert in G1's interpreter x86 post-barrier logic so that it refers to the right queue (G1DirtyCardQueue rather than pre-barrier's SATBMarkQueue) and moves the assert closer to the logic that exploits it. Doesn't change functionality.