### PR TITLE
Backport bd795946e777fccf797b1b69806217f988212f73

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JColorChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JColorChooser.java
@@ -175,7 +175,9 @@ public class JColorChooser extends JComponent implements Accessible {
      * @return the selected color or <code>null</code> if the user opted out
      * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
+     *
      * @see java.awt.GraphicsEnvironment#isHeadless
+     * @since 9
      */
     @SuppressWarnings("deprecation")
     public static Color showDialog(Component component, String title,

--- a/src/java.desktop/share/classes/javax/swing/colorchooser/AbstractColorChooserPanel.java
+++ b/src/java.desktop/share/classes/javax/swing/colorchooser/AbstractColorChooserPanel.java
@@ -229,6 +229,7 @@ public abstract class AbstractColorChooserPanel extends JPanel {
      *
      * @param b true if the transparency of a color can be selected
      * @see #isColorTransparencySelectionEnabled()
+     * @since 9
      */
     @BeanProperty(description
             = "Sets the transparency of a color selection on or off.")
@@ -241,6 +242,7 @@ public abstract class AbstractColorChooserPanel extends JPanel {
      *
      * @return true if the transparency of a color can be selected
      * @see #setColorTransparencySelectionEnabled(boolean)
+     * @since 9
      */
     public boolean isColorTransparencySelectionEnabled(){
         return true;


### PR DESCRIPTION
Backporting JDK-8343037: Missing @since tag on JColorChooser.showDialog overload. Trivial change, adding @since tag. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.