### PR TITLE
8350483: AArch64: turn on signum intrinsics by default on Ampere CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -158,6 +158,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
       FLAG_SET_DEFAULT(OnSpinWaitInstCount, 2);
     }
+    if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
+      FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
+    }
   }
 
   // ThunderX


### PR DESCRIPTION
Backport the commit to set -XX:+UseSignumIntrinsic by default for Ampere CPUs. It is to fix performance problem observed on JMH cases vm.compiler.Signum|java.lang.*MathBench.sig[nN]um*. In the worst test cases, run speed is 1~2% of the expected (patched) and functions got severely impacted. So, the fix can be regarded not only a performance fix but also a function **defect** fixing in a manner, which can be a point to support this backport request too. 

The commit is in jdk mainline and got successfully merged to jdk24u. It is of low risk as the patch is limited to Ampere CPUs only and well tested on Ampere-1A with related jmh and jtreg tier1 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8350483](https://bugs.openjdk.org/browse/JDK-8350483) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350483](https://bugs.openjdk.org/browse/JDK-8350483): AArch64: turn on signum intrinsics by default on Ampere CPUs (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1606/head:pull/1606` \
`$ git checkout pull/1606`

Update a local copy of the PR: \
`$ git checkout pull/1606` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1606`

View PR using the GUI difftool: \
`$ git pr show -t 1606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1606.diff">https://git.openjdk.org/jdk21u-dev/pull/1606.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1606#issuecomment-2785740990)
</details>
