### PR TITLE
8339995: Open source several AWT focus tests - series 6

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -83,6 +83,7 @@ public class IREncodingPrinter {
     private static final List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
         // x86
         "fma",
+        "f16c",
         // Intel SSE
         "sse",
         "sse2",

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -83,7 +83,6 @@ public class IREncodingPrinter {
     private static final List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
         // x86
         "fma",
-        "f16c",
         // Intel SSE
         "sse",
         "sse2",

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -466,8 +466,6 @@ java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemoni
 
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
-java/awt/Dialog/PrintToFileTest/PrintToFileRevoked.java 8029249 macosx-all
-java/awt/Dialog/PrintToFileTest/PrintToFileGranted.java 8029249 macosx-all
 java/awt/Dialog/ChoiceModalDialogTest.java 8161475 macosx-all
 java/awt/dnd/BadSerializationTest/BadSerializationTest.java 8277817 linux-x64,windows-x64
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -466,6 +466,8 @@ java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemoni
 
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
+java/awt/Dialog/PrintToFileTest/PrintToFileRevoked.java 8029249 macosx-all
+java/awt/Dialog/PrintToFileTest/PrintToFileGranted.java 8029249 macosx-all
 java/awt/Dialog/ChoiceModalDialogTest.java 8161475 macosx-all
 java/awt/dnd/BadSerializationTest/BadSerializationTest.java 8277817 linux-x64,windows-x64
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
@@ -812,4 +814,5 @@ java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 java/awt/Frame/SizeMinimizedTest.java 8305915 linux-x64
 java/awt/PopupMenu/PopupHangTest.java 8340022 windows-all
+java/awt/Focus/InactiveFocusRace.java 8023263 linux-all
 java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all

--- a/test/jdk/java/awt/Focus/ConsumedKeyEventTest.java
+++ b/test/jdk/java/awt/Focus/ConsumedKeyEventTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4700276
+ * @summary Peers process KeyEvents before KeyEventPostProcessors
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ConsumedKeyEventTest
+*/
+
+import java.awt.Canvas;
+import java.awt.Component;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.KeyboardFocusManager;
+import java.awt.KeyEventPostProcessor;
+import java.awt.event.KeyEvent;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class ConsumedKeyEventTest implements KeyEventPostProcessor {
+
+    private static final String INSTRUCTIONS = """
+            This is a Windows-only test.
+            When the test starts, you will see a Frame with two components in it,
+            components look like colored rectangles, one of them is lightweight, one is heavyweight.
+            Do the following:
+            1. Click the mouse on the left component.
+               If it isn't yellow after the click (that means it doesn't have focus), the test fails.
+            2. Press and release ALT key.
+               In the output window, the text should appear stating that those key events were consumed.
+               If no output appears, the test fails.
+            3. Press space bar. If system menu drops down, the test fails.
+            4. Click the right rectangle.
+               It should become red after the click. If it doesn't, it means that it didn't get the focus, and the test fails.
+            5. Repeat steps 2. and 3.
+            6. If the test didn't fail on any of the previous steps, the test passes.""";
+
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ConsumedKeyEventTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 5)
+                .columns(35)
+                .testUI(ConsumedKeyEventTest::createTestUI)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        KeyboardFocusManager.getCurrentKeyboardFocusManager().
+            addKeyEventPostProcessor((e) -> {
+                System.out.println("postProcessor(" + e + ")");
+                // consumes all ALT-events
+                if (e.getKeyCode() == KeyEvent.VK_ALT) {
+                    println("consumed " + e);
+                    e.consume();
+                    return true;
+                }
+                return false;
+        });
+        FocusRequestor requestor = new FocusRequestor();
+        Frame frame = new Frame("Main Frame");
+        frame.setLayout(new FlowLayout());
+
+        Canvas canvas = new CustomCanvas();
+        canvas.addMouseListener(requestor);
+        frame.add(canvas);
+        canvas.requestFocus();
+
+        Component lwComp = new LWComponent();
+        lwComp.addMouseListener(requestor);
+        frame.add(lwComp);
+
+        frame.pack();
+
+        return frame;
+    }
+
+    public boolean postProcessKeyEvent(KeyEvent e) {
+        System.out.println("postProcessor(" + e + ")");
+        // consumes all ALT-events
+        if (e.getKeyCode() == KeyEvent.VK_ALT) {
+            println("consumed " + e);
+            e.consume();
+            return true;
+        }
+        return false;
+    }
+
+    static void println(String messageIn) {
+        PassFailJFrame.log(messageIn);
+    }
+}// class ConsumedKeyEventTest
+
+class CustomCanvas extends Canvas {
+    CustomCanvas() {
+        super();
+        setName("HWComponent");
+        setSize(100, 100);
+        addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent fe) {
+                repaint();
+            }
+
+            public void focusLost(FocusEvent fe) {
+                repaint();
+            }
+        });
+    }
+
+    public void paint(Graphics g) {
+        if (isFocusOwner()) {
+            g.setColor(Color.YELLOW);
+        } else {
+            g.setColor(Color.GREEN);
+        }
+        g.fillRect(0, 0, 100, 100);
+    }
+
+}
+
+class LWComponent extends Component {
+    LWComponent() {
+        super();
+        setName("LWComponent");
+        addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent fe) {
+                repaint();
+            }
+
+            public void focusLost(FocusEvent fe) {
+                repaint();
+            }
+        });
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(100, 100);
+    }
+
+    public void paint(Graphics g) {
+        if (isFocusOwner()) {
+            g.setColor(Color.RED);
+        } else {
+            g.setColor(Color.BLACK);
+        }
+        g.fillRect(0, 0, 100, 100);
+    }
+
+}
+
+class FocusRequestor extends MouseAdapter {
+    static int counter = 0;
+    public void mouseClicked(MouseEvent me) {
+        System.out.println("mouseClicked on " + me.getComponent().getName());
+    }
+    public void mousePressed(MouseEvent me) {
+        System.out.println("mousePressed on " + me.getComponent().getName());
+        me.getComponent().requestFocus();
+    }
+    public void mouseReleased(MouseEvent me) {
+        System.out.println("mouseReleased on " + me.getComponent().getName());
+    }
+}
+

