### PR TITLE
8325910: Rename jnihelper.h

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/gclocker/libgcl001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/gclocker/libgcl001.cpp
@@ -23,7 +23,7 @@
 
 #include <jni.h>
 #include <stdlib.h>
-#include "jnihelper.h"
+#include "jnihelper.hpp"
 
 /*
   basic routine: provide critical sections and calculations

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnihelper.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnihelper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 // checked malloc to trap OOM conditions
 static void* c_malloc(JNIEnv* env, size_t size) {
   void* ret = malloc(size);
-  if (ret == NULL)
+  if (ret == nullptr)
     env->FatalError("malloc failed");
   return ret;
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress001.cpp
@@ -26,7 +26,7 @@
 /* Changed from strings.h to string.h for Windows. */
 #include <string.h>
 #include <stdlib.h>
-#include "jnihelper.h"
+#include "jnihelper.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 #include <jni.h>
 #include <stdio.h>
-#include "jnihelper.h"
+#include "jnihelper.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress003.cpp
@@ -24,7 +24,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "jnihelper.h"
+#include "jnihelper.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress004.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "jnihelper.h"
+#include "jnihelper.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress005.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "jnihelper.h"
+#include "jnihelper.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress006.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "jnihelper.h"
+#include "jnihelper.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress007.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 #include <jni.h>
 #include <stdio.h>
-#include "jnihelper.h"
+#include "jnihelper.hpp"
 
 extern "C" {
 


### PR DESCRIPTION
I backport this to make later backorts clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325910](https://bugs.openjdk.org/browse/JDK-8325910) needs maintainer approval

### Issue
 * [JDK-8325910](https://bugs.openjdk.org/browse/JDK-8325910): Rename jnihelper.h (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1768/head:pull/1768` \
`$ git checkout pull/1768`

Update a local copy of the PR: \
`$ git checkout pull/1768` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1768`

View PR using the GUI difftool: \
`$ git pr show -t 1768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1768.diff">https://git.openjdk.org/jdk21u-dev/pull/1768.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1768#issuecomment-2866999262)
</details>
