### PR TITLE
8352800: [PPC] OpenJDK fails to build on PPC after JDK-8350106

### DIFF
--- a/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/javaThread_linux_ppc.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "memory/metaspace.hpp"
+#include "os_linux.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaThread.hpp"
 


### PR DESCRIPTION
This pull request contains a backport of commit [9a87e213](https://github.com/openjdk/jdk/commit/9a87e2134ef531a6906454186517d3eee2e487c2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

It fixes build problems by adding an include.

The commit being backported was authored by Vladimir Petko on 27 Mar 2025 and was reviewed by Richard Reingruber and Aleksey Shipilev.

Risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8352800](https://bugs.openjdk.org/browse/JDK-8352800) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352800](https://bugs.openjdk.org/browse/JDK-8352800): [PPC] OpenJDK fails to build on PPC after JDK-8350106 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1972/head:pull/1972` \
`$ git checkout pull/1972`

Update a local copy of the PR: \
`$ git checkout pull/1972` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1972`

View PR using the GUI difftool: \
`$ git pr show -t 1972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1972.diff">https://git.openjdk.org/jdk21u-dev/pull/1972.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1972#issuecomment-3077450231)
</details>
