### PR TITLE
8315128: jdk/jfr/event/runtime/TestResidentSetSizeEvent.java fails with "The size should be less than or equal to peak"

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2503,7 +2503,9 @@ void os::jfr_report_memory_info() {
     // Send the RSS JFR event
     EventResidentSetSize event;
     event.set_size(info.resident_size);
-    event.set_peak(info.resident_size_max);
+    // We've seen that resident_size_max sometimes trails resident_size with one page.
+    // Make sure we always report size <= peak
+    event.set_peak(MAX2(info.resident_size_max, info.resident_size));
     event.commit();
   } else {
     // Log a warning


### PR DESCRIPTION
Backporting JDK-8315128: jdk/jfr/event/runtime/TestResidentSetSizeEvent.java fails with "The size should be less than or equal to peak". Fix adjusts the size threshold to avoid corner case resulting in failure. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8315128](https://bugs.openjdk.org/browse/JDK-8315128) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315128](https://bugs.openjdk.org/browse/JDK-8315128): jdk/jfr/event/runtime/TestResidentSetSizeEvent.java fails with "The size should be less than or equal to peak" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1736/head:pull/1736` \
`$ git checkout pull/1736`

Update a local copy of the PR: \
`$ git checkout pull/1736` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1736`

View PR using the GUI difftool: \
`$ git pr show -t 1736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1736.diff">https://git.openjdk.org/jdk21u-dev/pull/1736.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1736#issuecomment-2852018585)
</details>
