### PR TITLE
8340185: Use make -k on GHA to catch more build errors

### DIFF
--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ runs:
     - name: 'Build'
       id: build
       run: >
-        make LOG=info ${{ inputs.make-target }}
+        make -k LOG=info ${{ inputs.make-target }}
         || bash ./.github/scripts/gen-build-failure-report.sh "$GITHUB_STEP_SUMMARY"
       shell: bash
 


### PR DESCRIPTION
Quality of life improvement for GHA. Not entirely clean due to copyright years conflict, although bots believe it is.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340185](https://bugs.openjdk.org/browse/JDK-8340185) needs maintainer approval

### Issue
 * [JDK-8340185](https://bugs.openjdk.org/browse/JDK-8340185): Use make -k on GHA to catch more build errors (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1926/head:pull/1926` \
`$ git checkout pull/1926`

Update a local copy of the PR: \
`$ git checkout pull/1926` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1926`

View PR using the GUI difftool: \
`$ git pr show -t 1926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1926.diff">https://git.openjdk.org/jdk21u-dev/pull/1926.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1926#issuecomment-3005806002)
</details>
