### PR TITLE
8313654: Test WaitNotifySuspendedVThreadTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
@@ -24,20 +24,8 @@
 /*
  * @test
  *
- * @summary Test verifies set/get TLS data and verifies it's consistency.
- * Test set TLS with thread name which it belongs to and verify this information when getting test.
- *  -- cbThreadStart
- *  -- by AgentThread
- *
- * Test doesn't verify that TLS is not NULL because for some threads TLS is not initialized initially.
- * TODO:
- *  -- verify that TLS is not NULL (not possible to do with jvmti, ThreadStart might be called too late)
- *  -- add more events where TLS is set *first time*, it is needed to test lazily jvmtThreadState init
- *  -- set/get TLS from other JavaThreads (not from agent and current thread)
- *  -- set/get for suspened (blocked?) threads
- *  -- split test to "sanity" and "stress" version
- *  -- update properties to run jvmti stress tests non-concurrently?
- *
+ * @summary Test verifies that JVMTI raw monitor wait/notify works for
+ * suspended virtual thread.
  *
  * @requires vm.continuations
  * @library /test/lib
@@ -64,8 +52,6 @@ public class WaitNotifySuspendedVThreadTest {
         WaitNotifySuspendedVThreadTask.setBreakpoint();
         WaitNotifySuspendedVThreadTask task = new WaitNotifySuspendedVThreadTask();
         Thread t = Thread.ofVirtual().start(task);
-
-        Thread.sleep(1000);
         WaitNotifySuspendedVThreadTask.notifyRawMonitors(t);
         t.join();
     }


### PR DESCRIPTION
I would like to fix this test in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313654](https://bugs.openjdk.org/browse/JDK-8313654) needs maintainer approval

### Issue
 * [JDK-8313654](https://bugs.openjdk.org/browse/JDK-8313654): Test WaitNotifySuspendedVThreadTest.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1749/head:pull/1749` \
`$ git checkout pull/1749`

Update a local copy of the PR: \
`$ git checkout pull/1749` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1749`

View PR using the GUI difftool: \
`$ git pr show -t 1749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1749.diff">https://git.openjdk.org/jdk21u-dev/pull/1749.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1749#issuecomment-2855422441)
</details>
