### PR TITLE
8352895: UserCookie.java runs wrong test class

### DIFF
--- a/test/jdk/sun/net/www/protocol/http/UserCookie.java
+++ b/test/jdk/sun/net/www/protocol/http/UserCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 6439651
- * @modules jdk.httpserver
- * @run main/othervm UserAuth
  * @summary Sending "Cookie" header with JRE 1.5.0_07 doesn't work anymore
+ * @modules jdk.httpserver
+ * @run main/othervm UserCookie
  */
 
 import java.net.*;


### PR DESCRIPTION
Backport JDK-8352895 for parity with oracle.

Clean backport, change the test to run the correct test class, modified test passes after changes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352895](https://bugs.openjdk.org/browse/JDK-8352895) needs maintainer approval

### Issue
 * [JDK-8352895](https://bugs.openjdk.org/browse/JDK-8352895): UserCookie.java runs wrong test class (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1899/head:pull/1899` \
`$ git checkout pull/1899`

Update a local copy of the PR: \
`$ git checkout pull/1899` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1899`

View PR using the GUI difftool: \
`$ git pr show -t 1899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1899.diff">https://git.openjdk.org/jdk21u-dev/pull/1899.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1899#issuecomment-2983215551)
</details>
