### PR TITLE
8349492: Update sun/security/pkcs12/KeytoolOpensslInteropTest.java to use a recent Openssl version

### DIFF
--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=GenerateOpensslPKCS12
  * @bug 8076190 8242151 8153005 8266182
  * @summary This is java keytool <-> openssl interop test. This test generates
  *          some openssl keystores on the fly, java operates on it and
@@ -31,13 +31,24 @@
  *          Note: This test executes some openssl command, so need to set
  *          openssl path using system property "test.openssl.path" or it should
  *          be available in /usr/bin or /usr/local/bin
- *          Required OpenSSL version : OpenSSL 1.1.*
+ *          Required OpenSSL version : OpensslArtifactFetcher.OPENSSL_BUNDLE_VERSION
  *
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.util
- * @library /test/lib
- * @library /sun/security/pkcs11/
- * @run main/othervm/timeout=600 KeytoolOpensslInteropTest
+ * @library /test/lib /sun/security/pkcs11/
+ * @run main/othervm KeytoolOpensslInteropTest true
+ */
+
+/*
+ * @test id=UseExistingPKCS12
+ * @bug 8076190 8242151 8153005 8266182
+ * @summary This is java keytool <-> openssl interop test. This test uses
+ *          the existing PKCS12 files located in ./params dir and java operates on it
+ *
+ * @modules java.base/sun.security.pkcs
+ *          java.base/sun.security.util
+ * @library /test/lib /sun/security/pkcs11/
+ * @run main/othervm KeytoolOpensslInteropTest false
  */
 
 import jdk.test.lib.Asserts;
