### PR TITLE
8348365: Bad format string in CLDRDisplayNamesTest

### DIFF
--- a/test/jdk/java/util/TimeZone/CLDRDisplayNamesTest.java
+++ b/test/jdk/java/util/TimeZone/CLDRDisplayNamesTest.java
@@ -130,7 +130,7 @@ public class CLDRDisplayNamesTest {
         String displayName = zi.getDisplayName(false, TimeZone.SHORT, Locale.US);
         Locale.setDefault(originalLocale);
         if (!displayName.equals("GMT+05:00")) {
-            System.err.printf("Wrong display name for timezone Etc/GMT-5 : expected GMT+05:00,  Actual " + displayName);
+            System.err.println("Wrong display name for timezone Etc/GMT-5 : expected GMT+05:00,  Actual " + displayName);
             errors++;
         }
 


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8348365](https://bugs.openjdk.org/browse/JDK-8348365) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348365](https://bugs.openjdk.org/browse/JDK-8348365): Bad format string in CLDRDisplayNamesTest (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1944/head:pull/1944` \
`$ git checkout pull/1944`

Update a local copy of the PR: \
`$ git checkout pull/1944` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1944`

View PR using the GUI difftool: \
`$ git pr show -t 1944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1944.diff">https://git.openjdk.org/jdk21u-dev/pull/1944.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1944#issuecomment-3045203828)
</details>
