### PR TITLE
8353235: Test jdk/jfr/api/metadata/annotations/TestPeriod.java fails with IllegalArgumentException

### DIFF
--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
@@ -26,6 +26,7 @@ package jdk.jfr.api.metadata.annotations;
 import jdk.jfr.Event;
 import jdk.jfr.EventType;
 import jdk.jfr.Period;
+import jdk.jfr.FlightRecorder;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.Events;
 
@@ -44,6 +45,7 @@ public class TestPeriod {
 
     public static void main(String[] args) throws Exception {
         EventType periodicEvent = EventType.getEventType(PeriodicEvent.class);
+        FlightRecorder.addPeriodicEvent(PeriodicEvent.class, () -> {});
         String defaultValue = Events.getSetting(periodicEvent, Period.NAME).getDefaultValue();
         Asserts.assertEQ(defaultValue, "47 s", "Incorrect default value for period");
     }


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8353235](https://bugs.openjdk.org/browse/JDK-8353235) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353235](https://bugs.openjdk.org/browse/JDK-8353235): Test jdk/jfr/api/metadata/annotations/TestPeriod.java fails with IllegalArgumentException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1948/head:pull/1948` \
`$ git checkout pull/1948`

Update a local copy of the PR: \
`$ git checkout pull/1948` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1948`

View PR using the GUI difftool: \
`$ git pr show -t 1948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1948.diff">https://git.openjdk.org/jdk21u-dev/pull/1948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1948#issuecomment-3045502774)
</details>
