### PR TITLE
8313430: [JVMCI] fatal error: Never compilable: in JVMCI shutdown

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2234,7 +2234,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
         }
       }
     }
-    if (!task->is_success()) {
+    if (!task->is_success() && !JVMCI::in_shutdown()) {
       handle_compile_error(thread, task, nullptr, compilable, failure_reason);
     }
     if (event.should_commit()) {


### PR DESCRIPTION
Backporting JDK-8313430: [JVMCI] fatal error: Never compilable: in JVMCI shutdown. Backport makes `-XX:+AbortVMOnCompilationFailure` ignore abandoned compilations that can be scheduled during a VM shutdown. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313430](https://bugs.openjdk.org/browse/JDK-8313430) needs maintainer approval

### Issue
 * [JDK-8313430](https://bugs.openjdk.org/browse/JDK-8313430): [JVMCI] fatal error: Never compilable: in JVMCI shutdown (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1755/head:pull/1755` \
`$ git checkout pull/1755`

Update a local copy of the PR: \
`$ git checkout pull/1755` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1755`

View PR using the GUI difftool: \
`$ git pr show -t 1755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1755.diff">https://git.openjdk.org/jdk21u-dev/pull/1755.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1755#issuecomment-2859359982)
</details>
