### PR TITLE
8354530: AIX: sporadic unexpected errno when calling setsockopt in Net.joinOrDrop

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -653,6 +653,16 @@ Java_sun_nio_ch_Net_joinOrDrop4(JNIEnv *env, jobject this, jboolean join, jobjec
     // workaround macOS bug where IP_ADD_MEMBERSHIP fails intermittently
     if (n < 0 && errno == ENOMEM) {
         n = setsockopt(fdval(env,fdo), IPPROTO_IP, opt, optval, optlen);
+    }
+#endif
+#ifdef _AIX
+    // workaround AIX bug where IP_ADD_MEMBERSHIP fails intermittently
+    if (n < 0 && errno == EAGAIN) {
+        int countdown = 3;
+        while (n < 0 && errno == EAGAIN && countdown > 0) {
+            n = setsockopt(fdval(env,fdo), IPPROTO_IP, opt, optval, optlen);
+            countdown--;
+        }
     }
 #endif
 


### PR DESCRIPTION
Hi, the issue occurs also in JDK21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8354530](https://bugs.openjdk.org/browse/JDK-8354530) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354530](https://bugs.openjdk.org/browse/JDK-8354530): AIX: sporadic unexpected errno when calling setsockopt in Net.joinOrDrop (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1815/head:pull/1815` \
`$ git checkout pull/1815`

Update a local copy of the PR: \
`$ git checkout pull/1815` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1815`

View PR using the GUI difftool: \
`$ git pr show -t 1815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1815.diff">https://git.openjdk.org/jdk21u-dev/pull/1815.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1815#issuecomment-2894218711)
</details>
