### PR TITLE
8340621: Open source several AWT List tests

### DIFF
--- a/test/jdk/java/awt/List/DisabledListIsGreyTest.java
+++ b/test/jdk/java/awt/List/DisabledListIsGreyTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6354810
+ * @summary Items in the list are not grayed out when disabled, XToolkit
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DisabledListIsGreyTest
+*/
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+
+public class DisabledListIsGreyTest {
+
+    private static final String INSTRUCTIONS = """
+            1) After the test started you will see two lists.
+            2) One of them is enabled, and the second is disabled.
+            3) Check that the items of the disabled list are grayed.
+            4) If so, the test passed. Otherwise, failed.""";
+
+
+    public static void main(String[] args) throws Exception {
+         PassFailJFrame.builder()
+                .title("DisabledListIsGreyTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(DisabledListIsGreyTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        Frame frame = new Frame("DisabledListIsGreyTest Frame");
+        frame.setLayout(new FlowLayout());
+
+        List list1 = new List(3);
+        List list2 = new List(3);
+        for (int i = 0; i < 5; i++) {
+            list1.addItem("Item " + i);
+            list2.addItem("Item " + i);
+        }
+        frame.add(list1);
+
+        list2.setEnabled(false);
+        frame.add(list2);
+        frame.pack();
+        return frame;
+    }
+
+}

--- a/test/jdk/java/awt/List/ListFrameResizeTest.java
+++ b/test/jdk/java/awt/List/ListFrameResizeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4085379
+ * @summary List component not properly "resized" with GridBagLayout
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ListFrameResizeTest
+ */
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.List;
+
+public class ListFrameResizeTest {
+
+    private static final String INSTRUCTIONS = """
+        This test is for windows only.
+
+        1. A Frame will appear with a List
+           (the List occupies the whole Frame)
+        2. Minimize the Frame, the Frame is now in the Task Bar (ie.,iconified)
+        3. Right click (right mouse button) the icon in the task bar
+           and click on the 'maximize' menuitem to maximize the Frame
+        4. If you notice the List has not been resized
+           (ie.,if it partly occupies the Frame), then press FAIL else press PASS".""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ListFrameResizeTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(ListFrameResizeTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        wintest client = new wintest("ListFrameResizeTest Frame");
+        client.resize(500, 300);
+        client.setBackground(Color.blue);
+        return client;
+    }
+
+}
+
+class wintest extends Frame {
+    private List msg;
+
+    public wintest(String title) {
+        super(title);
+        msg = new List();
+        for (int i = 0; i < 100; i++) {
+            msg.add("" + i);
+        }
+
+        GridBagLayout gridbag = new GridBagLayout();
+        GridBagConstraints constraints = new GridBagConstraints();
+
+        setLayout(gridbag);
+
+        constraints.fill = GridBagConstraints.BOTH;
+
+        constraints.anchor = GridBagConstraints.CENTER;
+        constraints.insets = new Insets(10, 10, 10, 10);
+        constraints.ipadx = 0;
+        constraints.ipady = 0;
+        constraints.weightx = 1;
+        constraints.weighty = 1;
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+        constraints.gridwidth = GridBagConstraints.REMAINDER;
+        constraints.gridheight = GridBagConstraints.REMAINDER;
+        gridbag.setConstraints(msg, constraints);
+        add(msg);
+    }
+}

--- a/test/jdk/java/awt/List/MultiSelectionListCrashTest.java
+++ b/test/jdk/java/awt/List/MultiSelectionListCrashTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4201967
+ * @summary tests that a multiselection list doesn't causes crash when FileDialog is invoked
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MultiSelectionListCrashTest
+ */
+
+import java.awt.Button;
+import java.awt.FileDialog;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class MultiSelectionListCrashTest {
+
+    private static final String INSTRUCTIONS = """
+         Press "Invoke dialog" button to invoke a FileDialog.
+         When it appears close it by pressing cancel button.
+         If all remaining frames are enabled and
+         page fault didn't occur the test passed. Otherwise the test failed.
+
+         Try to invoke a FileDialog several times to verify that the bug doesn't exist.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("MultiSelectionListCrashTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(MultiSelectionListCrashTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+
+        Frame frame = new Frame("MultiSelectionListCrashTest frame");
+        Button button = new Button("Invoke dialog");
+        button.addActionListener(new FileDialogInvoker(frame));
+        List list = new List(4, true);
+        list.add("Item1");
+        list.add("Item2");
+        frame.setLayout(new FlowLayout());
+        frame.add(button);
+        frame.add(list);
+        frame.setSize(200, 200);
+        return frame;
+    }
+}
+
+class FileDialogInvoker implements ActionListener {
+     FileDialog fileDialog;
+
+     public FileDialogInvoker(Frame frame) {
+         fileDialog = new FileDialog(frame);
+     }
+
+     public void actionPerformed(ActionEvent e) {
+         fileDialog.setVisible(true);
+     }
+
+}

