### PR TITLE
8332551: Test vmTestbase/nsk/monitoring/MemoryNotificationInfo/from/from001/TestDescription.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryNotificationInfo/from/from001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryNotificationInfo/from/from001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,15 +34,20 @@
  *         MemoryNotificationInfo.from(CompositeData)
  *     returns correct results:
  *     1. null, if CompositeData is null;
- *     2. trows IllegalArgumentException, if CompositeData doest not represnt
+ *     2. throws IllegalArgumentException, if CompositeData does not represent
  *        MemoryNotificationInfo;
- *     3. correct MemoryNotificationInfo object, if CompositeData is correst (i.e
+ *     3. correct MemoryNotificationInfo object, if CompositeData is correct, i.e
  *        all attributes of the CompositeData must have correct values: pool name,
  *        count; init, used, committed, max (from MemoryUsage).
  * COMMENT
  *     Updated according to:
  *     5024531 Fix MBeans design flaw that restricts to use JMX CompositeData
  *
+ * Avoid running with -Xcomp due to rare failure where the MemoryPool does not
+ * increase in usage and send Notification.  Likely the timing changes so "eatMemory"
+ * completes before Notification/threshold processing.
+ *
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8332551](https://bugs.openjdk.org/browse/JDK-8332551) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332551](https://bugs.openjdk.org/browse/JDK-8332551): Test vmTestbase/nsk/monitoring/MemoryNotificationInfo/from/from001/TestDescription.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1878/head:pull/1878` \
`$ git checkout pull/1878`

Update a local copy of the PR: \
`$ git checkout pull/1878` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1878`

View PR using the GUI difftool: \
`$ git pr show -t 1878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1878.diff">https://git.openjdk.org/jdk21u-dev/pull/1878.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1878#issuecomment-2976517370)
</details>
