### PR TITLE
8314842: zgc/genzgc tests ignore vm flags

### DIFF
--- a/test/hotspot/jtreg/gc/x/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/x/TestAllocateHeapAt.java
@@ -41,7 +41,7 @@ public class TestAllocateHeapAt {
         final String heapBackingFile = "Heap Backing File: " + directory;
         final String failedToCreateFile = "Failed to create file " + directory;
 
-        ProcessTools.executeLimitedTestJava(
+        ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-XX:-ZGenerational",
             "-Xlog:gc*",

--- a/test/hotspot/jtreg/gc/x/TestPageCacheFlush.java
+++ b/test/hotspot/jtreg/gc/x/TestPageCacheFlush.java
@@ -68,7 +68,7 @@ public class TestPageCacheFlush {
     }
 
     public static void main(String[] args) throws Exception {
-        ProcessTools.executeLimitedTestJava(
+        ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-XX:-ZGenerational",
             "-Xms128M",

--- a/test/hotspot/jtreg/gc/x/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/x/TestSmallHeap.java
@@ -53,7 +53,7 @@ public class TestSmallHeap {
 
     public static void main(String[] args) throws Exception {
         for (var maxCapacity: args) {
-            ProcessTools.executeLimitedTestJava(
+            ProcessTools.executeTestJava(
                 "-XX:+UseZGC",
                 "-XX:-ZGenerational",
                 "-Xlog:gc,gc+init,gc+reloc,gc+heap",

--- a/test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
@@ -41,7 +41,7 @@ public class TestAllocateHeapAt {
         final String heapBackingFile = "Heap Backing File: " + directory;
         final String failedToCreateFile = "Failed to create file " + directory;
 
-        ProcessTools.executeLimitedTestJava(
+        ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-XX:+ZGenerational",
             "-Xlog:gc*",

--- a/test/hotspot/jtreg/gc/z/TestPageCacheFlush.java
+++ b/test/hotspot/jtreg/gc/z/TestPageCacheFlush.java
@@ -68,7 +68,7 @@ public class TestPageCacheFlush {
     }
 
     public static void main(String[] args) throws Exception {
-        ProcessTools.executeLimitedTestJava(
+        ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-XX:+ZGenerational",
             "-Xms128M",

--- a/test/hotspot/jtreg/gc/z/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/z/TestSmallHeap.java
@@ -53,7 +53,7 @@ public class TestSmallHeap {
 
     public static void main(String[] args) throws Exception {
         for (var maxCapacity: args) {
-            ProcessTools.executeLimitedTestJava(
+            ProcessTools.executeTestJava(
                 "-XX:+UseZGC",
                 "-XX:+ZGenerational",
                 "-Xlog:gc,gc+init,gc+reloc,gc+heap",


### PR DESCRIPTION
I backport this to keep the tests up-to-date. Many similar changes have been backported. Let's do this, too, to complete the job. This will simplify later backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8314842](https://bugs.openjdk.org/browse/JDK-8314842) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314842](https://bugs.openjdk.org/browse/JDK-8314842): zgc/genzgc tests ignore vm flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1623/head:pull/1623` \
`$ git checkout pull/1623`

Update a local copy of the PR: \
`$ git checkout pull/1623` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1623`

View PR using the GUI difftool: \
`$ git pr show -t 1623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1623.diff">https://git.openjdk.org/jdk21u-dev/pull/1623.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1623#issuecomment-2789521802)
</details>
