### PR TITLE
Backport ff165f9f0cf519144d7361b766bcce53d04c518e

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -497,7 +497,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             if (prefix) {
                 sb.append(" ");
             }
-            sb.append(getAnnotationMirrors());
+            sb.append(getAnnotationMirrors().toString(" "));
             sb.append(" ");
         }
     }

--- a/test/langtools/tools/javac/processing/model/type/AnnotatedTypeToString/AnnotatedTypeToString.java
+++ b/test/langtools/tools/javac/processing/model/type/AnnotatedTypeToString/AnnotatedTypeToString.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8284220
+ * @bug 8284220 8342934
  * @summary Tests DeclaredType.toString with type annotations present, for example that '@A
  * Map.Entry' is printed as 'java.util.@A Map.Entry' (and not '@A java.util.Map.Entry' or
  * 'java.util.@A Entry').

--- a/test/langtools/tools/javac/processing/model/type/AnnotatedTypeToString/Test.java
+++ b/test/langtools/tools/javac/processing/model/type/AnnotatedTypeToString/Test.java
@@ -32,6 +32,10 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE_USE)
 @interface A {}
 
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+@interface B {}
+
 public class Test {
     static class StaticNested {
         static class InnerMostStaticNested {}
@@ -41,8 +45,8 @@ public class Test {
         class InnerMost {}
     }
 
-    @ExpectedToString("p.Test.@p.A StaticNested")
-    @A StaticNested i;
+    @ExpectedToString("p.Test.@p.A @p.B StaticNested")
+    @A @B StaticNested i;
 
     @ExpectedToString("p.Test.StaticNested.@p.A InnerMostStaticNested")
     StaticNested.@A InnerMostStaticNested j;


### PR DESCRIPTION
This backport of [JDK-8342934](https://bugs.openjdk.org/browse/JDK-8342934) fixes a bug in `TypeMirror#toString` output.