### PR TITLE
8346998: Test nsk/jvmti/ResourceExhausted/resexhausted003 fails with java.lang.OutOfMemoryError when CDS is off

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,10 +39,7 @@
  *          /test/lib
  * @run main/othervm/native
  *      -agentlib:resexhausted=-waittime=5
- *      -Xms64m
- *      -Xmx64m
- *      -XX:MaxMetaspaceSize=9m
- *      -XX:-UseGCOverheadLimit
+ *      -XX:MaxMetaspaceSize=20m
  *      nsk.jvmti.ResourceExhausted.resexhausted003
  */
 


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346998](https://bugs.openjdk.org/browse/JDK-8346998) needs maintainer approval

### Issue
 * [JDK-8346998](https://bugs.openjdk.org/browse/JDK-8346998): Test nsk/jvmti/ResourceExhausted/resexhausted003 fails with java.lang.OutOfMemoryError when CDS is off (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1943/head:pull/1943` \
`$ git checkout pull/1943`

Update a local copy of the PR: \
`$ git checkout pull/1943` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1943`

View PR using the GUI difftool: \
`$ git pr show -t 1943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1943.diff">https://git.openjdk.org/jdk21u-dev/pull/1943.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1943#issuecomment-3044922353)
</details>