@@ -45,6 +56,7 @@ import jdk.test.lib.SecurityTools;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.security.OpensslArtifactFetcher;
+import jtreg.SkippedException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -67,22 +79,25 @@ import static sun.security.pkcs.ContentInfo.*;
 public class KeytoolOpensslInteropTest {
 
     public static void main(String[] args) throws Throwable {
-        String opensslPath = OpensslArtifactFetcher.getOpenssl1dot1dotStar();
-        if (opensslPath != null) {
-            // if preferred version of openssl is available perform all
-            // keytool <-> openssl interop tests
-            generateInitialKeystores(opensslPath);
-            testWithJavaCommands();
-            testWithOpensslCommands(opensslPath);
+        boolean generatePKCS12 = Boolean.parseBoolean(args[0]);
+        if (generatePKCS12) {
+            String opensslPath = OpensslArtifactFetcher.getOpensslPath();
+            if (opensslPath != null) {
+                // if the current version of openssl is available, perform all
+                // keytool <-> openssl interop tests
+                generateInitialKeystores(opensslPath);
+                testWithJavaCommands();
+                testWithOpensslCommands(opensslPath);
+            } else {
+                String exMsg = "Can't find the version: "
+                        + OpensslArtifactFetcher.getTestOpensslBundleVersion()
+                        + " of openssl binary on this machine, please install"
+                        + " and set openssl path with property 'test.openssl.path'";
+                throw new SkippedException(exMsg);
+            }
         } else {
-            // since preferred version of openssl is not available skip all
-            // openssl command dependent tests with a warning
-            System.out.println("\n\u001B[31mWarning: Can't find openssl "
-                    + "(version 1.1.*) binary on this machine, please install"
-                    + " and set openssl path with property "
-                    + "'test.openssl.path'. Now running only half portion of "
-                    + "the test, skipping all tests which depends on openssl "
-                    + "commands.\u001B[0m\n");
+            // since this scenario is using preexisting PKCS12, skip all
+            // openssl command dependent tests
             // De-BASE64 textual files in ./params to `pwd`
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(
                     Path.of(System.getProperty("test.src"), "params"),
@@ -103,6 +118,8 @@ public class KeytoolOpensslInteropTest {
 
     private static void generateInitialKeystores(String opensslPath)
             throws Throwable {
+        Path providerPath = OpensslArtifactFetcher.getProviderPath(opensslPath);
+
         keytool("-keystore ks -keyalg ec -genkeypair -storepass"
                 + " changeit -alias a -dname CN=A").shouldHaveExitValue(0);
 
@@ -123,7 +140,8 @@ public class KeytoolOpensslInteropTest {
         ProcessTools.executeCommand(opensslPath, "pkcs12", "-export", "-in",
                 "kandc", "-out", "os4", "-name", "a", "-passout",
                 "pass:changeit", "-certpbe", "PBE-SHA1-RC4-128", "-keypbe",
-                "PBE-SHA1-RC4-128", "-macalg", "SHA224")
+                "PBE-SHA1-RC4-128", "-macalg", "SHA224",
+                "-legacy", "-provider-path", providerPath.toString())
                 .shouldHaveExitValue(0);
 
         ProcessTools.executeCommand(opensslPath, "pkcs12", "-export", "-in",
@@ -480,12 +498,14 @@ public class KeytoolOpensslInteropTest {
         output1 = ProcessTools.executeCommand(opensslPath, "pkcs12", "-in",
                 "ksnopass", "-passin", "pass:changeit", "-info", "-nokeys",
                 "-nocerts");
-        output1.shouldNotHaveExitValue(0);
+        output1.shouldHaveExitValue(0)
+            .shouldContain("Warning: MAC is absent!");
 
         output1 = ProcessTools.executeCommand(opensslPath, "pkcs12", "-in",
                 "ksnopass", "-passin", "pass:changeit", "-info", "-nokeys",
                 "-nocerts", "-nomacver");
         output1.shouldHaveExitValue(0)
+            .shouldNotContain("Warning: MAC is absent!")
             .shouldNotContain("PKCS7 Encrypted data:")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 10000, PRF hmacWithSHA256")

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package jdk.test.lib.security;
 
 import java.io.File;
 
+import java.nio.file.Path;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.artifacts.Artifact;
@@ -33,43 +34,49 @@ import jdk.test.lib.artifacts.ArtifactResolverException;
 
 public class OpensslArtifactFetcher {
 
+    private static final String OPENSSL_BUNDLE_VERSION = "3.0.14";
+    private static final String OPENSSL_ORG = "jpg.tests.jdk.openssl";
+
     /**
-     * Gets the openssl binary path of version 1.1.*
+     * Gets the openssl binary path of OPENSSL_BUNDLE_VERSION
      *
      * Openssl selection flow:
         1. Check whether property test.openssl.path is set and it's the
-           preferred version(1.1.*) of openssl, then return that path.
-        2. Else look for already installed openssl (version 1.1.*) in system
+           current version of openssl, then return that path.
+        2. Else look for already installed openssl in system
            path /usr/bin/openssl or /usr/local/bin/openssl, then return that
            path.
-        3. Else try to download openssl (version 1.1.*) from the artifactory
+        3. Else try to download the current version of openssl from the artifactory
            and return that path, if download fails then return null.
      *
-     * @return openssl binary path of version 1.1.*
+     * @return openssl binary path of the current version
      */
-    public static String getOpenssl1dot1dotStar() {
-        String version = "1.1.";
-        String path = getOpensslFromSystemProp(version);
+    public static String getOpensslPath() {
+        String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
             return path;
-        } else {
-            path = getDefaultSystemOpensslPath(version);
-            if (path != null) {
-                return path;
-            } else if (Platform.is64bit()) {
-                if (Platform.isLinux()) {
-                    path = fetchOpenssl(LINUX_X64.class);
-                } else if (Platform.isOSX()) {
-                    path = fetchOpenssl(MACOSX_X64.class);
-                } else if (Platform.isWindows()) {
-                    path = fetchOpenssl(WINDOWS_X64.class);
-                }
-                if (verifyOpensslVersion(path, version)) {
-                    return path;
-                }
+        }
+        path = getDefaultSystemOpensslPath(OPENSSL_BUNDLE_VERSION);
+        if (path != null) {
+            return path;
+        }
+        if (Platform.isX64()) {
+            if (Platform.isLinux()) {
+                path = fetchOpenssl(LINUX_X64.class);
+            } else if (Platform.isOSX()) {
+                path = fetchOpenssl(MACOSX_X64.class);
+            } else if (Platform.isWindows()) {
+                path = fetchOpenssl(WINDOWS_X64.class);
+            }
+        } else if (Platform.isAArch64()) {
+            if (Platform.isLinux()) {
+                path = fetchOpenssl(LINUX_AARCH64.class);
+            }
+            if (Platform.isOSX()) {
+                path = fetchOpenssl(MACOSX_AARCH64.class);
             }
         }
-        return null;
+        return verifyOpensslVersion(path, OPENSSL_BUNDLE_VERSION) ? path : null;
     }
 
     private static String getOpensslFromSystemProp(String version) {
@@ -124,24 +131,52 @@ public class OpensslArtifactFetcher {
         return path;
     }
 
+    // retrieve the provider directory path from <OPENSSL_HOME>/bin/openssl
+    public static Path getProviderPath(String opensslPath) {
+        Path openSslRootPath = Path.of(opensslPath).getParent().getParent();
+        String libDir = "lib";
+        if (Platform.isX64() && (Platform.isLinux() || Platform.isWindows())) {
+            libDir = "lib64";
+        }
+        return openSslRootPath.resolve(libDir).resolve("ossl-modules");
+    }
+
+    public static String getTestOpensslBundleVersion() {
+        return OPENSSL_BUNDLE_VERSION;
+    }
+
     @Artifact(
-            organization = "jpg.tests.jdk.openssl",
+            organization = OPENSSL_ORG,
             name = "openssl-linux_x64",
-            revision = "1.1.1g",
+            revision = OPENSSL_BUNDLE_VERSION,
             extension = "zip")
     private static class LINUX_X64 { }
 
     @Artifact(
-            organization = "jpg.tests.jdk.openssl",
+            organization = OPENSSL_ORG,
+            name = "openssl-linux_aarch64",
+            revision = OPENSSL_BUNDLE_VERSION,
+            extension = "zip")
+    private static class LINUX_AARCH64{ }
+
+    @Artifact(
+            organization = OPENSSL_ORG,
             name = "openssl-macosx_x64",
-            revision = "1.1.1g",
+            revision = OPENSSL_BUNDLE_VERSION,
             extension = "zip")
     private static class MACOSX_X64 { }
 
     @Artifact(
-            organization = "jpg.tests.jdk.openssl",
+            organization = OPENSSL_ORG,
+            name = "openssl-macosx_aarch64",
+            revision = OPENSSL_BUNDLE_VERSION,
+            extension = "zip")
+    private static class MACOSX_AARCH64 { }
+
+    @Artifact(
+            organization = OPENSSL_ORG,
             name = "openssl-windows_x64",
-            revision = "1.1.1g",
+            revision = OPENSSL_BUNDLE_VERSION,
             extension = "zip")
     private static class WINDOWS_X64 { }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

Needed to adapt 
  return openSslRootPath.resolve(libDir, "ossl-modules");
because 8262742: "(fs) Add Path::resolve with varargs string"
is not in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349492](https://bugs.openjdk.org/browse/JDK-8349492) needs maintainer approval

### Issue
 * [JDK-8349492](https://bugs.openjdk.org/browse/JDK-8349492): Update sun/security/pkcs12/KeytoolOpensslInteropTest.java to use a recent Openssl version (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1756/head:pull/1756` \
`$ git checkout pull/1756`

Update a local copy of the PR: \
`$ git checkout pull/1756` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1756`

View PR using the GUI difftool: \
`$ git pr show -t 1756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1756.diff">https://git.openjdk.org/jdk21u-dev/pull/1756.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1756#issuecomment-2862197928)
</details>
