### PR TITLE
8183348: Better cleanup for jdk/test/sun/security/pkcs12/P12SecretKey.java

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4765,9 +4765,9 @@ public final class Formatter implements Closeable, Flushable {
                      DECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT_UPPER,
-                     LINE_SEPARATOR,
-                     PERCENT_SIGN -> true;
-                default -> false;
+                     LINE_SEPARATOR -> true;
+                // Don't put PERCENT_SIGN inside switch, as that will make the method size exceed 325 and cannot be inlined.
+                default -> c == PERCENT_SIGN;
             };
         }
 


### PR DESCRIPTION
Clean backport to fix a regression resulting from [JDK-8263038](https://bugs.openjdk.org/browse/JDK-8263038).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8183348](https://bugs.openjdk.org/browse/JDK-8183348) needs maintainer approval

### Issue
 * [JDK-8183348](https://bugs.openjdk.org/browse/JDK-8183348): Better cleanup for jdk/test/sun/security/pkcs12/P12SecretKey.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1826/head:pull/1826` \
`$ git checkout pull/1826`

Update a local copy of the PR: \
`$ git checkout pull/1826` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1826`

View PR using the GUI difftool: \
`$ git pr show -t 1826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1826.diff">https://git.openjdk.org/jdk21u-dev/pull/1826.diff</a>

</details>
