### PR TITLE
8356571: Re-enable -Wtype-limits for GCC in LCMS

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -309,7 +309,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBLCMS, \
         common/awt/debug \
         libawt/java2d, \
     HEADERS_FROM_SRC := $(LIBLCMS_HEADERS_FROM_SRC), \
-    DISABLED_WARNINGS_gcc := format-nonliteral type-limits stringop-truncation, \
+    DISABLED_WARNINGS_gcc := format-nonliteral stringop-truncation, \
     DISABLED_WARNINGS_clang := format-nonliteral, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9a0e6f33](https://github.com/openjdk/jdk/commit/9a0e6f338f34fb5da16d5f9eb710cdddd4302945) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 9 May 2025 and was reviewed by Julian Waters and Phil Race.

The change is the same as in mainline, but a different makefile is updated because [JDK-8330107](https://bugs.openjdk.org/browse/JDK-8330107) has not been backported to JDK 21.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8356571](https://bugs.openjdk.org/browse/JDK-8356571) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356571](https://bugs.openjdk.org/browse/JDK-8356571): Re-enable -Wtype-limits for GCC in LCMS (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1760/head:pull/1760` \
`$ git checkout pull/1760`

Update a local copy of the PR: \
`$ git checkout pull/1760` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1760`

View PR using the GUI difftool: \
`$ git pr show -t 1760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1760.diff">https://git.openjdk.org/jdk21u-dev/pull/1760.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1760#issuecomment-2865192964)
</details>
