### PR TITLE
8356778: Compiler add event logging in case of failures

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -33,6 +33,7 @@
 #include "c1/c1_ValueMap.hpp"
 #include "c1/c1_ValueStack.hpp"
 #include "code/debugInfoRec.hpp"
+#include "compiler/compilationLog.hpp"
 #include "compiler/compileLog.hpp"
 #include "compiler/compilerDirectives.hpp"
 #include "memory/resourceArea.hpp"
@@ -638,6 +639,13 @@ void Compilation::notice_inlined_method(ciMethod* method) {
 
 void Compilation::bailout(const char* msg) {
   assert(msg != nullptr, "bailout message must exist");
+  // record the bailout for hserr envlog
+  if (CompilationLog::log() != nullptr) {
+    CompilerThread* thread = CompilerThread::current();
+    CompileTask* task = thread->task();
+    CompilationLog::log()->log_failure(thread, task, msg, nullptr);
+  }
+
   if (!bailed_out()) {
     // keep first bailout message
     if (PrintCompilation || PrintBailouts) tty->print_cr("compilation bailout: %s", msg);

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1230,6 +1230,15 @@ int ciEnv::num_inlined_bytecodes() const {
 // ------------------------------------------------------------------
 // ciEnv::record_failure()
 void ciEnv::record_failure(const char* reason) {
+  // record the bailout for hserr envlog
+  if (reason != nullptr) {
+    if (CompilationLog::log() != nullptr) {
+      CompilerThread* thread = CompilerThread::current();
+      CompileTask* task = thread->task();
+      CompilationLog::log()->log_failure(thread, task, reason, nullptr);
+    }
+  }
+
   if (_failure_reason.get() == nullptr) {
     // Record the first failure reason.
     _failure_reason.set(reason);

--- a/src/hotspot/share/compiler/compilationLog.cpp
+++ b/src/hotspot/share/compiler/compilationLog.cpp
@@ -52,7 +52,11 @@ void CompilationLog::log_nmethod(JavaThread* thread, nmethod* nm) {
 
 void CompilationLog::log_failure(JavaThread* thread, CompileTask* task, const char* reason, const char* retry_message) {
   StringLogMessage lm;
-  lm.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
+  if (task == nullptr) {
+    lm.print("Id not known, task was 0;  COMPILE SKIPPED: %s", reason);
+  } else {
+    lm.print("%4d   COMPILE SKIPPED: %s", task->compile_id(), reason);
+  }
   if (retry_message != nullptr) {
     lm.append(" (%s)", retry_message);
   }


### PR DESCRIPTION
Backport of 8356778, header inclusion in c1_Compilation.cpp has diff in the stride

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8356778](https://bugs.openjdk.org/browse/JDK-8356778) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356778](https://bugs.openjdk.org/browse/JDK-8356778): Compiler add event logging in case of failures (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1902/head:pull/1902` \
`$ git checkout pull/1902`

Update a local copy of the PR: \
`$ git checkout pull/1902` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1902`

View PR using the GUI difftool: \
`$ git pr show -t 1902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1902.diff">https://git.openjdk.org/jdk21u-dev/pull/1902.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1902#issuecomment-2984322709)
</details>
