### PR TITLE
8353787: Increased number of SHA-384-Digest java.util.jar.Attributes$Name instances leading to higher memory footprint

### DIFF
--- a/src/java.base/share/classes/java/util/jar/Attributes.java
+++ b/src/java.base/share/classes/java/util/jar/Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -726,6 +726,7 @@ public class Attributes implements Map<Object,Object>, Cloneable {
                 addName(names, new Name("Created-By"));
                 addName(names, new Name("SHA1-Digest"));
                 addName(names, new Name("SHA-256-Digest"));
+                addName(names, new Name("SHA-384-Digest"));
                 KNOWN_NAMES = Map.copyOf(names);
             } else {
                 // Even if KNOWN_NAMES was read from archive, we still need


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

Resolved Copyright, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353787](https://bugs.openjdk.org/browse/JDK-8353787) needs maintainer approval

### Issue
 * [JDK-8353787](https://bugs.openjdk.org/browse/JDK-8353787): Increased number of SHA-384-Digest java.util.jar.Attributes$Name instances leading to higher memory footprint (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1680/head:pull/1680` \
`$ git checkout pull/1680`

Update a local copy of the PR: \
`$ git checkout pull/1680` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1680`

View PR using the GUI difftool: \
`$ git pr show -t 1680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1680.diff">https://git.openjdk.org/jdk21u-dev/pull/1680.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1680#issuecomment-2815075418)
</details>
