### PR TITLE
8341684: Typo in External Specifications link of java.util.Currency

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ import sun.util.logging.PlatformLogger;
  * with {@code Currency} or monetary values as it provides better handling of floating
  * point numbers and their operations.
  *
- * @spec http://www.iso.org/iso/home/standards/currency_codes.htm ISO - ISO 4217 - Currency codes
+ * @spec https://www.iso.org/iso-4217-currency-codes.html ISO - ISO 4217 - Currency codes
  * @see java.math.BigDecimal
  * @since 1.4
  */


### PR DESCRIPTION
Trivial and obvious fix of the documentation of Currency.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341684](https://bugs.openjdk.org/browse/JDK-8341684) needs maintainer approval

### Issue
 * [JDK-8341684](https://bugs.openjdk.org/browse/JDK-8341684): Typo in External Specifications link of java.util.Currency (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1969/head:pull/1969` \
`$ git checkout pull/1969`

Update a local copy of the PR: \
`$ git checkout pull/1969` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1969`

View PR using the GUI difftool: \
`$ git pr show -t 1969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1969.diff">https://git.openjdk.org/jdk21u-dev/pull/1969.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1969#issuecomment-3073329466)
</details>
