### PR TITLE
8340077: Open source few Checkbox tests - Set2

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -820,4 +820,7 @@ java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 java/awt/Frame/SizeMinimizedTest.java 8305915 linux-x64
 java/awt/PopupMenu/PopupHangTest.java 8340022 windows-all
 java/awt/Focus/InactiveFocusRace.java 8023263 linux-all
+java/awt/Checkbox/CheckboxBoxSizeTest.java 8340870 windows-all
+java/awt/Checkbox/CheckboxIndicatorSizeTest.java 8340870 windows-all
+java/awt/Checkbox/CheckboxNullLabelTest.java 8340870 windows-all
 java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all

--- a/test/jdk/java/awt/Checkbox/CheckboxBoxSizeTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxBoxSizeTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Checkbox;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Panel;
+
+/*
+ * @test
+ * @bug 4410522
+ * @requires (os.family == "windows")
+ * @summary The box size of the Checkbox control should be the same as
+ *          in Windows native applications.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CheckboxBoxSizeTest
+ */
+
+public class CheckboxBoxSizeTest {
+    private static final String INSTRUCTIONS = """
+            This test must be run at UI Scale of 100% AND
+            150% or greater.
+            Compare the size of box to any of native apps on Windows
+            (Eg. Font Dialog Settings on Word).
+            They should be the same.
+
+            If the sizes are same Press PASS, else Press FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .title("CheckboxBoxSizeTest Instructions")
+                      .instructions(INSTRUCTIONS)
+                      .rows((int) INSTRUCTIONS.lines().count() + 2)
+                      .columns(35)
+                      .testUI(CheckboxBoxSizeTest::createTestUI)
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        Frame frame = new Frame("CheckboxBoxSizeTest");
+        Panel panel = new Panel(new FlowLayout());
+        Checkbox checkbox = new Checkbox("Compare the box size");
+        panel.add(checkbox);
+        frame.add(panel);
+        frame.pack();
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Checkbox/CheckboxIndicatorSizeTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxIndicatorSizeTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Checkbox;
+import java.awt.CheckboxGroup;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4090493
+ * @summary Test for Checkbox indicator size
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CheckboxIndicatorSizeTest
+ */
+
+public class CheckboxIndicatorSizeTest implements ActionListener {
+    private static final String INSTRUCTIONS = """
+            Indicator size of Checkbox depends
+            on the platform font used to render the label.
+
+            In the frame you can see a group of checkboxes
+            and radio buttons.
+            Verify that all checkboxes and radio buttons have
+            indicators of the same size and proportional to
+            the uiScale and/or font-size.
+
+            Use menu to change the font size and the indicators
+            should scale proportionally.
+
+            If there is a bug, the checkbox/radiobutton with
+            dingbats label will have a smaller indicator.
+
+            Press PASS if the above conditions are true else Press FAIL.
+            """;
+    private static Frame frame;
+    private static Panel testPanel;
+
+    public static void main(String[] args) throws Exception {
+
+        CheckboxIndicatorSizeTest obj = new CheckboxIndicatorSizeTest();
+        PassFailJFrame.builder()
+                      .title("Test Instructions")
+                      .instructions(INSTRUCTIONS)
+                      .rows((int) INSTRUCTIONS.lines().count() + 3)
+                      .columns(60)
+                      .testUI(obj::createAndShowUI)
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private Frame createAndShowUI() {
+        frame = new Frame("CheckboxIndicatorSizeTest");
+
+        testPanel = new Panel(new GridLayout(0, 1));
+        testPanel.setFont(new Font("Dialog", Font.PLAIN, 12));
+        frame.add(testPanel);
+
+        MenuBar menuBar = new MenuBar();
+        Menu fontSizeMenu = new Menu("FontSize");
+
+        MenuItem size10 = new MenuItem("10");
+        size10.addActionListener(this);
+        fontSizeMenu.add(size10);
+
+        MenuItem size12 = new MenuItem("12");
+        size12.addActionListener(this);
+        fontSizeMenu.add(size12);
+
+        MenuItem size14 = new MenuItem("14");
+        size14.addActionListener(this);
+        fontSizeMenu.add(size14);
+
+        MenuItem size18 = new MenuItem("18");
+        size18.addActionListener(this);
+        fontSizeMenu.add(size18);
+
+        MenuItem size24 = new MenuItem("24");
+        size24.addActionListener(this);
+        fontSizeMenu.add(size24);
+
+        MenuItem size36 = new MenuItem("36");
+        size36.addActionListener(this);
+        fontSizeMenu.add(size36);
+
+        menuBar.add(fontSizeMenu);
+        frame.setMenuBar(menuBar);
+
+        Checkbox cbEnglishOnly
+            = new Checkbox("Toggle", true);
+        Checkbox cbDingbatsOnly
+            = new Checkbox("\u274a\u274b\u274c\u274d", true);
+        Checkbox cbEnglishDingbats
+            = new Checkbox("Toggle \u274a\u274d", true);
+        Checkbox cbDingbatsEnglish
+            = new Checkbox("\u274a\u274d toggle", true);
+
+        CheckboxGroup radioGroup = new CheckboxGroup();
+        Checkbox rbEnglishOnly
+            = new Checkbox("Radio", true, radioGroup);
+        Checkbox rbDingbatsOnly
+            = new Checkbox("\u274a\u274b\u274c\u274d", false, radioGroup);
+        Checkbox rbEnglishDingbats
+            = new Checkbox("Radio \u274a\u274d", false, radioGroup);
+        Checkbox rbDingbatsEnglish
+            = new Checkbox("\u274a\u274d radio", false, radioGroup);
+
+        Label cbLabel = new Label("Checkboxes");
+        cbLabel.setBackground(Color.YELLOW);
+        testPanel.add(cbLabel);
+        testPanel.add(cbEnglishOnly);
+        testPanel.add(cbDingbatsOnly);
+        testPanel.add(cbEnglishDingbats);
+        testPanel.add(cbDingbatsEnglish);
+
+        Label rbLabel = new Label("Radio buttons");
+        rbLabel.setBackground(Color.YELLOW);
+        testPanel.add(rbLabel);
+        testPanel.add(rbEnglishOnly);
+        testPanel.add(rbDingbatsOnly);
+        testPanel.add(rbEnglishDingbats);
+        testPanel.add(rbDingbatsEnglish);
+
+        frame.pack();
+        return frame;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        String sizeStr = e.getActionCommand();
+        int size = Integer.parseInt(sizeStr);
+        Font oldFont = testPanel.getFont();
+        Font newFont = new Font(oldFont.getName(), oldFont.getStyle(), size);
+        testPanel.setFont(newFont);
+        frame.pack();
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/Checkbox/CheckboxNullLabelTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxNullLabelTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Checkbox;
+import java.awt.CheckboxGroup;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Panel;
+
+/*
+ * @test
+ * @bug 4383735
+ * @summary Checkbox buttons are too small with java 1.3 and 1.4
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CheckboxNullLabelTest
+ */
+
+public class CheckboxNullLabelTest {
+    private static final String INSTRUCTIONS = """
+                        Please look at the frame titled 'CheckboxNullLabelTest'.
+                        Check if all the check boxes in each group
+                        (of 3 check boxes) have the same size.
+
+                        If the size of labeled check box is NOT the same as
+                        the size of non-labeled Press FAIL otherwise Press PASS.
+                        """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .title("Test Instructions")
+                      .instructions(INSTRUCTIONS)
+                      .rows((int) INSTRUCTIONS.lines().count() + 1)
+                      .columns(35)
+                      .testUI(CheckboxNullLabelTest::createAndShowUI)
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Frame f = new Frame("CheckboxNullLabelTest");
+        f.setLayout(new BorderLayout());
+        f.add(new CheckboxTest(Color.gray, new Font(null, 0, 12)), "North");
+        f.add(new CheckboxTest(Color.green, new Font(null, 0, 18)), "South");
+        f.add(new CheckboxTest(Color.red, new Font(null, 0, 24)), "East");
+        f.add(new CheckboxTest(Color.white, new Font(null, 0, 30)), "West");
+        f.add(new CheckboxTest(f.getBackground(), new Font(null, 0, 36)), "Center");
+        f.setSize(600, 450);
+        return f;
+    }
+
+    private static class CheckboxTest extends Panel {
+        Checkbox cb1, cb2, cb3;
+
+        CheckboxTest(Color background, Font font) {
+            setBackground(background);
+            CheckboxGroup cbg = new CheckboxGroup();
+
+            cb1 = new Checkbox(null, cbg, true);
+            cb1.setFont(font);
+
+            cb2 = new Checkbox("", cbg, true);
+            cb2.setFont(font);
+
+            cb3 = new Checkbox("Label", cbg, false);
+            cb3.setFont(font);
+
+            add(cb1);
+            add(cb2);
+            add(cb3);
+        }
+    }
+}

--- a/test/jdk/java/awt/Checkbox/CheckboxPreferredSizeTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxPreferredSizeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Checkbox;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Frame;
+
+/*
+ * @test
+ * @bug 4304049
+ * @summary tests that Checkbox fits into its preferred size entirely
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CheckboxPreferredSizeTest
+ */
+
+public class CheckboxPreferredSizeTest {
+    private static final String INSTRUCTIONS = """
+                    As the test starts, ensure that the
+                    whole checkbox with all its text is visible.
+                    If the checkbox is entirely visible, press PASS else,
+                    press FAIL.
+                    """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .title("Test Instructions")
+                      .instructions(INSTRUCTIONS)
+                      .rows((int) INSTRUCTIONS.lines().count() + 1)
+                      .columns(35)
+                      .testUI(CheckboxPreferredSizeTest::createAndShowUI)
+                      .build()
+                      .awaitAndCheck();
+    }
+
+     private static Frame createAndShowUI() {
+         Frame frame = new Frame("Checkbox Preferred Size Test");
+         frame.setBackground(Color.BLUE);
+         Checkbox box = new Checkbox("Checkbox_With_Some_Size");
+         box.setFont(new Font("Helvetica", Font.PLAIN, 36));
+         box.setBackground(Color.RED);
+         frame.add(box);
+         frame.pack();
+         return frame;
+     }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.08-oracle.

Resolved ProblemList, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340077](https://bugs.openjdk.org/browse/JDK-8340077) needs maintainer approval

### Issue
 * [JDK-8340077](https://bugs.openjdk.org/browse/JDK-8340077): Open source few Checkbox tests - Set2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1635/head:pull/1635` \
`$ git checkout pull/1635`

Update a local copy of the PR: \
`$ git checkout pull/1635` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1635`

View PR using the GUI difftool: \
`$ git pr show -t 1635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1635.diff">https://git.openjdk.org/jdk21u-dev/pull/1635.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1635#issuecomment-2792057077)
</details>
