### PR TITLE
8340639: Open source few more AWT List tests

### DIFF
--- a/test/jdk/java/awt/List/HorizScrollWorkTest.java
+++ b/test/jdk/java/awt/List/HorizScrollWorkTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6355467
+ * @summary Horizontal scroll bar thumb of a List does not stay at the end
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "linux")
+ * @run main/manual HorizScrollWorkTest
+*/
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+
+public class HorizScrollWorkTest {
+
+    private static final String INSTRUCTIONS = """
+            This is a linux only test.
+            Drag and drop the horizontal scroll bar thumb at the right end.
+            If the thumb does not stay at the right end, then the test failed. Otherwise passed.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("HorizScrollWorkTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int)INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(HorizScrollWorkTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        Frame frame = new Frame("HorizScrollWorkTest Frame");
+        List list = new List(4);
+
+        frame.setLayout (new FlowLayout());
+
+        list.add("veryyyyyyyyyyyyyyyyyyyyyyyyyy longgggggggggggggggggggggg stringggggggggggggggggggggg");
+
+        frame.add(list);
+        frame.pack();
+
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/List/HorizScrollbarEraseTest.java
+++ b/test/jdk/java/awt/List/HorizScrollbarEraseTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4895367
+ * @summary List scrolling w/ down arrow keys obscures horizontal scrollbar
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "linux")
+ * @run main/manual HorizScrollbarEraseTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.TextArea;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class HorizScrollbarEraseTest {
+
+    private static final String INSTRUCTIONS = """
+            This is a Unix-only test.
+            Do the four mini-tests below.
+            If the horizontal scrollbar is ever erased by a rectangle
+            of the background color, the test FAILS.
+            If the horizontal scrollbars remain painted, test passes.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("HorizScrollbarEraseTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(HorizScrollbarEraseTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        Frame frame = new Frame("HorizScrollbarEraseTest");
+        Panel borderPanel = new Panel();
+        borderPanel.setLayout(new BorderLayout());
+        Button focusedButton = new Button("Focus starts here");
+        borderPanel.add(focusedButton, BorderLayout.NORTH);
+
+        Panel gridPanel = new Panel();
+        gridPanel.setLayout(new GridLayout(0, 4));
+        borderPanel.add(gridPanel, BorderLayout.CENTER);
+
+        InstructionList il1 = new InstructionList("Tab to Item 2, then \n" +
+                                                   "press the down" +
+                                                    "arrow key to scroll down");
+        il1.list.select(2);
+        il1.list.makeVisible(0);
+        gridPanel.add(il1);
+
+        InstructionList il2 = new InstructionList("Tab to the next List,\n" +
+                                                  "then press the down\n" +
+                                                  "arrow key to select\n" +
+                                                  "the last item.");
+        il2.list.select(3);
+        il2.list.makeVisible(0);
+        gridPanel.add(il2);
+
+        InstructionList il3 = new InstructionList("Click the button to\n" +
+                                                  "programmatically\n" +
+                                                  "select item 3 (not showing)");
+        Button selectBtn = new Button("Click Me");
+        final List selectList = il3.list;
+        selectBtn.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                selectList.select(3);
+            }
+        });
+        il3.add(selectBtn, BorderLayout.CENTER);
+        gridPanel.add(il3);
+
+        InstructionList il4 = new InstructionList("Click the button to\nprogrammatically\ndeselect item 3\n(not showing)");
+        Button deselectBtn = new Button("Click Me");
+        final List deselectList = il4.list;
+        deselectBtn.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                deselectList.deselect(3);
+            }
+        });
+        il4.add(deselectBtn, BorderLayout.CENTER);
+        il4.list.select(3);
+        il4.list.makeVisible(0);
+        gridPanel.add(il4);
+
+        frame.add(borderPanel);
+        frame.pack();
+        return frame;
+
+    }
+}
+
+class InstructionList extends Panel {
+    TextArea ta;
+    public List list;
+
+    public InstructionList(String instructions) {
+        super();
+        setLayout(new BorderLayout());
+        ta = new TextArea(instructions, 6, 25, TextArea.SCROLLBARS_NONE);
+        ta.setFocusable(false);
+        list = new List();
+        for (int i = 0; i < 5; i++) {
+            list.add("Item " + i + ", a long, long, long, long item");
+        }
+        add(ta, BorderLayout.NORTH);
+        add(list, BorderLayout.SOUTH);
+     }
+}

