### PR TITLE
8340084: Open source AWT Frame related tests

### DIFF
--- a/test/jdk/java/awt/Frame/DefaultLocationTest.java
+++ b/test/jdk/java/awt/Frame/DefaultLocationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+
+/*
+ * @test
+ * @bug 4085599
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Test default location for frame
+ * @run main/manual DefaultLocationTest
+ */
+
+public class DefaultLocationTest {
+    private static Frame f;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                A small frame containing the label 'Hello World' should
+                appear in the upper left hand corner of the screen. The
+                exact location is dependent upon the window manager.
+
+                On Linux and Mac machines, the default location for frame
+                is below the taskbar or close to top-left corner.
+
+                Upon test completion, click Pass or Fail appropriately.""";
+
+        PassFailJFrame passFailJFrame = new PassFailJFrame("DefaultLocationTest " +
+                " Instructions", INSTRUCTIONS, 5, 10, 40);
+        EventQueue.invokeAndWait(DefaultLocationTest::createAndShowUI);
+        passFailJFrame.awaitAndCheck();
+    }
+
+    private static void createAndShowUI() {
+        f = new Frame("DefaultLocation");
+        f.add("Center", new Label("Hello World"));
+        f.pack();
+        PassFailJFrame.addTestWindow(f);
+        PassFailJFrame.positionTestWindow(
+                null, PassFailJFrame.Position.HORIZONTAL);
+        f.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/Frame/EmptyFrameTest.java
+++ b/test/jdk/java/awt/Frame/EmptyFrameTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+
+/*
+ * @test
+ * @bug 4237529
+ * @key headful
+ * @summary Test repainting of an empty frame
+ * @run main EmptyFrameTest
+ */
+
+public class EmptyFrameTest {
+    private static Frame f;
+    private static Robot robot;
+    private static volatile Point p;
+    private static volatile Dimension d;
+    private static final int TOLERANCE = 5;
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            EventQueue.invokeAndWait(() -> {
+                createAndShowUI();
+            });
+            robot.delay(1000);
+            f.setSize(50, 50);
+            robot.delay(500);
+            EventQueue.invokeAndWait(() -> {
+                p = f.getLocation();
+                d = f.getSize();
+            });
+            Rectangle rect = new Rectangle(p, d);
+            BufferedImage img = robot.createScreenCapture(rect);
+            if (chkImgBackgroundColor(img)) {
+                try {
+                    ImageIO.write(img, "png", new File("Frame.png"));
+                } catch (IOException ignored) {}
+                throw new RuntimeException("Frame doesn't repaint itself on resize");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        f = new Frame("EmptyFrameTest");
+        f.setUndecorated(true);
+        f.setBackground(Color.RED);
+        f.setVisible(true);
+    }
+
+    private static boolean chkImgBackgroundColor(BufferedImage img) {
+        for (int x = 1; x < img.getWidth() - 1; ++x) {
+            for (int y = 1; y < img.getHeight() - 1; ++y) {
+                Color c = new Color(img.getRGB(x, y));
+                if ((c.getRed() - Color.RED.getRed()) > TOLERANCE) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/test/jdk/java/awt/Frame/FrameLayoutTest.java
+++ b/test/jdk/java/awt/Frame/FrameLayoutTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Frame;
+
+/*
+ * @test
+ * @bug 4173503
+ * @library /java/awt/regtesthelpers
+ * @requires (os.family == "windows")
+ * @build PassFailJFrame
+ * @summary Tests that frame layout is performed when frame is maximized from taskbar
+ * @run main/manual FrameLayoutTest
+ */
+
+public class FrameLayoutTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Right-click on the taskbar button for this test. In the menu appeared,
+                choose Maximize. The frame will be maximized. Check if buttons inside
+                the frame are laid out properly, i.e. they occupy the frame entirely.
+
+                If so, test passes. If buttons occupy small rectangle in the top left
+                corner, test fails.""";
+
+        PassFailJFrame.builder()
+                .title("Frame's Layout Test Instruction")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(FrameLayoutTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("Maximize Test");
+        f.add(new Button("North"), BorderLayout.NORTH);
+        f.add(new Button("South"), BorderLayout.SOUTH);
+        f.add(new Button("East"), BorderLayout.EAST);
+        f.add(new Button("West"), BorderLayout.WEST);
+        f.add(new Button("Cent"), BorderLayout.CENTER);
+        f.pack();
+        f.setState(Frame.ICONIFIED);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Frame/FrameSetMinimumSizeTest.java
+++ b/test/jdk/java/awt/Frame/FrameSetMinimumSizeTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+
+/*
+ * @test
+ * @bug 4320050
+ * @key headful
+ * @summary Minimum size for java.awt.Frame is not being enforced.
+ * @run main FrameSetMinimumSizeTest
+ */
+
+public class FrameSetMinimumSizeTest {
+    private static Frame f;
+    private static volatile boolean passed;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            try {
+                createAndShowUI();
+
+                f.setSize(200, 200);
+                passed = verifyFrameSize(new Dimension(300, 300));
+                isFrameSizeOk(passed);
+
+                f.setSize(200, 400);
+                passed = verifyFrameSize(new Dimension(300, 400));
+                isFrameSizeOk(passed);
+
+                f.setSize(400, 200);
+                passed = verifyFrameSize(new Dimension(400, 300));
+                isFrameSizeOk(passed);
+
+                f.setMinimumSize(null);
+
+                f.setSize(200, 200);
+                passed = verifyFrameSize(new Dimension(200, 200));
+                isFrameSizeOk(passed);
+            } finally {
+                if (f != null) {
+                    f.dispose();
+                }
+            }
+        });
+    }
+
+    private static void createAndShowUI() {
+        f = new Frame("Minimum Size Test");
+        f.setSize(300, 300);
+        f.setMinimumSize(new Dimension(300, 300));
+        f.setVisible(true);
+    }
+
+    private static boolean verifyFrameSize(Dimension expected) {
+
+        if (f.getSize().width != expected.width || f.getSize().height != expected.height) {
+            return false;
+        }
+        return true;
+    }
+
+    private static void isFrameSizeOk(boolean passed) {
+        if (!passed) {
+            throw new RuntimeException("Frame's setMinimumSize not honoured for the" +
+                    " frame size: " + f.getSize());
+        }
+    }
+}

