### PR TITLE
8351484: Race condition in max stats in MonitorList::add

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -70,10 +70,14 @@ void MonitorList::add(ObjectMonitor* m) {
     m->set_next_om(head);
   } while (Atomic::cmpxchg(&_head, head, m) != head);
 
-  size_t count = Atomic::add(&_count, 1u);
-  if (count > max()) {
-    Atomic::inc(&_max);
-  }
+  size_t count = Atomic::add(&_count, 1u, memory_order_relaxed);
+  size_t old_max;
+  do {
+    old_max = Atomic::load(&_max);
+    if (count <= old_max) {
+      break;
+    }
+  } while (Atomic::cmpxchg(&_max, old_max, count, memory_order_relaxed) != old_max);
 }
 
 size_t MonitorList::count() const {

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -45,6 +45,7 @@ private:
   volatile size_t _max;
 
 public:
+  MonitorList() : _head(nullptr), _count(0), _max(0) {};
   void add(ObjectMonitor* monitor);
   size_t unlink_deflated(Thread* current, LogStream* ls, elapsedTimer* timer_p,
                          size_t deflated_count,

--- a/test/hotspot/gtest/runtime/test_synchronizer.cpp
+++ b/test/hotspot/gtest/runtime/test_synchronizer.cpp
@@ -22,9 +22,14 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/vmClasses.hpp"
 #include "memory/allocation.hpp"
+#include "memory/universe.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/objectMonitor.hpp"
 #include "runtime/synchronizer.hpp"
 #include "runtime/vm_version.hpp"
+#include "threadHelper.inline.hpp"
 #include "unittest.hpp"
 
 class SynchronizerTest : public ::testing::Test {
@@ -65,5 +70,39 @@ TEST_VM(SynchronizerTest, sanity) {
             << "the SharedGlobals.hc_sequence field is closer "
             << "to the struct end than a cache line which permits false "
             << "sharing.";
+  }
+}
+
+TEST_VM(SynchronizerTest, monitorListStats) {
+  JavaThread* THREAD = JavaThread::current();
+  ThreadInVMfromNative invm(THREAD);
+  ResourceMark rm(THREAD);
+
+  // Something to reference in OM. It makes no difference which oop it is,
+  // as long as it is correct.
+  oop obj = vmClasses::Byte_klass()->allocate_instance(THREAD);
+
+  HandleMark hm(THREAD);
+  Handle h_obj(THREAD, obj);
+
+  // Test various combinations of thread counts, including single-threaded test.
+  static const int MIN_THREADS = 1;
+  static const int MAX_THREADS = 16;
+  static const int OM_PER_THREAD = 1000;
+
+  for (int threads = MIN_THREADS; threads <= MAX_THREADS; threads *= 2) {
+    MonitorList list;
+
+    auto work = [&](Thread*, int) {
+      for (int c = 0; c < OM_PER_THREAD; c++) {
+        list.add(new ObjectMonitor(h_obj()));
+      }
+    };
+    TestThreadGroup<decltype(work)> workers{work, threads};
+    workers.doit();
+    workers.join();
+
+    EXPECT_EQ(list.count(), (size_t)(threads*OM_PER_THREAD));
+    EXPECT_EQ(list.max(), (size_t)(threads*OM_PER_THREAD));
   }
 }


### PR DESCRIPTION
Unclean backport of JDK-8351484. Fixes a race condition in `MonitorList::add`. The new test does not pass on `master`. Conflicts were related to the import statements in the test file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8351484](https://bugs.openjdk.org/browse/JDK-8351484) needs maintainer approval

### Issue
 * [JDK-8351484](https://bugs.openjdk.org/browse/JDK-8351484): Race condition in max stats in MonitorList::add (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1778/head:pull/1778` \
`$ git checkout pull/1778`

Update a local copy of the PR: \
`$ git checkout pull/1778` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1778`

View PR using the GUI difftool: \
`$ git pr show -t 1778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1778.diff">https://git.openjdk.org/jdk21u-dev/pull/1778.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1778#issuecomment-2880288080)
</details>
