### PR TITLE
8341162: Open source some of the AWT window test

### DIFF
--- a/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
+++ b/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6318630
+ * @summary Test that location by platform works
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestLocationByPlatform
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+
+public class TestLocationByPlatform {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            You should see two frames. One has locationByPlatform set, it
+            should be displayed somewhere on the screen most probably without
+            intersecting other Frames or stacked over normal frame with some
+            offset. Another has its location explicitly set to (0, 450).
+            Please verify that the frames are located correctly on the screen.
+
+            Also verify that the picture inside of frames looks the same
+            and consists of red descending triangle occupying exactly the bottom
+            half of the frame. Make sure that there is a blue rectangle exactly
+            surrounding the client area of frame with no pixels between it and
+            the frame's decorations. Press Pass if this all is true,
+            otherwise press Fail.
+            """;
+
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .rows(13)
+            .columns(40)
+            .build();
+        EventQueue.invokeAndWait(TestLocationByPlatform::createUI);
+        passFailJFrame.awaitAndCheck();
+    }
+    private static void createUI() {
+        Frame frame = new Frame("Normal");
+        frame.setLocation(0, 450);
+        Canvas c = new MyCanvas();
+        frame.add(c, BorderLayout.CENTER);
+        frame.pack();
+        PassFailJFrame.addTestWindow(frame);
+        frame.setVisible(true);
+
+        frame = new Frame("Location by platform");
+        frame.setLocationByPlatform(true);
+        c = new MyCanvas();
+        frame.add(c, BorderLayout.CENTER);
+        frame.pack();
+        PassFailJFrame.addTestWindow(frame);
+        frame.setVisible(true);
+    }
+
+    static class MyCanvas extends Canvas {
+        @Override
+        public Dimension getPreferredSize() {
+            return new Dimension(400, 400);
+        }
+
+        @Override
+        public void paint(Graphics g) {
+            g.setColor(Color.red);
+            for (int i = 399; i >= 0; i--) {
+                g.drawLine(400 - i - 1, 400 - i - 1,
+                    400 - i - 1, 399);
+            }
+            g.setColor(Color.blue);
+            g.drawLine(0, 0, 399, 0);
+            g.drawLine(0, 0, 0, 399);
+            g.drawLine(0, 399, 399, 399);
+            g.drawLine(399, 0, 399, 399);
+        }
+    }
+}

--- a/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
+++ b/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4177156
+ * @key headful
+ * @summary Tests that multiple level of window ownership doesn't cause
+ * NullPointerException when showing a Window
+ * @run main OwnedWindowShowTest
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Window;
+
+public class OwnedWindowShowTest {
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(OwnedWindowShowTest::runTest);
+    }
+
+    static void runTest() {
+        Frame parent = new Frame("OwnedWindowShowTest");
+        try {
+            Window owner = new Window(parent);
+            Window window = new Window(owner);
+            // Showing a window with multiple levels of ownership
+            // should not throw NullPointerException
+            window.setVisible(true);
+        } finally {
+            parent.dispose();
+        }
+    }
+}

--- a/test/jdk/java/awt/Window/ResizeTest/ResizeTest.java
+++ b/test/jdk/java/awt/Window/ResizeTest/ResizeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4225955
+ * @summary Tests that focus lost is delivered to a lightweight component
+ * in a disposed window
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ResizeTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+
+public class ResizeTest
+{
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            1) Push button A to create modal dialog 2.
+            2) Resize dialog 2, then click button B to hide it.
+            3) Push button A again. Dialog B should be packed to its original
+            size.
+            4) Push button B again to hide, and A to reshow.
+            Dialog B should still be the same size, then test is passed,
+            otherwise failed.
+            5) Push button B to hide the modal dialog and then select pass/fail.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(ResizeTest::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("1");
+        Dialog d = new Dialog(f, "2", true);
+        d.setLocationRelativeTo(null);
+        Button b2 = new Button("B");
+        b2.addActionListener(e -> d.setVisible(false));
+        d.setLayout(new BorderLayout());
+        d.add(b2, BorderLayout.CENTER);
+
+        Button b = new Button("A");
+        f.add(b, BorderLayout.CENTER);
+        b.addActionListener(e -> {
+            d.pack();
+            d.setVisible(true);
+        });
+        f.pack();
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
+++ b/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4084997
+ * @summary See if Window can be created without its size explicitly set
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ShowWindowTest
+ */
+
+import java.awt.Button;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class ShowWindowTest implements ActionListener
+{
+    private static Window window;
+    private static Button showButton;
+    private static Button hideButton;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            1. You should see a Frame with a "Show" and a "Hide" button in it.
+            2. Click on the "Show" button. A window with a "Hello World" Label
+            should appear
+            3. If the window does not appear, the test failed, otherwise passed.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(ShowWindowTest::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame frame = new Frame("ShowWindowTest");
+        frame.setLayout(new FlowLayout());
+        frame.setSize(100,100);
+        frame.add(showButton = new Button("Show"));
+        frame.add(hideButton = new Button("Hide"));
+
+        ActionListener handler = new ShowWindowTest();
+        showButton.addActionListener(handler);
+        hideButton.addActionListener(handler);
+
+        window = new Window(frame);
+        window.add("Center", new Label("Hello World"));
+        window.setLocationRelativeTo(null);
+        return frame;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (e.getSource() == showButton) {
+            window.pack();
+            window.setVisible(true);
+        } else if (e.getSource() == hideButton)
+            window.setVisible(false);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341162](https://bugs.openjdk.org/browse/JDK-8341162) needs maintainer approval

### Issue
 * [JDK-8341162](https://bugs.openjdk.org/browse/JDK-8341162): Open source some of the AWT window test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1629/head:pull/1629` \
`$ git checkout pull/1629`

Update a local copy of the PR: \
`$ git checkout pull/1629` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1629`

View PR using the GUI difftool: \
`$ git pr show -t 1629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1629.diff">https://git.openjdk.org/jdk21u-dev/pull/1629.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1629#issuecomment-2790891886)
</details>
