### PR TITLE
8359336: javac crashes with NPE while iterating params of MethodSymbol

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -131,6 +131,8 @@ public class ClassReader {
      */
     public boolean saveParameterNames;
 
+    private final boolean addTypeAnnotationsToSymbol;
+
     /**
      * The currently selected profile.
      */
@@ -296,6 +298,8 @@ public class ClassReader {
         typevars = WriteableScope.create(syms.noSymbol);
 
         lintClassfile = Lint.instance(context).isEnabled(LintCategory.CLASSFILE);
+
+        addTypeAnnotationsToSymbol = options.getBoolean("addTypeAnnotationsToSymbol", false);
 
         initAttributeReaders();
     }
@@ -2258,7 +2262,9 @@ public class ClassReader {
                 currentClassFile = classFile;
                 List<Attribute.TypeCompound> newList = deproxyTypeCompoundList(proxies);
                 sym.setTypeAttributes(newList.prependList(sym.getRawTypeAttributes()));
-                addTypeAnnotationsToSymbol(sym, newList);
+                if (addTypeAnnotationsToSymbol) {
+                    addTypeAnnotationsToSymbol(sym, newList);
+                }
             } finally {
                 currentClassFile = previousClassFile;
             }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/CompletionErrorOnEnclosingType.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/CompletionErrorOnEnclosingType.java
@@ -80,7 +80,7 @@ public class CompletionErrorOnEnclosingType {
                 new JavacTask(tb)
                         .outdir(out)
                         .classpath(out)
-                        .options("-XDrawDiagnostics")
+                        .options("-XDrawDiagnostics", "-XDaddTypeAnnotationsToSymbol=true")
                         .files(src.resolve("C.java"))
                         .run(Expect.FAIL)
                         .writeAll()

--- a/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
+++ b/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
@@ -33,7 +33,7 @@
  *          jdk.compiler/com.sun.tools.javac.util
  * @build JavacTestingAbstractProcessor DPrinter BasicAnnoTests
  * @compile/process -XDaccessInternalAPI -processor BasicAnnoTests -proc:only BasicAnnoTests.java
- * @compile/process -XDaccessInternalAPI -processor BasicAnnoTests -proc:only BasicAnnoTests
+ * @compile/process -XDaccessInternalAPI -XDaddTypeAnnotationsToSymbol=true -processor BasicAnnoTests -proc:only BasicAnnoTests
  */
 
 import java.io.PrintWriter;


### PR DESCRIPTION
This change temporarily disables the logic added by JDK-8341779 and related backports, to work around the crash reported in JDK-8359336.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8359336](https://bugs.openjdk.org/browse/JDK-8359336) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8359336: javac crashes with NPE while iterating params of MethodSymbol`

### Issue
 * [JDK-8359336](https://bugs.openjdk.org/browse/JDK-8359336): javac crashes with NPE while iterating params of MethodSymbol (**Bug** - P2)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1916/head:pull/1916` \
`$ git checkout pull/1916`

Update a local copy of the PR: \
`$ git checkout pull/1916` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1916`

View PR using the GUI difftool: \
`$ git pr show -t 1916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1916.diff">https://git.openjdk.org/jdk21u-dev/pull/1916.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1916#issuecomment-2997373237)
</details>
