### PR TITLE
8322141: SequenceInputStream.transferTo should not return as soon as Long.MAX_VALUE bytes have been transferred

### DIFF
--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -242,11 +242,14 @@ public class SequenceInputStream extends InputStream {
         if (getClass() == SequenceInputStream.class) {
             long transferred = 0;
             while (in != null) {
+                long numTransferred = in.transferTo(out);
+                // increment the total transferred byte count
+                // only if we haven't already reached the Long.MAX_VALUE
                 if (transferred < Long.MAX_VALUE) {
                     try {
-                        transferred = Math.addExact(transferred, in.transferTo(out));
+                        transferred = Math.addExact(transferred, numTransferred);
                     } catch (ArithmeticException ignore) {
-                        return Long.MAX_VALUE;
+                        transferred = Long.MAX_VALUE;
                     }
                 }
                 nextStream();


### PR DESCRIPTION
Backporting JDK-8322141: SequenceInputStream.transferTo should not return as soon as Long.MAX_VALUE bytes have been transferred. Addresses bug in `SequenceInputStream.transferTo()` and adds test. Ran GHA Sanity Checks, local Tier 1 and 2, and new `test/jdk/java/io/SequenceInputStream/TransferTo.java` tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322141](https://bugs.openjdk.org/browse/JDK-8322141) needs maintainer approval

### Issue
 * [JDK-8322141](https://bugs.openjdk.org/browse/JDK-8322141): SequenceInputStream.transferTo should not return as soon as Long.MAX_VALUE bytes have been transferred (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1693/head:pull/1693` \
`$ git checkout pull/1693`

Update a local copy of the PR: \
`$ git checkout pull/1693` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1693`

View PR using the GUI difftool: \
`$ git pr show -t 1693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1693.diff">https://git.openjdk.org/jdk21u-dev/pull/1693.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1693#issuecomment-2822231423)
</details>
