### PR TITLE
8336587: failure_handler lldb command times out on macosx-aarch64 core file

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,9 @@ native.core.timeout=600000
 cores=native.lldb
 native.lldb.app=lldb
 native.lldb.delimiter=\0
+# Core files can be very big and take a long time to load on macosx-aarch64.
+# The 20 seconds default timeout is not nearly enough.
+native.lldb.timeout=120000
 # Assume that java standard laucher has been used
 native.lldb.args=--core\0%p\0%java\0-o\0thread backtrace all\0-o\0quit
 


### PR DESCRIPTION
I backport this test change as it also goes to 21.0.9-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8336587](https://bugs.openjdk.org/browse/JDK-8336587) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336587](https://bugs.openjdk.org/browse/JDK-8336587): failure_handler lldb command times out on macosx-aarch64 core file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1824/head:pull/1824` \
`$ git checkout pull/1824`

Update a local copy of the PR: \
`$ git checkout pull/1824` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1824`

View PR using the GUI difftool: \
`$ git pr show -t 1824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1824.diff">https://git.openjdk.org/jdk21u-dev/pull/1824.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1824#issuecomment-2900939050)
</details>
