### PR TITLE
8341258: Open source few various AWT tests - Set1

### DIFF
--- a/test/jdk/java/awt/CardLayout/RemoveComponentTest/RemoveComponentTest.java
+++ b/test/jdk/java/awt/CardLayout/RemoveComponentTest/RemoveComponentTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4546123
+ * @summary CardLayout becomes unusable after deleting an element
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RemoveComponentTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+public class RemoveComponentTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                You should see a frame titled "Test Frame For
+                RemoveComponentTest". Try to select a few different panels from
+                the second menu. Make sure your last choice is the red panel.
+                Then click close (in first menu). After that you should be able
+                to select any panels except red one.
+                If that is the case, the test passes. Otherwise, the test failed.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(RemoveComponentTest::createUI)
+                .logArea(5)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        TestFrame frame = new TestFrame();
+        frame.setSize(200, 200);
+        return frame;
+    }
+}
+
+class TestFrame extends Frame implements ActionListener {
+    public Panel aPanel;
+    public TestPanel pageRed;
+    public TestPanel pageGreen;
+    public TestPanel pageBlue;
+    public String currentSelection = "";
+
+    public MenuItem mi;
+    public CardLayout theCardLayout;
+
+
+    public TestFrame() {
+        super("Test Frame For RemoveComponentTest");
+
+        setBackground(Color.black);
+        setLayout(new BorderLayout(5, 5));
+
+        MenuBar mb = new MenuBar();
+
+        Menu fileMenu = new Menu("File");
+        Menu pageMenu = new Menu("Pages");
+
+        mi = new MenuItem("Close");
+        mi.addActionListener(this);
+        fileMenu.add(mi);
+
+        mi = new MenuItem("Red");
+        mi.addActionListener(this);
+        pageMenu.add(mi);
+
+        mi = new MenuItem("Green");
+        mi.addActionListener(this);
+        pageMenu.add(mi);
+
+        mi = new MenuItem("Blue");
+        mi.addActionListener(this);
+        pageMenu.add(mi);
+
+        mb.add(fileMenu);
+        mb.add(pageMenu);
+
+        setMenuBar(mb);
+
+        aPanel = new Panel();
+        theCardLayout = new CardLayout();
+
+        aPanel.setLayout(theCardLayout);
+
+        pageRed = new TestPanel("PageRed", Color.red);
+        pageGreen = new TestPanel("PageGreen", Color.green);
+        pageBlue = new TestPanel("PageBlue", Color.blue);
+
+        aPanel.add("PageRed", pageRed);
+        aPanel.add("PageGreen", pageGreen);
+        aPanel.add("PageBlue", pageBlue);
+
+        add("Center", aPanel);
+        setSize(getPreferredSize());
+    }
+
+    public Insets getInsets() {
+        return new Insets(47, 9, 9, 9);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (e.getActionCommand().equals("Red")) {
+            theCardLayout.show(aPanel, "PageRed");
+            currentSelection = "PageRed";
+        } else if (e.getActionCommand().equals("Green")) {
+            theCardLayout.show(aPanel, "PageGreen");
+        } else if (e.getActionCommand().equals("Blue")) {
+            theCardLayout.show(aPanel, "PageBlue");
+        } else if (e.getActionCommand().equals("Close")) {
+            PassFailJFrame.log("Closing");
+
+            if (currentSelection.equals("PageRed")) {
+                PassFailJFrame.log("Remove page red");
+                theCardLayout.removeLayoutComponent(pageRed);
+            }
+        }
+    }
+}
+
+class TestPanel extends JPanel {
+    private String pageName;
+
+    TestPanel(String pageName, Color color) {
+        setBackground(color);
+        add(new JLabel(pageName));
+    }
+}

--- a/test/jdk/java/awt/GradientPaint/JerkyGradient.java
+++ b/test/jdk/java/awt/GradientPaint/JerkyGradient.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4221201
+ * @summary Test where the gradient drawn should remain in sync with the
+ *          rotating rectangle.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual JerkyGradient
+ */
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Paint;
+import java.awt.Panel;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+public class JerkyGradient extends Panel implements Runnable {
+    protected static Shape mShape;
+    protected static Paint mPaint;
+    protected static double mTheta;
+    static Thread animatorThread;
+    static BufferedImage mImg;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Watch at least one full rotation of the rectangle. Check that
+                the gradient drawn remains in sync with the rotating
+                rectangle. If so, pass this test. Otherwise, fail this test.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(JerkyGradient::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("Rotating Gradient Test");
+        JerkyGradient jg = new JerkyGradient();
+        f.add(jg);
+        f.setSize(200, 200);
+        return f;
+    }
+
+    public JerkyGradient() {
+        mShape = new Rectangle2D.Double(60, 50, 80, 100);
+        mPaint = new GradientPaint(0, 0, Color.red,
+                25, 25, Color.yellow,
+                true);
+        mImg = new BufferedImage(200, 200, BufferedImage.TYPE_INT_RGB);
+
+        animatorThread = new Thread(this);
+        animatorThread.setPriority(Thread.MIN_PRIORITY);
+        animatorThread.start();
+    }
+
+    public synchronized void run() {
+        Thread me = Thread.currentThread();
+        double increment = Math.PI / 36;
+        double twoPI = Math.PI * 2;
+
+        while (animatorThread == me) {
+            mTheta = (mTheta + increment) % twoPI;
+            repaint();
+            try {
+                wait(50);
+            } catch (InterruptedException ie) {
+                break;
+            }
+        }
+    }
+
+    public void update(Graphics g) {
+        Graphics2D g2 = mImg.createGraphics();
+        g2.setColor(getBackground());
+        g2.fillRect(0, 0, 200, 200);
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                            RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.rotate(mTheta, 100, 100);
+        g2.setPaint(Color.black);
+        g2.drawLine(100, 30, 100, 55);
+        g2.setPaint(mPaint);
+        g2.fill(mShape);
+        g2.setPaint(Color.black);
+        g2.draw(mShape);
+        paint(g);
+        g2.dispose();
+    }
+
+    public void paint(Graphics g) {
+        g.drawImage(mImg, 0, 0, null);
+    }
+}

