### PR TITLE
8341644: Compile error in cgroup coding when using toolchain clang

### DIFF
--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -64,16 +64,16 @@ class CgroupV2CpuController: public CgroupCpuController {
     bool is_read_only() override {
       return reader()->is_read_only();
     }
-    const char* subsystem_path() {
+    const char* subsystem_path() override {
       return reader()->subsystem_path();
     }
     bool needs_hierarchy_adjustment() override {
       return reader()->needs_hierarchy_adjustment();
     }
-    void set_subsystem_path(const char* cgroup_path) {
+    void set_subsystem_path(const char* cgroup_path) override {
       reader()->set_subsystem_path(cgroup_path);
     }
-    const char* mount_point() { return reader()->mount_point(); }
+    const char* mount_point() override { return reader()->mount_point(); }
     const char* cgroup_path() override { return reader()->cgroup_path(); }
 };
 
@@ -96,16 +96,16 @@ class CgroupV2MemoryController final: public CgroupMemoryController {
     bool is_read_only() override {
       return reader()->is_read_only();
     }
-    const char* subsystem_path() {
+    const char* subsystem_path() override {
       return reader()->subsystem_path();
     }
     bool needs_hierarchy_adjustment() override {
       return reader()->needs_hierarchy_adjustment();
     }
-    void set_subsystem_path(const char* cgroup_path) {
+    void set_subsystem_path(const char* cgroup_path) override {
       reader()->set_subsystem_path(cgroup_path);
     }
-    const char* mount_point() { return reader()->mount_point(); }
+    const char* mount_point() override { return reader()->mount_point(); }
     const char* cgroup_path() override { return reader()->cgroup_path(); }
 };
 


### PR DESCRIPTION
A patch 8 of 7 for: [[21u] Backport intention of 8322420: [Linux] cgroup v2: Limits in parent nested control groups are not detected](https://mail.openjdk.org/pipermail/jdk-updates-dev/2025-April/043206.html)

It has a patch dependency on PR 7 of 7: https://github.com/openjdk/jdk21u-dev/pull/1664

This backport is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341644](https://bugs.openjdk.org/browse/JDK-8341644) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341644](https://bugs.openjdk.org/browse/JDK-8341644): Compile error in cgroup coding when using toolchain clang (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1934/head:pull/1934` \
`$ git checkout pull/1934`

Update a local copy of the PR: \
`$ git checkout pull/1934` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1934`

View PR using the GUI difftool: \
`$ git pr show -t 1934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1934.diff">https://git.openjdk.org/jdk21u-dev/pull/1934.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1934#issuecomment-3028531690)
</details>
