### PR TITLE
8339769: Incorrect error message during startup if working directory does not exist

### DIFF
--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -521,11 +521,14 @@ GetJavaProperties(JNIEnv *env)
     {
         char buf[MAXPATHLEN];
         errno = 0;
-        if (getcwd(buf, sizeof(buf))  == NULL)
+        if (getcwd(buf, sizeof(buf)) == NULL) {
             JNU_ThrowByName(env, "java/lang/Error",
-             "Properties init: Could not determine current working directory.");
-        else
+            "Properties init: Could not determine current working directory.");
+            return NULL;
+        }
+        else {
             sprops.user_dir = strdup(buf);
+        }
     }
 
     sprops.file_separator = "/";


### PR DESCRIPTION
Backporting JDK-8339769: Incorrect error message during startup if working directory does not exist. Fix ensures correct error message by adding return statement. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8339769](https://bugs.openjdk.org/browse/JDK-8339769): Incorrect error message during startup if working directory does not exist (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1812/head:pull/1812` \
`$ git checkout pull/1812`

Update a local copy of the PR: \
`$ git checkout pull/1812` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1812`

View PR using the GUI difftool: \
`$ git pr show -t 1812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1812.diff">https://git.openjdk.org/jdk21u-dev/pull/1812.diff</a>

</details>
