### PR TITLE
8343452: Incorrect WINDOWS build variable is used in macroAssembler_x86.cpp

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3998,7 +3998,7 @@ RegSet MacroAssembler::call_clobbered_gp_registers() {
   RegSet regs;
 #ifdef _LP64
   regs += RegSet::of(rax, rcx, rdx);
-#ifndef WINDOWS
+#ifndef _WINDOWS
   regs += RegSet::of(rsi, rdi);
 #endif
   regs += RegSet::range(r8, r11);
@@ -4010,7 +4010,7 @@ RegSet MacroAssembler::call_clobbered_gp_registers() {
 
 XMMRegSet MacroAssembler::call_clobbered_xmm_registers() {
   int num_xmm_registers = XMMRegister::available_xmm_registers();
-#if defined(WINDOWS) && defined(_LP64)
+#if defined(_WINDOWS) && defined(_LP64)
   XMMRegSet result = XMMRegSet::range(xmm0, xmm5);
   if (num_xmm_registers > 16) {
      result += XMMRegSet::range(xmm16, as_XMMRegister(num_xmm_registers - 1));


### PR DESCRIPTION
Backporting JDK-8343452: Incorrect WINDOWS build variable is used in macroAssembler_x86.cpp. HotSpot VM build macro only defines _WINDOWS env variable (not WINDOWS). `call_clobbered_gp_registers()` and `call_clobbered_xmm_registers()` use the wrong variable name. Leads to RSI and RDI missing from list of clobbered register on windows, and may cause issue when calling native code which modifies them. Ran GHA Sanity Checks and local Tier 1 and 2 (though not on a Windows machine). Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343452](https://bugs.openjdk.org/browse/JDK-8343452) needs maintainer approval

### Issue
 * [JDK-8343452](https://bugs.openjdk.org/browse/JDK-8343452): Incorrect WINDOWS build variable is used in macroAssembler_x86.cpp (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1848/head:pull/1848` \
`$ git checkout pull/1848`

Update a local copy of the PR: \
`$ git checkout pull/1848` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1848`

View PR using the GUI difftool: \
`$ git pr show -t 1848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1848.diff">https://git.openjdk.org/jdk21u-dev/pull/1848.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1848#issuecomment-2940809127)
</details>
