### PR TITLE
8327370: (ch) sun.nio.ch.Poller.register throws AssertionError

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Poller.java
+++ b/src/java.base/share/classes/sun/nio/ch/Poller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,7 +151,12 @@ public abstract class Poller {
     private void register(int fdVal) throws IOException {
         Thread previous = map.putIfAbsent(fdVal, Thread.currentThread());
         assert previous == null;
-        implRegister(fdVal);
+        try {
+            implRegister(fdVal);
+        } catch (Throwable t) {
+            map.remove(fdVal);
+            throw t;
+        }
     }
 
     /**


### PR DESCRIPTION
Backporting JDK-8327370: (ch) sun.nio.ch.Poller.register throws AssertionError. Fixes an intermittent AssertionError observed in sun.nio.ch.Poller. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8327370](https://bugs.openjdk.org/browse/JDK-8327370) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327370](https://bugs.openjdk.org/browse/JDK-8327370): (ch) sun.nio.ch.Poller.register throws AssertionError (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1617/head:pull/1617` \
`$ git checkout pull/1617`

Update a local copy of the PR: \
`$ git checkout pull/1617` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1617`

View PR using the GUI difftool: \
`$ git pr show -t 1617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1617.diff">https://git.openjdk.org/jdk21u-dev/pull/1617.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1617#issuecomment-2787262336)
</details>
