### PR TITLE
8309953: Strengthen and optimize oopDesc age methods

### DIFF
--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -298,20 +298,22 @@ oop oopDesc::forwardee() const {
 
 // The following method needs to be MT safe.
 uint oopDesc::age() const {
-  assert(!mark().is_marked(), "Attempt to read age from forwarded mark");
-  if (has_displaced_mark()) {
-    return displaced_mark().age();
+  markWord m = mark();
+  assert(!m.is_marked(), "Attempt to read age from forwarded mark");
+  if (m.has_displaced_mark_helper()) {
+    return m.displaced_mark_helper().age();
   } else {
-    return mark().age();
+    return m.age();
   }
 }
 
 void oopDesc::incr_age() {
-  assert(!mark().is_marked(), "Attempt to increment age of forwarded mark");
-  if (has_displaced_mark()) {
-    set_displaced_mark(displaced_mark().incr_age());
+  markWord m = mark();
+  assert(!m.is_marked(), "Attempt to increment age of forwarded mark");
+  if (m.has_displaced_mark_helper()) {
+    m.set_displaced_mark_helper(m.displaced_mark_helper().incr_age());
   } else {
-    set_mark(mark().incr_age());
+    set_mark(m.incr_age());
   }
 }
 


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8309953

A clean backport. An minor optimization for oopDesc age. 

tier 1 passed locally. The logic is simple - store the `mark()` value into a var so we don't read it twice. The original commit is in tip for almost 2 years. Low risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8309953](https://bugs.openjdk.org/browse/JDK-8309953) needs maintainer approval

### Issue
 * [JDK-8309953](https://bugs.openjdk.org/browse/JDK-8309953): Strengthen and optimize oopDesc age methods (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1950/head:pull/1950` \
`$ git checkout pull/1950`

Update a local copy of the PR: \
`$ git checkout pull/1950` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1950`

View PR using the GUI difftool: \
`$ git pr show -t 1950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1950.diff">https://git.openjdk.org/jdk21u-dev/pull/1950.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1950#issuecomment-3049638214)
</details>
