### PR TITLE
8358310: ZGC: riscv, ppc ZPlatformAddressOffsetBits may return a too large value

### DIFF
--- a/src/hotspot/cpu/ppc/gc/x/xGlobals_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/x/xGlobals_ppc.cpp
@@ -82,12 +82,12 @@
 // Maximum value as per spec (Power ISA v2.07): 2 ^ 60 bytes, i.e. 1 EiB (exbibyte)
 static const unsigned int MAXIMUM_MAX_ADDRESS_BIT = 60;
 
-// Most modern power processors provide an address space with not more than 45 bit addressable bit,
-// that is an address space of 32 TiB in size.
-static const unsigned int DEFAULT_MAX_ADDRESS_BIT = 45;
-
-// Minimum value returned, if probing fails: 64 GiB
-static const unsigned int MINIMUM_MAX_ADDRESS_BIT = 36;
+// Default value if probing is not implemented for a certain platform
+// Max address bit is restricted by implicit assumptions in the code, for instance
+// the bit layout of XForwardingEntry or Partial array entry (see XMarkStackEntry) in mark stack
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
+// Minimum value returned, if probing fails
+static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
 
 // Determines the highest addressable bit of the virtual address space (depends on platform)
 // by trying to interact with memory in that address range,

--- a/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
@@ -35,9 +35,11 @@
 #include <sys/mman.h>
 #endif // LINUX
 
-// Default value if probing is not implemented for a certain platform: 128TB
-static const size_t DEFAULT_MAX_ADDRESS_BIT = 47;
-// Minimum value returned, if probing fails: 64GB
+// Default value if probing is not implemented for a certain platform
+// Max address bit is restricted by implicit assumptions in the code, for instance
+// the bit layout of ZForwardingEntry or Partial array entry (see ZMarkStackEntry) in mark stack
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
+// Minimum value returned, if probing fail
 static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
 
 static size_t probe_valid_max_address_bit() {

--- a/src/hotspot/cpu/riscv/gc/x/xGlobals_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/x/xGlobals_riscv.cpp
@@ -144,9 +144,11 @@
 //  * 63-48 Fixed (16-bits, always zero)
 //
 
-// Default value if probing is not implemented for a certain platform: 128TB
-static const size_t DEFAULT_MAX_ADDRESS_BIT = 47;
-// Minimum value returned, if probing fails: 64GB
+// Default value if probing is not implemented for a certain platform
+// Max address bit is restricted by implicit assumptions in the code, for instance
+// the bit layout of XForwardingEntry or Partial array entry (see XMarkStackEntry) in mark stack
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
+// Minimum value returned, if probing fails
 static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
 
 static size_t probe_valid_max_address_bit() {

--- a/src/hotspot/cpu/riscv/gc/z/zAddress_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zAddress_riscv.cpp
@@ -37,9 +37,11 @@
 #include <sys/mman.h>
 #endif // LINUX
 
-// Default value if probe is not implemented for a certain platform: 128TB
-static const size_t DEFAULT_MAX_ADDRESS_BIT = 47;
-// Minimum value returned, if probing fails: 64GB
+// Default value if probing is not implemented for a certain platform
+// Max address bit is restricted by implicit assumptions in the code, for instance
+// the bit layout of ZForwardingEntry or Partial array entry (see ZMarkStackEntry) in mark stack
+static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
+// Minimum value returned, if probing fail
 static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;
 
 static size_t probe_valid_max_address_bit() {


### PR DESCRIPTION
Backport of [JDK-8358310](https://bugs.openjdk.org/browse/JDK-8358310). Applies cleanly, but JDK21 still contains the non-generational version of ZGC which should also get updated. I'm using the same values as in the generational version.

Testing: SAP nightly tests have passed on PPC64 (including tier1-4)
riscv is tested by RealFYang. See comment below.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358310](https://bugs.openjdk.org/browse/JDK-8358310) needs maintainer approval

### Issue
 * [JDK-8358310](https://bugs.openjdk.org/browse/JDK-8358310): ZGC: riscv, ppc ZPlatformAddressOffsetBits may return a too large value (**Bug** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1845/head:pull/1845` \
`$ git checkout pull/1845`

Update a local copy of the PR: \
`$ git checkout pull/1845` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1845`

View PR using the GUI difftool: \
`$ git pr show -t 1845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1845.diff">https://git.openjdk.org/jdk21u-dev/pull/1845.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1845#issuecomment-2935192624)
</details>
