### PR TITLE
8342782: AWTEventMulticaster throws StackOverflowError using AquaButtonUI

### DIFF
--- a/src/java.desktop/share/classes/java/awt/AWTEventMulticaster.java
+++ b/src/java.desktop/share/classes/java/awt/AWTEventMulticaster.java
@@ -110,6 +110,8 @@ public class AWTEventMulticaster implements
     TextListener, InputMethodListener, HierarchyListener,
     HierarchyBoundsListener, MouseWheelListener {
 
+    private static final int MAX_UNBALANCED_TOP_NODES = 100;
+
     /**
      * A variable in the event chain (listener-a)
      */
@@ -954,6 +956,7 @@ public class AWTEventMulticaster implements
      * If listener-b is null, it returns listener-a
      * If neither are null, then it creates and returns
      * a new AWTEventMulticaster instance which chains a with b.
+     *
      * @param a event listener-a
      * @param b event listener-b
      * @return the resulting listener
@@ -961,7 +964,64 @@ public class AWTEventMulticaster implements
     protected static EventListener addInternal(EventListener a, EventListener b) {
         if (a == null)  return b;
         if (b == null)  return a;
-        return new AWTEventMulticaster(a, b);
+        AWTEventMulticaster n = new AWTEventMulticaster(a, b);
+        if (!needsRebalance(n)) {
+            return n;
+        }
+
+        EventListener[] array = getListeners(n, EventListener.class);
+        return rebalance(array, 0, array.length - 1);
+    }
+
+    /**
+     * Return true if the argument represents a binary tree that needs to be rebalanced.
+     */
+    private static boolean needsRebalance(AWTEventMulticaster l) {
+        int level = 0;
+        while (true) {
+            // The criteria for when we need a rebalance is subjective. This method checks
+            // up to a given threshold of the topmost nodes of a AWTEventMulticaster. If
+            // they all include one leaf node, then this method returns true. This criteria
+            // will be met after several consecutive iterations of `addInternal(a, b)`
+            if (++level > MAX_UNBALANCED_TOP_NODES) {
+                return true;
+            }
+            if (l.a instanceof AWTEventMulticaster aMulti) {
+                if (l.b instanceof AWTEventMulticaster) {
+                    // we reached a node where both children are AWTEventMulticaster: let's assume
+                    // the current node marks the start of a well-balanced subtree
+                    return false;
+                }
+                l = aMulti;
+            } else if (l.b instanceof AWTEventMulticaster bMulti) {
+                l = bMulti;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Recursively create a balanced tree that includes a given range of EventListeners.
+     *
+     * @param array the array of the EventListeners to consult
+     * @param index0 the lowest index (inclusive) that the return value must include
+     * @param index1 the highest index (inclusive) that the return value must include.
+     *
+     * @return a balanced tree. If index0 equals index1 then this returns an EventListener from
+     * the array provided. Otherwise this returns an AWTEventMulticaster.
+     */
+    private static EventListener rebalance(EventListener[] array, int index0, int index1) {
+        if (index0 == index1) {
+            return array[index0];
+        }
+        if (index0 == index1 - 1) {
+            return new AWTEventMulticaster(array[index0], array[index1]);
+        }
+        int mid = (index0 + index1) / 2;
+        return new AWTEventMulticaster(
+                rebalance(array, index0, mid),
+                rebalance(array, mid + 1, index1));
     }
 
     /**

--- a/test/jdk/java/awt/event/StressTest/LargeAWTEventMulticasterTest.java
+++ b/test/jdk/java/awt/event/StressTest/LargeAWTEventMulticasterTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
+import java.awt.AWTEventMulticaster;
+
+/*
+ * @test
+ * @bug 8342782
+ * @summary Tests large AWTEventMulticasters for StackOverflowErrors
+ * @run main LargeAWTEventMulticasterTest
+ */
+public class LargeAWTEventMulticasterTest {
+
+    /**
+     * This is an empty ActionListener that also has a numeric index.
+     */
+    static class IndexedActionListener implements ActionListener {
+        private final int index;
+
+        public IndexedActionListener(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        @Override
+        public String toString() {
+            return Integer.toString(index);
+        }
+    }
+
+    public static void main(String[] args) {
+        int maxA = 0;
+        try {
+            for (int a = 1; a < 200_000; a *= 2) {
+                maxA = a;
+                testAddingActionListener(a);
+            }
+        } finally {
+            System.out.println("maximum a = " + maxA);
+        }
+    }
+
+    private static void testAddingActionListener(int numberOfListeners) {
+        // step 1: create the large AWTEventMulticaster
+        ActionListener l = null;
+        for (int a = 0; a < numberOfListeners; a++) {
+            l = AWTEventMulticaster.add(l, new IndexedActionListener(a));
+        }
+
+        // Prior to 8342782 we could CREATE a large AWTEventMulticaster, but we couldn't
+        // always interact with it.
+
+        // step 2: dispatch an event
+        // Here we're making sure we don't get a StackOverflowError when we traverse the tree:
+        l.actionPerformed(null);
+
+        // step 3: make sure getListeners() returns elements in the correct order
+        // The resolution for 8342782 introduced a `rebalance` method; we want to
+        // double-check that the rebalanced tree preserves the appropriate order.
+        IndexedActionListener[] array = AWTEventMulticaster.getListeners(l, IndexedActionListener.class);
+        for (int b = 0; b < array.length; b++) {
+            if (b != array[b].getIndex())
+                throw new Error("the listeners are in the wrong order. " + b + " != " + array[b].getIndex());
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8342782: AWTEventMulticaster throws StackOverflowError using AquaButtonUI. Refactoring `AWTEventMulticaster` to avoid stack overflow error when using AquaButtonUI. Ran GHA Sanity Checks, local Tier 1 and 2, and new test. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342782](https://bugs.openjdk.org/browse/JDK-8342782) needs maintainer approval

### Issue
 * [JDK-8342782](https://bugs.openjdk.org/browse/JDK-8342782): AWTEventMulticaster throws StackOverflowError using AquaButtonUI (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1810/head:pull/1810` \
`$ git checkout pull/1810`

Update a local copy of the PR: \
`$ git checkout pull/1810` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1810`

View PR using the GUI difftool: \
`$ git pr show -t 1810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1810.diff">https://git.openjdk.org/jdk21u-dev/pull/1810.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1810#issuecomment-2892324584)
</details>
