### PR TITLE
8353709: Debug symbols bundle should contain full debug files when building --with-external-symbols-in-bundles=public

### DIFF
--- a/make/Bundles.gmk
+++ b/make/Bundles.gmk
@@ -242,7 +242,10 @@ ifneq ($(filter product-bundles% legacy-bundles, $(MAKECMDGOALS)), )
       )
 
   JDK_SYMBOLS_BUNDLE_FILES := \
-      $(call FindFiles, $(SYMBOLS_IMAGE_DIR))
+      $(filter-out \
+          %.stripped.pdb, \
+          $(call FindFiles, $(SYMBOLS_IMAGE_DIR)) \
+      )
 
   TEST_DEMOS_BUNDLE_FILES := $(filter $(JDK_DEMOS_IMAGE_HOMEDIR)/demo/%, \
       $(ALL_JDK_DEMOS_FILES))


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8353709](https://bugs.openjdk.org/browse/JDK-8353709), commit [ef58a805](https://github.com/openjdk/jdk24u/commit/ef58a805c1f71b00bf61f05ffdcca66264094f5b) from the [openjdk/jdk24u](https://git.openjdk.org/jdk24u) repository.

The commit being backported was authored by Christoph Langer on 10 Apr 2025 and had no reviewers.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353709](https://bugs.openjdk.org/browse/JDK-8353709) needs maintainer approval

### Issue
 * [JDK-8353709](https://bugs.openjdk.org/browse/JDK-8353709): Debug symbols bundle should contain full debug files when building --with-external-symbols-in-bundles=public (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1640/head:pull/1640` \
`$ git checkout pull/1640`

Update a local copy of the PR: \
`$ git checkout pull/1640` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1640`

View PR using the GUI difftool: \
`$ git pr show -t 1640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1640.diff">https://git.openjdk.org/jdk21u-dev/pull/1640.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1640#issuecomment-2796256413)
</details>
