### PR TITLE
8343804: Show the default time zone with -XshowSettings option

### DIFF
--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -71,6 +71,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeSet;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -295,6 +296,8 @@ public final class LauncherHelper {
                 Locale.getDefault(Category.DISPLAY).getDisplayName());
         ostream.println(INDENT + "default format locale = " +
                 Locale.getDefault(Category.FORMAT).getDisplayName());
+        ostream.println(INDENT + "default timezone = " +
+                TimeZone.getDefault().getID());
         ostream.println(INDENT + "tzdata version = " +
                 ZoneInfoFile.getVersion());
         if (!summaryMode) {

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ public class Settings extends TestHelper {
     private static final String BAD_SEC_OPTION_MSG = "Unrecognized security subcommand";
     private static final String SYSTEM_SETTINGS = "Operating System Metrics:";
     private static final String STACKSIZE_SETTINGS = "Stack Size:";
+    private static final String TIMEZONE_SETTINGS = "default timezone";
     private static final String TZDATA_SETTINGS = "tzdata version";
 
     static void containsAllOptions(TestResult tr) {
@@ -92,6 +93,7 @@ public class Settings extends TestHelper {
         checkContains(tr, SEC_SUMMARY_PROPS_SETTINGS);
         checkContains(tr, SEC_PROVIDER_SETTINGS);
         checkContains(tr, SEC_TLS_SETTINGS);
+        checkContains(tr, TIMEZONE_SETTINGS);
         checkContains(tr, TZDATA_SETTINGS);
         if (System.getProperty("os.name").contains("Linux")) {
             checkContains(tr, SYSTEM_SETTINGS);
@@ -160,6 +162,7 @@ public class Settings extends TestHelper {
         checkContains(tr, LOCALE_SETTINGS);
         checkContains(tr, AVAILABLE_LOCALES);
         checkNotContains(tr, LOCALE_SUMMARY_SETTINGS);
+        checkContains(tr, TIMEZONE_SETTINGS);
         checkContains(tr, TZDATA_SETTINGS);
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

In the test, I had to resolve the @bug line.
Also I omitted the edit of one test function that was added in 22.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343804](https://bugs.openjdk.org/browse/JDK-8343804) needs maintainer approval

### Issue
 * [JDK-8343804](https://bugs.openjdk.org/browse/JDK-8343804): Show the default time zone with -XshowSettings option (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1962/head:pull/1962` \
`$ git checkout pull/1962`

Update a local copy of the PR: \
`$ git checkout pull/1962` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1962`

View PR using the GUI difftool: \
`$ git pr show -t 1962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1962.diff">https://git.openjdk.org/jdk21u-dev/pull/1962.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1962#issuecomment-3062409903)
</details>
