### PR TITLE
8350383: Test: add more test case for string compare (UL case)

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics.java
@@ -155,6 +155,7 @@ public class TestStringIntrinsics {
                 char cL = latin1.charAt(indexL);
                 char cU = utf16.charAt(indexU);
                 invokeAndCheck(m, cL - cU, latin1, latin1.replace(cL, cU));
+                invokeAndCheck(m, cU - cL, latin1.replace(cL, cU), latin1);
                 invokeAndCheck(m, cU - cL, utf16, utf16.replace(cU, cL));
 
                 // Different lengths


### PR DESCRIPTION
I backport this test change as it also goes to 21.0.9-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350383](https://bugs.openjdk.org/browse/JDK-8350383) needs maintainer approval

### Issue
 * [JDK-8350383](https://bugs.openjdk.org/browse/JDK-8350383): Test: add more test case for string compare (UL case) (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1790/head:pull/1790` \
`$ git checkout pull/1790`

Update a local copy of the PR: \
`$ git checkout pull/1790` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1790`

View PR using the GUI difftool: \
`$ git pr show -t 1790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1790.diff">https://git.openjdk.org/jdk21u-dev/pull/1790.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1790#issuecomment-2884331759)
</details>
