### PR TITLE
Backport 90e433d72e73abf3252969f535451b56ecacc952

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -551,7 +551,6 @@ public class Annotate {
 
         if (expectedElementType.hasTag(ARRAY)) {
             return getAnnotationArrayValue(expectedElementType, tree, env);
-
         }
 
         //error recovery
@@ -703,11 +702,15 @@ public class Annotate {
         }
 
         JCNewArray na = (JCNewArray)tree;
+        List<JCExpression> elems = na.elems;
         if (na.elemtype != null) {
             log.error(na.elemtype.pos(), Errors.NewNotAllowedInAnnotation);
+            if (elems == null) {
+                elems = List.nil();
+            }
         }
         ListBuffer<Attribute> buf = new ListBuffer<>();
-        for (List<JCExpression> l = na.elems; l.nonEmpty(); l=l.tail) {
+        for (List<JCExpression> l = elems; l.nonEmpty(); l = l.tail) {
             buf.append(attributeAnnotationValue(types.elemtype(expectedElementType),
                     l.head,
                     env));

--- a/test/langtools/tools/javac/T8320144.java
+++ b/test/langtools/tools/javac/T8320144.java
@@ -1,0 +1,19 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8320144
+ * @summary Compilation crashes when a custom annotation with invalid default value is used
+ * @compile/fail/ref=T8320144.out -XDrawDiagnostics T8320144.java
+ */
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+public class T8320144 {
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE})
+    public @interface TestAnnotation {
+        public String[] excludeModules() default new String[0];
+        public String[] value() default new String[] { 3 };
+    }
+}

--- a/test/langtools/tools/javac/T8320144.out
+++ b/test/langtools/tools/javac/T8320144.out
@@ -1,0 +1,4 @@
+T8320144.java:16:54: compiler.err.new.not.allowed.in.annotation
+T8320144.java:17:45: compiler.err.new.not.allowed.in.annotation
+T8320144.java:17:56: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: int, java.lang.String)
+3 errors


### PR DESCRIPTION
Clean backport of JDK-8320144. Affected tests are still passing after the change. `T8320144.java` passes in this branch, and fails in `main`.