### PR TITLE
8351997: AArch64: Interpreter volatile reference stores with G1 are not sequentially consistent

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -1135,6 +1135,7 @@ void TemplateTable::aastore() {
   // Get the value we will store
   __ ldr(r0, at_tos());
   // Now store using the appropriate barrier
+  // Clobbers: r10, r11, r3
   do_oop_store(_masm, element_address, r0, IS_ARRAY);
   __ b(done);
 
@@ -1143,6 +1144,7 @@ void TemplateTable::aastore() {
   __ profile_null_seen(r2);
 
   // Store a null
+  // Clobbers: r10, r11, r3
   do_oop_store(_masm, element_address, noreg, IS_ARRAY);
 
   // Pop stack arguments
@@ -2774,6 +2776,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     __ pop(atos);
     if (!is_static) pop_and_check_object(obj);
     // Store into the field
+    // Clobbers: r10, r11, r3
     do_oop_store(_masm, field, r0, IN_HEAP);
     if (rc == may_rewrite) {
       patch_bytecode(Bytecodes::_fast_aputfield, bc, r1, true, byte_no);
@@ -2973,8 +2976,8 @@ void TemplateTable::fast_storefield(TosState state)
   // Must prevent reordering of the following cp cache loads with bytecode load
   __ membar(MacroAssembler::LoadLoad);
 
-  // test for volatile with r3
-  __ ldrw(r3, Address(r2, in_bytes(base +
+  // test for volatile with r5
+  __ ldrw(r5, Address(r2, in_bytes(base +
                                    ConstantPoolCacheEntry::flags_offset())));
 
   // replace index with field offset from cache entry
@@ -2982,7 +2985,7 @@ void TemplateTable::fast_storefield(TosState state)
 
   {
     Label notVolatile;
-    __ tbz(r3, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
+    __ tbz(r5, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
     __ membar(MacroAssembler::StoreStore | MacroAssembler::LoadStore);
     __ bind(notVolatile);
   }
@@ -2998,6 +3001,7 @@ void TemplateTable::fast_storefield(TosState state)
   // access field
   switch (bytecode()) {
   case Bytecodes::_fast_aputfield:
+    // Clobbers: r10, r11, r3
     do_oop_store(_masm, field, r0, IN_HEAP);
     break;
   case Bytecodes::_fast_lputfield:
@@ -3030,7 +3034,7 @@ void TemplateTable::fast_storefield(TosState state)
 
   {
     Label notVolatile;
-    __ tbz(r3, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
+    __ tbz(r5, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
     __ membar(MacroAssembler::StoreLoad | MacroAssembler::StoreStore);
     __ bind(notVolatile);
   }


### PR DESCRIPTION
Fixes AArch64 memory ordering problem. Readily manifests in new jcstress tests; there are sightings of related problems in JSR 133 tests. The patch is not clean, because [JDK-8301996](https://bugs.openjdk.org/browse/JDK-8301996) is in the way, and it is IMO too risky to backport. I resolved some hunks to match the intended behavior, after checking `do_oop_store` clobbers the same `r3` as in mainline.

Additional testing:
 - [x] Linux AArch64 server release, jcstress `RefDekker` test now passes
 - [x] Linux AArch64 server release, jcstress `seqcst.volatiles.ref` tests now pass
 - [x] Linux AArch64 server release, jcstress `all` tests now pass
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351997](https://bugs.openjdk.org/browse/JDK-8351997) needs maintainer approval

### Issue
 * [JDK-8351997](https://bugs.openjdk.org/browse/JDK-8351997): AArch64: Interpreter volatile reference stores with G1 are not sequentially consistent (**Bug** - P2 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1905/head:pull/1905` \
`$ git checkout pull/1905`

Update a local copy of the PR: \
`$ git checkout pull/1905` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1905`

View PR using the GUI difftool: \
`$ git pr show -t 1905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1905.diff">https://git.openjdk.org/jdk21u-dev/pull/1905.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1905#issuecomment-2987973029)
</details>
