### PR TITLE
8327125: SpinYield.report should report microseconds

### DIFF
--- a/src/hotspot/share/utilities/spinYield.cpp
+++ b/src/hotspot/share/utilities/spinYield.cpp
@@ -66,7 +66,7 @@ void SpinYield::report(outputStream* s) const {
   if (_sleep_time.value() != 0) { // Report sleep duration, if slept.
     separator = print_separator(s, separator);
     s->print("sleep = " UINT64_FORMAT " usecs",
-             _sleep_time.milliseconds());
+             _sleep_time.microseconds());
   }
   if (separator == initial_separator) {
     s->print("no waiting");


### PR DESCRIPTION
Backporting JDK-8327125: SpinYield.report should report microseconds. This change adjusts function logic to provide microsecond granularity (as indicated by output), rather than erroneous millisecond granularity. Ran GHA Sanity Checks and local Tier 1 and 2, Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327125](https://bugs.openjdk.org/browse/JDK-8327125) needs maintainer approval

### Issue
 * [JDK-8327125](https://bugs.openjdk.org/browse/JDK-8327125): SpinYield.report should report microseconds (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1854/head:pull/1854` \
`$ git checkout pull/1854`

Update a local copy of the PR: \
`$ git checkout pull/1854` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1854`

View PR using the GUI difftool: \
`$ git pr show -t 1854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1854.diff">https://git.openjdk.org/jdk21u-dev/pull/1854.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1854#issuecomment-2946289407)
</details>
