### PR TITLE
8335252: Reduce size of j.u.Formatter.Conversion#isValid

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4765,9 +4765,9 @@ public final class Formatter implements Closeable, Flushable {
                      DECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT_UPPER,
-                     LINE_SEPARATOR,
-                     PERCENT_SIGN -> true;
-                default -> false;
+                     LINE_SEPARATOR -> true;
+                // Don't put PERCENT_SIGN inside switch, as that will make the method size exceed 325 and cannot be inlined.
+                default -> c == PERCENT_SIGN;
             };
         }
 


### PR DESCRIPTION
Clean backport to fix a regression resulting from [JDK-8263038](https://bugs.openjdk.org/browse/JDK-8263038). No semantic change, test/jdk/java/util/Formatter tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8335252](https://bugs.openjdk.org/browse/JDK-8335252) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335252](https://bugs.openjdk.org/browse/JDK-8335252): Reduce size of j.u.Formatter.Conversion#isValid (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1827/head:pull/1827` \
`$ git checkout pull/1827`

Update a local copy of the PR: \
`$ git checkout pull/1827` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1827`

View PR using the GUI difftool: \
`$ git pr show -t 1827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1827.diff">https://git.openjdk.org/jdk21u-dev/pull/1827.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1827#issuecomment-2902568065)
</details>
