### PR TITLE
8350285: Shenandoah: Regression caused by ShenandoahLock under extreme contention

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -46,6 +46,7 @@ void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
   assert(!ALLOW_BLOCK || java_thread != nullptr, "Must have a Java thread when allowing block.");
   // Spin this much, but only on multi-processor systems.
   int ctr = os::is_MP() ? 0xFF : 0;
+  int yields = 0;
   // Apply TTAS to avoid more expensive CAS calls if the lock is still held by other thread.
   while (Atomic::load(&_state) == locked ||
          Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
@@ -68,14 +69,26 @@ void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
         // VM thread to arm the poll sooner.
         while (SafepointSynchronize::is_synchronizing() &&
                !SafepointMechanism::local_poll_armed(java_thread)) {
-          os::naked_yield();
+          yield_or_sleep(yields);
         }
       } else {
-        os::naked_yield();
+        yield_or_sleep(yields);
       }
     } else {
-      os::naked_yield();
+      yield_or_sleep(yields);
     }
+  }
+}
+
+void ShenandoahLock::yield_or_sleep(int &yields) {
+  // Simple yield-sleep policy: do one 100us sleep after every N yields.
+  // Tested with different values of N, and chose 3 for best performance.
+  if (yields < 3) {
+    os::naked_yield();
+    yields++;
+  } else {
+    os::naked_short_nanosleep(100000);
+    yields = 0;
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
@@ -42,6 +42,8 @@ private:
 
   template<bool ALLOW_BLOCK>
   void contended_lock_internal(JavaThread* java_thread);
+  static void yield_or_sleep(int &yields);
+
 public:
   ShenandoahLock() : _state(unlocked), _owner(nullptr) {};
 


### PR DESCRIPTION
Backport for ShenandoahLock performance regression issue. The fix involves sleeping for a very short duration every 3 yields, with the number of yields picked through manual testing.

Clean backport, ran GHA sanity checks and locally tested `tier1`, `tier2`, and `hotspot_gc_shenandoah`. `test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java` sometimes fails locally, but it also sometimes failed before the backport.
`test/jdk/java/nio/channels/DatagramChannel/SendReceiveMaxSize.java` fails locally, but it also fails locally before the backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8350285](https://bugs.openjdk.org/browse/JDK-8350285) needs maintainer approval

### Issue
 * [JDK-8350285](https://bugs.openjdk.org/browse/JDK-8350285): Shenandoah: Regression caused by ShenandoahLock under extreme contention (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1933/head:pull/1933` \
`$ git checkout pull/1933`

Update a local copy of the PR: \
`$ git checkout pull/1933` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1933`

View PR using the GUI difftool: \
`$ git pr show -t 1933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1933.diff">https://git.openjdk.org/jdk21u-dev/pull/1933.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1933#issuecomment-3021060147)
</details>
