### PR TITLE
8326389: [test] improve assertEquals failure output

### DIFF
--- a/test/lib/jdk/test/lib/Asserts.java
+++ b/test/lib/jdk/test/lib/Asserts.java
@@ -201,10 +201,7 @@ public class Asserts {
      */
     public static void assertEquals(Object lhs, Object rhs, String msg) {
         if ((lhs != rhs) && ((lhs == null) || !(lhs.equals(rhs)))) {
-            msg = Objects.toString(msg, "assertEquals")
-                    + ": expected " + Objects.toString(lhs)
-                    + " to equal " + Objects.toString(rhs);
-            fail(msg);
+            fail((msg == null ? "assertEquals" : msg) + " expected: " + lhs + " but was: " + rhs);
         }
     }
 


### PR DESCRIPTION
Let's backport this to fix the annoying message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326389](https://bugs.openjdk.org/browse/JDK-8326389) needs maintainer approval

### Issue
 * [JDK-8326389](https://bugs.openjdk.org/browse/JDK-8326389): [test] improve assertEquals failure output (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1787/head:pull/1787` \
`$ git checkout pull/1787`

Update a local copy of the PR: \
`$ git checkout pull/1787` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1787`

View PR using the GUI difftool: \
`$ git pr show -t 1787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1787.diff">https://git.openjdk.org/jdk21u-dev/pull/1787.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1787#issuecomment-2883431887)
</details>
