### PR TITLE
8338281: jshell does not run shutdown hooks

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/ExecutionControlForwarder.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/ExecutionControlForwarder.java
@@ -177,7 +177,7 @@ class ExecutionControlForwarder {
                     } catch (Throwable ex) {
                         // JShell-core not waiting for a result, ignore
                     }
-                    return true;
+                    return false;
                 }
                 default: {
                     Object arg = in.readObject();

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
@@ -49,6 +49,7 @@ import com.sun.jdi.ThreadReference;
 import com.sun.jdi.VMDisconnectedException;
 import com.sun.jdi.VirtualMachine;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import jdk.jshell.JShellConsole;
 import jdk.jshell.spi.ExecutionControl;
@@ -68,6 +69,8 @@ import jdk.jshell.execution.impl.ConsoleImpl.ConsoleOutputStream;
  * @since 9
  */
 public class JdiDefaultExecutionControl extends JdiExecutionControl {
+
+    private static final int SHUTDOWN_TIMEOUT = 1; //1 second
 
     private VirtualMachine vm;
     private Process process;
@@ -243,6 +246,20 @@ public class JdiDefaultExecutionControl extends JdiExecutionControl {
     @Override
     public void close() {
         super.close();
+
+        Process remoteProcess;
+
+        synchronized (this) {
+            remoteProcess = this.process;
+        }
+
+        if (remoteProcess != null) {
+            try {
+                remoteProcess.waitFor(SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                debug(ex, "waitFor remote");
+            }
+        }
         disposeVM();
     }
 

--- a/test/langtools/jdk/jshell/ShutdownTest.java
+++ b/test/langtools/jdk/jshell/ShutdownTest.java
@@ -28,6 +28,11 @@
  * @run testng ShutdownTest
  */
 
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.function.Consumer;
 
 import jdk.jshell.JShell;
@@ -35,8 +40,9 @@ import jdk.jshell.JShell.Subscription;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import org.testng.annotations.BeforeMethod;
 
-@Test
 public class ShutdownTest extends KullaTesting {
 
     int shutdownCount;
@@ -53,6 +59,7 @@ public class ShutdownTest extends KullaTesting {
         assertEquals(shutdownCount, 1);
     }
 
+    @Test
     public void testCloseCallback() {
         shutdownCount = 0;
         getState().onShutdown(this::shutdownCounter);
@@ -60,6 +67,7 @@ public class ShutdownTest extends KullaTesting {
         assertEquals(shutdownCount, 1);
     }
 
+    @Test
     public void testCloseUnsubscribe() {
         shutdownCount = 0;
         Subscription token = getState().onShutdown(this::shutdownCounter);
@@ -68,6 +76,7 @@ public class ShutdownTest extends KullaTesting {
         assertEquals(shutdownCount, 0);
     }
 
+    @Test
     public void testTwoShutdownListeners() {
         ShutdownListener listener1 = new ShutdownListener();
         ShutdownListener listener2 = new ShutdownListener();
@@ -116,6 +125,51 @@ public class ShutdownTest extends KullaTesting {
     public void testSubscriptionAfterShutdown() {
         assertEval("System.exit(0);");
         getState().onShutdown(e -> {});
+    }
+
+    @Test
+    public void testRunShutdownHooks() throws IOException {
+        Path temporary = Paths.get("temp");
+        Files.newOutputStream(temporary).close();
+        assertEval("import java.io.*;");
+        assertEval("import java.nio.file.*;");
+        assertEval("""
+                        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                            try {
+                                Files.delete(Paths.get("$TEMPORARY"));
+                            } catch (IOException ex) {
+                                //ignored
+                            }
+                        }))
+                        """.replace("$TEMPORARY", temporary.toAbsolutePath()
+                                                           .toString()
+                                                           .replace("\\", "\\\\")));
+        getState().close();
+        assertFalse(Files.exists(temporary));
+    }
+
+    private Method currentTestMethod;
+
+    @BeforeMethod
+    public void setUp(Method testMethod) {
+        currentTestMethod = testMethod;
+        super.setUp();
+    }
+
+    @BeforeMethod
+    public void setUp() {
+    }
+
+    @Override
+    public void setUp(Consumer<JShell.Builder> bc) {
+        Consumer<JShell.Builder> augmentedBuilder = switch (currentTestMethod.getName()) {
+            case "testRunShutdownHooks" -> builder -> {
+                builder.executionEngine(Presets.TEST_STANDARD_EXECUTION);
+                bc.accept(builder);
+            };
+            default -> bc;
+        };
+        super.setUp(augmentedBuilder);
     }
 
     private static class ShutdownListener implements Consumer<JShell> {


### PR DESCRIPTION
Backporting JDK-8338281: jshell does not run shutdown hooks. Adjusts logic to now exit the remote agent when receiving the CLOSE event and delays the JShell's close for a moment for the remote process to finish. Ran GHA Sanity Checks, local Tier 1 and 2, and adjusted test. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8338281](https://bugs.openjdk.org/browse/JDK-8338281) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8338281: jshell does not run shutdown hooks`

### Issue
 * [JDK-8338281](https://bugs.openjdk.org/browse/JDK-8338281): jshell does not run shutdown hooks (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1813/head:pull/1813` \
`$ git checkout pull/1813`

Update a local copy of the PR: \
`$ git checkout pull/1813` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1813`

View PR using the GUI difftool: \
`$ git pr show -t 1813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1813.diff">https://git.openjdk.org/jdk21u-dev/pull/1813.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1813#issuecomment-2892421033)
</details>
