### PR TITLE
8312246: NPE when HSDB visits bad oop

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -1096,7 +1096,9 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
                           G1CollectedHeap heap = (G1CollectedHeap)collHeap;
                           HeapRegion region = heap.hrm().getByAddress(handle);
 
-                          if (region.isFree()) {
+                          if (region == null) {
+                            // intentionally skip
+                          } else if (region.isFree()) {
                             anno = "Free ";
                             bad = false;
                           } else if (region.isYoung()) {


### PR DESCRIPTION
Backporting JDK-8312246: NPE when HSDB visits bad oop. Minor HSDB fix: corrects printing "bad oop" with throwing a NPE message to the console when a corrupted object is found. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312246](https://bugs.openjdk.org/browse/JDK-8312246) needs maintainer approval

### Issue
 * [JDK-8312246](https://bugs.openjdk.org/browse/JDK-8312246): NPE when HSDB visits bad oop (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1738/head:pull/1738` \
`$ git checkout pull/1738`

Update a local copy of the PR: \
`$ git checkout pull/1738` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1738`

View PR using the GUI difftool: \
`$ git pr show -t 1738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1738.diff">https://git.openjdk.org/jdk21u-dev/pull/1738.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1738#issuecomment-2852070580)
</details>
