### PR TITLE
8286789: Test forceEarlyReturn002.java timed out

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -60,12 +60,6 @@ vmTestbase/nsk/jvmti/scenarios/allocation/AP11/ap11t001/TestDescription.java 830
 ## assert in src/hotspot/share/oops/instanceStackChunkKlass.cpp:1042
 vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage006/TestDescription.java 8300709 generic-all
 
-####
-## NSK JDWP Tests failing with wrapper
-
-vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java 8286789 generic-all
-
-
 ##########
 ## NSK JDB Tests failing with wrapper
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@
  *         When test thread has finish execution debugger suspends thread and call command for this thread, INVALID_THREAD
  *         error is expected, then, debugger resumes test thread and call command again, INVALID_THREAD error should
  *         be returned in reply.
- *         - debuggee starts test thread which executes infinite loop in native method, debugger calls command for
+ *         - debuggee starts test thread which executes loop in native method, debugger calls command for
  *         this thread(without suspending) and expects THREAD_NOT_SUSPENDED error. Then, debugger suspends this thread
  *         and calls command again, OPAQUE_FRAME error is expected.
  *         - debugger creates ThreadStartEventRequest with suspend policy 'JDWP.SuspendPolicy.ALL' and forces debuggee start new thread.
@@ -247,6 +247,9 @@ public class forceEarlyReturn002 extends TestDebuggerType1 {
         debuggee.suspendThread(threadID);
         // suspended thread in native, expect OPAQUE_FRAME error
         sendCommand(threadID, value, true, JDWP.Error.OPAQUE_FRAME);
+
+        // signal native method to exit; the thread will be actually suspended
+        pipe.println(forceEarlyReturn002a.COMMAND_EXIT_THREAD_IN_NATIVE);
 
         // create request for ThreadStart event
         int requestID = createThreadStartEventRequest();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ public class forceEarlyReturn002a extends AbstractJDWPDebuggee {
 
     public final static String COMMAND_STOP_THREAD_IN_NATIVE = "stopInNative";
 
+    public final static String COMMAND_EXIT_THREAD_IN_NATIVE = "exitInNative";
+
     public final static String COMMAND_START_NEW_THREAD = "startNewThread";
 
     public boolean parseCommand(String command) {
@@ -48,6 +50,10 @@ public class forceEarlyReturn002a extends AbstractJDWPDebuggee {
 
         if (command.equals(COMMAND_STOP_THREAD_IN_NATIVE)) {
             stopThreadInNative();
+
+            return true;
+        } else if (command.equals(COMMAND_EXIT_THREAD_IN_NATIVE)) {
+            exitThreadInNative();
 
             return true;
         } else if (command.equals(COMMAND_START_NEW_THREAD)) {
@@ -94,6 +100,8 @@ public class forceEarlyReturn002a extends AbstractJDWPDebuggee {
     public volatile boolean threadInNative;
 
     private static native int nativeMethod(Object object);
+
+    private static native void exitThreadInNative();
 
     public static void main(String args[]) {
         new forceEarlyReturn002a().doTest(args);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/libforceEarlyReturn002a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/libforceEarlyReturn002a.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,23 +23,46 @@
 
 #include "jni.h"
 
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#include <atomic>
+
 extern "C" {
 
+static std::atomic<bool> wait_in_native(true);
+
+static void delay(int seconds) {
+#if defined(_WIN32)
+    Sleep(1000L * seconds);
+#else
+    sleep(seconds);
+#endif
+}
 
 JNIEXPORT jint JNICALL
 Java_nsk_jdwp_ThreadReference_ForceEarlyReturn_forceEarlyReturn002_forceEarlyReturn002a_nativeMethod(JNIEnv *env, jobject classObject, jobject object)
 {
-    static volatile int dummy_counter = 0;
     // notify another thread that thread in native method
     jclass klass = env->GetObjectClass(object);
     jfieldID field = env->GetFieldID(klass, "threadInNative", "Z");
     env->SetBooleanField(object, field, 1);
 
     // execute infinite loop to be sure that thread in native method
-    while (dummy_counter == 0) {}
+    while (wait_in_native) {
+        delay(1);
+    }
 
-    // Should not reach here
     return 0;
+}
+
+JNIEXPORT void JNICALL
+Java_nsk_jdwp_ThreadReference_ForceEarlyReturn_forceEarlyReturn002_forceEarlyReturn002a_exitThreadInNative(JNIEnv *env, jobject classObject)
+{
+    wait_in_native = false;
 }
 
 }


### PR DESCRIPTION
I would like to fix this test issue in 21.

Clean backport although skara didn't manage to do this automatically.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8286789](https://bugs.openjdk.org/browse/JDK-8286789) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286789](https://bugs.openjdk.org/browse/JDK-8286789): Test forceEarlyReturn002.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1740/head:pull/1740` \
`$ git checkout pull/1740`

Update a local copy of the PR: \
`$ git checkout pull/1740` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1740`

View PR using the GUI difftool: \
`$ git pr show -t 1740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1740.diff">https://git.openjdk.org/jdk21u-dev/pull/1740.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1740#issuecomment-2854310505)
</details>
