### PR TITLE
8340417: Open source some MenuBar tests - Set1

### DIFF
--- a/test/jdk/java/awt/MenuBar/CellsResize.java
+++ b/test/jdk/java/awt/MenuBar/CellsResize.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6502052
+ * @summary Menu cells must resize if font changes (XToolkit)
+ * @requires os.family == "linux"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CellsResize
+ */
+
+import java.awt.Button;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuComponent;
+import java.awt.MenuItem;
+import java.awt.Panel;
+import java.awt.PopupMenu;
+import java.awt.Toolkit;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class CellsResize {
+    private static Frame frame;
+    private static MenuBar menuBar;
+    private static PopupMenu popupMenu;
+    private static Menu barSubMenu;
+    private static Menu popupSubMenu;
+    private static boolean fontMultiplied = false;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Open all nested menus in menu bar.
+                2. Click on "popup-menu" button to show popup-menus.
+                3. Open all nested menus in popup-menu.
+                4. Click on "big-font" button (to make all menus have a
+                    bigger font).
+                5. Open all nested menus again (as described in 1, 2, 3).
+                6. If all menu items use a bigger font now and their labels fit
+                into menu-item size, press "pass", otherwise press "fail".
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(CellsResize::createUI)
+                .logArea(5)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI () {
+        if (!checkToolkit()) {
+            new RuntimeException("Toolkit check failed.");
+        }
+        frame = new Frame("MenuBar Cell Resize Test");
+
+        popupMenu = new PopupMenu();
+        popupMenu.add(createMenu(false));
+
+        frame.add(popupMenu);
+
+        menuBar = new MenuBar();
+        menuBar.add(createMenu(true));
+
+        frame.setMenuBar(menuBar);
+
+        Button bp = new Button("popup-menu");
+        bp.addMouseListener(new MouseAdapter() {
+            public void mouseReleased(MouseEvent e) {
+                popupMenu.show(e.getComponent(), e.getX(), e.getY());
+            }
+        });
+
+        Button bf = new Button("big-font");
+        bf.addMouseListener(new MouseAdapter() {
+            public void mouseReleased(MouseEvent e) {
+                bigFont();
+            }
+        });
+
+        Panel panel = new Panel();
+        panel.setLayout(new GridLayout(2, 1));
+        panel.add(bp);
+        panel.add(bf);
+
+        frame.add(panel);
+        frame.setSize(300, 300);
+        return frame;
+    }
+
+    static boolean checkToolkit() {
+        String toolkitName = Toolkit.getDefaultToolkit().getClass().getName();
+        return toolkitName.equals("sun.awt.X11.XToolkit");
+    }
+
+    static Menu createMenu(boolean bar) {
+        Menu menu1 = new Menu("Menu-1");
+        Menu menu11 = new Menu("Menu-11");
+        menu1.add(menu11);
+        if (bar) {
+            barSubMenu = menu11;
+        } else {
+            popupSubMenu = menu11;
+        }
+        menu11.add(new MenuItem("MenuItem"));
+        return menu1;
+    }
+
+    static void bigFont() {
+        if (fontMultiplied) {
+            return;
+        } else {
+            fontMultiplied = true;
+        }
+
+        multiplyFont(barSubMenu, 7);
+        multiplyFont(popupSubMenu, 7);
+
+        // NOTE: if previous two are moved below following
+        // two, they get their font multiplied twice.
+
+        multiplyFont(menuBar, 5);
+        multiplyFont(popupMenu, 5);
+    }
+
+    static void multiplyFont(MenuComponent comp, int times) {
+        Font font = comp.getFont();
+        float size = font.getSize() * times;
+        comp.setFont(font.deriveFont(size));
+    }
+}

