### PR TITLE
Backport ba9f44c90fe8da2d97d67b6878ac2c0c14e35bd0

### DIFF
--- a/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
+++ b/src/hotspot/cpu/ppc/methodHandles_ppc.cpp
@@ -360,7 +360,9 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
         ? -1                                  // enforce receiver null check
         : oopDesc::klass_offset_in_bytes();   // regular null-checking behavior
 
-      __ null_check_throw(receiver_reg, klass_offset, temp1, Interpreter::throw_NullPointerException_entry());
+      address NullPointerException_entry = for_compiler_entry ? StubRoutines::throw_NullPointerException_at_call_entry()
+                                                              : Interpreter::throw_NullPointerException_entry();
+      __ null_check_throw(receiver_reg, klass_offset, temp1, NullPointerException_entry);
 
       if (iid != vmIntrinsics::_linkToSpecial || VerifyMethodHandles) {
         __ load_klass(temp1_recv_klass, receiver_reg);

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -1041,7 +1041,7 @@ void TemplateTable::bastore() {
 
   // Need to check whether array is boolean or byte
   // since both types share the bastore bytecode.
-  __ load_klass(Rscratch, Rarray);
+  __ load_klass_check_null_throw(Rscratch, Rarray, Rscratch);
   __ lwz(Rscratch, in_bytes(Klass::layout_helper_offset()), Rscratch);
   int diffbit = exact_log2(Klass::layout_helper_boolean_diffbit());
   __ testbitdi(CCR0, R0, Rscratch, diffbit);


### PR DESCRIPTION
Almost clean backport of [JDK-8357793](https://bugs.openjdk.org/browse/JDK-8357793). I only had to change `SharedRuntime` to `StubRoutines` because [JDK-8337987](https://bugs.openjdk.org/browse/JDK-8337987) is not in 21.