### PR TITLE
8355370: Include server name in HTTP test server thread names to improve diagnostics

### DIFF
--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -765,7 +765,7 @@ public interface HttpServerAdapters {
     /**
      * A version agnostic adapter class for HTTP Servers.
      */
-    public static abstract class HttpTestServer {
+    abstract class HttpTestServer implements AutoCloseable {
         private static final class ServerLogging {
             private static final Logger logger = Logger.getLogger("com.sun.net.httpserver");
             static void enableLogging() {
@@ -781,6 +781,11 @@ public interface HttpServerAdapters {
         public abstract InetSocketAddress getAddress();
         public abstract Version getVersion();
         public abstract void setRequestApprover(final Predicate<String> approver);
+
+        @Override
+        public void close() throws Exception {
+            stop();
+        }
 
         public String serverAuthority() {
             InetSocketAddress address = getAddress();
@@ -971,6 +976,13 @@ public interface HttpServerAdapters {
                 System.out.println("Http2TestServerImpl: stop");
                 impl.stop();
             }
+
+            @Override
+            public void close() throws Exception {
+                System.out.println("Http2TestServerImpl: close");
+                impl.close();
+            }
+
             @Override
             public HttpTestContext addHandler(HttpTestHandler handler, String path) {
                 System.out.println("Http2TestServerImpl[" + getAddress()


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle

ConnectionReuseTest.java passes which uses the edited files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8355370](https://bugs.openjdk.org/browse/JDK-8355370) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355370](https://bugs.openjdk.org/browse/JDK-8355370): Include server name in HTTP test server thread names to improve diagnostics (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1960/head:pull/1960` \
`$ git checkout pull/1960`

Update a local copy of the PR: \
`$ git checkout pull/1960` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1960`

View PR using the GUI difftool: \
`$ git pr show -t 1960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1960.diff">https://git.openjdk.org/jdk21u-dev/pull/1960.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1960#issuecomment-3058101795)
</details>
