### PR TITLE
8356053: Test java/awt/Toolkit/Headless/HeadlessToolkit.java fails by timeout

### DIFF
--- a/test/jdk/java/awt/Toolkit/Headless/HeadlessToolkit.java
+++ b/test/jdk/java/awt/Toolkit/Headless/HeadlessToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,20 @@
  * questions.
  */
 
-import javax.imageio.ImageIO;
-import java.awt.*;
+import java.awt.AWTEvent;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.HeadlessException;
+import java.awt.Image;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.event.AWTEventListener;
 import java.awt.event.KeyEvent;
@@ -35,8 +47,9 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URL;
 import java.util.Map;
+
+import javax.imageio.ImageIO;
 
 /*
  * @test
@@ -44,7 +57,6 @@ import java.util.Map;
  *          in headless mode
  * @run main/othervm -Djava.awt.headless=true HeadlessToolkit
  */
-
 public class HeadlessToolkit {
 
     class awtEventListener implements AWTEventListener {
@@ -275,13 +287,12 @@ public class HeadlessToolkit {
             im = tk.createImage(image.getAbsolutePath());
             im.flush();
 
+            im = tk.getImage(image.toURI().toURL());
+            im.flush();
+
+            im = tk.createImage(image.toURI().toURL());
+            im.flush();
         }
-
-        im = tk.getImage(new URL("https://openjdk.org/images/openjdk.png"));
-        im.flush();
-
-        im = tk.createImage(new URL("https://openjdk.org/images/openjdk.png"));
-        im.flush();
 
         MemoryImageSource mis;
         int pixels[] = new int[50 * 50];


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [375f3dc9](https://github.com/openjdk/jdk/commit/375f3dc9ed0f1704e726d0d704420c38a0a5513c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 9 May 2025 and was reviewed by Phil Race and Alexander Zuev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8356053](https://bugs.openjdk.org/browse/JDK-8356053) needs maintainer approval

### Issue
 * [JDK-8356053](https://bugs.openjdk.org/browse/JDK-8356053): Test java/awt/Toolkit/Headless/HeadlessToolkit.java fails by timeout (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1771/head:pull/1771` \
`$ git checkout pull/1771`

Update a local copy of the PR: \
`$ git checkout pull/1771` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1771`

View PR using the GUI difftool: \
`$ git pr show -t 1771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1771.diff">https://git.openjdk.org/jdk21u-dev/pull/1771.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1771#issuecomment-2871969098)
</details>
