### PR TITLE
8359402: Test CloseDescriptors.java should throw SkippedException when there is no lsof/sctp

### DIFF
--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @bug 8238274
  * @summary Potential leak file descriptor for SCTP
  * @requires (os.family == "linux")
+ * @library /test/lib
+ * @build jtreg.SkippedException
  * @run main/othervm/timeout=250 CloseDescriptors
  */
 
@@ -52,9 +54,7 @@ public class CloseDescriptors {
 
     public static void main(String[] args) throws Exception {
         if (!Util.isSCTPSupported()) {
-            System.out.println("SCTP protocol is not supported");
-            System.out.println("Test cannot be run");
-            return;
+            throw new jtreg.SkippedException("SCTP protocol is not supported");
         }
 
         List<String> lsofDirs = List.of("/usr/bin", "/usr/sbin");
@@ -63,9 +63,7 @@ public class CloseDescriptors {
                             .filter(f -> Files.isExecutable(f))
                             .findFirst();
         if (!lsof.isPresent()) {
-            System.out.println("Cannot locate lsof in " + lsofDirs);
-            System.out.println("Test cannot be run");
-            return;
+            throw new jtreg.SkippedException("Cannot locate lsof in " + lsofDirs);
         }
 
         try (ServerSocket ss = new ServerSocket(0)) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a16d2355](https://github.com/openjdk/jdk/commit/a16d23557b101504ed2ff95cf1a3c5ba11afe33d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 17 Jun 2025 and was reviewed by Volkan Yazici and Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359402](https://bugs.openjdk.org/browse/JDK-8359402) needs maintainer approval

### Issue
 * [JDK-8359402](https://bugs.openjdk.org/browse/JDK-8359402): Test CloseDescriptors.java should throw SkippedException when there is no lsof/sctp (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1909/head:pull/1909` \
`$ git checkout pull/1909`

Update a local copy of the PR: \
`$ git checkout pull/1909` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1909`

View PR using the GUI difftool: \
`$ git pr show -t 1909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1909.diff">https://git.openjdk.org/jdk21u-dev/pull/1909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1909#issuecomment-2989960070)
</details>
