### PR TITLE
8292955: Collections.checkedMap Map.merge does not properly check key and value

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4050,6 +4050,7 @@ public class Collections {
         public V merge(K key, V value,
                 BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
             Objects.requireNonNull(remappingFunction);
+            typeCheck(key, value);
             return m.merge(key, value, (v1, v2) -> {
                 V newValue = remappingFunction.apply(v1, v2);
                 typeCheck(null, newValue);

--- a/test/jdk/java/util/Collections/CheckedMapBash.java
+++ b/test/jdk/java/util/Collections/CheckedMapBash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,13 +23,14 @@
 
 /*
  * @test
- * @bug     4904067 5023830 7129185 8072015
+ * @bug     4904067 5023830 7129185 8072015 8292955
  * @summary Unit test for Collections.checkedMap
  * @author  Josh Bloch
  * @run testng CheckedMapBash
  * @key randomness
  */
 
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -182,5 +183,12 @@ public class CheckedMapBash {
              (Supplier) () -> Collections.checkedNavigableMap(new TreeMap().descendingMap(), Integer.class, Integer.class)},
         };
         return Arrays.asList(params);
+    }
+
+    @Test(groups = "type_check")
+    public static void testCheckedMapMerge() {
+        Map m = Collections.checkedMap(new HashMap<>(), Integer.class, Integer.class);
+        Assert.assertThrows(ClassCastException.class, () -> m.merge("key", "value", (v1, v2) -> null));
+        Assert.assertThrows(ClassCastException.class, () -> m.merge("key", 3, (v1, v2) -> v2));
     }
 }


### PR DESCRIPTION
Clean backport. This ensures Collections.checkedMap Map.merge fails when key value types don't match. Affected test on linux x64 and GHA passes.

I'm not entirely sure if this would be a good backport, given that this would change the behavior in the scenario of a failed type mismatch. Nevertheless, I wanted to submit a request to check whether these type of backports are acceptable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8292955](https://bugs.openjdk.org/browse/JDK-8292955) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292955](https://bugs.openjdk.org/browse/JDK-8292955): Collections.checkedMap Map.merge does not properly check key and value (**Bug** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1730/head:pull/1730` \
`$ git checkout pull/1730`

Update a local copy of the PR: \
`$ git checkout pull/1730` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1730`

View PR using the GUI difftool: \
`$ git pr show -t 1730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1730.diff">https://git.openjdk.org/jdk21u-dev/pull/1730.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1730#issuecomment-2845986386)
</details>
