### PR TITLE
8347296: WinInstallerUiTest fails in local test runs if the path to test work directory is longer that regular

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinInstallerUiTest.java
+++ b/test/jdk/tools/jpackage/windows/WinInstallerUiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,13 +122,13 @@ public class WinInstallerUiTest {
         StringBuilder sb = new StringBuilder(cmd.name());
         sb.append("With");
         if (withDirChooser) {
-            sb.append("DirChooser");
+            sb.append("Dc"); // DirChooser
         }
         if (withShortcutPrompt) {
-            sb.append("ShortcutPrompt");
+            sb.append("Sp"); // ShortcutPrompt
         }
         if (withLicense) {
-            sb.append("License");
+            sb.append("L"); // License
         }
         cmd.setArgumentValue("--name", sb.toString());
     }


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347296](https://bugs.openjdk.org/browse/JDK-8347296) needs maintainer approval

### Issue
 * [JDK-8347296](https://bugs.openjdk.org/browse/JDK-8347296): WinInstallerUiTest fails in local test runs if the path to test work directory is longer that regular (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1751/head:pull/1751` \
`$ git checkout pull/1751`

Update a local copy of the PR: \
`$ git checkout pull/1751` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1751`

View PR using the GUI difftool: \
`$ git pr show -t 1751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1751.diff">https://git.openjdk.org/jdk21u-dev/pull/1751.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1751#issuecomment-2857995569)
</details>
