### PR TITLE
8316452: java/lang/instrument/modules/AppendToClassPathModuleTest.java ignores VM flags

### DIFF
--- a/test/jdk/java/lang/instrument/modules/AppendToClassPathModuleTest.java
+++ b/test/jdk/java/lang/instrument/modules/AppendToClassPathModuleTest.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8169909
+ * @requires vm.flagless
  * @library src /test/lib
  * @build test/*
  * @run shell AppendToClassPathModuleTest.sh


### PR DESCRIPTION
I backport this to keep the tests up-to-date. Many similar changes have been backported. Let's do this, too, to complete the job. This will simplify later backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316452](https://bugs.openjdk.org/browse/JDK-8316452) needs maintainer approval

### Issue
 * [JDK-8316452](https://bugs.openjdk.org/browse/JDK-8316452): java/lang/instrument/modules/AppendToClassPathModuleTest.java ignores VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1625/head:pull/1625` \
`$ git checkout pull/1625`

Update a local copy of the PR: \
`$ git checkout pull/1625` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1625`

View PR using the GUI difftool: \
`$ git pr show -t 1625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1625.diff">https://git.openjdk.org/jdk21u-dev/pull/1625.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1625#issuecomment-2789619088)
</details>
