### PR TITLE
Backport e7e8f60c9bedd5622525cc4339300b438eedc9fd

### DIFF
--- a/test/jdk/tools/jimage/JImageToolTest.java
+++ b/test/jdk/tools/jimage/JImageToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 /*
  * @test
  * @library /test/lib
+ * @requires vm.flagless
  * @build jdk.test.lib.process.ProcessTools
  * @summary Test to check if jimage tool exists and is working
  * @run main/timeout=360 JImageToolTest


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.