--- a/test/jdk/java/awt/MenuBar/MenuBarRemoveMenu/MenuBarRemoveMenuTest.java
+++ b/test/jdk/java/awt/MenuBar/MenuBarRemoveMenu/MenuBarRemoveMenuTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4275848
+ * @summary Tests that MenuBar is painted correctly after its submenu is removed
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuBarRemoveMenuTest
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class MenuBarRemoveMenuTest implements ActionListener {
+    private static MenuBar menubar;
+    private static Button removeButton;
+    private static Button addButton;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Press "Remove menu" button. If you see that both menus
+                disappeared, the test failed. Otherwise try to add and remove
+                menu several times to verify that the test passed. Every time
+                you press "Remove menu" button only one menu should go away.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(MenuBarRemoveMenuTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame frame = new Frame();
+        menubar = new MenuBar();
+        removeButton = new Button("Remove menu");
+        addButton = new Button("Add menu");
+        removeButton.addActionListener(new MenuBarRemoveMenuTest());
+        addButton.addActionListener(new MenuBarRemoveMenuTest());
+        addButton.setEnabled(false);
+        menubar.add(new Menu("menu"));
+        menubar.add(new Menu("menu"));
+        frame.setMenuBar(menubar);
+        frame.setLayout(new GridLayout(1, 2));
+        frame.add(removeButton);
+        frame.add(addButton);
+        frame.pack();
+        return frame;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (e.getSource() == removeButton) {
+            menubar.remove(0);
+            removeButton.setEnabled(false);
+            addButton.setEnabled(true);
+        } else {
+            menubar.add(new Menu("menu"));
+            removeButton.setEnabled(true);
+            addButton.setEnabled(false);
+        }
+    }
+}

--- a/test/jdk/java/awt/MenuBar/MenuNPE/MenuNPE.java
+++ b/test/jdk/java/awt/MenuBar/MenuNPE/MenuNPE.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5005194
+ * @summary Frame.remove(getMenuBar()) throws NPE if the frame doesn't
+ *       have a menu bar
+ * @key headful
+ * @run main MenuNPE
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+public class MenuNPE {
+    private static Frame frame;
+    public static void main(String[] args) throws Exception {
+        try {
+            frame = new Frame("Menu NPE");
+            MenuBar menuBar = new MenuBar();
+            Menu menu1 = new Menu("Menu 01");
+            MenuItem menuLabel = new MenuItem("Item 01");
+            menu1.add(menuLabel);
+            menuBar.add(menu1);
+            frame.setMenuBar(menuBar);
+            frame.setSize(200, 200);
+            frame.setVisible(true);
+            frame.validate();
+            frame.remove(frame.getMenuBar());
+            frame.remove(frame.getMenuBar());
+            System.out.println("Test passed.");
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/MenuBar/SetMBarWhenHidden/SetMBarWhenHidden.java
+++ b/test/jdk/java/awt/MenuBar/SetMBarWhenHidden/SetMBarWhenHidden.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4105881
+ * @summary Sets the menu bar while frame window is hidden, then shows
+    frame again
+ * @key headful
+ * @run main SetMBarWhenHidden
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.Rectangle;
+
+// test case for 4105881: FRAME.SETSIZE() DOESN'T WORK FOR SOME SOLARIS WITH
+// JDK115+CASES ON
+public class SetMBarWhenHidden {
+    private static Frame f;
+    private static Rectangle startBounds;
+    private static Rectangle endBounds;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                f = new Frame("Set MenuBar When Hidden Test");
+                Menu file;
+                Menu edit;
+                MenuBar menubar = new MenuBar();
+                file = new Menu("File");
+                menubar.add(file);
+                edit = new Menu("Edit");
+                menubar.add(edit);
+                edit.setEnabled(false);
+                f.setMenuBar(menubar);
+                f.setSize(200, 200);
+                startBounds = f.getBounds();
+                System.out.println("About to call setVisible(false)");
+                f.setVisible(false);
+                System.out.println("About to call setSize(500, 500)");
+                f.setSize(500, 500);
+                // create a new menubar and add
+                MenuBar menubar1 = new MenuBar();
+                menubar1.add(file);
+                menubar1.add(edit);
+                System.out.println("About to call setMenuBar");
+                f.setMenuBar(menubar1);
+                System.out.println("About to call setVisible(true)");
+                f.setVisible(true);
+                endBounds = f.getBounds();
+            });
+            if (startBounds.getHeight() > endBounds.getHeight() &&
+                startBounds.getWidth() > endBounds.getWidth()) {
+                throw new RuntimeException("Test failed. Frame size didn't " +
+                        "change.\nStart: " + startBounds + "\n" +
+                        "End: " + endBounds);
+            } else {
+                System.out.println("Test passed.\nStart: " + startBounds +
+                        "\nEnd: " + endBounds);
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8340417](https://bugs.openjdk.org/browse/JDK-8340417) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340417](https://bugs.openjdk.org/browse/JDK-8340417): Open source some MenuBar tests - Set1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1631/head:pull/1631` \
`$ git checkout pull/1631`

Update a local copy of the PR: \
`$ git checkout pull/1631` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1631`

View PR using the GUI difftool: \
`$ git pr show -t 1631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1631.diff">https://git.openjdk.org/jdk21u-dev/pull/1631.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1631#issuecomment-2790925037)
</details>
