### PR TITLE
8332641: Update nsk.share.jpda.Jdb to don't use finalization

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Jdb.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Jdb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 package nsk.share.jdb;
 
 import nsk.share.*;
-import nsk.share.jpda.*;
 
 import java.util.*;
 import java.io.*;
@@ -36,7 +35,7 @@ import java.util.regex.*;
  * This class provides abilities to launch it, to send command,
  * to read reply on the command, to set breakpoint on entry in debugggee's method.
  */
-public class Jdb extends LocalProcess implements Finalizable {
+public class Jdb extends LocalProcess {
     /** File to log <i>stdout</i> stream */
     static final String JDB_STDOUT_FILE = "jdb.stdout";
     /** File to log <i>stderr</i> stream */
@@ -95,11 +94,8 @@ public class Jdb extends LocalProcess implements Finalizable {
         return launcher;
     }
 
-    public void finalizeAtExit() throws Throwable {
-        finalize();
-    }
 
-    public void finalize() throws Throwable {
+    public void close() {
         if (fout != null) {
 //            fout.flush();
             fout.close();
@@ -116,7 +112,6 @@ public class Jdb extends LocalProcess implements Finalizable {
         if (jdbStderrReader != null) {
             jdbStderrReader.close();
         }
-        super.finalize();
     }
 
     /** Create <i>Jdb</i> object. */
@@ -961,10 +956,10 @@ public class Jdb extends LocalProcess implements Finalizable {
 
                     System.out.println("Unsuccessful launch of attaching jdb. Next try...");
                     try {
-                        jdb.finalize();
+                        jdb.close();
                     } catch (Throwable t) {
                         t.printStackTrace(getLauncher().getLog().getOutStream());
-                        throw new Failure("Caught unexpected error while finalizing jdb: " + t);
+                        throw new Failure("Caught unexpected error while closing jdb streams: " + t);
                     }
                     break;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,8 @@
 package nsk.share.jdb;
 
 import nsk.share.*;
-import nsk.share.jpda.*;
 
 import java.io.*;
-import java.util.*;
 
 public abstract class JdbTest {
     public static final int PASSED = 0;            // Exit code for passed test
@@ -174,6 +172,14 @@ public abstract class JdbTest {
                     } else {
                         failure("jdb abnormally exited with code: " + code);
                     }
+
+                    try {
+                        jdb.close();
+                    } catch (Throwable ex) {
+                        failure("Caught exception/error while closing jdb streams:\n\t" + ex);
+                        ex.printStackTrace(log.getOutStream());
+                    }
+
                     jdb = null;
 
                     if (debuggee != null
@@ -204,19 +210,19 @@ public abstract class JdbTest {
 
                 if (jdb != null) {
                     try {
-                        jdb.finalize();
+                        jdb.close();
                     } catch (Throwable ex) {
-                        failure("Caught exception/error while finalization of jdb:\n\t" + ex);
+                        failure("Caught exception/error while closing jdb streams:\n\t" + ex);
                         ex.printStackTrace(log.getOutStream());
                     }
                 } else {
-                    log.complain("jdb reference is null, cannot run jdb.finalize() method");
+                    log.complain("jdb reference is null, cannot run jdb.close() method");
                 }
 
                 if (debuggee != null) {
                     debuggee.killDebuggee();
                 } else {
-                    log.complain("debuggee reference is null, cannot run debuggee.finalize() method");
+                    log.complain("debuggee reference is null, cannot run debuggee.killDebuggee() method");
                 }
 
             }


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332641](https://bugs.openjdk.org/browse/JDK-8332641) needs maintainer approval

### Issue
 * [JDK-8332641](https://bugs.openjdk.org/browse/JDK-8332641): Update nsk.share.jpda.Jdb to don't use finalization (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1688/head:pull/1688` \
`$ git checkout pull/1688`

Update a local copy of the PR: \
`$ git checkout pull/1688` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1688`

View PR using the GUI difftool: \
`$ git pr show -t 1688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1688.diff">https://git.openjdk.org/jdk21u-dev/pull/1688.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1688#issuecomment-2818062361)
</details>
