### PR TITLE
8280818: Expand bug8033699.java to iterate over all LaFs

### DIFF
--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -43,9 +43,9 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 public class bug8033699 {
-
     private static JFrame mainFrame;
     private static Robot robot;
     private static JButton btnStart;
@@ -57,64 +57,80 @@ public class bug8033699 {
     private static JRadioButton radioBtnSingle;
 
     public static void main(String[] args) throws Throwable {
-        SwingUtilities.invokeAndWait(() -> {
-            changeLAF();
-            createAndShowGUI();
-        });
-
         robot = new Robot();
-        robot.waitForIdle();
-        robot.delay(1000);
 
-        // tab key test grouped radio button
-        runTest1();
-        robot.delay(100);
-
-        // tab key test non-grouped radio button
-        runTest2();
-        robot.delay(100);
-
-        // shift tab key test grouped and non-grouped radio button
-        runTest3();
-        robot.delay(100);
-
-        // left/up key test in grouped radio button
-        runTest4();
-        robot.delay(100);
-
-        // down/right key test in grouped radio button
-        runTest5();
-        robot.delay(100);
-
-        // tab from radio button in group to next component in the middle of button group layout
-        runTest6();
-        robot.delay(100);
-
-        // tab to radio button in group from component in the middle of button group layout
-        runTest7();
-        robot.delay(100);
-
-        // down key circle back to first button in grouped radio button
-        runTest8();
-        robot.delay(100);
-
-        // Verify that ActionListener is called when a RadioButton is selected using arrow key.
-        runTest9();
-        robot.delay(100);
-
-        SwingUtilities.invokeAndWait(() -> mainFrame.dispose());
+        // Get all installed Look and Feels
+        UIManager.LookAndFeelInfo[] lafs = UIManager.getInstalledLookAndFeels();
+        for (UIManager.LookAndFeelInfo laf : lafs) {
+            testLaF(laf);
+        }
     }
 
-    private static void changeLAF() {
-        String currentLAF = UIManager.getLookAndFeel().toString();
-        System.out.println(currentLAF);
-        currentLAF = currentLAF.toLowerCase();
-        if (currentLAF.contains("nimbus")) {
-            try {
-                UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
+    private static void testLaF(UIManager.LookAndFeelInfo laf) throws Exception {
+        try {
+            System.out.println("Testing LaF: " + laf.getName());
+            SwingUtilities.invokeAndWait(() -> {
+                setLookAndFeel(laf);
+                createAndShowGUI();
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            // tab key test grouped radio button
+            runTest1();
+            robot.delay(100);
+
+            // tab key test non-grouped radio button
+            runTest2();
+            robot.delay(100);
+
+            // shift tab key test grouped and non-grouped radio button
+            runTest3();
+            robot.delay(100);
+
+            // left/up key test in grouped radio button
+            runTest4();
+            robot.delay(100);
+
+            // down/right key test in grouped radio button
+            runTest5();
+            robot.delay(100);
+
+            // tab from radio button in group to next component in the middle of button group layout
+            runTest6();
+            robot.delay(100);
+
+            // tab to radio button in group from component in the middle of button group layout
+            runTest7();
+            robot.delay(100);
+
+            // down key circle back to first button in grouped radio button
+            runTest8();
+            robot.delay(100);
+
+            // Verify that ActionListener is called when a RadioButton is selected using arrow key.
+            runTest9();
+            robot.delay(100);
+        } catch (Exception e) {
+            throw new RuntimeException("Error testing LaF: " + laf.getName(), e);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (mainFrame != null) {
+                    mainFrame.dispose();
+                    mainFrame = null;
+                }
+            });
+        }
+    }
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException |
+                 IllegalAccessException | UnsupportedLookAndFeelException e) {
+            System.err.println("Error setting LaF: " + laf.getName());
+            throw new RuntimeException("Failed to set look and feel", e);
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8280818](https://bugs.openjdk.org/browse/JDK-8280818) needs maintainer approval

### Issue
 * [JDK-8280818](https://bugs.openjdk.org/browse/JDK-8280818): Expand bug8033699.java to iterate over all LaFs (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1953/head:pull/1953` \
`$ git checkout pull/1953`

Update a local copy of the PR: \
`$ git checkout pull/1953` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1953`

View PR using the GUI difftool: \
`$ git pr show -t 1953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1953.diff">https://git.openjdk.org/jdk21u-dev/pull/1953.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1953#issuecomment-3052394278)
</details>