--- a/test/jdk/java/awt/Frame/PackTwiceTest.java
+++ b/test/jdk/java/awt/Frame/PackTwiceTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.TextField;
+
+/*
+ * @test
+ * @bug 4097744
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary packing a frame twice stops it resizing
+ * @run main/manual PackTwiceTest
+ */
+
+public class PackTwiceTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. You would see a Frame titled 'TestFrame'
+                2. The Frame displays a text as below:
+                    'I am a lengthy sentence...can you see me?'
+                3. If you can see the full text without resizing the frame
+                   using mouse, press 'Pass' else press 'Fail'.""";
+
+        PassFailJFrame.builder()
+                .title("PackTwiceTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(PackTwiceTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("PackTwiceTest TestFrame");
+        TextField tf = new TextField();
+        f.add(tf, "Center");
+        tf.setText("I am a short sentence");
+        f.pack();
+        f.pack();
+        tf.setText("I am a lengthy sentence...can you see me?");
+        f.pack();
+        f.requestFocus();
+        return f;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340084](https://bugs.openjdk.org/browse/JDK-8340084) needs maintainer approval

### Issue
 * [JDK-8340084](https://bugs.openjdk.org/browse/JDK-8340084): Open source AWT Frame related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1607/head:pull/1607` \
`$ git checkout pull/1607`

Update a local copy of the PR: \
`$ git checkout pull/1607` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1607`

View PR using the GUI difftool: \
`$ git pr show -t 1607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1607.diff">https://git.openjdk.org/jdk21u-dev/pull/1607.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1607#issuecomment-2786294184)
</details>