--- a/test/jdk/java/awt/List/ScrollbarPresenceTest.java
+++ b/test/jdk/java/awt/List/ScrollbarPresenceTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6336384
+ * @summary ScrollBar does not show up correctly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollbarPresenceTest
+*/
+
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.List;
+
+public class ScrollbarPresenceTest {
+
+    private static final String INSTRUCTIONS = """
+        You will see a list,
+        If a vertical scrollbar appears on the list and the list is big enough
+        to show all items then the test failed else the test passed.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ScrollbarPresenceTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(ScrollbarPresenceTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        Frame frame = new Frame("ScrollbarPresenceTest Frame");
+        List list = new List();
+
+        for (int i = 0; i < 6; i++) {
+            list.addItem("Row " + i);
+        }
+
+        list.setFont(new Font("MonoSpaced", Font.PLAIN, 12));
+        list.setBounds(30, 30, 128, 104);
+        frame.add(list);
+
+        frame.pack();
+        return frame;
+    }
+
+}

--- a/test/jdk/java/awt/List/SetForegroundTest.java
+++ b/test/jdk/java/awt/List/SetForegroundTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6246467
+ * @summary Tests that list works correctly if user specified foreground colors on XToolkit/Motif
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetForegroundTest
+ */
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Checkbox;
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.ScrollPane;
+
+public class SetForegroundTest {
+
+    private static final String INSTRUCTIONS = """
+        To make sure, that for each component
+        (Button, Checkbox, Label, List, TextArea, TextField, Choice)
+        in the frame,
+        the title exist and the color of the title is red.
+        If not, the test failed.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("SetForegroundTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(SetForegroundTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        Frame frame = new Frame();
+        ScrollPane sp = new ScrollPane() {
+            public Dimension getPreferredSize() {
+                return new Dimension(180, 180);
+            }
+        };
+        Panel p = new Panel();
+        Component childs[] = new Component[] {new Button("button"),
+                                              new Checkbox("checkbox"),
+                                              new Label("label"),
+                                              new List(3, false),
+                                              new TextArea("text area"),
+                                              new TextField("text field"),
+                                              new Choice()};
+
+        p.setLayout (new FlowLayout ());
+
+        sp.add(p);
+
+        sp.validate();
+
+        frame.add(sp);
+        for (int i = 0; i < childs.length; i++){
+            childs[i].setForeground(Color.red);
+        }
+
+        for (int i = 0; i < childs.length; i++) {
+            p.add(childs[i]);
+            if (childs[i] instanceof List) {
+                ((List)childs[i]).add("list1");
+                ((List)childs[i]).add("list2");
+            } else if (childs[i] instanceof Choice) {
+                ((Choice)childs[i]).add("choice1");
+                ((Choice)childs[i]).add("choice2");
+            }
+        }
+        frame.pack();
+        return frame;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8340639](https://bugs.openjdk.org/browse/JDK-8340639) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340639](https://bugs.openjdk.org/browse/JDK-8340639): Open source few more AWT List tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1615/head:pull/1615` \
`$ git checkout pull/1615`

Update a local copy of the PR: \
`$ git checkout pull/1615` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1615`

View PR using the GUI difftool: \
`$ git pr show -t 1615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1615.diff">https://git.openjdk.org/jdk21u-dev/pull/1615.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1615#issuecomment-2787050700)
</details>
