### PR TITLE
8314166: Update googletest to v1.14.0

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1112,13 +1112,13 @@ just unpacked.</p>
 Test framework. The top directory, which contains both
 <code>googletest</code> and <code>googlemock</code> directories, should
 be specified via <code>--with-gtest</code>. The minimum supported
-version of Google Test is 1.13.0, whose source code can be obtained:</p>
+version of Google Test is 1.14.0, whose source code can be obtained:</p>
 <ul>
 <li>by downloading and unpacking the source bundle from <a
-href="https://github.com/google/googletest/releases/tag/v1.13.0">here</a></li>
-<li>or by checking out <code>v1.13.0</code> tag of
+href="https://github.com/google/googletest/releases/tag/v1.14.0">here</a></li>
+<li>or by checking out <code>v1.14.0</code> tag of
 <code>googletest</code> project:
-<code>git clone -b v1.13.0 https://github.com/google/googletest</code></li>
+<code>git clone -b v1.14.0 https://github.com/google/googletest</code></li>
 </ul>
 <p>To execute the most basic tests (tier 1), use:</p>
 <pre><code>make run-test-tier1</code></pre>

--- a/doc/building.md
+++ b/doc/building.md
@@ -881,11 +881,11 @@ Download the latest `.tar.gz` file, unpack it, and point `--with-jtreg` to the
 Building of Hotspot Gtest suite requires the source code of Google
 Test framework.  The top directory, which contains both `googletest`
 and `googlemock` directories, should be specified via `--with-gtest`.
-The minimum supported version of Google Test is 1.13.0, whose source
+The minimum supported version of Google Test is 1.14.0, whose source
 code can be obtained:
 
- * by downloading and unpacking the source bundle from [here](https://github.com/google/googletest/releases/tag/v1.13.0)
- * or by checking out `v1.13.0` tag of `googletest` project: `git clone -b v1.13.0 https://github.com/google/googletest`
+ * by downloading and unpacking the source bundle from [here](https://github.com/google/googletest/releases/tag/v1.14.0)
+ * or by checking out `v1.14.0` tag of `googletest` project: `git clone -b v1.14.0 https://github.com/google/googletest`
 
 To execute the most basic tests (tier 1), use:
 ```

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -29,7 +29,7 @@
 
 # Minimum supported versions
 JTREG_MINIMUM_VERSION=7.3.1
-GTEST_MINIMUM_VERSION=1.13.0
+GTEST_MINIMUM_VERSION=1.14.0
 
 ###############################################################################
 #

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -25,7 +25,7 @@
 
 # Versions and download locations for dependencies used by GitHub Actions (GHA)
 
-GTEST_VERSION=1.13.0
+GTEST_VERSION=1.14.0
 JTREG_VERSION=7.3.1+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1267,7 +1267,7 @@ var getJibProfilesDependencies = function (input, common) {
         gtest: {
             organization: common.organization,
             ext: "tar.gz",
-            revision: "1.13.0+1.0"
+            revision: "1.14.0+1.0"
         },
 
         libffi: {


### PR DESCRIPTION
Backport of JDK-8314166. Applies almost cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314166](https://bugs.openjdk.org/browse/JDK-8314166) needs maintainer approval

### Issue
 * [JDK-8314166](https://bugs.openjdk.org/browse/JDK-8314166): Update googletest to v1.14.0 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1863/head:pull/1863` \
`$ git checkout pull/1863`

Update a local copy of the PR: \
`$ git checkout pull/1863` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1863`

View PR using the GUI difftool: \
`$ git pr show -t 1863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1863.diff">https://git.openjdk.org/jdk21u-dev/pull/1863.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1863#issuecomment-2958947615)
</details>
