### PR TITLE
8332880: JFR GCHelper class recognizes "Archive" regions as valid

### DIFF
--- a/test/lib/jdk/test/lib/jfr/GCHelper.java
+++ b/test/lib/jdk/test/lib/jfr/GCHelper.java
@@ -197,8 +197,7 @@ public class GCHelper {
                                                            "Survivor",
                                                            "Starts Humongous",
                                                            "Continues Humongous",
-                                                           "Old",
-                                                           "Archive"
+                                                           "Old"
                                                          };
 
         g1HeapRegionTypes = Collections.unmodifiableList(Arrays.asList(g1HeapRegionTypeLiterals));


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332880](https://bugs.openjdk.org/browse/JDK-8332880) needs maintainer approval

### Issue
 * [JDK-8332880](https://bugs.openjdk.org/browse/JDK-8332880): JFR GCHelper class recognizes "Archive" regions as valid (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1700/head:pull/1700` \
`$ git checkout pull/1700`

Update a local copy of the PR: \
`$ git checkout pull/1700` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1700`

View PR using the GUI difftool: \
`$ git pr show -t 1700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1700.diff">https://git.openjdk.org/jdk21u-dev/pull/1700.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1700#issuecomment-2824338384)
</details>
