### PR TITLE
8333326: Linux Alpine build fails after 8302744

### DIFF
--- a/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
@@ -34,6 +34,9 @@
 
 #include <stdio.h>
 
+// for basename
+#include <libgen.h>
+
 typedef struct {
   const char* mount_path;
   const char* root_path;
@@ -47,6 +50,7 @@ static bool file_exists(const char* filename) {
   return os::stat(filename, &st) == 0;
 }
 
+// we rely on temp_file returning modifiable memory in resource area.
 static char* temp_file(const char* prefix) {
   const testing::TestInfo* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
   stringStream path;
@@ -89,7 +93,7 @@ static void fill_file(const char* path, const char* content) {
 }
 
 TEST(cgroupTest, read_numerical_key_value_failure_cases) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -135,7 +139,7 @@ TEST(cgroupTest, read_numerical_key_value_failure_cases) {
 }
 
 TEST(cgroupTest, read_numerical_key_value_success_cases) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -235,7 +239,7 @@ TEST(cgroupTest, read_numerical_key_value_null) {
 }
 
 TEST(cgroupTest, read_number_tests) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   constexpr julong bad = 0xBAD;
   EXPECT_TRUE(b != nullptr) << "basename was null";
@@ -289,7 +293,7 @@ TEST(cgroupTest, read_number_tests) {
 }
 
 TEST(cgroupTest, read_string_tests) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -355,7 +359,7 @@ TEST(cgroupTest, read_string_tests) {
 }
 
 TEST(cgroupTest, read_number_tuple_test) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;


### PR DESCRIPTION
A patch 2 of 6 for: [[21u] Backport intention of 8322420: [Linux] cgroup v2: Limits in parent nested control groups are not detected](https://mail.openjdk.org/pipermail/jdk-updates-dev/2025-April/043206.html)

It has a patch dependency on PR 1 of 6: https://github.com/openjdk/jdk21u-dev/pull/1648

This backport is clean.

The whole patchset has been tested on CentOS-7.9 (for cgroup v1) and on Fedora 40 (for cgroup v2) for test/hotspot/jtreg/containers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8333326](https://bugs.openjdk.org/browse/JDK-8333326) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #1648 must be integrated first

### Issue
 * [JDK-8333326](https://bugs.openjdk.org/browse/JDK-8333326): Linux Alpine build fails after 8302744 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1660/head:pull/1660` \
`$ git checkout pull/1660`

Update a local copy of the PR: \
`$ git checkout pull/1660` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1660`

View PR using the GUI difftool: \
`$ git pr show -t 1660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1660.diff">https://git.openjdk.org/jdk21u-dev/pull/1660.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1660#issuecomment-2809101862)
</details>