--- a/test/jdk/java/awt/List/ScrollbarPositionTest.java
+++ b/test/jdk/java/awt/List/ScrollbarPositionTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4024943
+ * @summary  Test for position of List scrollbar when it is added
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollbarPositionTest
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class ScrollbarPositionTest {
+    static int item = 0;
+    static List list;
+    static Button addButton, delButton;
+
+    private static final String INSTRUCTIONS = """
+        Click on the "Add List Item" button many times
+        until the vertical scrollbar appears.
+        Verify that the displayed vertical scrollbar does not take the space
+        that was occupied by buttons before the scrollbar is shown.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ScrollbarPositionTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(ScrollbarPositionTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        Panel pan;
+
+        Frame frame = new Frame("ScrollbarPositionTest Frame");
+        frame.setLayout(new GridLayout(1, 2));
+        list = new List();
+        frame.add(list);
+        frame.add(pan = new Panel());
+        pan.setLayout(new GridLayout(4, 1));
+
+        MyListener listener = new MyListener();
+        addButton = new Button("Add List Item");
+        addButton.addActionListener(listener);
+        pan.add(addButton);
+
+        delButton = new Button("Delete List Item");
+        delButton.addActionListener(listener);
+        pan.add(delButton);
+
+        frame.pack();
+        return frame;
+    }
+
+    static class MyListener implements ActionListener {
+        public void actionPerformed(ActionEvent evt) {
+            if (evt.getSource() == addButton) {
+                String s = "item";
+                for (int i = 0; i <= item; i++) {
+                    s = s +" "+Integer.toString(i);
+                }
+                item++;
+                list.addItem(s);
+            } else if (evt.getSource() == delButton) {
+                int i;
+                if ((i = list.countItems()) > 0) {
+                    list.delItem(i - 1);
+                    --item;
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/List/SelectedItemVisibilityTest.java
+++ b/test/jdk/java/awt/List/SelectedItemVisibilityTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4676536
+ * @summary REGRESSION: makeVisible() method of List Component does not perform
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SelectedItemVisibilityTest
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.List;
+
+public class SelectedItemVisibilityTest {
+
+    static List list1, list2;
+    static int visibleItem = 4;
+    static int selectedItems[] = {6, 7, 8};
+    static String selectedItemsStr = "";
+
+    static {
+        for (int i = 0 ; i < selectedItems.length ; i++) {
+            selectedItemsStr += ""+selectedItems[i]+" ";
+        }
+    }
+
+    private static final String INSTRUCTIONS =
+            "You should see two lists.\n" +
+            "\n" +
+            "list1: \n" +
+            "\t1. the first visible item should be " + visibleItem +
+            "\n\t2. the selected item should be " + selectedItems[0] +
+            "\n" +
+            "list2:\n" +
+            "\t1. the first visible item should be " + visibleItem +
+            "\n\t2. the selected items should be " + selectedItemsStr +
+            "\n" +
+            "\nIf it is so the test passed else failed.";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("SelectedItemVisibilityTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(SelectedItemVisibilityTest::createTestUI)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+
+        Frame frame = new Frame("SelectedItemVisibilityTest Frame");
+        frame.setLayout(new FlowLayout());
+
+        // list1
+        list1 = new List(4);
+        for (int i = 0; i < 20; i++) {
+            list1.add(""+i);
+        }
+        list1.makeVisible(visibleItem);
+        list1.select(selectedItems[0]);
+        frame.add(new Label("list1:"));
+        frame.add(list1);
+
+        // list2
+        list2 = new List(4);
+        list2.setMultipleMode(true);
+        for (int i = 0; i < 20; i++) {
+            list2.add(""+i);
+        }
+        list2.makeVisible(visibleItem);
+        for (int i = 0 ; i < selectedItems.length ; i++) {
+            list2.select(selectedItems[i]);
+        }
+        frame.add(new Label("list2:"));
+        frame.add(list2);
+        frame.setSize(200, 200);
+
+        // common output
+        String s;
+        int sel[];
+
+        PassFailJFrame.log("list1: ");
+        PassFailJFrame.log("\tgetVisibleIndex="+list1.getVisibleIndex());
+        sel = list1.getSelectedIndexes();
+        s = "\tgetSelectedIndexes=";
+        for (int i = 0 ; i < sel.length ; i++) {
+            s += "" + sel[i] + " ";
+        }
+        PassFailJFrame.log(s);
+
+        PassFailJFrame.log("list2: ");
+        PassFailJFrame.log("\tgetVisibleIndex="+list2.getVisibleIndex());
+        sel = list2.getSelectedIndexes();
+        s = "\tgetSelectedIndexes=";
+        for (int i = 0 ; i < sel.length ; i++) {
+            s += "" + sel[i] + " ";
+        }
+        PassFailJFrame.log(s);
+        return frame;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340621](https://bugs.openjdk.org/browse/JDK-8340621) needs maintainer approval

### Issue
 * [JDK-8340621](https://bugs.openjdk.org/browse/JDK-8340621): Open source several AWT List tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1634/head:pull/1634` \
`$ git checkout pull/1634`

Update a local copy of the PR: \
`$ git checkout pull/1634` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1634`

View PR using the GUI difftool: \
`$ git pr show -t 1634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1634.diff">https://git.openjdk.org/jdk21u-dev/pull/1634.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1634#issuecomment-2792045255)
</details>
