### PR TITLE
8313290: Misleading exception message from STS.Subtask::get when task forked after shutdown

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -576,8 +576,6 @@ public class StructuredTaskScope<T> implements AutoCloseable {
         }
 
         SubtaskImpl<U> subtask = new SubtaskImpl<>(this, task, round);
-        boolean started = false;
-
         if (s < SHUTDOWN) {
             // create thread to run task
             Thread thread = factory.newThread(subtask);
@@ -588,15 +586,14 @@ public class StructuredTaskScope<T> implements AutoCloseable {
             // attempt to start the thread
             try {
                 flock.start(thread);
-                started = true;
             } catch (IllegalStateException e) {
                 // shutdown by another thread, or underlying flock is shutdown due
                 // to unstructured use
             }
         }
 
-        // force owner to join if thread started
-        if (started && Thread.currentThread() == flock.owner() && round > forkRound) {
+        // force owner to join if this is the first fork in the round
+        if (Thread.currentThread() == flock.owner() && round > forkRound) {
             forkRound = round;
         }
 
@@ -933,7 +930,8 @@ public class StructuredTaskScope<T> implements AutoCloseable {
                 T r = (T) result;
                 return r;
             }
-            throw new IllegalStateException("Subtask not completed or did not complete successfully");
+            throw new IllegalStateException(
+                    "Result is unavailable or subtask did not complete successfully");
         }
 
         @Override
@@ -943,7 +941,8 @@ public class StructuredTaskScope<T> implements AutoCloseable {
             if (result instanceof AltResult alt && alt.state() == State.FAILED) {
                 return alt.exception();
             }
-            throw new IllegalStateException("Subtask not completed or did not complete with exception");
+            throw new IllegalStateException(
+                    "Exception is unavailable or subtask did not complete with exception");
         }
 
         @Override

--- a/test/jdk/java/util/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java
+++ b/test/jdk/java/util/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java
@@ -279,6 +279,7 @@ class StructuredTaskScopeTest {
                 executed.set(true);
                 return null;
             });
+            scope.join();
             assertEquals(Subtask.State.UNAVAILABLE, subtask.state());
             assertThrows(IllegalStateException.class, subtask::get);
             assertThrows(IllegalStateException.class, subtask::exception);
@@ -670,22 +671,6 @@ class StructuredTaskScopeTest {
             // join should complete
             scope.join();
             assertEquals("foo", subtask.get());
-        }
-    }
-
-    /**
-     * Test that shutdown prevents new threads from starting.
-     */
-    @Test
-    void testShutdownWithFork() throws Exception {
-        ThreadFactory factory = task -> null;
-        try (var scope = new StructuredTaskScope<Object>(null, factory)) {
-            scope.shutdown();
-            // should not invoke the ThreadFactory to create thread
-            Subtask<Void> subtask = scope.fork(() -> null);
-            assertEquals(Subtask.State.UNAVAILABLE, subtask.state());
-            assertThrows(IllegalStateException.class, subtask::get);
-            assertThrows(IllegalStateException.class, subtask::exception);
         }
     }
 
@@ -1377,6 +1362,7 @@ class StructuredTaskScopeTest {
 
             // fork after shutdown
             Subtask<Void> subtask = scope.fork(task);
+            scope.join();
             assertEquals(task, subtask.task());
             assertEquals(Subtask.State.UNAVAILABLE, subtask.state());
             assertThrows(IllegalStateException.class, subtask::get);


### PR DESCRIPTION
Clean backport. Fixes misleading error message from StructuredTaskScope.get(). Affected test passes on linux x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313290](https://bugs.openjdk.org/browse/JDK-8313290) needs maintainer approval

### Issue
 * [JDK-8313290](https://bugs.openjdk.org/browse/JDK-8313290): Misleading exception message from STS.Subtask::get when task forked after shutdown (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1720/head:pull/1720` \
`$ git checkout pull/1720`

Update a local copy of the PR: \
`$ git checkout pull/1720` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1720`

View PR using the GUI difftool: \
`$ git pr show -t 1720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1720.diff">https://git.openjdk.org/jdk21u-dev/pull/1720.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1720#issuecomment-2836855794)
</details>
