### PR TITLE
8352684: Opensource JInternalFrame tests - series1

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/bug4131008.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4131008.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4131008
+ * @summary JInternalFrame should refresh title after it changing
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4131008
+*/
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JButton;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.UIManager;
+
+public class bug4131008 {
+
+    private static final String INSTRUCTIONS = """
+        Press button "Change title" at the internal frame "Old".
+        If title of this frame will replaced by "New",
+        then test passed, else test fails.""";
+
+    public static void main(String[] args) throws Exception {
+
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+
+        PassFailJFrame.builder()
+            .title("bug4131008 Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(50)
+            .testUI(bug4131008::createTestUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4131008");
+        JInternalFrame jif = new JInternalFrame("Old");
+        JDesktopPane jdp = new JDesktopPane();
+        frame.setContentPane(jdp);
+
+        jif.setSize(150, 100);
+        jif.setVisible(true);
+        JButton bt = new JButton("Change title");
+        bt.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                jif.setTitle("New");
+            }
+        });
+        jif.getContentPane().add(bt);
+        jdp.add(jif);
+        try {
+            jif.setSelected(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        frame.setSize(300, 200);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4176136.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4176136.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4176136
+ * @summary Default close operation JInternalFrame.DO_NOTHING_ON_CLOSE works correctly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4176136
+ */
+
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+
+public class bug4176136 {
+
+    private static final String INSTRUCTIONS = """
+        Click the close button of the internal frame.
+        You will see the close button activate,
+             but nothing else should happen.
+        If the internal frame closes, the test fails.
+        If it doesn't close, the test passes.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4176136 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(25)
+                .testUI(bug4176136::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4176136");
+        JDesktopPane dp = new JDesktopPane();
+        frame.add(dp);
+        JInternalFrame inf = new JInternalFrame();
+        dp.add(inf);
+        inf.setDefaultCloseOperation(JInternalFrame.DO_NOTHING_ON_CLOSE);
+        inf.setSize(100, 100);
+        inf.setClosable(true);
+        inf.setVisible(true);
+        frame.setSize(200, 200);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4244536.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4244536.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4244536
+ * @summary Tests that Motif JInternalFrame can be maximized
+ *          after it was iconified.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4244536
+ */
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.UIManager;
+
+public class bug4244536 {
+
+    private static final String INSTRUCTIONS = """
+        Minimize the internal frame using the minimize button.
+        Then double-click on it to restore its size.
+        Then press the maximize button.
+        If the frame gets maximized, test passes.
+        If its size don't change, test fails.""";
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel(
+                  "com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+
+        PassFailJFrame.builder()
+                .title("bug4244536 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(50)
+                .testUI(bug4244536::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4244536");
+        JDesktopPane desktop = new JDesktopPane();
+        JInternalFrame jif = new JInternalFrame("Internal Frame");
+        jif.setSize(150, 150);
+        jif.setMaximizable(true);
+        jif.setIconifiable(true);
+        jif.setVisible(true);
+        desktop.add(jif);
+        frame.add("Center", desktop);
+        frame.setSize(300, 300);
+        return frame;
+    }
+
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4305284.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4305284.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4305284
+ * @summary JInternalFrames can't be sized off of the desktop
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4305284
+ */
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+
+public class bug4305284 {
+
+    private static final String INSTRUCTIONS = """
+        Try to resize the shown internal frame.
+        If it can't be sized of the desktop bounds,
+        then test passes, else test fails.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4305284 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(25)
+                .testUI(bug4305284::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4305284");
+        JInternalFrame jif = new JInternalFrame("Test",
+                                 true, true, true, true);
+        JDesktopPane dp = new JDesktopPane();
+        frame.setContentPane(dp);
+        dp.add(jif);
+
+        try {
+            jif.setBounds(50, 50, 200, 200);
+            jif.setMaximum(false);
+            jif.setVisible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        frame.setSize(300, 300);
+        return frame;
+    }
+
+}


### PR DESCRIPTION
I backport this test change as it also goes to 21.0.9-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352684](https://bugs.openjdk.org/browse/JDK-8352684) needs maintainer approval

### Issue
 * [JDK-8352684](https://bugs.openjdk.org/browse/JDK-8352684): Opensource JInternalFrame tests - series1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1797/head:pull/1797` \
`$ git checkout pull/1797`

Update a local copy of the PR: \
`$ git checkout pull/1797` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1797`

View PR using the GUI difftool: \
`$ git pr show -t 1797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1797.diff">https://git.openjdk.org/jdk21u-dev/pull/1797.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1797#issuecomment-2886533997)
</details>