--- a/test/jdk/java/awt/Focus/EmptyWindowKeyTest.java
+++ b/test/jdk/java/awt/Focus/EmptyWindowKeyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4464723
+ * @summary Tests simple KeyAdapter / KeyListener on an empty, focusable window
+ * @key headful
+ * @run main EmptyWindowKeyTest
+*/
+
+import java.awt.AWTEvent;
+import java.awt.Frame;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.Robot;
+
+public class EmptyWindowKeyTest {
+
+    static volatile boolean passed1, passed2;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        MainFrame mainFrame = new MainFrame();
+        mainFrame.setSize(50,50);
+        mainFrame.addKeyListener(new KeyboardTracker());
+        robot.waitForIdle();
+        robot.delay(1000);
+        robot.keyPress(KeyEvent.VK_A);
+        robot.keyRelease(KeyEvent.VK_A);
+        robot.waitForIdle();
+        robot.delay(1000);
+        if (!passed1 || !passed2) {
+            throw new RuntimeException("KeyPress/keyRelease not seen," +
+                       "passed1 " + passed1 + " passed2 " + passed2);
+        }
+    }
+
+    static public class KeyboardTracker extends KeyAdapter {
+        public KeyboardTracker() { }
+        public void keyTyped(KeyEvent e) {}
+
+        public void keyPressed(KeyEvent e) {
+            if (e.getKeyText(e.getKeyCode()).equals("A")) {
+                passed1 = true;
+            }
+        }
+        public void keyReleased(KeyEvent e) {
+            if (e.getKeyText(e.getKeyCode()).equals("A")) {
+                passed2 = true;
+            }
+        }
+    }
+
+    static public class MainFrame extends Frame {
+
+        public MainFrame() {
+            super();
+            enableEvents(AWTEvent.KEY_EVENT_MASK);
+            setVisible(true);
+        }
+
+    }
+
+}
+

