### PR TITLE
8335710: serviceability/dcmd/vm/SystemDumpMapTest.java and SystemMapTest.java fail on Linux Alpine after 8322475

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -47,8 +47,8 @@ public class SystemMapTestBase {
         regexBase_committed + "/bin/java",
         // libjvm
         regexBase_committed + "/lib/.*/libjvm.so",
-        // vdso library, should be part of all user space apps on all architectures OpenJDK supports.
-        regexBase_committed + "\\[vdso\\]",
+        // heap segment, should be part of all user space apps on all architectures OpenJDK supports.
+        regexBase_committed + "\\[heap\\]",
         // we should see the hs-perf data file, and it should appear as shared as well as committed
         regexBase_shared_and_committed + "hsperfdata_.*"
     };


### PR DESCRIPTION
Backport of c703d290425f85a06e61d72c9672ac2adac92db9

Reviewed-by: stuefe, lucy
(cherry picked from commit c703d290425f85a06e61d72c9672ac2adac92db9)