### PR TITLE
8326090: Rename jvmti_aod.h

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002/attach002Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002/attach002Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 #include "ExceptionCheckingJniEnv.hpp"
 
 extern "C" {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/attach002aAgent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/attach002aAgent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach008/attach008Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach008/attach008Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach009/attach009Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach009/attach009Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach012/attach012Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach012/attach012Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach014/attach014Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach014/attach014Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Agent01.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Agent01.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Target.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Target.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach020/attach020Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach020/attach020Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach021/attach021Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach021/attach021Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 #include "ExceptionCheckingJniEnv.hpp"
 
 extern "C" {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach022/attach022Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach022/attach022Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 #include "ExceptionCheckingJniEnv.hpp"
 
 extern "C" {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach037/attach037Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach037/attach037Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach038/attach038Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach038/attach038Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach039/attach039Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach039/attach039Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach040/attach040Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach040/attach040Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach041/attach041Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach041/attach041Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach042/attach042Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach042/attach042Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent01.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent01.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent02.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent02.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent03.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent03.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach046/attach046Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach046/attach046Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach050/attach050Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach050/attach050Agent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 #define ON_UNLOAD_MARKER "attach050.on_unload"
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/sharedAgents/simpleAgent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/sharedAgents/simpleAgent00.cpp
@@ -26,7 +26,7 @@
 #include <jni.h>
 #include <jvmti.h>
 #include <aod.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.cpp
@@ -22,7 +22,7 @@
  */
 #include <string.h>
 #include <stdlib.h>
-#include <jvmti_aod.h>
+#include <jvmti_aod.hpp>
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,8 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-#ifndef NSK_SHARE_JVMTI_AOD_H
-#define NSK_SHARE_JVMTI_AOD_H
+#ifndef NSK_SHARE_JVMTI_AOD_HPP
+#define NSK_SHARE_JVMTI_AOD_HPP
 
 #include <aod.h>
 #include <jvmti.h>
@@ -68,8 +68,8 @@ int nsk_jvmti_aod_getThreadName(jvmtiEnv * jvmti, jthread thread, char threadNam
 
 // events enabling/disabling
 
-#define nsk_jvmti_aod_enableEvent(X,Y)  NSK_JVMTI_VERIFY(X->SetEventNotificationMode(JVMTI_ENABLE, Y, NULL))
-#define nsk_jvmti_aod_disableEvent(X,Y) NSK_JVMTI_VERIFY(X->SetEventNotificationMode(JVMTI_DISABLE, Y, NULL))
+#define nsk_jvmti_aod_enableEvent(X,Y)  NSK_JVMTI_VERIFY(X->SetEventNotificationMode(JVMTI_ENABLE, Y, nullptr))
+#define nsk_jvmti_aod_disableEvent(X,Y) NSK_JVMTI_VERIFY(X->SetEventNotificationMode(JVMTI_DISABLE, Y, nullptr))
 
 int nsk_jvmti_aod_enableEvents(jvmtiEnv* jvmti, jvmtiEvent events[], int eventsNumber);
 int nsk_jvmti_aod_disableEvents(jvmtiEnv* jvmti, jvmtiEvent events[], int eventsNumber);
@@ -90,4 +90,4 @@ void printCapabilities(jvmtiCapabilities caps);
 
 }
 
-#endif /* END OF NSK_SHARE_JVMTI_AOD_H */
+#endif /* END OF NSK_SHARE_JVMTI_AOD_HPP */


### PR DESCRIPTION
I backport this to make later backorts clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326090](https://bugs.openjdk.org/browse/JDK-8326090) needs maintainer approval

### Issue
 * [JDK-8326090](https://bugs.openjdk.org/browse/JDK-8326090): Rename jvmti_aod.h (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1769/head:pull/1769` \
`$ git checkout pull/1769`

Update a local copy of the PR: \
`$ git checkout pull/1769` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1769`

View PR using the GUI difftool: \
`$ git pr show -t 1769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1769.diff">https://git.openjdk.org/jdk21u-dev/pull/1769.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1769#issuecomment-2867099072)
</details>
