### PR TITLE
8353237: [AArch64] Incorrect result of VectorizedHashCode intrinsic on Cortex-A53

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -107,7 +107,8 @@ address C2_MacroAssembler::arrays_hashcode(Register ary, Register cnt, Register 
   assert(is_power_of_2(unroll_factor), "can't use this value to calculate the jump target PC");
   andr(tmp2, cnt, unroll_factor - 1);
   adr(tmp1, BR_BASE);
-  sub(tmp1, tmp1, tmp2, ext::sxtw, 3);
+  // For Cortex-A53 offset is 4 because 2 nops are generated.
+  sub(tmp1, tmp1, tmp2, ext::sxtw, VM_Version::supports_a53mac() ? 4 : 3);
   movw(tmp2, 0x1f);
   br(tmp1);
 
@@ -115,6 +116,11 @@ address C2_MacroAssembler::arrays_hashcode(Register ary, Register cnt, Register 
   for (size_t i = 0; i < unroll_factor; ++i) {
     load(tmp1, Address(post(ary, type2aelembytes(eltype))), eltype);
     maddw(result, result, tmp2, tmp1);
+    // maddw generates an extra nop for Cortex-A53 (see maddw definition in macroAssembler).
+    // Generate 2nd nop to have 4 instructions per iteration.
+    if (VM_Version::supports_a53mac()) {
+      nop();
+    }
   }
   bind(BR_BASE);
   subsw(cnt, cnt, unroll_factor);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5472,7 +5472,8 @@ class StubGenerator: public StubCodeGenerator {
     __ andr(rscratch2, cnt, vf - 1);
     __ bind(TAIL_SHORTCUT);
     __ adr(rscratch1, BR_BASE);
-    __ sub(rscratch1, rscratch1, rscratch2, ext::uxtw, 3);
+    // For Cortex-A53 offset is 4 because 2 nops are generated.
+    __ sub(rscratch1, rscratch1, rscratch2, ext::uxtw, VM_Version::supports_a53mac() ? 4 : 3);
     __ movw(rscratch2, 0x1f);
     __ br(rscratch1);
 
@@ -5480,6 +5481,11 @@ class StubGenerator: public StubCodeGenerator {
       __ load(rscratch1, Address(__ post(ary, type2aelembytes(eltype))),
                                    eltype);
       __ maddw(result, result, rscratch2, rscratch1);
+      // maddw generates an extra nop for Cortex-A53 (see maddw definition in macroAssembler).
+      // Generate 2nd nop to have 4 instructions per iteration.
+      if (VM_Version::supports_a53mac()) {
+        __ nop();
+      }
     }
     __ bind(BR_BASE);
 


### PR DESCRIPTION
Fixes Cortex A53 regression in 21.0.7. While the patch is fairly recent, it is also predicated on A53 "feature", so all other AArch64 code is not affected. We have seen customer reports that current 21.0.7 is broken without this patch on A53.

Testing:
 - [x] Linux AArch64 server fastdebug, `tier1`
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353237](https://bugs.openjdk.org/browse/JDK-8353237) needs maintainer approval

### Issue
 * [JDK-8353237](https://bugs.openjdk.org/browse/JDK-8353237): [AArch64] Incorrect result of VectorizedHashCode intrinsic on Cortex-A53 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1832/head:pull/1832` \
`$ git checkout pull/1832`

Update a local copy of the PR: \
`$ git checkout pull/1832` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1832`

View PR using the GUI difftool: \
`$ git pr show -t 1832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1832.diff">https://git.openjdk.org/jdk21u-dev/pull/1832.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1832#issuecomment-2909414006)
</details>
