### PR TITLE
8353138: Screen capture for test TaskbarPositionTest.java, failure case

### DIFF
--- a/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
+++ b/test/jdk/javax/swing/Popup/TaskbarPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,11 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
 
+import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
@@ -337,11 +341,11 @@ public class TaskbarPositionTest implements ActionListener {
             }
         }
 
-        try {
-            // Use Robot to automate the test
-            Robot robot = new Robot();
-            robot.setAutoDelay(50);
+        // Use Robot to automate the test
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
 
+        try {
             SwingUtilities.invokeAndWait(TaskbarPositionTest::new);
 
             robot.waitForIdle();
@@ -442,12 +446,28 @@ public class TaskbarPositionTest implements ActionListener {
             hidePopup(robot);
 
             robot.waitForIdle();
+        } catch (Throwable t) {
+            saveScreenCapture(robot, screens);
+            throw t;
         } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();
                 }
             });
+        }
+    }
+
+    private static void saveScreenCapture(Robot robot, GraphicsDevice[] screens) {
+        for (int i = 0; i < screens.length; i++) {
+            Rectangle bounds = screens[i].getDefaultConfiguration()
+                    .getBounds();
+            BufferedImage image = robot.createScreenCapture(bounds);
+            try {
+                ImageIO.write(image, "png", new File("Screenshot.png"));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353138](https://bugs.openjdk.org/browse/JDK-8353138) needs maintainer approval

### Issue
 * [JDK-8353138](https://bugs.openjdk.org/browse/JDK-8353138): Screen capture for test TaskbarPositionTest.java, failure case (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1647/head:pull/1647` \
`$ git checkout pull/1647`

Update a local copy of the PR: \
`$ git checkout pull/1647` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1647`

View PR using the GUI difftool: \
`$ git pr show -t 1647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1647.diff">https://git.openjdk.org/jdk21u-dev/pull/1647.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1647#issuecomment-2800090488)
</details>
