### PR TITLE
8311821: Simplify ParallelGCThreadsConstraintFunc after CMS removal

### DIFF
--- a/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.cpp
+++ b/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.cpp
@@ -28,20 +28,6 @@
 #include "runtime/globals.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-JVMFlag::Error ParallelGCThreadsConstraintFuncParallel(uint value, bool verbose) {
-  // Parallel GC passes ParallelGCThreads when creating GrowableArray as 'int' type parameter.
-  // So can't exceed with "max_jint"
-
-  if (UseParallelGC && (value > (uint)max_jint)) {
-    JVMFlag::printError(verbose,
-                        "ParallelGCThreads (" UINT32_FORMAT ") must be "
-                        "less than or equal to " UINT32_FORMAT " for Parallel GC\n",
-                        value, max_jint);
-    return JVMFlag::VIOLATES_CONSTRAINT;
-  }
-  return JVMFlag::SUCCESS;
-}
-
 JVMFlag::Error InitialTenuringThresholdConstraintFuncParallel(uintx value, bool verbose) {
   // InitialTenuringThreshold is only used for ParallelGC.
   if (UseParallelGC && (value > MaxTenuringThreshold)) {

--- a/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.hpp
+++ b/src/hotspot/share/gc/parallel/jvmFlagConstraintsParallel.hpp
@@ -30,7 +30,6 @@
 
 // Parallel Subconstraints
 #define PARALLEL_GC_CONSTRAINTS(f)                          \
-  f(uint, ParallelGCThreadsConstraintFuncParallel)          \
   f(uintx, InitialTenuringThresholdConstraintFuncParallel)  \
   f(uintx, MaxTenuringThresholdConstraintFuncParallel)
 

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -131,9 +131,11 @@
   product(bool, UseShenandoahGC, false,                                     \
           "Use the Shenandoah garbage collector")                           \
                                                                             \
+  /* notice: the max range value here is INT_MAX not UINT_MAX  */           \
+  /* to protect from overflows                                 */           \
   product(uint, ParallelGCThreads, 0,                                       \
           "Number of parallel threads parallel gc will use")                \
-          constraint(ParallelGCThreadsConstraintFunc,AfterErgo)             \
+          range(0, INT_MAX)                                                 \
                                                                             \
   product(bool, UseDynamicNumberOfGCThreads, true,                          \
           "Dynamically choose the number of threads up to a maximum of "    \

--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
+++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
@@ -53,20 +53,6 @@
 // checking functions,  FLAG_IS_CMDLINE() is used to check if
 // the flag has been set by the user and so should be checked.
 
-// As ParallelGCThreads differs among GC modes, we need constraint function.
-JVMFlag::Error ParallelGCThreadsConstraintFunc(uint value, bool verbose) {
-  JVMFlag::Error status = JVMFlag::SUCCESS;
-
-#if INCLUDE_PARALLELGC
-  status = ParallelGCThreadsConstraintFuncParallel(value, verbose);
-  if (status != JVMFlag::SUCCESS) {
-    return status;
-  }
-#endif
-
-  return status;
-}
-
 static JVMFlag::Error MinPLABSizeBounds(const char* name, size_t value, bool verbose) {
   if ((GCConfig::is_gc_selected(CollectedHeap::G1) || GCConfig::is_gc_selected(CollectedHeap::Parallel)) &&
       (value < PLAB::min_size())) {

--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.hpp
+++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.hpp
@@ -41,7 +41,6 @@
  * an appropriate error value.
  */
 #define SHARED_GC_CONSTRAINTS(f)                               \
- f(uint,   ParallelGCThreadsConstraintFunc)                    \
  f(size_t, YoungPLABSizeConstraintFunc)                        \
  f(size_t, OldPLABSizeConstraintFunc)                          \
  f(uintx,  MinHeapFreeRatioConstraintFunc)                     \

--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
@@ -111,14 +111,14 @@ public class TestParallelGCThreads {
       }
     }
 
-    // 4294967295 == (unsigned int) -1
-    // So setting ParallelGCThreads=4294967295 should give back 4294967295
+    // Test the max value for ParallelGCThreads
+    // So setting ParallelGCThreads=2147483647 should give back 2147483647
     long count = getParallelGCThreadCount(
         "-XX:+UseSerialGC",
-        "-XX:ParallelGCThreads=4294967295",
+        "-XX:ParallelGCThreads=2147483647",
         "-XX:+PrintFlagsFinal",
         "-version");
-    Asserts.assertEQ(count, 4294967295L, "Specifying ParallelGCThreads=4294967295 does not set the thread count properly!");
+    Asserts.assertEQ(count, 2147483647L, "Specifying ParallelGCThreads=2147483647 does not set the thread count properly!");
   }
 
   public static long getParallelGCThreadCount(String... flags) throws Exception {


### PR DESCRIPTION
nearly clean backport of JDK-8311821. Moves ParallelGCThreadsConstraintFuncParallel to shared code as ParallelGCThreadsConstraintFunc after CMS removal.

tier1 & modified tests passes.

Conflicts were due to type changes on tip `uintx` -> `uint`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8311821](https://bugs.openjdk.org/browse/JDK-8311821) needs maintainer approval

### Issue
 * [JDK-8311821](https://bugs.openjdk.org/browse/JDK-8311821): Simplify ParallelGCThreadsConstraintFunc after CMS removal (**Enhancement** - P4 - Rejected)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1828/head:pull/1828` \
`$ git checkout pull/1828`

Update a local copy of the PR: \
`$ git checkout pull/1828` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1828`

View PR using the GUI difftool: \
`$ git pr show -t 1828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1828.diff">https://git.openjdk.org/jdk21u-dev/pull/1828.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1828#issuecomment-2904015740)
</details>
