### PR TITLE
8352512: TestVectorZeroCount: counter not reset between iterations

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
@@ -50,8 +50,13 @@ public class TestVectorZeroCount {
     private static final long[] LONG_EXPECTED_TRAILING = new long[SIZE];
     private static final long[] LONG_RESULT_TRAILING = new long[SIZE];
 
-    private static int intCounter = Integer.MIN_VALUE;
-    private static int longIterations = 100_000_000;
+    private static final int INT_START_INDEX  = Integer.MIN_VALUE;
+    private static final int INT_END_INDEX    = Integer.MAX_VALUE;
+    private static final int LONG_START_INDEX = 0;
+    private static final int LONG_END_INDEX   = 100_000_000;
+
+    private static int intCounter;
+    private static int longCounter;
 
     public static boolean testInt() {
         boolean done = false;
@@ -59,7 +64,7 @@ public class TestVectorZeroCount {
         // Non-vectorized loop as baseline (not vectorized because source array is initialized)
         for (int i = 0; i < SIZE; ++i) {
             INT_VALUES[i] = intCounter++;
-            if (intCounter == Integer.MAX_VALUE) {
+            if (intCounter == INT_END_INDEX) {
                 done = true;
             }
             INT_EXPECTED_LEADING[i] = Integer.numberOfLeadingZeros(INT_VALUES[i]);
@@ -92,7 +97,7 @@ public class TestVectorZeroCount {
         for (int i = 0; i < SIZE; ++i) {
             // Use random values because the long range is too large to iterate over it
             LONG_VALUES[i] = RANDOM.nextLong();
-            if (longIterations-- == 0) {
+            if (longCounter++ == LONG_END_INDEX) {
                 done = true;
             }
             LONG_EXPECTED_LEADING[i] = Long.numberOfLeadingZeros(LONG_VALUES[i]);
@@ -121,6 +126,8 @@ public class TestVectorZeroCount {
     public static void main(String[] args) {
         // Run twice to make sure compiled code is used from the beginning
         for (int i = 0; i < 2; ++i) {
+            intCounter = INT_START_INDEX;
+            longCounter = LONG_START_INDEX;
             while (!testLong()) ;
             while (!testInt()) ;
         }


### PR DESCRIPTION
Clean backport of [JDK-8352512](https://bugs.openjdk.org/browse/JDK-8352512).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352512](https://bugs.openjdk.org/browse/JDK-8352512) needs maintainer approval

### Issue
 * [JDK-8352512](https://bugs.openjdk.org/browse/JDK-8352512): TestVectorZeroCount: counter not reset between iterations (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1672/head:pull/1672` \
`$ git checkout pull/1672`

Update a local copy of the PR: \
`$ git checkout pull/1672` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1672`

View PR using the GUI difftool: \
`$ git pr show -t 1672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1672.diff">https://git.openjdk.org/jdk21u-dev/pull/1672.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1672#issuecomment-2812369855)
</details>
