### PR TITLE
8315827: Kitchensink.java and RenaissanceStressTest.java  time out with jvmti module errors

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/javaThreadStatus.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "jfr/recorder/jfrRecorder.hpp"
 #include "jfr/periodic/sampling/jfrCallTrace.hpp"
@@ -200,7 +201,7 @@ void OSThreadSampler::protected_task(const SuspendedThreadTaskContext& context) 
       ev->set_starttime(_suspend_time);
       ev->set_endtime(_suspend_time); // fake to not take an end time
       ev->set_sampledThread(JfrThreadLocal::thread_id(jt));
-      ev->set_state(static_cast<u8>(java_lang_Thread::get_thread_status(_thread_oop)));
+      ev->set_state(static_cast<u8>(JavaThreadStatus::RUNNABLE));
     }
   }
 }
@@ -230,7 +231,7 @@ static void write_native_event(JfrThreadSampleClosure& closure, JavaThread* jt, 
   EventNativeMethodSample *ev = closure.next_event_native();
   ev->set_starttime(JfrTicks::now());
   ev->set_sampledThread(JfrThreadLocal::thread_id(jt));
-  ev->set_state(static_cast<u8>(java_lang_Thread::get_thread_status(thread_oop)));
+  ev->set_state(static_cast<u8>(JavaThreadStatus::RUNNABLE));
 }
 
 void JfrNativeSamplerCallback::call() {


### PR DESCRIPTION
Backporting JDK-8315827: Kitchensink.java and RenaissanceStressTest.java time out with jvmti module errors. Fix prevents deadlock case by avoiding reading the thread status from the thread object as part of sampling (since we already know the state at this point). Adds test. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315827](https://bugs.openjdk.org/browse/JDK-8315827) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315827](https://bugs.openjdk.org/browse/JDK-8315827): Kitchensink.java and RenaissanceStressTest.java  time out with jvmti module errors (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1735/head:pull/1735` \
`$ git checkout pull/1735`

Update a local copy of the PR: \
`$ git checkout pull/1735` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1735`

View PR using the GUI difftool: \
`$ git pr show -t 1735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1735.diff">https://git.openjdk.org/jdk21u-dev/pull/1735.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1735#issuecomment-2852010768)
</details>
