### PR TITLE
8340389: vmTestbase/gc/gctests/PhantomReference/phantom001/TestDescription.java Test exit code: 97 with -Xcomp UseAVX=3

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -177,14 +177,15 @@ public class phantom001 extends ThreadedGCTest {
             // If referent is finalizable, provoke GCs and wait for finalization.
             if (type.equals("class")) {
                 progress("Waiting for finalization: " + type);
+                WhiteBox.getWhiteBox().fullGC();
                 for (int checks = 0; !finalized && !shouldTerminate(); ++checks) {
-                    // There are scenarios where one WB.fillGC() isn't enough,
-                    // but 10 iterations really ought to be sufficient.
+                    // Wait for up to 10 iterations that the finalizer has been run,
+                    // this ought to be sufficient. Full GCs and other threads might
+                    // starve out the finalizer thread, requiring more waiting.
                     if (checks > 10) {
                         fail("Waiting for finalization: " + type);
                         return;
                     }
-                    WhiteBox.getWhiteBox().fullGC();
                     // Give some time for finalizer to run.
                     try {
                         Thread.sleep(checks * 100);


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340389](https://bugs.openjdk.org/browse/JDK-8340389) needs maintainer approval

### Issue
 * [JDK-8340389](https://bugs.openjdk.org/browse/JDK-8340389): vmTestbase/gc/gctests/PhantomReference/phantom001/TestDescription.java Test exit code: 97 with -Xcomp UseAVX=3 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1879/head:pull/1879` \
`$ git checkout pull/1879`

Update a local copy of the PR: \
`$ git checkout pull/1879` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1879`

View PR using the GUI difftool: \
`$ git pr show -t 1879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1879.diff">https://git.openjdk.org/jdk21u-dev/pull/1879.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1879#issuecomment-2977147434)
</details>
