### PR TITLE
8319572: Test jdk/incubator/vector/LoadJsvmlTest.java ignores VM flags

### DIFF
--- a/test/jdk/jdk/incubator/vector/LoadJsvmlTest.java
+++ b/test/jdk/jdk/incubator/vector/LoadJsvmlTest.java
@@ -29,6 +29,7 @@
  * @requires vm.compiler2.enabled
  * @requires os.arch == "x86_64" | os.arch == "amd64"
  * @requires os.family == "linux" | os.family == "windows"
+ * @requires vm.flagless
  * @library /test/lib
  * @run main LoadJsvmlTest
  */


### PR DESCRIPTION
I backport this to keep the tests up-to-date. Most subissues of https://bugs.openjdk.org/browse/JDK-8319566: "Some corelibs tests ignore vm options" have been backported. Let's do this, too, to complete the job. This will simplify later backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319572](https://bugs.openjdk.org/browse/JDK-8319572) needs maintainer approval

### Issue
 * [JDK-8319572](https://bugs.openjdk.org/browse/JDK-8319572): Test jdk/incubator/vector/LoadJsvmlTest.java ignores VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1621/head:pull/1621` \
`$ git checkout pull/1621`

Update a local copy of the PR: \
`$ git checkout pull/1621` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1621`

View PR using the GUI difftool: \
`$ git pr show -t 1621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1621.diff">https://git.openjdk.org/jdk21u-dev/pull/1621.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1621#issuecomment-2789468326)
</details>
