### PR TITLE
8358534: Bailout in Conv2B::Ideal when type of cmp input is not supported

### DIFF
--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -77,6 +77,11 @@ Node* Conv2BNode::Ideal(PhaseGVN* phase, bool can_reshape) {
         assert(false, "Unrecognized comparison for Conv2B: %s", NodeClassNames[in(1)->Opcode()]);
       }
 
+      // Skip the transformation if input is unexpected.
+      if (cmp == nullptr) {
+        return nullptr;
+      }
+
       // Replace Conv2B with the cmove
       Node* bol = phase->transform(new BoolNode(cmp, BoolTest::eq));
       return new CMoveINode(bol, phase->intcon(1), phase->intcon(0), TypeInt::BOOL);


### PR DESCRIPTION
Clean bailout from the optimization added in JDK 21. While the patch is fairly recent, it does not come with elevated risk, as it just skips the optimization in the case where the alternative is compiler crash. This crash is seen in real world: https://github.com/adoptium/adoptium-support/issues/1191

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358534](https://bugs.openjdk.org/browse/JDK-8358534) needs maintainer approval

### Issue
 * [JDK-8358534](https://bugs.openjdk.org/browse/JDK-8358534): Bailout in Conv2B::Ideal when type of cmp input is not supported (**Bug** - P3 - Approved)


### Reviewers
 * [Cesar Soares Lucas](https://openjdk.org/census#cslucas) (@JohnTortugo - no project role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1904/head:pull/1904` \
`$ git checkout pull/1904`

Update a local copy of the PR: \
`$ git checkout pull/1904` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1904`

View PR using the GUI difftool: \
`$ git pr show -t 1904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1904.diff">https://git.openjdk.org/jdk21u-dev/pull/1904.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1904#issuecomment-2987813870)
</details>
