### PR TITLE
8324880: Rename get_stack_trace.h

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/libGetStackTraceAndRetransformTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/libGetStackTraceAndRetransformTest.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
-#include "../get_stack_trace.h"
+#include "../get_stack_trace.hpp"
 
 
 extern "C" {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/GetStackTraceCurrentThreadTest/libGetStackTraceCurrentThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/GetStackTraceCurrentThreadTest/libGetStackTraceCurrentThreadTest.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
-#include "../get_stack_trace.h"
+#include "../get_stack_trace.hpp"
 
 
 extern "C" {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/get_stack_trace.hpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/get_stack_trace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,8 @@
  * questions.
  */
 
-#ifndef GET_STACK_TRACE_H
-#define GET_STACK_TRACE_H
+#ifndef GET_STACK_TRACE_HPP
+#define GET_STACK_TRACE_HPP
 #include "jvmti.h"
 
 typedef struct {
@@ -81,18 +81,18 @@ int compare_stack_trace(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
         lambda_idx = lambda - expected_frames[exp_idx].cls;
         printf("Comparing only first %zu chars in classname.\n", lambda_idx);
       }
-      if (class_signature == NULL || strncmp(class_signature, expected_frames[exp_idx].cls, lambda_idx) != 0) {
+      if (class_signature == nullptr || strncmp(class_signature, expected_frames[exp_idx].cls, lambda_idx) != 0) {
         printf("(frame#%d) wrong class sig: \"%s\", expected: \"%s\"\n",
                exp_idx, class_signature, expected_frames[exp_idx].cls);
         result = JNI_FALSE;
       }
 
-      if (name == NULL || strcmp(name, expected_frames[exp_idx].name) != 0) {
+      if (name == nullptr || strcmp(name, expected_frames[exp_idx].name) != 0) {
         printf("(frame#%d) wrong method name: \"%s\", expected: \"%s\"\n",
                exp_idx, name, expected_frames[exp_idx].name);
         result = JNI_FALSE;
       }
-      if (sig == NULL || strcmp(sig, expected_frames[exp_idx].sig) != 0) {
+      if (sig == nullptr || strcmp(sig, expected_frames[exp_idx].sig) != 0) {
         printf("(frame#%d) wrong method sig: \"%s\", expected: \"%s\"\n",
                exp_idx, sig, expected_frames[exp_idx].sig);
         result = JNI_FALSE;
@@ -103,4 +103,4 @@ int compare_stack_trace(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
 }
 
 
-#endif //GET_STACK_TRACE_H
+#endif //GET_STACK_TRACE_HPP

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr03/libgetstacktr03.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
-#include "../get_stack_trace.h"
+#include "../get_stack_trace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr04/libgetstacktr04.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr04/libgetstacktr04.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
-#include "../get_stack_trace.h"
+#include "../get_stack_trace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr05/libgetstacktr05.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr05/libgetstacktr05.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
-#include "../get_stack_trace.h"
+#include "../get_stack_trace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr06/libgetstacktr06.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr06/libgetstacktr06.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
-#include "../get_stack_trace.h"
+#include "../get_stack_trace.hpp"
 
 
 extern "C" {

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr07/libgetstacktr07.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr07/libgetstacktr07.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
-#include "../get_stack_trace.h"
+#include "../get_stack_trace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr08/libgetstacktr08.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/getstacktr08/libgetstacktr08.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.h"
-#include "../get_stack_trace.h"
+#include "../get_stack_trace.hpp"
 
 extern "C" {
 


### PR DESCRIPTION
I backport this to get later test backports clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324880](https://bugs.openjdk.org/browse/JDK-8324880) needs maintainer approval

### Issue
 * [JDK-8324880](https://bugs.openjdk.org/browse/JDK-8324880): Rename get_stack_trace.h (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1762/head:pull/1762` \
`$ git checkout pull/1762`

Update a local copy of the PR: \
`$ git checkout pull/1762` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1762`

View PR using the GUI difftool: \
`$ git pr show -t 1762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1762.diff">https://git.openjdk.org/jdk21u-dev/pull/1762.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1762#issuecomment-2866099188)
</details>
