### PR TITLE
8350106: [PPC] Avoid ticks_unknown_not_Java AsyncGetCallTrace() if JavaFrameAnchor::_last_Java_pc not set

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/javaThread_aix_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2014 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,6 +28,7 @@
 #include "memory/metaspace.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/os.inline.hpp"
 
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
@@ -47,9 +48,17 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
     intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
-    // pc can be seen as null because not all writers use store pc + release store sp.
-    // Simply discard the sample in this very rare case.
-    if (pc == nullptr) return false;
+    if (pc == nullptr) {
+      // This is not uncommon. Many c1/c2 runtime stubs do not set the pc in the anchor.
+      intptr_t* top_sp = os::Aix::ucontext_get_sp((const ucontext_t*)ucontext);
+      if ((uint64_t)sp <= ((frame::common_abi*)top_sp)->callers_sp) {
+        // The interrupt occurred either in the last java frame or in its direct callee.
+        // We cannot be sure that the link register LR was already saved to the
+        // java frame. Therefore we discard this sample.
+        return false;
+      }
+      // The last java pc will be found in the abi part of the last java frame.
+    }
     *fr_addr = frame(sp, pc);
     return true;
   }

--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,17 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
     intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
-    // pc can be seen as null because not all writers use store pc + release store sp.
-    // Simply discard the sample in this very rare case.
-    if (pc == nullptr) return false;
+    if (pc == nullptr) {
+      // This is not uncommon. Many c1/c2 runtime stubs do not set the pc in the anchor.
+      intptr_t* top_sp = os::Linux::ucontext_get_sp((const ucontext_t*)ucontext);
+      if ((uint64_t)sp <= ((frame::common_abi*)top_sp)->callers_sp) {
+        // The interrupt occurred either in the last java frame or in its direct callee.
+        // We cannot be sure that the link register LR was already saved to the
+        // java frame. Therefore we discard this sample.
+        return false;
+      }
+      // The last java pc will be found in the abi part of the last java frame.
+    }
     *fr_addr = frame(sp, pc);
     return true;
   }


### PR DESCRIPTION
This pull request contains a backport of commit [030c85de](https://github.com/openjdk/jdk/commit/030c85de1376123615e804f98084cb3723205819) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Richard Reingruber on 11 Mar 2025 and was reviewed by Martin Doerr.

It does not apply because of copyright header differences and because `frame::kind` doesn't exist yet in jdk21u but appears in the context of the changes.

Risk is low because the patch is small and ppc only. The code is only reached when profiling with jfr or async-profiler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8350106](https://bugs.openjdk.org/browse/JDK-8350106) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350106](https://bugs.openjdk.org/browse/JDK-8350106): [PPC] Avoid ticks_unknown_not_Java AsyncGetCallTrace() if JavaFrameAnchor::_last_Java_pc not set (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1971/head:pull/1971` \
`$ git checkout pull/1971`

Update a local copy of the PR: \
`$ git checkout pull/1971` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1971`

View PR using the GUI difftool: \
`$ git pr show -t 1971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1971.diff">https://git.openjdk.org/jdk21u-dev/pull/1971.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1971#issuecomment-3077451290)
</details>
