### PR TITLE
8325680: Uninitialised memory in deleteGSSCB of GSSLibStub.c:179

### DIFF
--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -196,7 +196,10 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
     return GSS_C_NO_CHANNEL_BINDINGS;
   }
 
-  cb = malloc(sizeof(struct gss_channel_bindings_struct));
+  // initialize cb as zeroes to avoid uninitialized pointer being
+  // freed when deleteGSSCB is called at cleanup.
+  cb = calloc(1, sizeof(struct gss_channel_bindings_struct));
+
   if (cb == NULL) {
     gssThrowOutOfMemoryError(env, NULL);
     return NULL;
@@ -216,9 +219,6 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
       cb->initiator_addrtype = GSS_C_AF_NULLADDR;
       cb->acceptor_addrtype = GSS_C_AF_NULLADDR;
   }
-  // addresses needs to be initialized to empty
-  memset(&cb->initiator_address, 0, sizeof(cb->initiator_address));
-  memset(&cb->acceptor_address, 0, sizeof(cb->acceptor_address));
 
   /* set up initiator address */
   jinetAddr = (*env)->CallObjectMethod(env, jcb,


### PR DESCRIPTION
Backporting JDK-8325680: Uninitialised memory in deleteGSSCB of GSSLibStub.c:179. This patch addresses the issue by using `calloc` in place of `malloc` and removes a couple redundant lines. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325680](https://bugs.openjdk.org/browse/JDK-8325680) needs maintainer approval

### Issue
 * [JDK-8325680](https://bugs.openjdk.org/browse/JDK-8325680): Uninitialised memory in deleteGSSCB of GSSLibStub.c:179 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1689/head:pull/1689` \
`$ git checkout pull/1689`

Update a local copy of the PR: \
`$ git checkout pull/1689` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1689`

View PR using the GUI difftool: \
`$ git pr show -t 1689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1689.diff">https://git.openjdk.org/jdk21u-dev/pull/1689.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1689#issuecomment-2821872827)
</details>
