### PR TITLE
8317264: Pattern.Bound has `static` fields that should be `static final`.

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -5529,10 +5529,10 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
      * they are ignored for purposes of finding word boundaries.
      */
     static final class Bound extends Node {
-        static int LEFT = 0x1;
-        static int RIGHT= 0x2;
-        static int BOTH = 0x3;
-        static int NONE = 0x4;
+        static final int LEFT = 0x1;
+        static final int RIGHT= 0x2;
+        static final int BOTH = 0x3;
+        static final int NONE = 0x4;
         int type;
         boolean useUWORD;
         Bound(int n, boolean useUWORD) {


### PR DESCRIPTION
Clean backport of JDK-8317264. The fields are never assigned after initialization. final leads to shorter bytecode. It's a minor performance optimization in Regex.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317264](https://bugs.openjdk.org/browse/JDK-8317264) needs maintainer approval

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8317264: Pattern.Bound has `static` fields that should be `static final`.`

### Issue
 * [JDK-8317264](https://bugs.openjdk.org/browse/JDK-8317264): Pattern.Bound has `static` fields that should be `static final`. (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1622/head:pull/1622` \
`$ git checkout pull/1622`

Update a local copy of the PR: \
`$ git checkout pull/1622` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1622`

View PR using the GUI difftool: \
`$ git pr show -t 1622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1622.diff">https://git.openjdk.org/jdk21u-dev/pull/1622.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1622#issuecomment-2822338338)
</details>
