### PR TITLE
8325456: Rename nsk_mutex.h

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <stdlib.h>
-#include "nsk_mutex.h"
+#include "nsk_mutex.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,8 @@
  * questions.
  */
 
-#ifndef NSK_MUTEX_H
-#define NSK_MUTEX_H
+#ifndef NSK_MUTEX_HPP
+#define NSK_MUTEX_HPP
 
 extern "C" {
 


### PR DESCRIPTION
I backport this ot make later backports clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325456](https://bugs.openjdk.org/browse/JDK-8325456) needs maintainer approval

### Issue
 * [JDK-8325456](https://bugs.openjdk.org/browse/JDK-8325456): Rename nsk_mutex.h (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1765/head:pull/1765` \
`$ git checkout pull/1765`

Update a local copy of the PR: \
`$ git checkout pull/1765` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1765`

View PR using the GUI difftool: \
`$ git pr show -t 1765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1765.diff">https://git.openjdk.org/jdk21u-dev/pull/1765.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1765#issuecomment-2866220966)
</details>
