### PR TITLE
8339836: Open source several AWT Mouse tests - Batch 1

### DIFF
--- a/test/jdk/java/awt/Mouse/MouseEnterExitTest.java
+++ b/test/jdk/java/awt/Mouse/MouseEnterExitTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Robot;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+/*
+ * @test
+ * @bug 4050138
+ * @key headful
+ * @summary Test to verify Lightweight components don't get
+ *          enter/exit during drags
+ * @run main MouseEnterExitTest
+ */
+
+class LWSquare extends Container {
+    int width;
+    int height;
+
+    public LWSquare(Color color, int w, int h) {
+        setBackground(color);
+        setLayout(new FlowLayout());
+        width = w;
+        height = h;
+        addMouseListener(new EnterExitAdapter(this));
+        setName("LWSquare-" + color.toString());
+    }
+
+    public void paint(Graphics g) {
+        g.setColor(getBackground());
+        g.fillRect(0, 0, getSize().width, getSize().height);
+        super.paint(g);
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(width, height);
+    }
+
+    public Cursor getCursor() {
+        return new Cursor(Cursor.CROSSHAIR_CURSOR);
+    }
+}
+
+class MouseFrame extends Frame {
+    public LWSquare lw;
+
+    public MouseFrame() {
+        super("MouseEnterExitTest");
+        setLayout(new FlowLayout());
+
+        lw = new LWSquare(Color.red, 75, 75);
+        add(lw);
+        setBounds(50, 50, 300, 200);
+        setVisible(true);
+        System.out.println(getInsets());
+
+        addMouseListener(new EnterExitAdapter(this));
+        addWindowListener(
+                new WindowAdapter() {
+                    public void windowClosing(WindowEvent ev) {
+                        dispose();
+                    }
+                }
+        );
+        addKeyListener(
+                new KeyAdapter() {
+                    public void keyPressed(KeyEvent ev) {
+                        MouseEnterExitTest.getFrame().setTitle("MouseEnterExitTest");
+                    }
+                }
+        );
+    }
+}
+
+
+public class MouseEnterExitTest {
+    static MouseFrame testFrame;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        robot.setAutoDelay(100);
+        try {
+            EventQueue.invokeAndWait(() -> testFrame = new MouseFrame());
+            if (testFrame.lw.getBackground() != Color.red) {
+                throw new RuntimeException("Initial Background color not matching");
+            }
+            robot.waitForIdle();
+            robot.delay(100);
+            EventQueue.invokeAndWait(() -> robot.mouseMove(
+                    testFrame.getLocationOnScreen().x + testFrame.getSize().width / 2,
+                    testFrame.getLocationOnScreen().y + testFrame.getSize().height / 2));
+            robot.waitForIdle();
+            robot.delay(100);
+
+            if (testFrame.lw.getBackground() != Color.green) {
+                throw new RuntimeException("Initial Background color not matching");
+            }
+            EventQueue.invokeAndWait(() -> robot.mouseMove(
+                    testFrame.getLocationOnScreen().x + testFrame.getSize().width * 2,
+                    testFrame.getLocationOnScreen().y + testFrame.getSize().height / 2));
+            robot.waitForIdle();
+            robot.delay(100);
+
+            if (testFrame.lw.getBackground() != Color.red) {
+                throw new RuntimeException("Initial Background color not matching");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (testFrame != null) {
+                    testFrame.dispose();
+                }
+            });
+        }
+    }
+
+    public static Frame getFrame() {
+        return testFrame;
+    }
+}
+
+class EnterExitAdapter extends MouseAdapter {
+    Component compToColor;
+    Color colorNormal;
+
+    EnterExitAdapter(Component comp) {
+        compToColor = comp;
+        colorNormal = comp.getBackground();
+    }
+
+    public void mouseEntered(MouseEvent ev) {
+        compToColor.setBackground(Color.green);
+        compToColor.repaint();
+    }
+
+    public void mouseExited(MouseEvent ev) {
+        compToColor.setBackground(colorNormal);
+        compToColor.repaint();
+    }
+}

