### PR TITLE
8342633: javax/management/security/HashedPasswordFileTest.java creates tmp file in src dir

### DIFF
--- a/test/jdk/javax/management/security/HashedPasswordFileTest.java
+++ b/test/jdk/javax/management/security/HashedPasswordFileTest.java
@@ -110,9 +110,7 @@ public class HashedPasswordFileTest {
     }
 
     private String getPasswordFilePath() {
-        String testDir = System.getProperty("test.src");
-        String testFileName = "jmxremote.password";
-        return testDir + File.separator + testFileName;
+        return "jmxremote.password";
     }
 
     private File createNewPasswordFile() throws IOException {


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342633](https://bugs.openjdk.org/browse/JDK-8342633) needs maintainer approval

### Issue
 * [JDK-8342633](https://bugs.openjdk.org/browse/JDK-8342633): javax/management/security/HashedPasswordFileTest.java creates tmp file in src dir (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1643/head:pull/1643` \
`$ git checkout pull/1643`

Update a local copy of the PR: \
`$ git checkout pull/1643` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1643`

View PR using the GUI difftool: \
`$ git pr show -t 1643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1643.diff">https://git.openjdk.org/jdk21u-dev/pull/1643.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1643#issuecomment-2797188021)
</details>
