### PR TITLE
8357968: RISC-V: Interpreter volatile reference stores with G1 are not sequentially consistent

### DIFF
--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -123,24 +123,6 @@ static inline Address at_tos_p5() {
   return Address(esp, Interpreter::expr_offset_in_bytes(5));
 }
 
-// Miscellaneous helper routines
-// Store an oop (or null) at the Address described by obj.
-// If val == noreg this means store a null
-static void do_oop_store(InterpreterMacroAssembler* _masm,
-                         Address dst,
-                         Register val,
-                         DecoratorSet decorators) {
-  assert(val == noreg || val == x10, "parameter is just for looks");
-  __ store_heap_oop(dst, val, x28, x29, x13, decorators);
-}
-
-static void do_oop_load(InterpreterMacroAssembler* _masm,
-                        Address src,
-                        Register dst,
-                        DecoratorSet decorators) {
-  __ load_heap_oop(dst, src, x28, x29, decorators);
-}
-
 Address TemplateTable::at_bcp(int offset) {
   assert(_desc->uses_bcp(), "inconsistent uses_bcp information");
   return Address(xbcp, offset);
@@ -770,7 +752,7 @@ void TemplateTable::aaload() {
   index_check(x10, x11); // leaves index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
   __ shadd(x10, x11, x10, t0, LogBytesPerHeapOop);
-  do_oop_load(_masm, Address(x10), x10, IS_ARRAY);
+  __ load_heap_oop(x10, Address(x10), x28, x29, IS_ARRAY);
 }
 
 void TemplateTable::baload() {
@@ -1082,7 +1064,7 @@ void TemplateTable::aastore() {
   // Get the value we will store
   __ ld(x10, at_tos());
   // Now store using the appropriate barrier
-  do_oop_store(_masm, element_address, x10, IS_ARRAY);
+  __ store_heap_oop(element_address, x10, x28, x29, x13, IS_ARRAY);
   __ j(done);
 
   // Have a null in x10, x13=array, x12=index.  Store null at ary[idx]
@@ -1090,7 +1072,7 @@ void TemplateTable::aastore() {
   __ profile_null_seen(x12);
 
   // Store a null
-  do_oop_store(_masm, element_address, noreg, IS_ARRAY);
+  __ store_heap_oop(element_address, noreg, x28, x29, x13, IS_ARRAY);
 
   // Pop stack arguments
   __ bind(done);
@@ -2429,7 +2411,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   __ sub(t0, flags, (u1)atos);
   __ bnez(t0, notObj);
   // atos
-  do_oop_load(_masm, field, x10, IN_HEAP);
+  __ load_heap_oop(x10, field, x28, x29, IN_HEAP);
   __ push(atos);
   if (rc == may_rewrite) {
     patch_bytecode(Bytecodes::_fast_agetfield, bc, x11);
@@ -2689,7 +2671,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     __ add(off, obj, off); // if static, obj from cache, else obj from stack.
     const Address field(off, 0);
     // Store into the field
-    do_oop_store(_masm, field, x10, IN_HEAP);
+    __ store_heap_oop(field, x10, x28, x29, x13, IN_HEAP);
     if (rc == may_rewrite) {
       patch_bytecode(Bytecodes::_fast_aputfield, bc, x11, true, byte_no);
     }
@@ -2942,10 +2924,10 @@ void TemplateTable::fast_storefield(TosState state) {
   __ add(x11, x12, x11);
   const Address field(x11, 0);
 
-  // access field
+  // access field, must not clobber x13 - flags
   switch (bytecode()) {
     case Bytecodes::_fast_aputfield:
-      do_oop_store(_masm, field, x10, IN_HEAP);
+      __ store_heap_oop(field, x10, x28, x29, x15, IN_HEAP);
       break;
     case Bytecodes::_fast_lputfield:
       __ access_store_at(T_LONG, IN_HEAP, field, x10, noreg, noreg, noreg);
@@ -3033,7 +3015,7 @@ void TemplateTable::fast_accessfield(TosState state) {
   // access field
   switch (bytecode()) {
     case Bytecodes::_fast_agetfield:
-      do_oop_load(_masm, field, x10, IN_HEAP);
+      __ load_heap_oop(x10, field, x28, x29, IN_HEAP);
       __ verify_oop(x10);
       break;
     case Bytecodes::_fast_lgetfield:
@@ -3092,7 +3074,7 @@ void TemplateTable::fast_xaccess(TosState state) {
       break;
     case atos:
       __ add(x10, x10, x11);
-      do_oop_load(_masm, Address(x10, 0), x10, IN_HEAP);
+      __ load_heap_oop(x10, Address(x10, 0), x28, x29, IN_HEAP);
       __ verify_oop(x10);
       break;
     case ftos:


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c5a1543e](https://github.com/openjdk/jdk/commit/c5a1543ee3e68775f09ca29fb07efd9aebfdb33e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Robbin Ehn on 2 Jun 2025 and was reviewed by Erik Österlund, Fredrik Bredberg, Aleksey Shipilev and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8357968](https://bugs.openjdk.org/browse/JDK-8357968) needs maintainer approval

### Issue
 * [JDK-8357968](https://bugs.openjdk.org/browse/JDK-8357968): RISC-V: Interpreter volatile reference stores with G1 are not sequentially consistent (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1910/head:pull/1910` \
`$ git checkout pull/1910`

Update a local copy of the PR: \
`$ git checkout pull/1910` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1910`

View PR using the GUI difftool: \
`$ git pr show -t 1910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1910.diff">https://git.openjdk.org/jdk21u-dev/pull/1910.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1910#issuecomment-2990026070)
</details>
