### PR TITLE
8350111: [PPC] AsyncGetCallTrace crashes when called while handling SIGTRAP

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,6 +188,15 @@ bool frame::safe_for_sender(JavaThread *thread) {
   // linkages it must be safe
 
   if (!fp_safe) {
+    return false;
+  }
+
+  if (sender_pc() == nullptr) {
+    // Likely the return pc was not yet stored to stack. We rather discard this
+    // sample also because we would hit an assertion in frame::setup(). We can
+    // find any other random value if the return pc was not yet stored to
+    // stack. We rely on consistency checks to handle this (see
+    // e.g. find_initial_Java_frame())
     return false;
   }
 


### PR DESCRIPTION
This pull request contains a backport of commit [e4d3c97c](https://github.com/openjdk/jdk/commit/e4d3c97c0f388fc4b1684b78844f2166277ffd91) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Richard Reingruber on 27 Feb 2025 and was reviewed by Martin Doerr and Thomas Stuefe.

The backport is actually clean (besides copyright header conflict).

Risk is low because the patch is very small and affects only ppc. The code is only reached when profiling with jfr or async-profiler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8350111](https://bugs.openjdk.org/browse/JDK-8350111) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350111](https://bugs.openjdk.org/browse/JDK-8350111): [PPC] AsyncGetCallTrace crashes when called while handling SIGTRAP (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1968/head:pull/1968` \
`$ git checkout pull/1968`

Update a local copy of the PR: \
`$ git checkout pull/1968` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1968`

View PR using the GUI difftool: \
`$ git pr show -t 1968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1968.diff">https://git.openjdk.org/jdk21u-dev/pull/1968.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1968#issuecomment-3077451617)
</details>
