### PR TITLE
8357193: [VS 2022 17.14] Warning C5287 in debugInit.c: enum type mismatch during build

### DIFF
--- a/make/modules/jdk.jdwp.agent/Lib.gmk
+++ b/make/modules/jdk.jdwp.agent/Lib.gmk
@@ -58,6 +58,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     DISABLED_WARNINGS_clang_EventRequestImpl.c := self-assign, \
     DISABLED_WARNINGS_clang_inStream.c := sometimes-uninitialized, \
     DISABLED_WARNINGS_clang_log_messages.c := format-nonliteral, \
+    DISABLED_WARNINGS_microsoft_debugInit.c := 5287, \
     EXTRA_HEADER_DIRS := \
       include \
       libjdwp/export, \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [5f38d1bb](https://github.com/openjdk/jdk/commit/5f38d1bb94d008c33c1a7af12c81ee0e15371e13) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 21 May 2025 and was reviewed by Serguei Spitsyn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8357193](https://bugs.openjdk.org/browse/JDK-8357193) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357193](https://bugs.openjdk.org/browse/JDK-8357193): [VS 2022 17.14] Warning C5287 in debugInit.c: enum type mismatch during build (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1823/head:pull/1823` \
`$ git checkout pull/1823`

Update a local copy of the PR: \
`$ git checkout pull/1823` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1823`

View PR using the GUI difftool: \
`$ git pr show -t 1823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1823.diff">https://git.openjdk.org/jdk21u-dev/pull/1823.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1823#issuecomment-2899743719)
</details>
