### PR TITLE
8358159: Empty mode/padding in cipher transformations

### DIFF
--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -448,19 +448,25 @@ public class Cipher {
         String[] parts = tokenizeTransformation(transformation);
 
         String alg = parts[0];
-        String mode = parts[1];
-        String pad = parts[2];
+        String mode = (parts[1].length() == 0 ? null : parts[1]);
+        String pad = (parts[2].length() == 0 ? null : parts[2]);
 
-        if ((mode.length() == 0) && (pad.length() == 0)) {
+        if ((mode == null) && (pad == null)) {
             // Algorithm only
             Transform tr = new Transform(alg, "", null, null);
             return Collections.singletonList(tr);
         } else {
             // Algorithm w/ at least mode or padding or both
             List<Transform> list = new ArrayList<>(4);
-            list.add(new Transform(alg, "/" + mode + "/" + pad, null, null));
-            list.add(new Transform(alg, "/" + mode, null, pad));
-            list.add(new Transform(alg, "//" + pad, mode, null));
+            if ((mode != null) && (pad != null)) {
+                list.add(new Transform(alg, "/" + mode + "/" + pad, null, null));
+            }
+            if (mode != null) {
+                list.add(new Transform(alg, "/" + mode, null, pad));
+            }
+            if (pad != null) {
+                list.add(new Transform(alg, "//" + pad, mode, null));
+            }
             list.add(new Transform(alg, "", mode, pad));
             return list;
         }

--- a/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
+++ b/test/jdk/javax/crypto/Cipher/TestEmptyModePadding.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8358159
+ * @summary test that the Cipher.getInstance() handles
+ * transformations with empty mode and/or padding
+ * @run main TestEmptyModePadding
+ */
+
+
+import java.security.*;
+import javax.crypto.*;
+
+public class TestEmptyModePadding {
+
+    public static void main(String[] args) throws Exception {
+        Provider provider = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
+
+        test("AES", provider);
+        test("AES/ECB/PKCS5Padding", provider);
+        test("AES//PKCS5Padding", provider);        // Empty mode
+        test("AES/CBC/", provider);                 // Empty padding
+        test("AES/ /NoPadding", provider);          // Mode is a space
+        test("AES/CBC/ ", provider);                // Padding is a space
+        test("AES/ / ", provider);                  // Both mode and padding are spaces
+        test("AES//", provider);                    // Both mode and padding are missing
+
+    }
+
+    private static void test(String transformation, Provider provider) throws Exception {
+        Cipher c = Cipher.getInstance(transformation, provider);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3ff83ec4](https://github.com/openjdk/jdk/commit/3ff83ec49e561c44dd99508364b8ba068274b63a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Varada M on 10 Jun 2025 and was reviewed by Amit Kumar and Valerie Peng.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8358159](https://bugs.openjdk.org/browse/JDK-8358159) needs maintainer approval

### Issue
 * [JDK-8358159](https://bugs.openjdk.org/browse/JDK-8358159): Empty mode/padding in cipher transformations (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1867/head:pull/1867` \
`$ git checkout pull/1867`

Update a local copy of the PR: \
`$ git checkout pull/1867` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1867`

View PR using the GUI difftool: \
`$ git pr show -t 1867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1867.diff">https://git.openjdk.org/jdk21u-dev/pull/1867.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1867#issuecomment-2962433542)
</details>
