### PR TITLE
8217914: java/net/httpclient/ConnectTimeoutHandshakeSync.java failed on connection refused while doing POST

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractConnectTimeoutHandshake.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeoutHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,10 +44,11 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+
+import jdk.test.lib.net.URIBuilder;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
-import static java.lang.String.format;
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
@@ -56,7 +57,7 @@ import static java.time.Duration.*;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.testng.Assert.fail;
 
-public abstract class AbstractConnectTimeoutHandshake {
+abstract class AbstractConnectTimeoutHandshake {
 
     // The number of iterations each testXXXClient performs.
     static final int TIMES = 2;
@@ -197,15 +198,15 @@ public abstract class AbstractConnectTimeoutHandshake {
 
     // -- Infrastructure
 
-    static String serverAuthority(Server server) {
-        return InetAddress.getLoopbackAddress().getHostName() + ":"
-                + server.getPort();
-    }
-
     @BeforeTest
     public void setup() throws Exception {
         server = new Server();
-        httpsURI = URI.create("https://" + serverAuthority(server) + "/foo");
+        httpsURI = URIBuilder.newBuilder()
+                .scheme("https")
+                .loopback()
+                .port(server.getPort())
+                .path("/foo")
+                .build();
         out.println("HTTPS URI: " + httpsURI);
     }
 

--- a/test/jdk/java/net/httpclient/ConnectTimeoutHandshakeAsync.java
+++ b/test/jdk/java/net/httpclient/ConnectTimeoutHandshakeAsync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import org.testng.annotations.Test;
  * @test
  * @summary Tests connection timeouts during SSL handshake
  * @bug 8208391
+ * @library /test/lib
+ * @build AbstractConnectTimeoutHandshake
  * @run testng/othervm ConnectTimeoutHandshakeAsync
  */
 

--- a/test/jdk/java/net/httpclient/ConnectTimeoutHandshakeSync.java
+++ b/test/jdk/java/net/httpclient/ConnectTimeoutHandshakeSync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import org.testng.annotations.Test;
  * @test
  * @summary Tests connection timeouts during SSL handshake
  * @bug 8208391
+ * @library /test/lib
+ * @build AbstractConnectTimeoutHandshake
  * @run testng/othervm ConnectTimeoutHandshakeSync
  */
 


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8217914](https://bugs.openjdk.org/browse/JDK-8217914) needs maintainer approval

### Issue
 * [JDK-8217914](https://bugs.openjdk.org/browse/JDK-8217914): java/net/httpclient/ConnectTimeoutHandshakeSync.java failed on connection refused while doing POST (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1959/head:pull/1959` \
`$ git checkout pull/1959`

Update a local copy of the PR: \
`$ git checkout pull/1959` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1959`

View PR using the GUI difftool: \
`$ git pr show -t 1959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1959.diff">https://git.openjdk.org/jdk21u-dev/pull/1959.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1959#issuecomment-3058031402)
</details>
