### PR TITLE
8322149: ConcurrentHashMap smarter presizing for copy constructor and putAll

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -848,7 +848,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @param m the map
      */
     public ConcurrentHashMap(Map<? extends K, ? extends V> m) {
-        this.sizeCtl = DEFAULT_CAPACITY;
+        this(m.size());
         putAll(m);
     }
 
@@ -1084,7 +1084,9 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @param m mappings to be stored in this map
      */
     public void putAll(Map<? extends K, ? extends V> m) {
-        tryPresize(m.size());
+        if (table != null) {
+            tryPresize(size() + m.size());
+        }
         for (Map.Entry<? extends K, ? extends V> e : m.entrySet())
             putVal(e.getKey(), e.getValue(), false);
     }

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -48,6 +49,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class Maps {
     private SimpleRandom rng;
     private Map<Integer, Integer> map;
+    private Map<Integer, Integer> staticMap;
     private Integer[] key;
 
     private int removesPerMaxRandom;
@@ -55,9 +57,11 @@ public class Maps {
     private int total;
     private int position;
 
+    @Param("10000")
+    private int nkeys;
+
     @Setup
     public void initTest() {
-        int nkeys = 10000;
         int pRemove = 10;
         int pInsert = 90;
         removesPerMaxRandom = (int) ((pRemove / 100.0 * 0x7FFFFFFFL));
@@ -65,10 +69,12 @@ public class Maps {
 
         rng = new SimpleRandom();
         map = new ConcurrentHashMap<>();
+        staticMap = new ConcurrentHashMap<>();
         total = 0;
         key = new Integer[nkeys];
         for (int i = 0; i < key.length; ++i) {
             key[i] = rng.next();
+            staticMap.put(rng.next(), rng.next());
         }
         position = key.length / 2;
     }
@@ -104,6 +110,21 @@ public class Maps {
         }
         total += r;
         position = pos;
+    }
+
+    @Benchmark
+    public ConcurrentHashMap<Integer, Integer> testConcurrentHashMapCopyConstructor() {
+        return new ConcurrentHashMap<>(staticMap);
+    }
+
+    @Benchmark
+    public ConcurrentHashMap<Integer, Integer> testConcurrentHashMapPutAll() {
+        ConcurrentHashMap<Integer, Integer> map = new ConcurrentHashMap<>(nkeys);
+        for (int i = 0; i < nkeys; ++i) {
+            map.put(rng.next(), rng.next());
+        }
+        map.putAll(staticMap);
+        return map;
     }
 
     private static class SimpleRandom {


### PR DESCRIPTION
Clean backport of JDK-8322149. Clear performance gains (30%) for `ConcurrentHashMap#putAll` and copy constructor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8322149](https://bugs.openjdk.org/browse/JDK-8322149) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322149](https://bugs.openjdk.org/browse/JDK-8322149): ConcurrentHashMap smarter presizing for copy constructor and putAll (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1841/head:pull/1841` \
`$ git checkout pull/1841`

Update a local copy of the PR: \
`$ git checkout pull/1841` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1841`

View PR using the GUI difftool: \
`$ git pr show -t 1841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1841.diff">https://git.openjdk.org/jdk21u-dev/pull/1841.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1841#issuecomment-2919610345)
</details>
