### PR TITLE
8333680: com/sun/tools/attach/BasicTests.java fails with "SocketException: Permission denied: connect"

### DIFF
--- a/test/jdk/com/sun/tools/attach/Agent.java
+++ b/test/jdk/com/sun/tools/attach/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * the given port.
  */
 import java.net.Socket;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.io.IOException;
 
@@ -38,7 +39,7 @@ public class Agent {
         int port = Integer.parseInt(args);
         System.out.println("Agent connecting back to Tool....");
         Socket s = new Socket();
-        s.connect( new InetSocketAddress(port) );
+        s.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), port));
         System.out.println("Agent connected to Tool.");
         s.close();
     }

--- a/test/jdk/com/sun/tools/attach/BasicTests.java
+++ b/test/jdk/com/sun/tools/attach/BasicTests.java
@@ -23,6 +23,8 @@
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.List;
@@ -213,7 +215,8 @@ public class BasicTests {
 
             System.out.println(" - Test: End-to-end connection with agent");
 
-            ServerSocket ss = new ServerSocket(0);
+            ServerSocket ss = new ServerSocket();
+            ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
             int port = ss.getLocalPort();
 
             System.out.println(" - Loading Agent.jar into target VM ...");
@@ -231,7 +234,8 @@ public class BasicTests {
 
             System.out.println(" - Test: End-to-end connection with RedefineAgent");
 
-            ServerSocket ss2 = new ServerSocket(0);
+            ServerSocket ss2 = new ServerSocket();
+            ss2.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
             int port2 = ss2.getLocalPort();
 
             System.out.println(" - Loading RedefineAgent.jar into target VM ...");

--- a/test/jdk/com/sun/tools/attach/RedefineAgent.java
+++ b/test/jdk/com/sun/tools/attach/RedefineAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * 6446941 java.lang.instrument: multiple agent attach fails (first agent chooses capabilities)
  */
 import java.net.Socket;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.io.IOException;
 import java.util.Arrays;
@@ -104,7 +105,7 @@ public class RedefineAgent implements ClassFileTransformer {
         int port = Integer.parseInt(args);
         System.out.println("RedefineAgent connecting back to Tool....");
         Socket s = new Socket();
-        s.connect( new InetSocketAddress(port) );
+        s.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), port));
         System.out.println("RedefineAgent connected to Tool.");
 
         testRedefine(inst);


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333680](https://bugs.openjdk.org/browse/JDK-8333680) needs maintainer approval

### Issue
 * [JDK-8333680](https://bugs.openjdk.org/browse/JDK-8333680): com/sun/tools/attach/BasicTests.java fails with "SocketException: Permission denied: connect" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1723/head:pull/1723` \
`$ git checkout pull/1723`

Update a local copy of the PR: \
`$ git checkout pull/1723` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1723`

View PR using the GUI difftool: \
`$ git pr show -t 1723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1723.diff">https://git.openjdk.org/jdk21u-dev/pull/1723.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1723#issuecomment-2839342744)
</details>