--- a/test/jdk/java/awt/Mouse/MouseEnterExitTest2.java
+++ b/test/jdk/java/awt/Mouse/MouseEnterExitTest2.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GridLayout;
+import java.awt.Rectangle;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+/*
+ * @test
+ * @bug 4150851
+ * @summary Tests enter and exit events when a lightweight component is on a border
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MouseEnterExitTest2
+ */
+
+public class MouseEnterExitTest2 {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Verify that white component turns black whenever mouse enters the frame,
+                   except when it enters the red rectangle.
+                2. When the mouse enters the red part of the frame the component should stay white.
+                """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(EntryExitTest.initialize())
+                .build()
+                .awaitAndCheck();
+    }
+}
+
+class EntryExitTest extends Component {
+    boolean inWin;
+
+    public Dimension getPreferredSize() {
+        return new Dimension(200, 150);
+    }
+
+    public void paint(Graphics g) {
+        Color c1, c2;
+        String s;
+        if (inWin) {
+            c1 = Color.black;
+            c2 = Color.white;
+            s = "IN";
+        } else {
+            c2 = Color.black;
+            c1 = Color.white;
+            s = "OUT";
+        }
+        g.setColor(c1);
+        Rectangle r = getBounds();
+        g.fillRect(0, 0, r.width, r.height);
+        g.setColor(c2);
+        g.drawString(s, r.width / 2, r.height / 2);
+    }
+
+    public static Frame initialize() {
+        EntryExitTest test = new EntryExitTest();
+        MouseListener frameEnterExitListener = new MouseAdapter() {
+            public void mouseEntered(MouseEvent e) {
+                test.inWin = true;
+                test.repaint();
+            }
+
+            public void mouseExited(MouseEvent e) {
+                test.inWin = false;
+                test.repaint();
+            }
+        };
+
+        Frame f = new Frame("Mouse Modifier Test");
+
+        f.add(test);
+        Component jc = new Component() {
+            public Dimension getPreferredSize() {
+                return new Dimension(100, 50);
+            }
+
+            public void paint(Graphics g) {
+                Dimension d = getSize();
+                g.setColor(Color.red);
+                g.fillRect(0, 0, d.width, d.height);
+            }
+        };
+        final Container cont = new Container() {
+            public Dimension getPreferredSize() {
+                return new Dimension(100, 100);
+            }
+        };
+        cont.setLayout(new GridLayout(2, 1));
+        cont.add(jc);
+        jc.addMouseListener(new MouseAdapter() {
+            public void mouseEntered(MouseEvent e) {
+                //System.out.println("Component entered");
+            }
+            public void mouseExited(MouseEvent e) {
+                //System.out.println("Component exited");
+            }
+        });
+
+        f.add(cont, BorderLayout.NORTH);
+        f.addMouseListener(frameEnterExitListener);
+        f.pack();
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Mouse/MouseEnterExitTest3.java
+++ b/test/jdk/java/awt/Mouse/MouseEnterExitTest3.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import javax.swing.JButton;
+
+/*
+ * @test
+ * @bug 4431868
+ * @summary Tests that hw container doesn't receive mouse enter/exit events when mouse
+ *          is moved between its lw and hw children
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MouseEnterExitTest3
+ */
+
+public class MouseEnterExitTest3 {
+    static final Button button = new Button("Button");
+    static final JButton jbutton = new JButton("JButton");
+    static final Frame frame = new Frame("Mouse Enter/Exit Test");
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Move the mouse between Button and JButton
+                2. Verify that the frame doesn't receive enter/exit events
+                   (Enter/exit events are dumped to the area below)
+                4. If you see enter/exit events dumped the test fails
+                        """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(initialize())
+                .logArea(4)
+                .build()
+                .awaitAndCheck();
+    }
+
+    final static MouseListener listener = new MouseAdapter() {
+        public void mouseEntered(MouseEvent e) {
+            PassFailJFrame.log(e.toString());
+        }
+
+        public void mouseExited(MouseEvent e) {
+            PassFailJFrame.log(e.toString());
+        }
+    };
+
+    public static Frame initialize() {
+        frame.setLayout(new GridLayout(2, 1));
+        frame.add(button);
+        frame.add(jbutton);
+        frame.addMouseListener(listener);
+        frame.pack();
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Mouse/MouseEnterExitTest4.java
+++ b/test/jdk/java/awt/Mouse/MouseEnterExitTest4.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.Window;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+/*
+ * @test
+ * @bug 4431868
+ * @key headful
+ * @summary Tests that window totally obscured by its child doesn't receive
+ *          enter/exit events when located over another frame
+ * @run main MouseEnterExitTest4
+ */
+
+public class MouseEnterExitTest4 {
+    static Button button = new Button("Button");
+    static Frame frame = new Frame("Mouse Enter/Exit test");
+    static Window window = new Window(frame);
+    static MouseListener listener = new MouseAdapter() {
+        public void mouseEntered(MouseEvent e) {
+            throw new RuntimeException("Test failed due to Mouse Enter event");
+        }
+
+        public void mouseExited(MouseEvent e) {
+            throw new RuntimeException("Test failed due to Mouse Exit event");
+        }
+    };
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        robot.setAutoDelay(100);
+        try {
+            EventQueue.invokeAndWait(() -> {
+                button.setBackground(Color.red);
+                window.add(button);
+                frame.setBounds(100, 100, 300, 300);
+                window.setBounds(200, 200, 100, 100);
+                window.addMouseListener(listener);
+                window.setVisible(true);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(200);
+            EventQueue.invokeAndWait(() -> robot.mouseMove(
+                    frame.getLocationOnScreen().x + frame.getSize().width / 2,
+                    frame.getLocationOnScreen().y + frame.getSize().height / 2));
+            robot.waitForIdle();
+            robot.delay(200);
+            EventQueue.invokeAndWait(() -> robot.mouseMove(
+                    window.getLocationOnScreen().x + window.getSize().width * 2,
+                    window.getLocationOnScreen().y + window.getSize().height / 2));
+            robot.waitForIdle();
+            robot.delay(500);
+            System.out.println("Test Passed");
+
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+               if (frame != null) {
+                   frame.dispose();
+               }
+               if (window != null) {
+                   window.dispose();
+               }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/Mouse/MousePressedTest.java
+++ b/test/jdk/java/awt/Mouse/MousePressedTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Container;
+import java.awt.GridLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JScrollPane;
+import javax.swing.JToggleButton;
+
+/*
+ * @test
+ * @bug 4268759
+ * @summary Tests whether clicking on the edge of a lightweight button
+ *          causes sticking behavior
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MousePressedTest
+ */
+
+public class MousePressedTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Click and hold on the very bottom border (2-pixel-wide border) of the
+                   JButton. Then drag the mouse straight down out of the JButton and
+                   into the JRadioButton, and release the mouse button
+                2. If the component remains highlighted as if the mouse button is still
+                   down, the test fails
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(initialize())
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFrame initialize() {
+        JFrame f = new JFrame("JButton Test");
+        JPanel p = new JPanel();
+        p.setLayout(new GridLayout(2, 2));
+        JButton b = new JButton("JButton");
+        p.add(b);
+        JCheckBox cb = new JCheckBox("JCheckBox");
+        p.add(cb);
+        JRadioButton rb = new JRadioButton("JRadioButton");
+        p.add(rb);
+        p.add(new JToggleButton("JToggleButton"));
+
+        JScrollPane j = new JScrollPane(p,
+                JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
+
+        Container c = f.getContentPane();
+        c.setLayout(new GridLayout(1, 1));
+        c.add(j);
+        f.pack();
+        return f;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8339836](https://bugs.openjdk.org/browse/JDK-8339836) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339836](https://bugs.openjdk.org/browse/JDK-8339836): Open source several AWT Mouse tests - Batch 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1636/head:pull/1636` \
`$ git checkout pull/1636`

Update a local copy of the PR: \
`$ git checkout pull/1636` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1636`

View PR using the GUI difftool: \
`$ git pr show -t 1636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1636.diff">https://git.openjdk.org/jdk21u-dev/pull/1636.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1636#issuecomment-2795087184)
</details>
