### PR TITLE
8353655: Clean up and open source KeyEvent related tests (Part 1)

### DIFF
--- a/test/jdk/java/awt/event/KeyEvent/FrenchKeyboard.java
+++ b/test/jdk/java/awt/event/KeyEvent/FrenchKeyboard.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4308606
+ * @summary Tests whether the keys on the numeric keyboard work
+ *            correctly under French input locale.
+ * @key i18n
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FrenchKeyboard
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.lang.reflect.InvocationTargetException;
+
+public class FrenchKeyboard extends Frame {
+    static String INSTRUCTIONS = """
+           This test is intended for computers with French input method. If French
+           input method can not be enabled or your keyboard does not have a numeric
+           keypad press "Pass" to skip the test.
+           Make sure that French input method is active and the NumLock is on.
+           Click on the text field in the window called "Check your keys"
+           and type once of each of the following keys on the numeric keypad:
+           /*-+1234567890
+           If all the expected characters are displayed exactly once press "Pass".
+           If any characters do not display or display multiple times press "Fail".
+           """;
+
+    public FrenchKeyboard() {
+        super("Check your keys");
+        setLayout(new BorderLayout());
+        TextField tf = new TextField(30);
+        add(tf, BorderLayout.CENTER);
+        pack();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("FrenchKeyboard Instructions")
+                .instructions(INSTRUCTIONS)
+                .testUI(FrenchKeyboard::new)
+                .build()
+                .awaitAndCheck();
+    }
+}
+

--- a/test/jdk/java/awt/event/KeyEvent/HomeEndKeyTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/HomeEndKeyTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 4268912 4115514
+ * summary Ensures that KeyEvent has right results for the following
+ *          non-numpad keys: Home/Eng/PageUp/PageDn
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual HomeEndKeyTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+
+
+public class HomeEndKeyTest extends Frame implements KeyListener {
+   static String INSTRUCTIONS = """
+           Before starting this test make sure that system shortcuts and
+           keybindings for the keys in the list below are disabled.
+           For example pressing "Print Screen" key should not launch
+           screen capturing software.
+           Click on the text field in the window named "Check keyCode values"
+           and one by one start typing the keys in the list below.
+           (If you do not have some of the keys on your keyboard skip it
+           and move to the next line).
+           After clicking each key look at the log area - the printed name
+           and key code should correspond to the ones for the key you typed.
+           Note that on some systems the graphical symbol for the key
+           can be printed instead of the symbolic name.
+           If you do not encounter unexpected key codes for the keys you typed,
+           press "Pass". Otherwise press "Fail".
+
+                    Key     Keycode
+                    -------------------------
+                    PrintScreen  154
+                    ScrollLock   145
+                    Pause         19
+
+                    Insert       155
+                    Del          127
+                    Home          36
+                    End           35
+                    PageUp        33
+                    PageDown      34
+
+                    Left Arrow    37
+                    Up Arrow      38
+                    Right Arrow   39
+                    Down Arrow    40
+           """;
+
+   public HomeEndKeyTest() {
+       super("Check KeyCode values");
+       setLayout(new BorderLayout());
+       TextField tf = new TextField(30);
+       tf.addKeyListener(this);
+       add(tf, BorderLayout.CENTER);
+       pack();
+   }
+
+    public void keyPressed(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    public void keyTyped(KeyEvent ignore) {
+    }
+
+    public void keyReleased(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    protected void printKey(KeyEvent evt) {
+        String str;
+        switch (evt.getID()) {
+        case KeyEvent.KEY_PRESSED:
+            str = "KEY_PRESSED";
+            break;
+        case KeyEvent.KEY_RELEASED:
+            str = "KEY_RELEASED";
+            break;
+        default:
+            str = "unknown type";
+        }
+
+        str = str + ":name=" + KeyEvent.getKeyText(evt.getKeyCode()) +
+            " keyCode=" + evt.getKeyCode();
+        PassFailJFrame.log(str);
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("HomeEndKeyTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .logArea(20)
+                .testUI(HomeEndKeyTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/NumpadTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/NumpadTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4083691
+ * @summary Ensures that KeyEvent has right results for the following
+ *         keys \*-+
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual NumpadTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+
+
+public class NumpadTest extends Frame implements KeyListener {
+   static String INSTRUCTIONS = """
+           This test requires a keyboard with a numeric keypad (numpad).
+           If your keyboard does not have a numpad press "Pass" to skip testing.
+           Make sure NumLock is on.
+           Click on the text field in the window named "Check KeyChar values".
+           Then, type the following keys/characters in the TextField.
+           using the numpad keys:
+           /*-+
+
+           Verify that the keyChar and keyCode is correct for each key pressed.
+           Remember that the keyCode for the KEY_TYPED event should be zero.
+           Also verify that the character you typed appears in the TextField.
+
+           Key    Name        keyChar    Keycode
+           -------------------------------------
+            /     Divide       /  47        111
+            *     Multiply     *  42        106
+            -     Subtract     -  45        109
+            +     Add          +  43        107
+
+           Now repeat with the NumLock off.
+
+           If all keycodes are valid and expected characters appear
+           in the text field press "Pass". Otherwise press "Fail".
+           """;
+
+   public NumpadTest() {
+       super("Check KeyChar values");
+       setLayout(new BorderLayout());
+       TextField tf = new TextField(30);
+       tf.addKeyListener(this);
+       add(tf, BorderLayout.CENTER);
+       pack();
+   }
+    public void keyPressed(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    public void keyTyped(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    public void keyReleased(KeyEvent evt) {
+        printKey(evt);
+    }
+
+    protected void printKey(KeyEvent evt) {
+        switch (evt.getID()) {
+          case KeyEvent.KEY_TYPED:
+            break;
+          case KeyEvent.KEY_PRESSED:
+            break;
+          case KeyEvent.KEY_RELEASED:
+            break;
+          default:
+            return;
+        }
+
+        if (evt.isActionKey()) {
+            PassFailJFrame.log("params= " + evt.paramString() + "  KeyChar:  " +
+              (int) evt.getKeyChar() + "   Action Key");
+        } else {
+            PassFailJFrame.log("params= " + evt.paramString() + "  KeyChar:  " +
+              (int) evt.getKeyChar());
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("NumpadTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .logArea(20)
+                .testUI(NumpadTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
Backport JDK-8353655 for parity with oracle.

Clean backport, adding new tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353655](https://bugs.openjdk.org/browse/JDK-8353655) needs maintainer approval

### Issue
 * [JDK-8353655](https://bugs.openjdk.org/browse/JDK-8353655): Clean up and open source KeyEvent related tests (Part 1) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1862/head:pull/1862` \
`$ git checkout pull/1862`

Update a local copy of the PR: \
`$ git checkout pull/1862` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1862`

View PR using the GUI difftool: \
`$ git pr show -t 1862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1862.diff">https://git.openjdk.org/jdk21u-dev/pull/1862.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1862#issuecomment-2958121518)
</details>
