### PR TITLE
8318811: Compiler directives parser swallows a character after line comments

### DIFF
--- a/src/hotspot/share/utilities/json.cpp
+++ b/src/hotspot/share/utilities/json.cpp
@@ -580,7 +580,7 @@ u_char JSON::skip_line_comment() {
     return 0;
   }
   next();
-  return next();
+  return peek();
 }
 
 /*

--- a/test/hotspot/jtreg/compiler/compilercontrol/parser/DirectiveParserTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/parser/DirectiveParserTest.java
@@ -33,6 +33,9 @@
 
 package compiler.compilercontrol.parser;
 
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+
 import compiler.compilercontrol.share.JSONFile;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -52,6 +55,7 @@ public class DirectiveParserTest {
         emptyFile();
         noFile();
         directory();
+        lineCommentTest();
     }
 
     private static void simpleTest() {
@@ -144,5 +148,21 @@ public class DirectiveParserTest {
         OutputAnalyzer output = HugeDirectiveUtil.execute(Utils.TEST_SRC);
         Asserts.assertNE(output.getExitValue(), 0, ERROR_MSG + "directory as "
                 + "a name");
+    }
+
+    private static void lineCommentTest() {
+        String fileName = "lineComment.json";
+        try {
+            PrintStream out = new PrintStream(fileName);
+            out.println("[{");
+            out.println("  match: \"*::*\",");
+            out.println("  c2: { Exclude: true } // c1 only for startup");
+            out.println("}]");
+            out.close();
+        } catch (FileNotFoundException e) {
+            throw new Error("TESTBUG: can't open/create file " + fileName, e);
+        }
+        OutputAnalyzer output = HugeDirectiveUtil.execute(fileName);
+        output.shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
Backporting JDK-8318811: Compiler directives parser swallows a character after line comments. Fixes JSON::skip_line_comment() to match specification and "return the first token after the line comment without consuming it" by using `peek` instead of `next`. Adds test. Ran GHA Sanity Checks, local Tier 1 and 2, and new `test/hotspot/jtreg/compiler/compilercontrol/parser/DirectiveParserTest.java` tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8318811](https://bugs.openjdk.org/browse/JDK-8318811) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318811](https://bugs.openjdk.org/browse/JDK-8318811): Compiler directives parser swallows a character after line comments (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1717/head:pull/1717` \
`$ git checkout pull/1717`

Update a local copy of the PR: \
`$ git checkout pull/1717` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1717`

View PR using the GUI difftool: \
`$ git pr show -t 1717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1717.diff">https://git.openjdk.org/jdk21u-dev/pull/1717.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1717#issuecomment-2830934760)
</details>
