### PR TITLE
8347299: Add annotations to test cases in LicenseTest

### DIFF
--- a/test/jdk/tools/jpackage/share/LicenseTest.java
+++ b/test/jdk/tools/jpackage/share/LicenseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import static jdk.internal.util.OperatingSystem.LINUX;
+import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.PackageTest;
@@ -67,6 +69,7 @@ import jdk.jpackage.test.TKit;
  * @key jpackagePlatformPackage
  * @build jdk.jpackage.test.*
  * @compile LicenseTest.java
+ * @requires (jpackage.test.SQETest != null)
  * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=LicenseTest.testCommon
  */
@@ -78,18 +81,14 @@ import jdk.jpackage.test.TKit;
  * @key jpackagePlatformPackage
  * @build jdk.jpackage.test.*
  * @compile LicenseTest.java
- * @requires (os.family == "linux")
  * @requires (jpackage.test.SQETest == null)
  * @run main/othervm/timeout=1440 -Xmx512m jdk.jpackage.test.Main
- *  --jpt-run=LicenseTest.testCustomDebianCopyright
- *  --jpt-run=LicenseTest.testCustomDebianCopyrightSubst
- *  --jpt-run=LicenseTest.testLinuxLicenseInUsrTree
- *  --jpt-run=LicenseTest.testLinuxLicenseInUsrTree2
- *  --jpt-run=LicenseTest.testLinuxLicenseInUsrTree3
- *  --jpt-run=LicenseTest.testLinuxLicenseInUsrTree4
+ *  --jpt-run=LicenseTest
  */
 
 public class LicenseTest {
+
+    @Test
     public static void testCommon() {
         PackageTest test = new PackageTest().configureHelloApp()
         .addInitializer(cmd -> {
@@ -102,26 +101,32 @@ public class LicenseTest {
         test.run();
     }
 
+    @Test(ifOS = LINUX)
     public static void testLinuxLicenseInUsrTree() {
         testLinuxLicenseInUsrTree("/usr");
     }
 
+    @Test(ifOS = LINUX)
     public static void testLinuxLicenseInUsrTree2() {
         testLinuxLicenseInUsrTree("/usr/local");
     }
 
+    @Test(ifOS = LINUX)
     public static void testLinuxLicenseInUsrTree3() {
         testLinuxLicenseInUsrTree("/usr/foo");
     }
 
+    @Test(ifOS = LINUX)
     public static void testLinuxLicenseInUsrTree4() {
         testLinuxLicenseInUsrTree("/usrbuz");
     }
 
+    @Test(ifOS = LINUX)
     public static void testCustomDebianCopyright() {
         new CustomDebianCopyrightTest().run();
     }
 
+    @Test(ifOS = LINUX)
     public static void testCustomDebianCopyrightSubst() {
         new CustomDebianCopyrightTest().withSubstitution(true).run();
     }


### PR DESCRIPTION
Backporting JDK-8347299: Add annotations to test cases in LicenseTest. Adding missing `jdk.jpackage.test.Annotations.Test` annotations to test cases in LicenseTest test and update jtreg command line accordingly. Ran GHA Sanity Checks, local Tier 1 and 2, and adjusted test directly. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347299](https://bugs.openjdk.org/browse/JDK-8347299) needs maintainer approval

### Issue
 * [JDK-8347299](https://bugs.openjdk.org/browse/JDK-8347299): Add annotations to test cases in LicenseTest (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1872/head:pull/1872` \
`$ git checkout pull/1872`

Update a local copy of the PR: \
`$ git checkout pull/1872` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1872`

View PR using the GUI difftool: \
`$ git pr show -t 1872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1872.diff">https://git.openjdk.org/jdk21u-dev/pull/1872.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1872#issuecomment-2972956861)
</details>
