### PR TITLE
8343170: java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java does not show the default cursor

### DIFF
--- a/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
+++ b/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
@@ -44,16 +44,18 @@ import javax.swing.border.BevelBorder;
 
 public class JPanelCursorTest {
     public static void main(String[] args) throws Exception {
-        String INSTRUCTIONS = """
+        final String INSTRUCTIONS = """
                 This test checks for setCursor in a JPanel when added to a
                 JFrame's contentPane.
 
                 1. Verify that the cursor in the left side of the test window
-                    is a default cursor.
+                    is a text cursor.
                 2. Verify that the cursor changes to the crosshair cursor when
                     pointing over the button.
                 3. Verify that the cursor changes to the hand cursor when in
                     the right side of the splitpane (and not on the button).
+                4. Verify that the cursor changes to the wait cursor when in
+                    the empty bottom section of the test window.
 
                 If true, then pass the test. Otherwise, fail this test.
                 """;
@@ -61,14 +63,14 @@ public class JPanelCursorTest {
         PassFailJFrame.builder()
                 .title("Test Instructions")
                 .instructions(INSTRUCTIONS)
-                .columns(35)
+                .columns(37)
                 .testUI(JPanelCursorTest::createUI)
                 .build()
                 .awaitAndCheck();
     }
 
     public static JFrame createUI() {
-        JFrame frame = new JFrame();
+        JFrame frame = new JFrame("Cursor Test Frame");
 
         JSplitPane j = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         ExtJComponent pane = new ExtJComponent();
@@ -78,11 +80,12 @@ public class JPanelCursorTest {
         j.setLeftComponent(pane);
         j.setRightComponent(panel);
         j.setContinuousLayout(true);
+        j.setSize(200, 200);
 
-        frame.getContentPane().add("Center", j);
-        pane.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
+        frame.getContentPane().add("North", j);
+        pane.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
         frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        frame.pack();
+        frame.setSize(300, 200);
         return frame;
     }
 }
@@ -96,7 +99,7 @@ class ExtJComponent extends JComponent {
         setBorder(new BevelBorder(BevelBorder.RAISED));
     }
     public void paintComponent(Graphics g) {
-        g.drawString("Default", 20, 30);
+        g.drawString("Text", 20, 30);
     }
     public Dimension getPreferredSize() {
         return new Dimension(100, 100);
@@ -104,7 +107,7 @@ class ExtJComponent extends JComponent {
 }
 
 class CursorBugPanel extends JPanel {
-    public CursorBugPanel () {
+    public CursorBugPanel() {
         // BUG: fails to set cursor for panel
         setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 


### PR DESCRIPTION
I backport this to fix this recently backported test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343170](https://bugs.openjdk.org/browse/JDK-8343170) needs maintainer approval

### Issue
 * [JDK-8343170](https://bugs.openjdk.org/browse/JDK-8343170): java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java does not show the default cursor (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1612/head:pull/1612` \
`$ git checkout pull/1612`

Update a local copy of the PR: \
`$ git checkout pull/1612` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1612`

View PR using the GUI difftool: \
`$ git pr show -t 1612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1612.diff">https://git.openjdk.org/jdk21u-dev/pull/1612.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1612#issuecomment-2786640404)
</details>
