### PR TITLE
8332921: Ctrl+C does not call shutdown hooks after JLine upgrade

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -51,7 +51,9 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
     public JdkConsole console(boolean isTTY, Charset charset) {
         try {
             Terminal terminal = TerminalBuilder.builder().encoding(charset)
-                                               .exec(false).build();
+                                               .exec(false)
+                                               .nativeSignals(false)
+                                               .build();
             return new JdkConsoleImpl(terminal);
         } catch (IllegalStateException ise) {
             //cannot create a non-dumb, non-exec terminal,

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -158,7 +158,7 @@ class ConsoleIOContext extends IOContext {
             terminal = TerminalBuilder.builder().inputStreamWrapper(in -> {
                 input.setInputStream(in);
                 return nonBlockingInput;
-            }).build();
+            }).nativeSignals(false).build();
             useComplexDeprecationHighlight = !OSUtils.IS_WINDOWS;
         }
         this.allowIncompleteInputs = allowIncompleteInputs;


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

Resolved one file because "https://bugs.openjdk.org/browse/JDK-8330998: System.console() writes to stderr when stdout is redirected" and others are not in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332921](https://bugs.openjdk.org/browse/JDK-8332921) needs maintainer approval

### Issue
 * [JDK-8332921](https://bugs.openjdk.org/browse/JDK-8332921): Ctrl+C does not call shutdown hooks after JLine upgrade (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1779/head:pull/1779` \
`$ git checkout pull/1779`

Update a local copy of the PR: \
`$ git checkout pull/1779` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1779`

View PR using the GUI difftool: \
`$ git pr show -t 1779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1779.diff">https://git.openjdk.org/jdk21u-dev/pull/1779.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1779#issuecomment-2882811689)
</details>
