### PR TITLE
8355249: Remove the use of WMIC from the entire source code

### DIFF
--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -216,9 +216,9 @@ else ifeq ($(OPENJDK_TARGET_OS), macosx)
 else ifeq ($(OPENJDK_TARGET_OS), windows)
   NUM_CORES := $(NUMBER_OF_PROCESSORS)
   MEMORY_SIZE := $(shell \
-      $(EXPR) `wmic computersystem get totalphysicalmemory -value \
-          | $(GREP) = | $(SED) 's/\\r//g' \
-          | $(CUT) -d "=" -f 2-` / 1024 / 1024 \
+      $(EXPR) `powershell -Command \
+          "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" \
+          | $(SED) 's/\\r//g' ` / 1024 / 1024 \
   )
 endif
 ifeq ($(NUM_CORES), )

--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,8 @@ AC_DEFUN([BPERF_CHECK_MEMORY_SIZE],
     FOUND_MEM=yes
   elif test "x$OPENJDK_BUILD_OS" = xwindows; then
     # Windows, but without cygwin
-    MEMORY_SIZE=`wmic computersystem get totalphysicalmemory -value | grep = | cut -d "=" -f 2-`
+    MEMORY_SIZE=`powershell -Command \
+        "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" | $SED 's/\\r//g' `
     MEMORY_SIZE=`expr $MEMORY_SIZE / 1024 / 1024`
     FOUND_MEM=yes
   fi

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,10 @@
 #
 
 config.execSuffix=.exe
-config.getChildren.app=bash
+config.getChildren.app=powershell
 config.getChildren.pattern=%p
-config.getChildren.args=-c\0wmic process where ParentProcessId=%p get ProcessId | tail -n+2
 config.getChildren.args.delimiter=\0
+config.getChildren.args=-NoLogo\0-Command\0"Get-CimInstance Win32_Process -Filter \\\"ParentProcessId = %p\\\" | Select-Object ProcessId" | tail -n+4
 ################################################################################
 # process info to gather
 ################################################################################
@@ -39,8 +39,9 @@ native.pattern=%p
 native.javaOnly=false
 native.args=%p
 
-native.info.app=wmic
-native.info.args=process where processId=%p list full
+native.info.app=powershell
+native.info.delimiter=\0
+native.info.args=-NoLogo\0-Command\0"Get-WmiObject Win32_Process -Filter \\\"ProcessId = %p\\\" | Format-List -Property *"
 
 native.pmap.app=pmap
 native.pmap.normal.args=%p
@@ -96,8 +97,9 @@ system.events.delimiter=\0
 system.events.system.args=-NoLogo\0-Command\0Get-EventLog System -After (Get-Date).AddDays(-1) | Format-List
 system.events.application.args=-NoLogo\0-Command\0Get-EventLog Application -After (Get-Date).AddDays(-1) | Format-List
 
-system.os.app=wmic
-system.os.args=os get /format:list
+system.os.app=powershell
+system.os.delimiter=\0
+system.os.args=-NoLogo\0-Command\0Get-WmiObject Win32_OperatingSystem | Format-List -Property *
 
 process.top.app=top
 process.top.args=-b -n 1

--- a/test/jdk/tools/jpackage/windows/Win8301247Test.java
+++ b/test/jdk/tools/jpackage/windows/Win8301247Test.java
@@ -93,31 +93,32 @@ public class Win8301247Test {
     private static Optional<Long> findMainAppLauncherPID(JPackageCommand cmd,
             int expectedCount) {
         // Get the list of PIDs and PPIDs of app launcher processes. Run setWinRunWithEnglishOutput(true) for JDK-8344275.
-        // wmic process where (name = "foo.exe") get ProcessID,ParentProcessID
-        List<String> output = Executor.of("wmic", "process", "where", "(name",
-                "=",
-                "\"" + cmd.appLauncherPath().getFileName().toString() + "\"",
-                ")", "get", "ProcessID,ParentProcessID").dumpOutput(true).
-                saveOutput().setWinRunWithEnglishOutput(true).executeAndGetOutput();
+        // powershell -NoLogo -NoProfile -NonInteractive -CommandAdd commentMore actions
+        //   "Get-CimInstance Win32_Process -Filter \"Name = 'foo.exe'\" | select ProcessID,ParentProcessID"
+        String command = "Get-CimInstance Win32_Process -Filter \\\"Name = '"
+                + cmd.appLauncherPath().getFileName().toString()
+                + "'\\\" | select ProcessID,ParentProcessID";
+        List<String> output = Executor.of("powershell", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command)
+                .dumpOutput(true).saveOutput().setWinRunWithEnglishOutput(true).executeAndGetOutput();
 
         if (expectedCount == 0) {
-            TKit.assertEquals("No Instance(s) Available.", output.getFirst().
-                    trim(), "Check no app launcher processes found running");
-            return Optional.empty();
+            if (output.size() < 1) {
+                return Optional.empty();
+            }
         }
 
-        String[] headers = Stream.of(output.getFirst().split("\\s+", 2)).map(
+        String[] headers = Stream.of(output.get(1).split("\\s+", 2)).map(
                 String::trim).map(String::toLowerCase).toArray(String[]::new);
         Pattern pattern;
         if (headers[0].equals("parentprocessid") && headers[1].equals(
                 "processid")) {
-            pattern = Pattern.compile("^(?<ppid>\\d+)\\s+(?<pid>\\d+)\\s+$");
+            pattern = Pattern.compile("^\\s+(?<ppid>\\d+)\\s+(?<pid>\\d+)$");
         } else if (headers[1].equals("parentprocessid") && headers[0].equals(
                 "processid")) {
-            pattern = Pattern.compile("^(?<pid>\\d+)\\s+(?<ppid>\\d+)\\s+$");
+            pattern = Pattern.compile("^\\s+(?<pid>\\d+)\\s+(?<ppid>\\d+)$");
         } else {
             throw new RuntimeException(
-                    "Unrecognizable output of \'wmic process\' command");
+                    "Unrecognizable output of \'Get-CimInstance Win32_Process\' command");
         }
 
         List<long[]> processes = output.stream().skip(1).map(line -> {

--- a/test/jdk/tools/jpackage/windows/Win8301247Test.java
+++ b/test/jdk/tools/jpackage/windows/Win8301247Test.java
@@ -93,7 +93,7 @@ public class Win8301247Test {
     private static Optional<Long> findMainAppLauncherPID(JPackageCommand cmd,
             int expectedCount) {
         // Get the list of PIDs and PPIDs of app launcher processes. Run setWinRunWithEnglishOutput(true) for JDK-8344275.
-        // powershell -NoLogo -NoProfile -NonInteractive -CommandAdd commentMore actions
+        // powershell -NoLogo -NoProfile -NonInteractive -Command
         //   "Get-CimInstance Win32_Process -Filter \"Name = 'foo.exe'\" | select ProcessID,ParentProcessID"
         String command = "Get-CimInstance Win32_Process -Filter \\\"Name = '"
                 + cmd.appLauncherPath().getFileName().toString()
@@ -121,7 +121,7 @@ public class Win8301247Test {
                     "Unrecognizable output of \'Get-CimInstance Win32_Process\' command");
         }
 
-        List<long[]> processes = output.stream().skip(1).map(line -> {
+        List<long[]> processes = output.stream().skip(3).map(line -> {
             Matcher m = pattern.matcher(line);
             long[] pids = null;
             if (m.matches()) {


### PR DESCRIPTION
Hi all,

This is a backport of JDK-8355249 : Remove the use of WMIC from the entire source code

JDK-8355249 is an enhancement, but the future removal of WMIC will affect any version of jdk, so I think it needs to be backported.

Original patch does not apply cleanly because JDK-8340311 is not backported to jdk21. For this reason, I modified Win8301247Test.java instead of WindowsHelper.java.

I confirmed that Win8301247Test.java passes on Windows Server 2022.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8355249](https://bugs.openjdk.org/browse/JDK-8355249) needs maintainer approval

### Issue
 * [JDK-8355249](https://bugs.openjdk.org/browse/JDK-8355249): Remove the use of WMIC from the entire source code (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1912/head:pull/1912` \
`$ git checkout pull/1912`

Update a local copy of the PR: \
`$ git checkout pull/1912` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1912`

View PR using the GUI difftool: \
`$ git pr show -t 1912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1912.diff">https://git.openjdk.org/jdk21u-dev/pull/1912.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1912#issuecomment-2994624391)
</details>
