### PR TITLE
8314136: Test java/net/httpclient/CancelRequestTest.java failed: WARNING: tracker for HttpClientImpl(42) has outstanding operations

### DIFF
--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -35,9 +35,6 @@
  */
 // *                     -Dseed=3582896013206826205L
 // *                     -Dseed=5784221742235559231L
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
 import jdk.internal.net.http.common.OperationTrackers.Tracker;
 import jdk.test.lib.RandomFactory;
 import jdk.test.lib.net.SimpleSSLContext;
@@ -56,8 +53,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.Reference;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpConnectTimeoutException;
@@ -80,17 +75,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 
-import static java.lang.System.arraycopy;
 import static java.lang.System.out;
 import static java.lang.System.err;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class CancelRequestTest implements HttpServerAdapters {
@@ -179,19 +172,19 @@ public class CancelRequestTest implements HttpServerAdapters {
     }
 
     @AfterClass
-    static final void printFailedTests(ITestContext context) {
+    static void printFailedTests(ITestContext context) {
         out.println("\n=========================");
         var failed = context.getFailedTests().getAllResults().stream()
-                .collect(Collectors.toMap(r -> name(r), ITestResult::getThrowable));
+                .collect(Collectors.toMap(CancelRequestTest::name, ITestResult::getThrowable));
         FAILURES.putAll(failed);
         try {
             out.printf("%n%sCreated %d servers and %d clients%n",
                     now(), serverCount.get(), clientCount.get());
             if (FAILURES.isEmpty()) return;
             out.println("Failed tests: ");
-            FAILURES.entrySet().forEach((e) -> {
-                out.printf("\t%s: %s%n", e.getKey(), e.getValue());
-                e.getValue().printStackTrace(out);
+            FAILURES.forEach((key, value) -> {
+                out.printf("\t%s: %s%n", key, value);
+                value.printStackTrace(out);
             });
             if (tasksFailed) {
                 System.out.println("WARNING: Some tasks failed");
@@ -327,7 +320,7 @@ public class CancelRequestTest implements HttpServerAdapters {
             out.println("cf2 after cancel: " + cf2);
             try {
                 String body = cf2.get().body();
-                assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
+                assertEquals(body, String.join("", BODY.split("\\|")));
                 throw new AssertionError("Expected CancellationException not received");
             } catch (ExecutionException x) {
                 out.println("Got expected exception: " + x);
@@ -348,14 +341,14 @@ public class CancelRequestTest implements HttpServerAdapters {
             // completed yet - so wait for it here...
             try {
                 String body = response.get().body();
-                assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
+                assertEquals(body, String.join("", BODY.split("\\|")));
                 if (mayInterruptIfRunning) {
                     // well actually - this could happen... In which case we'll need to
                     // increase the latency in the server handler...
                     throw new AssertionError("Expected Exception not received");
                 }
             } catch (ExecutionException x) {
-                assertEquals(response.isDone(), true);
+                assertTrue(response.isDone());
                 Throwable wrapped = x.getCause();
                 Throwable cause = wrapped;
                 if (mayInterruptIfRunning) {
@@ -383,11 +376,11 @@ public class CancelRequestTest implements HttpServerAdapters {
                 }
             }
 
-            assertEquals(response.isDone(), true);
-            assertEquals(response.isCancelled(), false);
+            assertTrue(response.isDone());
+            assertFalse(response.isCancelled());
             assertEquals(cf1.isCancelled(), hasCancellationException);
-            assertEquals(cf2.isDone(), true);
-            assertEquals(cf2.isCancelled(), false);
+            assertTrue(cf2.isDone());
+            assertFalse(cf2.isCancelled());
             assertEquals(latch.getCount(), 0);
 
             var error = TRACKER.check(tracker, 1000,
@@ -397,6 +390,8 @@ public class CancelRequestTest implements HttpServerAdapters {
             Reference.reachabilityFence(client);
             if (error != null) throw error;
         }
+        assert client != null;
+        if (!sameClient) client.close();
     }
 
     @Test(dataProvider = "asyncurls")
@@ -413,7 +408,7 @@ public class CancelRequestTest implements HttpServerAdapters {
 
             CompletableFuture<CompletableFuture<?>> cancelFuture = new CompletableFuture<>();
 
-            Iterable<byte[]> iterable = new Iterable<byte[]>() {
+            Iterable<byte[]> iterable = new Iterable<>() {
                 @Override
                 public Iterator<byte[]> iterator() {
                     // this is dangerous
@@ -448,7 +443,7 @@ public class CancelRequestTest implements HttpServerAdapters {
             out.println("cf2 after cancel: " + cf2);
             try {
                 String body = cf2.get().body();
-                assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
+                assertEquals(body, String.join("", BODY.split("\\|")));
                 throw new AssertionError("Expected CancellationException not received");
             } catch (ExecutionException x) {
                 out.println("Got expected exception: " + x);
@@ -469,14 +464,14 @@ public class CancelRequestTest implements HttpServerAdapters {
             // completed yet - so wait for it here...
             try {
                 String body = response.get().body();
-                assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
+                assertEquals(body, String.join("", BODY.split("\\|")));
                 if (mayInterruptIfRunning) {
                     // well actually - this could happen... In which case we'll need to
                     // increase the latency in the server handler...
                     throw new AssertionError("Expected Exception not received");
                 }
             } catch (ExecutionException x) {
-                assertEquals(response.isDone(), true);
+                assertTrue(response.isDone());
                 Throwable wrapped = x.getCause();
                 assertTrue(CancellationException.class.isAssignableFrom(wrapped.getClass()));
                 Throwable cause = wrapped.getCause();
@@ -495,11 +490,11 @@ public class CancelRequestTest implements HttpServerAdapters {
                 }
             }
 
-            assertEquals(response.isDone(), true);
-            assertEquals(response.isCancelled(), false);
+            assertTrue(response.isDone());
+            assertFalse(response.isCancelled());
             assertEquals(cf1.isCancelled(), hasCancellationException);
-            assertEquals(cf2.isDone(), true);
-            assertEquals(cf2.isCancelled(), false);
+            assertTrue(cf2.isDone());
+            assertFalse(cf2.isCancelled());
             assertEquals(latch.getCount(), 0);
 
             var error = TRACKER.check(tracker, 1000,
@@ -509,6 +504,8 @@ public class CancelRequestTest implements HttpServerAdapters {
             Reference.reachabilityFence(client);
             if (error != null) throw error;
         }
+        assert client != null;
+        if (!sameClient) client.close();
     }
 
     @Test(dataProvider = "urls")
@@ -572,17 +569,19 @@ public class CancelRequestTest implements HttpServerAdapters {
             } else {
                 assert failed == null;
                 out.println(uriStr + ": got body: " + body);
-                assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
+                assertEquals(body, String.join("", BODY.split("\\|")));
             }
             out.println("next iteration");
 
-            var error = TRACKER.check(tracker, 1000,
+            var error = TRACKER.check(tracker, 2000,
                     (t) -> t.getOutstandingOperations() > 0 || t.getOutstandingSubscribers() > 0,
                     "subscribers for testPostInterrupt(%s)\n\t step [%s]".formatted(req.uri(), i),
                     false);
             Reference.reachabilityFence(client);
             if (error != null) throw error;
         }
+        assert client != null;
+        if (!sameClient) client.close();
     }
 
 


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314136](https://bugs.openjdk.org/browse/JDK-8314136) needs maintainer approval

### Issue
 * [JDK-8314136](https://bugs.openjdk.org/browse/JDK-8314136): Test java/net/httpclient/CancelRequestTest.java failed: WARNING: tracker for HttpClientImpl(42) has outstanding operations (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1686/head:pull/1686` \
`$ git checkout pull/1686`

Update a local copy of the PR: \
`$ git checkout pull/1686` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1686`

View PR using the GUI difftool: \
`$ git pr show -t 1686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1686.diff">https://git.openjdk.org/jdk21u-dev/pull/1686.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1686#issuecomment-2818041931)
</details>
