### PR TITLE
8347840: Fix testlibrary compilation warnings

### DIFF
--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
-    DISABLED_WARNINGS := deprecation removal preview, \
     JAVAC_FLAGS := --enable-preview, \
 ))
 

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -141,7 +141,6 @@ class HugePageConfiguration {
             while (scanner.hasNextLine()) {
                 Matcher mat = pat.matcher(scanner.nextLine());
                 if (mat.matches()) {
-                    scanner.close();
                     return Long.parseLong(mat.group(1)) * 1024;
                 }
             }

--- a/test/lib/jdk/test/lib/Asserts.java
+++ b/test/lib/jdk/test/lib/Asserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -640,7 +640,7 @@ public class Asserts {
             testMethod.execute();
         } catch (Throwable exc) {
             if (expected.isInstance(exc)) {
-                return (T) exc;
+                return expected.cast(exc);
             } else {
                 fail(Objects.toString(msg, "An unexpected exception was thrown.")
                         + " Expected " + expected.getName(), exc);

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -429,7 +429,7 @@ public class LingeredApp {
         }
     }
 
-    /**
+    /*
      *  High level interface for test writers
      */
 
@@ -592,6 +592,7 @@ public class LingeredApp {
      * This part is the application itself. First arg is optional "forceCrash".
      * Following arg is the lock file name.
      */
+    @SuppressWarnings("restricted")
     public static void main(String args[]) {
         boolean forceCrash = false;
 

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ public class ArtifactResolver {
         try {
             String managerName = System.getProperty("jdk.test.lib.artifacts.artifactmanager");
             if (managerName != null) {
-                manager = (ArtifactManager) Class.forName(managerName).newInstance();
+                manager = (ArtifactManager) Class.forName(managerName).getDeclaredConstructor().newInstance();
             } else if (System.getenv().containsKey(JibArtifactManager.JIB_HOME_ENV_NAME)) {
                 manager = JibArtifactManager.newInstance();
             } else {

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolverException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,14 @@
 
 package jdk.test.lib.artifacts;
 
+import java.io.Serial;
+
 /**
  * Thrown by the ArtifactResolver when failing to resolve an Artifact.
  */
 public class ArtifactResolverException extends Exception {
+    @Serial
+    private static final long serialVersionUID = 8341884506180926911L;
 
     public ArtifactResolverException(String message) {
         super(message);

--- a/test/lib/jdk/test/lib/artifacts/JibArtifactManager.java
+++ b/test/lib/jdk/test/lib/artifacts/JibArtifactManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public class JibArtifactManager implements ArtifactManager {
             ClassLoader oldContextLoader = currentThread.getContextClassLoader();
             currentThread.setContextClassLoader(classLoader);
 
-            Class jibServiceFactory = classLoader.loadClass(JIB_SERVICE_FACTORY);
+            Class<?> jibServiceFactory = classLoader.loadClass(JIB_SERVICE_FACTORY);
             try {
                 Object jibArtifactInstaller = jibServiceFactory.getMethod("createJibArtifactInstaller").invoke(null);
                 return new JibArtifactManager(jibArtifactInstaller, classLoader);

--- a/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
+++ b/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ package jdk.test.lib.classloader;
 import jdk.test.whitebox.WhiteBox;
 
 import java.io.File;
+import java.io.Serial;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -42,6 +43,9 @@ import java.util.stream.Stream;
 
 public class ClassUnloadCommon {
     public static class TestFailure extends RuntimeException {
+        @Serial
+        private static final long serialVersionUID = -8108935949624559549L;
+
         TestFailure(String msg) {
             super(msg);
         }

--- a/test/lib/jdk/test/lib/classloader/GeneratingClassLoader.java
+++ b/test/lib/jdk/test/lib/classloader/GeneratingClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,13 @@ class TemplateClass {
 
 public class GeneratingClassLoader extends ClassLoader {
 
-    public synchronized Class loadClass(String name) throws ClassNotFoundException {
+    public synchronized Class<?> loadClass(String name) throws ClassNotFoundException {
         return loadClass(name, false);
     }
 
-    public synchronized Class loadClass(String name, boolean resolve)
+    public synchronized Class<?> loadClass(String name, boolean resolve)
             throws ClassNotFoundException {
-        Class c = findLoadedClass(name);
+        Class<?> c = findLoadedClass(name);
         if (c != null) {
             return c;
         }
@@ -129,7 +129,7 @@ public class GeneratingClassLoader extends ClassLoader {
                 throw new RuntimeException("Class name not found in template class file");
             }
         }
-        return (byte[]) bytecode.clone();
+        return bytecode.clone();
     }
 
     private void readByteCode() throws ClassNotFoundException {

--- a/test/lib/jdk/test/lib/classloader/GeneratingCompilingClassLoader.java
+++ b/test/lib/jdk/test/lib/classloader/GeneratingCompilingClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,7 +202,7 @@ public class GeneratingCompilingClassLoader extends ClassLoader {
      */
     public Class<?>[] getGeneratedClasses(int sizeFactor, int numClasses) throws IOException {
         GeneratedClass[] gc = getGeneratedClass(sizeFactor, numClasses);
-        Class<?>[] classes = new Class[numClasses];
+        Class<?>[] classes = new Class<?>[numClasses];
         for (int i = 0; i < numClasses; ++i) {
             classes[i] = defineClass(gc[i].name, gc[i].bytes, 0 , gc[i].bytes.length);
         }

--- a/test/lib/jdk/test/lib/format/ArrayDiff.java
+++ b/test/lib/jdk/test/lib/format/ArrayDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public class ArrayDiff<E> implements Diff {
      * @throws NullPointerException if at least one of the arrays is null
      * @return an ArrayDiff instance for the two arrays and formatting parameters provided
      */
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public static ArrayDiff<?> of(Object first, Object second, int width, int contextBefore) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);

--- a/test/lib/jdk/test/lib/hprof/model/JavaHeapObject.java
+++ b/test/lib/jdk/test/lib/hprof/model/JavaHeapObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,12 +34,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import jdk.test.lib.hprof.util.Misc;
-
-
-/**
- *
- * @author      Bill Foote
- */
 
 /**
  * Represents an object that's allocated out of the Java heap.  It occupies

--- a/test/lib/jdk/test/lib/hprof/model/JavaStatic.java
+++ b/test/lib/jdk/test/lib/hprof/model/JavaStatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,6 @@
  */
 
 package jdk.test.lib.hprof.model;
-
-/**
- *
- * @author      Bill Foote
- */
 
 /**
  * Represents the value of a static field of a JavaClass

--- a/test/lib/jdk/test/lib/hprof/model/JavaThing.java
+++ b/test/lib/jdk/test/lib/hprof/model/JavaThing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,6 @@
  */
 
 package jdk.test.lib.hprof.model;
-
-/**
- *
- * @author      Bill Foote
- */
-
 
 /**
  * Represents a java "Thing".  A thing is anything that can be the value of

--- a/test/lib/jdk/test/lib/hprof/model/Root.java
+++ b/test/lib/jdk/test/lib/hprof/model/Root.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,6 @@
 package jdk.test.lib.hprof.model;
 
 import jdk.test.lib.hprof.util.Misc;
-
-/**
- *
- * @author      Bill Foote
- */
-
 
 /**
  * Represents a member of the rootset, that is, one of the objects that

--- a/test/lib/jdk/test/lib/hprof/model/Snapshot.java
+++ b/test/lib/jdk/test/lib/hprof/model/Snapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,16 +30,12 @@
 
 package jdk.test.lib.hprof.model;
 
+import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.util.*;
 
 import jdk.test.lib.hprof.parser.ReadBuffer;
 import jdk.test.lib.hprof.util.Misc;
-
-/**
- *
- * @author      Bill Foote
- */
 
 /**
  * Represents a snapshot of the Java objects in the VM at one instant.
@@ -626,7 +622,7 @@ public class Snapshot implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         readBuf.close();
     }
 

--- a/test/lib/jdk/test/lib/hprof/model/StackFrame.java
+++ b/test/lib/jdk/test/lib/hprof/model/StackFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,6 @@
  */
 
 package jdk.test.lib.hprof.model;
-
-/**
- *
- * @author      Bill Foote
- */
-
 
 /**
  * Represents a stack frame.

--- a/test/lib/jdk/test/lib/hprof/model/StackTrace.java
+++ b/test/lib/jdk/test/lib/hprof/model/StackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,6 @@
  */
 
 package jdk.test.lib.hprof.model;
-
-/**
- *
- * @author      Bill Foote
- */
-
 
 /**
  * Represents a stack trace, that is, an ordered collection of stack frames.

--- a/test/lib/jdk/test/lib/hprof/parser/FileReadBuffer.java
+++ b/test/lib/jdk/test/lib/hprof/parser/FileReadBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ class FileReadBuffer implements ReadBuffer {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         file.close();
     }
 }

--- a/test/lib/jdk/test/lib/hprof/parser/MappedReadBuffer.java
+++ b/test/lib/jdk/test/lib/hprof/parser/MappedReadBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,7 +127,7 @@ class MappedReadBuffer implements ReadBuffer {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         file.close();
     }
 

--- a/test/lib/jdk/test/lib/hprof/parser/ReadBuffer.java
+++ b/test/lib/jdk/test/lib/hprof/parser/ReadBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,4 +43,5 @@ public interface ReadBuffer extends AutoCloseable {
     public short getShort(long pos) throws IOException;
     public int   getInt(long pos) throws IOException;
     public long  getLong(long pos) throws IOException;
+    public void  close() throws IOException;
 }

--- a/test/lib/jdk/test/lib/hprof/parser/Reader.java
+++ b/test/lib/jdk/test/lib/hprof/parser/Reader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,7 @@ public abstract class Reader {
      * @param heapFile The name of a file containing a heap dump
      * @param callStack If true, read the call stack of allocaation sites
      */
+    @SuppressWarnings("try")
     public static Snapshot readFile(String heapFile, boolean callStack,
                                     int debugLevel)
             throws IOException {
@@ -136,6 +137,7 @@ public abstract class Reader {
      *
      * @param heapFile The name of a file containing a heap dump
      */
+    @SuppressWarnings("try")
     public static String getStack(String heapFile, int debugLevel)
             throws IOException {
         int dumpNumber = 1;

--- a/test/lib/jdk/test/lib/jfr/Events.java
+++ b/test/lib/jdk/test/lib/jfr/Events.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,7 +233,7 @@ public class Events {
 
     private static void assertThread(RecordedThread eventThread, Thread thread) {
         assertNotNull(eventThread, "Thread in event was null");
-        assertEquals(eventThread.getJavaThreadId(), thread.getId(), "Wrong thread id");
+        assertEquals(eventThread.getJavaThreadId(), thread.threadId(), "Wrong thread id");
         assertEquals(eventThread.getJavaName(), thread.getName(), "Wrong thread name");
 
         ThreadGroup threadGroup = thread.getThreadGroup();

--- a/test/lib/jdk/test/lib/jvmti/DebugeeClass.java
+++ b/test/lib/jdk/test/lib/jvmti/DebugeeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 package jdk.test.lib.jvmti;
+
+import java.io.Serial;
 
 /**
  * Base class for debuggee class in JVMTI tests.
@@ -49,6 +51,7 @@ public class DebugeeClass {
     /**
      * This method is used to load library with native methods implementation, if needed.
      */
+    @SuppressWarnings("restricted")
     public static void loadLibrary(String name) {
         try {
             System.loadLibrary(name);
@@ -70,6 +73,9 @@ public class DebugeeClass {
     }
 
     public class Failure extends RuntimeException {
+        @Serial
+        private static final long serialVersionUID = -4069390356498980839L;
+
         public Failure() {
         }
 

--- a/test/lib/jdk/test/lib/management/ThreadMXBeanTool.java
+++ b/test/lib/jdk/test/lib/management/ThreadMXBeanTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public final class ThreadMXBeanTool {
                 + Integer.toHexString(System.identityHashCode(object));
         ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
         while (thread.isAlive()) {
-            ThreadInfo ti = tmx.getThreadInfo(thread.getId());
+            ThreadInfo ti = tmx.getThreadInfo(thread.threadId());
             if (ti.getThreadState() == state
                     && (want == null || want.equals(ti.getLockName()))) {
                 return;
@@ -60,7 +60,7 @@ public final class ThreadMXBeanTool {
     public static void waitUntilInNative(Thread thread) throws InterruptedException {
         ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
         while (thread.isAlive()) {
-            ThreadInfo ti = tmx.getThreadInfo(thread.getId());
+            ThreadInfo ti = tmx.getThreadInfo(thread.threadId());
             if (ti.isInNative()) {
                 return;
             }

--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,7 @@ public class IPSupport {
         }
     }
 
+    @SuppressWarnings("try")
     private static boolean isSupported(Class<? extends InetAddress> addressType) {
         ProtocolFamily family = addressType == Inet4Address.class ?
                 StandardProtocolFamily.INET : StandardProtocolFamily.INET6;

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -987,7 +987,7 @@ public final class ProcessTools {
         String[] classArgs = new String[args.length - 2];
         System.arraycopy(args, 2, classArgs, 0, args.length - 2);
         Class<?> c = Class.forName(className);
-        Method mainMethod = c.getMethod("main", new Class[] { String[].class });
+        Method mainMethod = c.getMethod("main", new Class<?>[] { String[].class });
         mainMethod.setAccessible(true);
 
         if (testThreadFactoryName.equals("Virtual")) {

--- a/test/lib/jdk/test/lib/thread/VThreadPinner.java
+++ b/test/lib/jdk/test/lib/thread/VThreadPinner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,9 @@ public class VThreadPinner {
                 throw e;
             if (ex instanceof Error e)
                 throw e;
-            throw (X) ex;
+            @SuppressWarnings("unchecked")
+            var x = (X) ex;
+            throw x;
         }
     }
 

--- a/test/lib/jdk/test/lib/thread/VThreadRunner.java
+++ b/test/lib/jdk/test/lib/thread/VThreadRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,9 @@ public class VThreadRunner {
                 throw e;
             if (ex instanceof Error e)
                 throw e;
-            throw (X) ex;
+            @SuppressWarnings("unchecked")
+            var x = (X) ex;
+            throw x;
         }
     }
 

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -266,7 +266,7 @@ public final class FileUtils {
                     (new InputStreamReader(proc.getInputStream()));
                 // Skip the first line as it is the "df" output header.
                 if (reader.readLine() != null ) {
-                    Set mountPoints = new HashSet();
+                    Set<String> mountPoints = new HashSet<>();
                     String mountPoint = null;
                     while ((mountPoint = reader.readLine()) != null) {
                         if (!mountPoints.add(mountPoint)) {
@@ -299,8 +299,8 @@ public final class FileUtils {
             };
         });
 
-        final AtomicReference throwableReference =
-            new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> throwableReference =
+            new AtomicReference<>();
         thr.setUncaughtExceptionHandler(
             new Thread.UncaughtExceptionHandler() {
                 public void uncaughtException(Thread t, Throwable e) {
@@ -315,7 +315,7 @@ public final class FileUtils {
             throw new RuntimeException(ie);
         }
 
-        Throwable uncaughtException = (Throwable)throwableReference.get();
+        Throwable uncaughtException = throwableReference.get();
         if (uncaughtException != null) {
             throw new RuntimeException(uncaughtException);
         }
@@ -365,6 +365,7 @@ public final class FileUtils {
     }
 
     // Return the current process handle count
+    @SuppressWarnings("restricted")
     public static long getProcessHandleCount() {
         if (IS_WINDOWS) {
             if (!nativeLibLoaded) {


### PR DESCRIPTION
I would like to backport this to keep the test suite up to date. 

make/test/BuildTestLib.gmk
I had to resolve, the code and listed warnings differ considerably.
Nevertheless obvious resolve.

test/lib/jdk/test/lib/apps/LingeredApp.java
test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
test/lib/jdk/test/lib/hprof/model/JavaHeapObject.java
test/lib/jdk/test/lib/hprof/model/Root.java
test/lib/jdk/test/lib/hprof/model/Snapshot.java
test/lib/jdk/test/lib/jfr/Events.java
test/lib/jdk/test/lib/net/IPSupport.java
test/lib/jdk/test/lib/thread/VThreadPinner.java
test/lib/jdk/test/lib/thread/VThreadRunner.java
Resolved Copyright.

test/lib/jdk/test/lib/os/linux/HugePageConfiguration.java
This file was moved by "8340422: ZGC: TestAllocateHeapAt.java should not run with transparent hugepages".
The patch to the code applies clean after adapting the path, only the Copyright requires resolving.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347840](https://bugs.openjdk.org/browse/JDK-8347840) needs maintainer approval

### Issue
 * [JDK-8347840](https://bugs.openjdk.org/browse/JDK-8347840): Fix testlibrary compilation warnings (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1830/head:pull/1830` \
`$ git checkout pull/1830`

Update a local copy of the PR: \
`$ git checkout pull/1830` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1830`

View PR using the GUI difftool: \
`$ git pr show -t 1830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1830.diff">https://git.openjdk.org/jdk21u-dev/pull/1830.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1830#issuecomment-2906874055)
</details>
