### PR TITLE
8343426: ConcurrentSkipListMap.spliterator() can no longer split the stream

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -3217,14 +3217,14 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
     }
     // factory method for KeySpliterator
     final KeySpliterator<K,V> keySpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
         return new KeySpliterator<K,V>(comparator, h, n, null, est);
@@ -3303,14 +3303,14 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
 
     // Almost the same as keySpliterator()
     final ValueSpliterator<K,V> valueSpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
         return new ValueSpliterator<K,V>(comparator, h, n, null, est);
@@ -3407,14 +3407,14 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
 
     // Almost the same as keySpliterator()
     final EntrySpliterator<K,V> entrySpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
         return new EntrySpliterator<K,V>(comparator, h, n, null, est);

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -3161,7 +3161,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                         current = n;
                         Index<K,V> r = q.down;
                         row = (s.right != null) ? s : s.down;
-                        est -= est >>> 2;
+                        est >>>= 1;
                         return new KeySpliterator<K,V>(cmp, r, e, sk, est);
                     }
                 }
@@ -3251,7 +3251,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                         current = n;
                         Index<K,V> r = q.down;
                         row = (s.right != null) ? s : s.down;
-                        est -= est >>> 2;
+                        est >>>= 1;
                         return new ValueSpliterator<K,V>(cmp, r, e, sk, est);
                     }
                 }
@@ -3337,7 +3337,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                         current = n;
                         Index<K,V> r = q.down;
                         row = (s.right != null) ? s : s.down;
-                        est -= est >>> 2;
+                        est >>>= 1;
                         return new EntrySpliterator<K,V>(cmp, r, e, sk, est);
                     }
                 }


### PR DESCRIPTION
Backporting JDK-8344253: Test java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java failed. Fixes an intermittent failure with the `java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java failed` test in situations where a decrement wouldn't complete, since unsigned shift right twice would lead to decrementing estimated size by 0. Backporting alongside the related issue: JDK-8344253: https://github.com/openjdk/jdk21u-dev/pull/1895. Ran GHA Sanity Checks, and local Tier 1 and 2. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8344253](https://bugs.openjdk.org/browse/JDK-8344253) needs maintainer approval
- [ ] [JDK-8343426](https://bugs.openjdk.org/browse/JDK-8343426) needs maintainer approval

### Issues
 * [JDK-8343426](https://bugs.openjdk.org/browse/JDK-8343426): ConcurrentSkipListMap.spliterator() can no longer split the stream (**Bug** - P3 - Rejected)
 * [JDK-8344253](https://bugs.openjdk.org/browse/JDK-8344253): Test java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java failed (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1906/head:pull/1906` \
`$ git checkout pull/1906`

Update a local copy of the PR: \
`$ git checkout pull/1906` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1906`

View PR using the GUI difftool: \
`$ git pr show -t 1906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1906.diff">https://git.openjdk.org/jdk21u-dev/pull/1906.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1906#issuecomment-2989698916)
</details>