--- a/test/jdk/java/awt/Focus/InactiveFocusRace.java
+++ b/test/jdk/java/awt/Focus/InactiveFocusRace.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4697451
+ * @summary Test that there is no race between focus component in inactive window and window activation
+ * @key headful
+ * @run main InactiveFocusRace
+*/
+
+import java.awt.Button;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.InputEvent;
+
+public class InactiveFocusRace {
+
+    static Frame activeFrame, inactiveFrame;
+    Button activeButton, inactiveButton1, inactiveButton2;
+    Semaphore sema;
+    final static int TIMEOUT = 10000;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            InactiveFocusRace test = new InactiveFocusRace();
+            test.init();
+            test.start();
+        } finally {
+            if (activeFrame != null) {
+                activeFrame.dispose();
+            }
+            if (inactiveFrame != null) {
+                inactiveFrame.dispose();
+            }
+        }
+    }
+
+    public void init() {
+        activeButton = new Button("active button");
+        inactiveButton1 = new Button("inactive button1");
+        inactiveButton2 = new Button("inactive button2");
+        activeFrame = new Frame("Active frame");
+        inactiveFrame = new Frame("Inactive frame");
+        inactiveFrame.setLayout(new FlowLayout());
+        activeFrame.add(activeButton);
+        inactiveFrame.add(inactiveButton1);
+        inactiveFrame.add(inactiveButton2);
+        activeFrame.pack();
+        activeFrame.setLocation(300, 10);
+        inactiveFrame.pack();
+        inactiveFrame.setLocation(300, 300);
+        sema = new Semaphore();
+
+        inactiveButton1.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent e) {
+                System.err.println("Button 1 got focus");
+            }
+        });
+        inactiveButton2.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent e) {
+                System.err.println("Button2 got focus");
+                sema.raise();
+            }
+        });
+        activeFrame.addWindowListener(new WindowAdapter() {
+            public void windowActivated(WindowEvent e) {
+                System.err.println("Window activated");
+                sema.raise();
+            }
+        });
+    }
+
+    public void start() {
+        Robot robot = null;
+        try {
+            robot = new Robot();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to create robot");
+        }
+
+        inactiveFrame.setVisible(true);
+        activeFrame.setVisible(true);
+
+        // Wait for active frame to become active
+        try {
+            sema.doWait(TIMEOUT);
+        } catch (InterruptedException ie) {
+            throw new RuntimeException("Wait was interrupted");
+        }
+        if (!sema.getState()) {
+            throw new RuntimeException("Frame doesn't become active on show");
+        }
+        sema.setState(false);
+
+        // press on second button in inactive frame
+        Point loc = inactiveButton2.getLocationOnScreen();
+        robot.mouseMove(loc.x+5, loc.y+5);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        // after all second button should be focus owner.
+        try {
+            sema.doWait(TIMEOUT);
+        } catch (InterruptedException ie) {
+            throw new RuntimeException("Wait was interrupted");
+        }
+        if (!sema.getState()) {
+            throw new RuntimeException("Button2 didn't become focus owner");
+        }
+        Toolkit.getDefaultToolkit().sync();
+        robot.waitForIdle();
+        if (!(KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() == inactiveButton2)) {
+            throw new RuntimeException("Button2 should be the focus owner after all");
+        }
+
+    }
+
+}
+
+class Semaphore {
+    boolean state = false;
+    int waiting = 0;
+    public Semaphore() {
+    }
+    public void doWait() throws InterruptedException {
+        synchronized(this) {
+            if (state) return;
+            waiting++;
+            wait();
+            waiting--;
+        }
+    }
+    public void doWait(int timeout) throws InterruptedException {
+        synchronized(this) {
+            if (state) return;
+            waiting++;
+            wait(timeout);
+            waiting--;
+        }
+    }
+    public void raise() {
+        synchronized(this) {
+            state = true;
+            if (waiting > 0) {
+                notifyAll();
+            }
+        }
+    }
+    public boolean getState() {
+        synchronized(this) {
+            return state;
+        }
+    }
+    public void setState(boolean newState) {
+        synchronized(this) {
+            state = newState;
+        }
+    }
+}

--- a/test/jdk/java/awt/Focus/InitialPrintDlgFocusTest.java
+++ b/test/jdk/java/awt/Focus/InitialPrintDlgFocusTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4688591
+ * @summary Tab key hangs in Native Print Dialog on win32
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual InitialPrintDlgFocusTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dialog;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.JobAttributes;
+import java.awt.PageAttributes;
+import java.awt.PrintJob;
+import java.awt.Toolkit;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+
+public class InitialPrintDlgFocusTest {
+
+    private static final String INSTRUCTIONS = """
+            After the tests starts you will see a frame titled "PrintTest".
+            Press the "Print" button and the print dialog should appear.
+            If you are able to transfer focus between components of the Print dialog
+            using the TAB key, then the test passes else the test fails.
+
+            Note: close the Print dialog before clicking on "Pass" or "Fail" buttons.""";
+
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("InitialPrintDlgFocusTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(InitialPrintDlgFocusTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        return new PrintTest();
+
+    }
+}
+
+class PrintTest extends JFrame implements ActionListener {
+
+    JButton b;
+    JobAttributes jbattrib;
+    Toolkit tk ;
+    PageAttributes pgattrib;
+
+    public PrintTest() {
+        setTitle("PrintTest");
+        setSize(500, 400);
+
+        b = new JButton("Print");
+        jbattrib = new JobAttributes();
+        tk = Toolkit.getDefaultToolkit();
+        pgattrib = new PageAttributes();
+        getContentPane().setLayout(new FlowLayout());
+        getContentPane().add(b);
+
+        b.addActionListener(this);
+
+    }
+
+    public void actionPerformed(ActionEvent ae) {
+        if(ae.getSource()==b)
+            jbattrib.setDialog(JobAttributes.DialogType.NATIVE);
+
+        PrintJob pjob = tk.getPrintJob(this, "Printing Test",
+                                       jbattrib, pgattrib);
+
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339995](https://bugs.openjdk.org/browse/JDK-8339995) needs maintainer approval

### Issue
 * [JDK-8339995](https://bugs.openjdk.org/browse/JDK-8339995): Open source several AWT focus tests - series 6 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1614/head:pull/1614` \
`$ git checkout pull/1614`

Update a local copy of the PR: \
`$ git checkout pull/1614` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1614`

View PR using the GUI difftool: \
`$ git pr show -t 1614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1614.diff">https://git.openjdk.org/jdk21u-dev/pull/1614.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1614#issuecomment-2786717353)
</details>
