### PR TITLE
8321053: Use ByteArrayInputStream.buf directly when parameter of transferTo() is trusted

### DIFF
--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -207,10 +207,25 @@ public class ByteArrayInputStream extends InputStream {
     public synchronized long transferTo(OutputStream out) throws IOException {
         int len = count - pos;
         if (len > 0) {
+            // 'tmpbuf' is null if and only if 'out' is trusted
+            byte[] tmpbuf;
+            Class<?> outClass = out.getClass();
+            if (outClass == ByteArrayOutputStream.class ||
+                outClass == FileOutputStream.class ||
+                outClass == PipedOutputStream.class)
+                tmpbuf = null;
+            else
+                tmpbuf = new byte[Integer.min(len, MAX_TRANSFER_SIZE)];
+
             int nwritten = 0;
             while (nwritten < len) {
                 int nbyte = Integer.min(len - nwritten, MAX_TRANSFER_SIZE);
-                out.write(buf, pos, nbyte);
+                // if 'out' is not trusted, transfer via a temporary buffer
+                if (tmpbuf != null) {
+                    System.arraycopy(buf, pos, tmpbuf, 0, nbyte);
+                    out.write(tmpbuf, 0, nbyte);
+                } else
+                    out.write(buf, pos, nbyte);
                 pos += nbyte;
                 nwritten += nbyte;
             }

--- a/test/jdk/java/io/ByteArrayInputStream/TransferToTrusted.java
+++ b/test/jdk/java/io/ByteArrayInputStream/TransferToTrusted.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8321053
+ * @summary Verify ByteArrayInputStream.buf is used directly by
+ *          ByteArrayInputStream.transferTo only when its OutputStream
+ *          parameter is trusted
+ * @key randomness
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Random;
+
+public class TransferToTrusted {
+    private static final Random RND = new Random(System.nanoTime());
+
+    private static class UntrustedOutputStream extends OutputStream {
+        UntrustedOutputStream() {
+            super();
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            Objects.checkFromIndexSize(off, len, b.length);
+            byte[] tmp = new byte[len];
+            RND.nextBytes(tmp);
+            System.arraycopy(tmp, 0, b, off, len);
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            write(new byte[] {(byte)b});
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        byte[] buf = new byte[RND.nextInt(1025)];
+        System.out.println("buf.length: " + buf.length);
+        RND.nextBytes(buf);
+        byte[] dup = Arrays.copyOf(buf, buf.length);
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(dup);
+        bais.mark(dup.length);
+
+        OutputStream[] outputStreams = new OutputStream[] {
+            new ByteArrayOutputStream(),
+            new UntrustedOutputStream()
+        };
+
+        for (OutputStream out : outputStreams) {
+            System.err.println("out: " + out.getClass().getName());
+
+            bais.transferTo(out);
+            bais.reset();
+            try {
+                if (!Arrays.equals(buf, bais.readAllBytes()))
+                    throw new RuntimeException("Internal buffer was modified");
+            } finally {
+                out.close();
+            }
+            bais.reset();
+        }
+    }
+}


### PR DESCRIPTION
Clean backport. Fixes bug with ByteArrayInputStream.transferTo(OutputStream) passing ByteArrayInputStream.buf to OutputStream parameters not in package java.io. Change passes added `test/jdk/java/io/ByteArrayInputStream/TransferToTrusted.java` on linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8321053](https://bugs.openjdk.org/browse/JDK-8321053) needs maintainer approval

### Issue
 * [JDK-8321053](https://bugs.openjdk.org/browse/JDK-8321053): Use ByteArrayInputStream.buf directly when parameter of transferTo() is trusted (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1669/head:pull/1669` \
`$ git checkout pull/1669`

Update a local copy of the PR: \
`$ git checkout pull/1669` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1669`

View PR using the GUI difftool: \
`$ git pr show -t 1669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1669.diff">https://git.openjdk.org/jdk21u-dev/pull/1669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1669#issuecomment-2810964898)
</details>
