### PR TITLE
8332368: ubsan aarch64: immediate_aarch64.cpp:298:31: runtime error: shift exponent 32 is too large for 32-bit type 'int'

### DIFF
--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -856,7 +856,8 @@ void ArchDesc::declare_pipe_classes(FILE *fp_hpp) {
   fprintf(fp_hpp, "  }\n\n");
   fprintf(fp_hpp, "  void step(uint cycles) {\n");
   fprintf(fp_hpp, "    _used = 0;\n");
-  fprintf(fp_hpp, "    _mask <<= cycles;\n");
+  fprintf(fp_hpp, "    uint max_shift = 8 * sizeof(_mask) - 1;\n");
+  fprintf(fp_hpp, "    _mask <<= (cycles < max_shift) ? cycles : max_shift;\n");
   fprintf(fp_hpp, "  }\n\n");
   fprintf(fp_hpp, "  friend class Pipeline_Use;\n");
   fprintf(fp_hpp, "};\n\n");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d783a940](https://github.com/openjdk/jdk/commit/d783a940988677dc91975f884adeaf9f047f7e07) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Boris Ulasevich on 22 Apr 2025 and was reviewed by Andrew Dinn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332368](https://bugs.openjdk.org/browse/JDK-8332368) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332368: ubsan aarch64: immediate_aarch64.cpp:298:31: runtime error: shift exponent 32 is too large for 32-bit type 'int'`

### Issue
 * [JDK-8332368](https://bugs.openjdk.org/browse/JDK-8332368): ubsan aarch64: immediate_aarch64.cpp:298:31: runtime error: shift exponent 32 is too large for 32-bit type 'int' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1913/head:pull/1913` \
`$ git checkout pull/1913`

Update a local copy of the PR: \
`$ git checkout pull/1913` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1913`

View PR using the GUI difftool: \
`$ git pr show -t 1913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1913.diff">https://git.openjdk.org/jdk21u-dev/pull/1913.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1913#issuecomment-2994702003)
</details>
