### PR TITLE
Backport 2b57f402c46104d4aba784a891ba90604f5e9e4c

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -3217,14 +3217,14 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
     }
     // factory method for KeySpliterator
     final KeySpliterator<K,V> keySpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
         return new KeySpliterator<K,V>(comparator, h, n, null, est);
@@ -3303,14 +3303,14 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
 
     // Almost the same as keySpliterator()
     final ValueSpliterator<K,V> valueSpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
         return new ValueSpliterator<K,V>(comparator, h, n, null, est);
@@ -3407,14 +3407,14 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
 
     // Almost the same as keySpliterator()
     final EntrySpliterator<K,V> entrySpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
         return new EntrySpliterator<K,V>(comparator, h, n, null, est);


### PR DESCRIPTION
Backporting JDK-8343426: ConcurrentSkipListMap.spliterator() can no longer split the stream. Since Java 10, the trySplit() method for spliterators for the ConcurrentSkipListMap always returned null, causing parallel streams to be broken for ConcurrentSkipListMap and ConcurrentSkipListSet since. This change fixes the logic for considering the head.node.next field in addition to head.node. Ran GHA Sanity Checks, local Tier 1 and 2, and new test directly. Patch is clean.