### PR TITLE
8347173: java/net/DatagramSocket/InterruptibleDatagramSocket.java fails with virtual thread factory

### DIFF
--- a/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
+++ b/test/jdk/java/net/DatagramSocket/InterruptibleDatagramSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import static java.lang.Thread.sleep;
  * @test
  * @summary Check interrupt mechanism for DatagramSocket,
  *      MulticastSocket, and DatagramSocketAdaptor
+ * @library /test/lib
  * @run main InterruptibleDatagramSocket
  */
 
@@ -97,6 +98,10 @@ public class InterruptibleDatagramSocket {
     }
 
     public static void main(String[] args) throws Exception {
+        if (Thread.currentThread().isVirtual()) {
+            throw new jtreg.SkippedException(
+                    "skipping test execution - main thread is a virtual thread");
+        }
         try (DatagramSocket s = new DatagramSocket()) {
             System.out.println("Testing interrupt of DatagramSocket receive " +
                     "on endpoint " + s.getLocalSocketAddress());


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8347173](https://bugs.openjdk.org/browse/JDK-8347173) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347173](https://bugs.openjdk.org/browse/JDK-8347173): java/net/DatagramSocket/InterruptibleDatagramSocket.java fails with virtual thread factory (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1705/head:pull/1705` \
`$ git checkout pull/1705`

Update a local copy of the PR: \
`$ git checkout pull/1705` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1705`

View PR using the GUI difftool: \
`$ git pr show -t 1705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1705.diff">https://git.openjdk.org/jdk21u-dev/pull/1705.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1705#issuecomment-2828003563)
</details>
