### PR TITLE
8353568: SEGV_BNDERR signal code adjust definition

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -48,8 +48,12 @@
 
 #include <signal.h>
 
-#if !defined(SEGV_BNDERR)
-#define SEGV_BNDERR 3
+#define SEGV_BNDERR_value 3
+
+#if defined(SEGV_BNDERR)
+STATIC_ASSERT(SEGV_BNDERR == SEGV_BNDERR_value);
+#else
+#define SEGV_BNDERR SEGV_BNDERR_value
 #endif
 
 static const char* get_signal_name(int sig, char* out, size_t outlen);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353568](https://bugs.openjdk.org/browse/JDK-8353568) needs maintainer approval

### Issue
 * [JDK-8353568](https://bugs.openjdk.org/browse/JDK-8353568): SEGV_BNDERR signal code adjust definition (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1843/head:pull/1843` \
`$ git checkout pull/1843`

Update a local copy of the PR: \
`$ git checkout pull/1843` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1843`

View PR using the GUI difftool: \
`$ git pr show -t 1843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1843.diff">https://git.openjdk.org/jdk21u-dev/pull/1843.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1843#issuecomment-2930477401)
</details>
