### PR TITLE
8352942: jdk/jfr/startupargs/TestMemoryOptions.java fails with 32-bit build

### DIFF
--- a/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
+++ b/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
@@ -485,6 +485,7 @@ public class TestMemoryOptions {
             if (flightRecorderOptions != null) {
                 pb = ProcessTools.createTestJavaProcessBuilder("--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED",
                                                                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                                                               "-Xmx256m",
                                                                flightRecorderOptions,
                                                                "-XX:StartFlightRecording",
                                                                SUT.class.getName(),
@@ -493,6 +494,7 @@ public class TestMemoryOptions {
                 // default, no FlightRecorderOptions passed
                 pb = ProcessTools.createTestJavaProcessBuilder("--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED",
                                                                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                                                               "-Xmx256m",
                                                                "-XX:StartFlightRecording",
                                                                SUT.class.getName(),
                                                                tc.getTestName());


### PR DESCRIPTION
Hi all,

This is a backport of JDK-8352942: jdk/jfr/startupargs/TestMemoryOptions.java fails with 32-bit build

I couldn't reproduce the bug reported in JDK-8352942 in 21u but it will potentially happen as described in https://github.com/openjdk/jdk/pull/24646#issue-2995156538 . So I think this fix should be backported to 21u.

Original patch apply cleanly to 21u.

Testing: TestMemoryOptions.java executed by 32/64bit module passes on RHEL9 and Winsows Server 2019

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352942](https://bugs.openjdk.org/browse/JDK-8352942) needs maintainer approval

### Issue
 * [JDK-8352942](https://bugs.openjdk.org/browse/JDK-8352942): jdk/jfr/startupargs/TestMemoryOptions.java fails with 32-bit build (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1793/head:pull/1793` \
`$ git checkout pull/1793`

Update a local copy of the PR: \
`$ git checkout pull/1793` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1793`

View PR using the GUI difftool: \
`$ git pr show -t 1793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1793.diff">https://git.openjdk.org/jdk21u-dev/pull/1793.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1793#issuecomment-2886367624)
</details>
