### PR TITLE
8330598: java/net/httpclient/Http1ChunkedTest.java fails with java.util.MissingFormatArgumentException: Format specifier '%s'

### DIFF
--- a/test/jdk/java/net/httpclient/Http1ChunkedTest.java
+++ b/test/jdk/java/net/httpclient/Http1ChunkedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ public class Http1ChunkedTest {
                         }
                     }
                     if (!received) {
-                        System.out.printf("%s: Unexpected headers received: dropping request.%n");
+                        System.out.printf("%s: Unexpected headers received: dropping request.%n", name);
                         continue;
                     }
                     OutputStream os = serverConn.getOutputStream();


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8330598](https://bugs.openjdk.org/browse/JDK-8330598) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330598](https://bugs.openjdk.org/browse/JDK-8330598): java/net/httpclient/Http1ChunkedTest.java fails with java.util.MissingFormatArgumentException: Format specifier '%s' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1698/head:pull/1698` \
`$ git checkout pull/1698`

Update a local copy of the PR: \
`$ git checkout pull/1698` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1698`

View PR using the GUI difftool: \
`$ git pr show -t 1698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1698.diff">https://git.openjdk.org/jdk21u-dev/pull/1698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1698#issuecomment-2824216900)
</details>