--- a/test/jdk/java/awt/GradientPaint/ShearTest.java
+++ b/test/jdk/java/awt/GradientPaint/ShearTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4171820
+ * @summary Checks that GradientPaint responds to shearing transforms correctly
+ *          The gradients drawn should be parallel to the sides of the
+ *          indicated anchor rectangle.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ShearTest
+ */
+
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+
+public class ShearTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This test displays 2 rows each containing 4 gradient fills. Each
+                gradient fill is labeled depending on whether the line or lines
+                of the gradient should be truly vertical, truly horizontal, or
+                some slanted diagonal direction. The test passes if the direction
+                of each gradient matches its label.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ShearTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("Shear Gradient Test");
+        f.setLayout(new GridLayout(0, 1));
+        f.add(getPanelSet(false), "North");
+        f.add(getPanelSet(true), "Center");
+        f.setSize(500, 300);
+        return f;
+    }
+
+    public static Panel getPanelSet(boolean horizontal) {
+        String direven = horizontal ? "Slanted" : "Vertical";
+        String dirodd = horizontal ? "Horizontal" : "Slanted";
+
+        Panel p = new Panel();
+        p.setLayout(new GridLayout(0, 4));
+        p.add(new ShearCanvas(direven, false, horizontal, false, true));
+        p.add(new ShearCanvas(dirodd,  false, horizontal, true,  false));
+        p.add(new ShearCanvas(direven, true,  horizontal, false, true));
+        p.add(new ShearCanvas(dirodd,  true,  horizontal, true,  false));
+
+        return p;
+    }
+
+    public static class ShearCanvas extends Canvas {
+        public static final int GRADW = 30;
+
+        public static final Rectangle anchor =
+            new Rectangle(-GRADW / 2, -GRADW / 2, GRADW, GRADW);
+
+        public static final Color faintblue = new Color(0f, 0f, 1.0f, 0.35f);
+
+        private AffineTransform txform;
+        private GradientPaint grad;
+        private String label;
+
+        public ShearCanvas(String label,
+                           boolean cyclic, boolean horizontal,
+                           boolean shearx, boolean sheary) {
+            txform = new AffineTransform();
+            if (shearx) {
+                txform.shear(-.5, 0);
+            }
+            if (sheary) {
+                txform.shear(0, -.5);
+            }
+            int relx = horizontal ? 0 : GRADW / 2;
+            int rely = horizontal ? GRADW / 2 : 0;
+            grad = new GradientPaint(-relx, -rely, Color.green,
+                                     relx, rely, Color.yellow, cyclic);
+            this.label = label;
+        }
+
+        public void paint(Graphics g) {
+            Graphics2D g2d = (Graphics2D) g;
+
+            AffineTransform at = g2d.getTransform();
+            g2d.translate(75, 75);
+            g2d.transform(txform);
+            g2d.setPaint(grad);
+            g2d.fill(g.getClip());
+            g2d.setColor(faintblue);
+            g2d.fill(anchor);
+            g2d.setTransform(at);
+
+            Dimension d = getSize();
+            g2d.setColor(Color.black);
+            g2d.drawRect(0, 0, d.width - 1, d.height - 1);
+            g2d.drawString(label, 5, d.height - 5);
+            g2d.dispose();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341258](https://bugs.openjdk.org/browse/JDK-8341258) needs maintainer approval

### Issue
 * [JDK-8341258](https://bugs.openjdk.org/browse/JDK-8341258): Open source few various AWT tests - Set1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1630/head:pull/1630` \
`$ git checkout pull/1630`

Update a local copy of the PR: \
`$ git checkout pull/1630` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1630`

View PR using the GUI difftool: \
`$ git pr show -t 1630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1630.diff">https://git.openjdk.org/jdk21u-dev/pull/1630.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1630#issuecomment-2790925439)
</details>
