### PR TITLE
Backport ad48846edd894073d89839a2771271553b4e27cd

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import jdk.test.whitebox.code.BlobType;
 /**
  * @test TestCodeCacheFull
  * @requires vm.hasJFR
+ * @requires vm.opt.UseCodeCacheFlushing == null | vm.opt.UseCodeCacheFlushing == true
  *
  * @library /test/lib
  * @modules jdk.jfr


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ad48846e](https://github.com/openjdk/jdk/commit/ad48846edd894073d89839a2771271553b4e27cd) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 1 Apr 2025 and was reviewed by Thomas Schatzl.

Thanks!