### PR TITLE
8354802: MAX_SECS definition is unused in os_linux

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -138,8 +138,6 @@
 
 #define MAX_PATH    (2 * K)
 
-#define MAX_SECS 100000000
-
 // for timer info max values which include all bits
 #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354802](https://bugs.openjdk.org/browse/JDK-8354802) needs maintainer approval

### Issue
 * [JDK-8354802](https://bugs.openjdk.org/browse/JDK-8354802): MAX_SECS definition is unused in os_linux (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1731/head:pull/1731` \
`$ git checkout pull/1731`

Update a local copy of the PR: \
`$ git checkout pull/1731` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1731`

View PR using the GUI difftool: \
`$ git pr show -t 1731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1731.diff">https://git.openjdk.org/jdk21u-dev/pull/1731.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1731#issuecomment-2846514907)
</details>
