### PR TITLE
8326233: Utils#copySSLParameters loses needClientAuth Setting

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -601,7 +601,12 @@ public final class Utils {
         p1.setMaximumPacketSize(p.getMaximumPacketSize());
         // JDK 8 EXCL END
         p1.setEndpointIdentificationAlgorithm(p.getEndpointIdentificationAlgorithm());
-        p1.setNeedClientAuth(p.getNeedClientAuth());
+        if (p.getNeedClientAuth()) {
+            p1.setNeedClientAuth(true);
+        }
+        if (p.getWantClientAuth()) {
+            p1.setWantClientAuth(true);
+        }
         String[] protocols = p.getProtocols();
         if (protocols != null) {
             p1.setProtocols(protocols.clone());
@@ -609,7 +614,6 @@ public final class Utils {
         p1.setSNIMatchers(p.getSNIMatchers());
         p1.setServerNames(p.getServerNames());
         p1.setUseCipherSuitesOrder(p.getUseCipherSuitesOrder());
-        p1.setWantClientAuth(p.getWantClientAuth());
         return p1;
     }
 

--- a/test/jdk/java/net/httpclient/HttpClientBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @bug 8209137
+ * @bug 8209137 8326233
  * @summary HttpClient[.Builder] API and behaviour checks
  * @library /test/lib
  * @build jdk.test.lib.net.SimpleSSLContext
@@ -270,6 +270,34 @@ public class HttpClientBuilderTest {
         c.setProtocols(new String[] { "D" });
         try (var closer = closeable(builder)) {
             assertTrue(closer.build().sslParameters().getProtocols()[0].equals("C"));
+        }
+        // test defaults for needClientAuth and wantClientAuth
+        builder.sslParameters(new SSLParameters());
+        try (var closer = closeable(builder)) {
+            assertFalse(closer.build().sslParameters().getNeedClientAuth(),
+                    "needClientAuth() was expected to be false");
+            assertFalse(closer.build().sslParameters().getWantClientAuth(),
+                    "wantClientAuth() was expected to be false");
+        }
+        // needClientAuth = true and thus wantClientAuth = false
+        SSLParameters needClientAuthParams = new SSLParameters();
+        needClientAuthParams.setNeedClientAuth(true);
+        builder.sslParameters(needClientAuthParams);
+        try (var closer = closeable(builder)) {
+            assertTrue(closer.build().sslParameters().getNeedClientAuth(),
+                    "needClientAuth() was expected to be true");
+            assertFalse(closer.build().sslParameters().getWantClientAuth(),
+                    "wantClientAuth() was expected to be false");
+        }
+        // wantClientAuth = true and thus needClientAuth = false
+        SSLParameters wantClientAuthParams = new SSLParameters();
+        wantClientAuthParams.setWantClientAuth(true);
+        builder.sslParameters(wantClientAuthParams);
+        try (var closer = closeable(builder)) {
+            assertTrue(closer.build().sslParameters().getWantClientAuth(),
+                    "wantClientAuth() was expected to be true");
+            assertFalse(closer.build().sslParameters().getNeedClientAuth(),
+                    "needClientAuth() was expected to be false");
         }
     }
 


### PR DESCRIPTION
Backporting JDK-8326233: Utils#copySSLParameters loses needClientAuth Setting. When the java.net.HttpClient.Builder is configured with a SSLParameters instance whose needClientAuth is set to true, then it is expected that the HttpClient that's built from such a builder will have its SSLParameters with needClientAuth as true and wantClientAuth as false. This change fixes a bug in the internal implementation of a the HttpClient which leads to the value for needClientAuth was getting reset to false. Adds test for expected behavior. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8326233](https://bugs.openjdk.org/browse/JDK-8326233) needs maintainer approval

### Issue
 * [JDK-8326233](https://bugs.openjdk.org/browse/JDK-8326233): Utils#copySSLParameters loses needClientAuth Setting (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1618/head:pull/1618` \
`$ git checkout pull/1618`

Update a local copy of the PR: \
`$ git checkout pull/1618` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1618`

View PR using the GUI difftool: \
`$ git pr show -t 1618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1618.diff">https://git.openjdk.org/jdk21u-dev/pull/1618.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1618#issuecomment-2787321690)
</details>
