### PR TITLE
8249831: Test sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java is marked with @ignore

### DIFF
--- a/test/jdk/sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java
+++ b/test/jdk/sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,20 +27,32 @@
  * @requires os.family == "windows"
  * @library /test/lib
  * @summary Test "keytool -list" displays correctly same named certificates
- * @ignore Uses certutil.exe that isn't guaranteed to be installed
  */
 
 import jdk.test.lib.process.ProcessTools;
 
+import java.io.IOException;
 import java.security.KeyStore;
 import java.util.Collections;
+import jtreg.SkippedException;
 
 public class NonUniqueAliases {
     public static void main(String[] args) throws Throwable {
-
         try {
-            String testSrc = System.getProperty("test.src", ".");
+            runTest();
+        } catch (IOException ex) {
+            // It uses certutil.exe that isn't guaranteed to be installed
+            String certutilMsg = "Cannot run program \"certutil\"";
+            if (ex.getMessage().contains(certutilMsg)) {
+                throw new SkippedException("certutil is not installed");
+            }
+            throw ex;
+        }
+    }
 
+    private static void runTest() throws Exception {
+        String testSrc = System.getProperty("test.src", ".");
+        try {
             // removing the alias NonUniqueName if it already exists
             ProcessTools.executeCommand("certutil", "-user", "-delstore", "MY",
                     "NonUniqueName");


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8249831](https://bugs.openjdk.org/browse/JDK-8249831) needs maintainer approval

### Issue
 * [JDK-8249831](https://bugs.openjdk.org/browse/JDK-8249831): Test sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java is marked with @<!---->ignore (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1746/head:pull/1746` \
`$ git checkout pull/1746`

Update a local copy of the PR: \
`$ git checkout pull/1746` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1746`

View PR using the GUI difftool: \
`$ git pr show -t 1746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1746.diff">https://git.openjdk.org/jdk21u-dev/pull/1746.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1746#issuecomment-2854793156)
</details>
