### PR TITLE
8338236: Compile error in cgroup code on Linux when using clang

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ class CgroupV1Controller: public CgroupController {
 
     void set_subsystem_path(char *cgroup_path);
     char *subsystem_path() override { return _path; }
-    bool is_read_only() { return _read_only; }
+    bool is_read_only() override { return _read_only; }
 };
 
 class CgroupV1MemoryController final : public CgroupMemoryController {

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Red Hat Inc.
+ * Copyright (c) 2020, 2024, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,8 +125,8 @@ class CgroupV2Subsystem: public CgroupSubsystem {
     const char * container_type() override {
       return "cgroupv2";
     }
-    CachingCgroupController<CgroupMemoryController>* memory_controller() { return _memory; }
-    CachingCgroupController<CgroupCpuController>* cpu_controller() { return _cpu; }
+    CachingCgroupController<CgroupMemoryController>* memory_controller() override { return _memory; }
+    CachingCgroupController<CgroupCpuController>* cpu_controller() override { return _cpu; }
 };
 
 #endif // CGROUP_V2_SUBSYSTEM_LINUX_HPP


### PR DESCRIPTION
A patch 5 of 6 for: [[21u] Backport intention of 8322420: [Linux] cgroup v2: Limits in parent nested control groups are not detected](https://mail.openjdk.org/pipermail/jdk-updates-dev/2025-April/043206.html)

It has a patch dependency on PR 4 of 6: https://github.com/openjdk/jdk21u-dev/pull/1662

This backport is clean.

The whole patchset has been tested on CentOS-7.9 (for cgroup v1) and on Fedora 40 (for cgroup v2) for test/hotspot/jtreg/containers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8338236](https://bugs.openjdk.org/browse/JDK-8338236) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1662 must be integrated first

### Issue
 * [JDK-8338236](https://bugs.openjdk.org/browse/JDK-8338236): Compile error in cgroup code on Linux when using clang (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1663/head:pull/1663` \
`$ git checkout pull/1663`

Update a local copy of the PR: \
`$ git checkout pull/1663` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1663`

View PR using the GUI difftool: \
`$ git pr show -t 1663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1663.diff">https://git.openjdk.org/jdk21u-dev/pull/1663.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1663#issuecomment-2809225292)
</details>
