### PR TITLE
8332631: Update nsk.share.jpda.BindServer to don't use finalization

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/BindServer.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/BindServer.java
@@ -28,7 +28,6 @@ import java.net.*;
 import java.util.*;
 
 import nsk.share.*;
-import nsk.share.jpda.*;
 
 /**
  * <code>BindServer</code> is an utility to perform JPDA tests
@@ -58,7 +57,7 @@ import nsk.share.jpda.*;
  * @see DebugeeBinder
  * @see DebugeeArgumentHandler
  */
-public class BindServer implements Finalizable {
+public final class BindServer {
 
     /** Version of <code>BindServer</code> implementation. */
     public static final long VERSION = 2;
@@ -88,7 +87,6 @@ public class BindServer implements Finalizable {
 
     private static String pathConvertions[][] = null;
 
-    private ListeningThread listeningThread = null;
 
     private int totalRequests = 0;
     private int acceptedRequests = 0;
@@ -149,8 +147,6 @@ public class BindServer implements Finalizable {
         log = new Log(out, argHandler);
         logger = new Log.Logger(log, "");
 
-        registerCleanup();
-
         logger.trace(TRACE_LEVEL_THREADS, "BindServer: starting main thread");
 
         logger.display("Listening to port: " + argHandler.getBindPortNumber());
@@ -178,45 +174,39 @@ public class BindServer implements Finalizable {
 
         BufferedReader stdIn = new BufferedReader(
             new InputStreamReader(System.in));
+        try (ListeningThread listeningThread = new ListeningThread(this)) {
+            listeningThread.bind();
+            listeningThread.start();
 
-        listeningThread = new ListeningThread(this);
-        listeningThread.bind();
-        listeningThread.start();
+            System.out.println("\n"
+                              + "BindServer started" + "\n"
+                              + "Type \"exit\" to shut down BindServer"
+                              + "\n");
 
-        System.out.println("\n"
-                          + "BindServer started" + "\n"
-                          + "Type \"exit\" to shut down BindServer"
-                          + "\n");
-
-        for (;;) {
-            try {
-                String userInput = stdIn.readLine();
-                if (userInput == null || userInput.equals("exit")
-                        || userInput.equals("quit")) {
-                    logger.display("Shutting down BindServer");
-                    stdIn.close();
-                    stdIn = null;
-                    break;
-                } else if (userInput.trim().equals("")) {
-                    continue;
-                } else {
-                    System.out.println("ERROR: Unknown command: " + userInput);
+            for (; ; ) {
+                try {
+                    String userInput = stdIn.readLine();
+                    if (userInput == null || userInput.equals("exit")
+                            || userInput.equals("quit")) {
+                        logger.display("Shutting down BindServer");
+                        stdIn.close();
+                        stdIn = null;
+                        break;
+                    } else if (userInput.trim().equals("")) {
+                        continue;
+                    } else {
+                        System.out.println("ERROR: Unknown command: " + userInput);
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace(log.getOutStream());
+                    throw new Failure("Caught exception while reading console command:\n\t"
+                            + e);
                 }
-            } catch(IOException e) {
-                e.printStackTrace(log.getOutStream());
-                throw new Failure("Caught exception while reading console command:\n\t"
-                                    + e);
             }
-        }
 
-        printSummary(System.out);
+            printSummary(System.out);
 
-        logger.trace(TRACE_LEVEL_THREADS, "BindServer: exiting main thread");
-        try {
-            cleanup();
-        } catch (Throwable e) {
-            e.printStackTrace(log.getOutStream());
-            logger.complain("Caught exception while finalization of BindServer:\n\t" + e);
+            logger.trace(TRACE_LEVEL_THREADS, "BindServer: exiting main thread");
         }
 
         return PASSED;
@@ -387,38 +377,6 @@ public class BindServer implements Finalizable {
         waitInterruptThread(thr, THREAD_TIMEOUT);
     }
 
-    /**
-     * Close <code>BindServer</code> by finishing all threads and closing
-     * all conections.
-     */
-    public synchronized void close() {
-        if (listeningThread != null) {
-            listeningThread.close();
-            listeningThread = null;
-        }
-    }
-
-    /**
-     * Make finalization of <code>BindServer</code> object by invoking
-     * method <code>close()</code>.
-     *
-     * @see #close()
-     */
-    @Override
-    public void cleanup() {
-        close();
-    }
-
-    /**
-     * Make finalization of <code>BindServer</code> object at program exit
-     * by invoking method <code>cleanup()</code>.
-     *
-     */
-    public void finalizeAtExit() throws Throwable {
-        cleanup();
-        logger.trace(TRACE_LEVEL_THREADS, "BindServer: finalization at exit completed");
-    }
-
 ///////// Thread listening a TCP/IP socket //////////
 
     /**
@@ -427,7 +385,7 @@ public class BindServer implements Finalizable {
      *
      * @see ServingThread
      */
-    private static class ListeningThread extends Thread {
+    private static class ListeningThread extends Thread implements AutoCloseable {
         private volatile boolean shouldStop = false;
         private volatile boolean closed = false;
 
@@ -673,23 +631,29 @@ public class BindServer implements Finalizable {
 
         /**
          * Close thread by closing all connections and waiting
-         * foor thread finished.
+         * for thread to finish.
          *
          * @see #closeConnection()
          */
+        @Override
         public synchronized void close() {
             if (closed) {
                 return;
             }
-            closeHostConnection();
-            if (servingThread != null) {
-                servingThread.close();
-                servingThread = null;
+            try {
+                closeHostConnection();
+                if (servingThread != null) {
+                    servingThread.close();
+                    servingThread = null;
+                }
+                waitForThread(THREAD_TIMEOUT);
+                closeConnection();
+                closed = true;
+                logger.trace(TRACE_LEVEL_THREADS, "ListeningThread closed");
+            } catch (Throwable e) {
+                e.printStackTrace(log.getOutStream());
+                logger.complain("Caught exception while closing ListeningThread:\n\t" + e);
             }
-            waitForThread(THREAD_TIMEOUT);
-            closeConnection();
-            closed = true;
-            logger.trace(TRACE_LEVEL_THREADS, "ListeningThread closed");
         }
 
     } // ListeningThread


### PR DESCRIPTION
I backport this to keep the 21 u tests up to date.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332631](https://bugs.openjdk.org/browse/JDK-8332631) needs maintainer approval

### Issue
 * [JDK-8332631](https://bugs.openjdk.org/browse/JDK-8332631): Update nsk.share.jpda.BindServer to don't use finalization (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1752/head:pull/1752` \
`$ git checkout pull/1752`

Update a local copy of the PR: \
`$ git checkout pull/1752` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1752`

View PR using the GUI difftool: \
`$ git pr show -t 1752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1752.diff">https://git.openjdk.org/jdk21u-dev/pull/1752.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1752#issuecomment-2858767684)
</details>
