### PR TITLE
8356989: Unexpected null in C2 compiled code

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -1223,14 +1223,10 @@ void ConnectionGraph::process_call_arguments(CallNode *call) {
             }
             PointsToNode* src_ptn = ptnode_adr(src->_idx);
             assert(src_ptn != nullptr, "should be registered");
-            if (arg_ptn != src_ptn) {
-              // Special arraycopy edge:
-              // A destination object's field can't have the source object
-              // as base since objects escape states are not related.
-              // Only escape state of destination object's fields affects
-              // escape state of fields in source object.
-              add_arraycopy(call, es, src_ptn, arg_ptn);
-            }
+            // Special arraycopy edge:
+            // Only escape state of destination object's fields affects
+            // escape state of fields in source object.
+            add_arraycopy(call, es, src_ptn, arg_ptn);
           }
         }
       }

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestArrayCopySameSrcDstInitializesNonEscapingArray.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestArrayCopySameSrcDstInitializesNonEscapingArray.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8356989
+ * @summary Unexpected null in C2 compiled code
+ * @run main/othervm -XX:-BackgroundCompilation TestArrayCopySameSrcDstInitializesNonEscapingArray
+ * @run main TestArrayCopySameSrcDstInitializesNonEscapingArray
+ */
+
+ public class TestArrayCopySameSrcDstInitializesNonEscapingArray {
+    private static volatile int volatileField;
+
+    public static void main(String[] args) {
+        Object obj = new Object();
+        for (int i = 0; i < 20_000; i++) {
+            test1(obj);
+        }
+    }
+
+    private static void test1(Object obj) {
+        A a = new A();
+        Object[] array = new Object[2];
+        array[0] = obj;
+        a.field = array;
+        System.arraycopy(array, 0, array, 1, 1);
+        if (a.field[1] == null) {
+            throw new RuntimeException("Can't be null");
+        }
+    }
+
+    private static class A {
+        Object[] field;
+
+        public A() {
+            field = null;
+        }
+    }
+}


### PR DESCRIPTION
The original bug caused an incorrect null value when using `System.arraycopy()`. This backport fixes it by removing the check in `src/hotspot/share/opto/escape.cpp` for a destination object's field being the same as the source object.

The backport also includes a test for this specific bug.

Clean backport, ran GHA Sanity Checks, and locally tested `tier1`, `tier2`, and `hotspot_all`. test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java sometimes fails locally, but this is the same as it was before the backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8356989](https://bugs.openjdk.org/browse/JDK-8356989) needs maintainer approval

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8356989](https://bugs.openjdk.org/browse/JDK-8356989): Unexpected null in C2 compiled code (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1851/head:pull/1851` \
`$ git checkout pull/1851`

Update a local copy of the PR: \
`$ git checkout pull/1851` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1851`

View PR using the GUI difftool: \
`$ git pr show -t 1851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1851.diff">https://git.openjdk.org/jdk21u-dev/pull/1851.diff</a>

</details>
