### PR TITLE
8345447: test/jdk/javax/swing/JToolBar/4529206/bug4529206.java fails in ubuntu22.04

### DIFF
--- a/test/jdk/javax/swing/JToolBar/4529206/bug4529206.java
+++ b/test/jdk/javax/swing/JToolBar/4529206/bug4529206.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
+import javax.swing.plaf.basic.BasicToolBarUI;
 
 /*
  * @test
@@ -45,7 +46,7 @@ public class bug4529206 {
     static JButton jButton1;
 
     private static void test() {
-        frame = new JFrame();
+        frame = new JFrame("bug4529206");
         JPanel jPanFrame = (JPanel) frame.getContentPane();
         jPanFrame.setLayout(new BorderLayout());
         frame.setSize(new Dimension(200, 100));
@@ -64,7 +65,7 @@ public class bug4529206 {
     }
 
     private static void makeToolbarFloat() {
-        javax.swing.plaf.basic.BasicToolBarUI ui = (javax.swing.plaf.basic.BasicToolBarUI) jToolBar1.getUI();
+        BasicToolBarUI ui = (BasicToolBarUI) jToolBar1.getUI();
         if (!ui.isFloating()) {
             ui.setFloatingLocation(100, 100);
             ui.setFloating(true, jToolBar1.getLocation());
@@ -79,16 +80,17 @@ public class bug4529206 {
         try {
             SwingUtilities.invokeAndWait(() -> test());
             Robot robot = new Robot();
-            robot.setAutoWaitForIdle(true);
+            robot.waitForIdle();
             robot.delay(1000);
 
             SwingUtilities.invokeAndWait(() -> makeToolbarFloat());
+            robot.waitForIdle();
             robot.delay(300);
 
             SwingUtilities.invokeAndWait(() -> {
                 if (frame.isFocused()) {
-                    throw
-                      new RuntimeException("setFloating does not work correctly");
+                    throw new RuntimeException(
+                        "setFloating does not work correctly");
                 }
             });
         } finally {


### PR DESCRIPTION
I backport this test change as it also goes to 21.0.9-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345447](https://bugs.openjdk.org/browse/JDK-8345447) needs maintainer approval

### Issue
 * [JDK-8345447](https://bugs.openjdk.org/browse/JDK-8345447): test/jdk/javax/swing/JToolBar/4529206/bug4529206.java fails in ubuntu22.04 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1784/head:pull/1784` \
`$ git checkout pull/1784`

Update a local copy of the PR: \
`$ git checkout pull/1784` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1784`

View PR using the GUI difftool: \
`$ git pr show -t 1784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1784.diff">https://git.openjdk.org/jdk21u-dev/pull/1784.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1784#issuecomment-2883362595)
</details>
