### PR TITLE
8345337: JFR: jfr view should display all direct subfields for an event type

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
@@ -340,9 +340,10 @@ final class FieldBuilder {
                 var subFields = we.field().getFields().reversed();
                 if (!subFields.isEmpty() && !KNOWN_TYPES.contains(we.field().getTypeName())) {
                     for (ValueDescriptor subField : subFields) {
-                        String n = we.name + "." + subField.getName();
-                        String l = we.label + " : " + makeLabel(subField, false);
-                        if (stack.size() < 2) { // Limit depth to 2
+                        // Limit depth to 2
+                        if (!we.name.contains(".")) {
+                            String n = we.name + "." + subField.getName();
+                            String l = we.label + " : " + makeLabel(subField, false);
                             stack.push(new WildcardElement(n, l, subField));
                         }
                     }


### PR DESCRIPTION
Backporting JDK-8345337: JFR: jfr view should display all direct subfields for an event type. Adjusting logic for `jfr view` command to display all direct subfields for an event type. Ran GHA Sanity Checks, local Tier 1 and 2, and testing under `jdk/jdk/jfr`. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345337](https://bugs.openjdk.org/browse/JDK-8345337) needs maintainer approval

### Issue
 * [JDK-8345337](https://bugs.openjdk.org/browse/JDK-8345337): JFR: jfr view should display all direct subfields for an event type (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1873/head:pull/1873` \
`$ git checkout pull/1873`

Update a local copy of the PR: \
`$ git checkout pull/1873` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1873`

View PR using the GUI difftool: \
`$ git pr show -t 1873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1873.diff">https://git.openjdk.org/jdk21u-dev/pull/1873.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1873#issuecomment-2972965048)
</details>
