### PR TITLE
8329729: java/util/Properties/StoreReproducibilityTest.java times out

### DIFF
--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,9 @@ import java.util.TimeZone;
  * @test
  * @summary Tests that the Properties.store() APIs generate output that is reproducible
  * @bug 8231640 8282023 8316540
+ * @comment The test launches several processes and in the presence of -Xcomp it's too slow
+ *          and thus causes timeouts
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @run driver StoreReproducibilityTest
  */


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329729](https://bugs.openjdk.org/browse/JDK-8329729) needs maintainer approval

### Issue
 * [JDK-8329729](https://bugs.openjdk.org/browse/JDK-8329729): java/util/Properties/StoreReproducibilityTest.java times out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1679/head:pull/1679` \
`$ git checkout pull/1679`

Update a local copy of the PR: \
`$ git checkout pull/1679` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1679`

View PR using the GUI difftool: \
`$ git pr show -t 1679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1679.diff">https://git.openjdk.org/jdk21u-dev/pull/1679.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1679#issuecomment-2813536945)
</details>
