### PR TITLE
8308033: The jcmd thread dump related tests should test virtual threads

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,6 @@
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8308026 generic-all
 serviceability/jvmti/GetThreadListStackTraces/OneGetThreadListStackTraces.java 8308027 generic-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 generic-all
-serviceability/dcmd/thread/PrintConcurrentLocksTest.java 8308033 generic-all
-serviceability/dcmd/thread/PrintTest.java 8308033 generic-all
-serviceability/dcmd/thread/ThreadDumpToFileTest.java 8308033 generic-all
-serviceability/tmtools/jstack/DaemonThreadTest.java 8308033 generic-all
 
 ####
 ## Classes not unloaded as expected (TODO, need to check if FJ keeps a reference)

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 
@@ -171,6 +172,9 @@ public class PrintTest {
 
     @Test
     public void jmx() {
+        if (Thread.currentThread().isVirtual()) {
+            throw new SkipException("skipping test since current thread is virtual thread");
+        }
         run(new JMXExecutor());
     }
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstack/DaemonThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstack/DaemonThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ public class DaemonThreadTest {
     static class NormalThread extends Thread {
 
         NormalThread() {
+            setDaemon(false);
         }
 
         @Override

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -30,9 +30,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
 
-sun/tools/jcmd/JcmdOutputEncodingTest.java 8308033 generic-all
-sun/tools/jstack/BasicJStackTest.java 8308033 generic-all
-
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8308035 windows-x64
 
 javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-x64

--- a/test/jdk/sun/tools/jstack/BasicJStackTest.java
+++ b/test/jdk/sun/tools/jstack/BasicJStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,11 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.JDKToolLauncher;
 
+import jtreg.SkippedException;
+
 /*
  * @test
- * @bug 8273187
+ * @bug 8273187 8308033
  * @summary Unit test for jstack utility
  * @library /test/lib
  * @run main BasicJStackTest
@@ -42,6 +44,13 @@ public class BasicJStackTest {
     private static ProcessBuilder processBuilder = new ProcessBuilder();
 
     public static void main(String[] args) throws Exception {
+        if (Thread.currentThread().isVirtual()) {
+            // This test runs jstack against the current process and then asserts the
+            // presence of current thread in the stacktraces. We skip this test
+            // when the current thread is a virtual thread since "jstack" command doesn't
+            // print the stacktraces of virtual threads.
+            throw new SkippedException("skipping test since current thread is a virtual thread");
+        }
         testJstackNoArgs();
         testJstack_l();
         testJstackUTF8Encoding();


### PR DESCRIPTION
Backporting JDK-8308033: The jcmd thread dump related tests should test virtual threads. Test code change that adjusts jcmd tests that fail when using a virtual thread test factory and attempting to verify stack dumps. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8308033](https://bugs.openjdk.org/browse/JDK-8308033) needs maintainer approval

### Issue
 * [JDK-8308033](https://bugs.openjdk.org/browse/JDK-8308033): The jcmd thread dump related tests should test virtual threads (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1807/head:pull/1807` \
`$ git checkout pull/1807`

Update a local copy of the PR: \
`$ git checkout pull/1807` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1807`

View PR using the GUI difftool: \
`$ git pr show -t 1807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1807.diff">https://git.openjdk.org/jdk21u-dev/pull/1807.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1807#issuecomment-2892252691)
</details>
