### PR TITLE
Backport b9d7a75adee8a96cf47bbe73e3009102ceda9589

### DIFF
--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
@@ -35,7 +35,7 @@ import jdk.test.lib.jfr.Events;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm jdk.jfr.api.metadata.annotations.TestLabel
+ * @run main/othervm jdk.jfr.api.metadata.annotations.TestPeriod
  */
 public class TestPeriod {
 

--- a/test/jdk/jdk/jfr/api/metadata/settingdescriptor/TestGetContentType.java
+++ b/test/jdk/jdk/jfr/api/metadata/settingdescriptor/TestGetContentType.java
@@ -38,7 +38,7 @@ import jdk.test.lib.jfr.Events;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.api.metadata.settingdescriptor.TestGetDescription
+ * @run main/othervm jdk.jfr.api.metadata.settingdescriptor.TestGetContentType
  */
 public class TestGetContentType {
 
@@ -49,7 +49,7 @@ public class TestGetContentType {
         Asserts.assertNull(plain.getContentType());
 
         SettingDescriptor annotatedType = Events.getSetting(type, "annotatedType");
-        Asserts.assertNull(annotatedType.getContentType(), Timestamp.class.getName());
+        Asserts.assertEquals(annotatedType.getContentType(), Timestamp.class.getName());
 
         SettingDescriptor newName = Events.getSetting(type, "newName");
         Asserts.assertEquals(newName.getContentType(), Timespan.class.getName());
@@ -58,7 +58,7 @@ public class TestGetContentType {
         Asserts.assertNull(overridden.getContentType());
 
         SettingDescriptor protectedBase = Events.getSetting(type, "protectedBase");
-        Asserts.assertEquals(protectedBase.getContentType(), Frequency.class);
+        Asserts.assertEquals(protectedBase.getContentType(), Frequency.class.getName());
 
         SettingDescriptor publicBase = Events.getSetting(type, "publicBase");
         Asserts.assertEquals(publicBase.getContentType(), Timestamp.class.getName());


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.