### PR TITLE
Backport d0052c032cc1927e7e92f04cfedab20e0c4e0293

### DIFF
--- a/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
@@ -34,6 +34,9 @@
 
 #include <stdio.h>
 
+// for basename
+#include <libgen.h>
+
 typedef struct {
   const char* mount_path;
   const char* root_path;
@@ -47,6 +50,7 @@ static bool file_exists(const char* filename) {
   return os::stat(filename, &st) == 0;
 }
 
+// we rely on temp_file returning modifiable memory in resource area.
 static char* temp_file(const char* prefix) {
   const testing::TestInfo* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
   stringStream path;
@@ -89,7 +93,7 @@ static void fill_file(const char* path, const char* content) {
 }
 
 TEST(cgroupTest, read_numerical_key_value_failure_cases) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -135,7 +139,7 @@ TEST(cgroupTest, read_numerical_key_value_failure_cases) {
 }
 
 TEST(cgroupTest, read_numerical_key_value_success_cases) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -235,7 +239,7 @@ TEST(cgroupTest, read_numerical_key_value_null) {
 }
 
 TEST(cgroupTest, read_number_tests) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   constexpr julong bad = 0xBAD;
   EXPECT_TRUE(b != nullptr) << "basename was null";
@@ -289,7 +293,7 @@ TEST(cgroupTest, read_number_tests) {
 }
 
 TEST(cgroupTest, read_string_tests) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -355,7 +359,7 @@ TEST(cgroupTest, read_string_tests) {
 }
 
 TEST(cgroupTest, read_number_tuple_test) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;


### PR DESCRIPTION
A patch 2 of 6 for: [[21u] Backport intention of 8322420: [Linux] cgroup v2: Limits in parent nested control groups are not detected](https://mail.openjdk.org/pipermail/jdk-updates-dev/2025-April/043206.html)

It has a patch dependency on PR 1 of 6: https://github.com/openjdk/jdk21u-dev/pull/1648

This backport is clean.

The whole patchset has been tested on CentOS-7.9 (for cgroup v1) and on Fedora 40 (for cgroup v2) for test/hotspot/jtreg/containers.
