### PR TITLE
Backport 3eeb681a0de87baa12b6eac5966e7f707b76c8bf

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/Unicode.java
+++ b/src/java.base/share/classes/sun/nio/cs/Unicode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,12 @@ abstract class Unicode extends Charset
                 || (cs instanceof UTF_16BE)
                 || (cs instanceof UTF_16LE)
                 || (cs instanceof UTF_16LE_BOM)
+                || (cs instanceof CESU_8)
+                || (cs instanceof UTF_32)
+                || (cs instanceof UTF_32BE)
+                || (cs instanceof UTF_32BE_BOM)
+                || (cs instanceof UTF_32LE)
+                || (cs instanceof UTF_32LE_BOM)
                 || (cs.name().equals("GBK"))
                 || (cs.name().equals("GB18030"))
                 || (cs.name().equals("ISO-8859-2"))

--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/EUC_JP_Open.java.template
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/EUC_JP_Open.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,8 @@ public class EUC_JP_Open
     public boolean contains(Charset cs) {
         return ((cs.name().equals("US-ASCII"))
                 || (cs instanceof JIS_X_0201)
-                || (cs instanceof EUC_JP));
+                || (cs instanceof EUC_JP)
+                || (cs instanceof EUC_JP_Open));
     }
 
     public CharsetDecoder newDecoder() {

--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/JISAutoDetect.java
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/JISAutoDetect.java
@@ -59,7 +59,8 @@ public class JISAutoDetect
         return ((cs.name().equals("US-ASCII"))
                 || (cs instanceof SJIS)
                 || (cs instanceof EUC_JP)
-                || (cs instanceof ISO2022_JP));
+                || (cs instanceof ISO2022_JP)
+                || (cs instanceof JISAutoDetect));
     }
 
     public boolean canEncode() {

--- a/test/jdk/java/nio/charset/Charset/Contains.java
+++ b/test/jdk/java/nio/charset/Charset/Contains.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /* @test
  * @summary Unit test for charset containment
- * @bug 6798572
+ * @bug 6798572 8167252
  * @modules jdk.charsets
  */
 
@@ -93,6 +93,8 @@ public class Contains {
         ck(cp1252, cp1252, true);
 
         checkUTF();
+
+        containsSelfTest();
     }
 
     static void checkUTF() throws Exception {
@@ -101,6 +103,27 @@ public class Contains {
                 ck(Charset.forName(utfName),
                    Charset.forName(csName),
                    true);
+    }
+
+    /**
+     * Tests the assertion in the contains() method: "Every charset contains itself."
+     */
+    static void containsSelfTest() {
+        boolean failed = false;
+
+        for (var entry : Charset.availableCharsets().entrySet()) {
+            Charset charset = entry.getValue();
+            boolean contains = charset.contains(charset);
+
+            System.out.println("Charset(" + charset.name() + ").contains(Charset(" + charset.name()
+                        + ")) returns " + contains);
+            if (!contains) {
+                failed = true;
+            }
+        }
+        if (failed) {
+            throw new RuntimeException("Charset.contains(itself) returns false for some charsets");
+        }
     }
 
     static String[] utfNames = {"utf-16",


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle

I needed to do a full rebuild to make the change take effect.