### PR TITLE
8320948: NPE due to unreported compiler error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -1089,7 +1089,10 @@ public class DeferredAttr extends JCTree.Visitor {
             boolean isLambdaOrMemberRef =
                     dt.tree.hasTag(REFERENCE) || dt.tree.hasTag(LAMBDA);
             boolean needsRecoveryType =
-                    pt == null || (isLambdaOrMemberRef && !types.isFunctionalInterface(pt));
+                    pt == null ||
+                            ((dt instanceof ArgumentAttr.ArgumentType<?> at) &&
+                            at.speculativeTypes.values().stream().allMatch(type -> type.hasTag(ERROR))) ||
+                            (isLambdaOrMemberRef && !types.isFunctionalInterface(pt));
             Type ptRecovery = needsRecoveryType ? Type.recoveryType: pt;
             dt.check(attr.new RecoveryInfo(deferredAttrContext, ptRecovery) {
                 @Override

--- a/test/langtools/tools/javac/recovery/CrashDueToUnreportedError.java
+++ b/test/langtools/tools/javac/recovery/CrashDueToUnreportedError.java
@@ -1,0 +1,29 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8320948
+ * @summary NPE due to unreported compiler error
+ * @compile/fail/ref=CrashDueToUnreportedError.out -XDrawDiagnostics CrashDueToUnreportedError.java
+ */
+
+import java.util.List;
+
+public class CrashDueToUnreportedError {
+    class Builder {
+        private Builder(Person person, String unused) {}
+        public Builder withTypes(Entity<String> entities) {
+            return new Builder(Person.make(Entity.combineAll(entities)));
+        }
+    }
+
+    interface Person {
+        static <E> Person make(List<? extends Entity<E>> eventSubtypes) {
+            return null;
+        }
+    }
+
+    class Entity<E> {
+        public static <Root> List<? extends Entity<Root>> combineAll(Entity<Root> subtypes) {
+            return null;
+        }
+    }
+}

--- a/test/langtools/tools/javac/recovery/CrashDueToUnreportedError.out
+++ b/test/langtools/tools/javac/recovery/CrashDueToUnreportedError.out
@@ -1,0 +1,2 @@
+CrashDueToUnreportedError.java:14:43: compiler.err.prob.found.req: (compiler.misc.infer.no.conforming.assignment.exists: E,compiler.misc.type.captureof: 1, ? extends CrashDueToUnreportedError.Entity<Root>,Root, (compiler.misc.inconvertible.types: java.util.List<compiler.misc.type.captureof: 2, ? extends CrashDueToUnreportedError.Entity<Root>>, java.util.List<? extends CrashDueToUnreportedError.Entity<java.lang.Object>>))
+1 error


### PR DESCRIPTION
Backporting JDK-8320948: NPE due to unreported compiler error. The compiler decides not to report compiler error while doing recovery on deferred types - this fix looks into the speculative types of a deferred type and if all the speculative types are erroneous, then use a recovery type as the target type, which later on in the pipeline will imply reporting errors if any. Adds test. Ran GHA Sanity Checks, local Tier 1 and 2, and new `test/langtools/tools/javac/recovery/CrashDueToUnreportedError.java` tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320948](https://bugs.openjdk.org/browse/JDK-8320948) needs maintainer approval

### Issue
 * [JDK-8320948](https://bugs.openjdk.org/browse/JDK-8320948): NPE due to unreported compiler error (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1696/head:pull/1696` \
`$ git checkout pull/1696`

Update a local copy of the PR: \
`$ git checkout pull/1696` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1696`

View PR using the GUI difftool: \
`$ git pr show -t 1696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1696.diff">https://git.openjdk.org/jdk21u-dev/pull/1696.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1696#issuecomment-2822266462)
</details>
