### PR TITLE
8353489: Increase timeout and improve Windows compatibility in test/jdk/java/lang/ProcessBuilder/Basic.java

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,8 +36,8 @@
  * @requires !vm.musl
  * @requires vm.flagless
  * @library /test/lib
- * @run main/othervm/native/timeout=300 -Djava.security.manager=allow Basic
- * @run main/othervm/native/timeout=300 -Djava.security.manager=allow -Djdk.lang.Process.launchMechanism=fork Basic
+ * @run main/othervm/native/timeout=360 -Djava.security.manager=allow Basic
+ * @run main/othervm/native/timeout=360 -Djava.security.manager=allow -Djdk.lang.Process.launchMechanism=fork Basic
  * @author Martin Buchholz
  */
 
@@ -209,7 +209,7 @@ public class Basic {
 
     private static final Runtime runtime = Runtime.getRuntime();
 
-    private static final String[] winEnvCommand = {"cmd.exe", "/c", "set"};
+    private static final String[] winEnvCommand = {"cmd.exe", "/d", "/c", "set"};
 
     private static String winEnvFilter(String env) {
         return env.replaceAll("\r", "")
@@ -1914,7 +1914,9 @@ public class Basic {
         // Test Runtime.exec(...envp...) with envstrings without any `='
         //----------------------------------------------------------------
         try {
-            String[] cmdp = {"echo"};
+            // In Windows CMD (`cmd.exe`), `echo/` outputs a newline (i.e., an empty line).
+            // Wrapping it with `cmd.exe /c` ensures compatibility in both native Windows and Cygwin environments.
+            String[] cmdp = Windows.is() ? new String[]{"cmd.exe", "/c", "echo/"} : new String[]{"echo"};
             String[] envp = {"Hello", "World"}; // Yuck!
             Process p = Runtime.getRuntime().exec(cmdp, envp);
             equal(commandOutput(p), "\n");


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

trivial resolves. 
To make it compile, I had to re-add the import of Field.
Head had several larger changes that included this file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8353489](https://bugs.openjdk.org/browse/JDK-8353489) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353489](https://bugs.openjdk.org/browse/JDK-8353489): Increase timeout and improve Windows compatibility in test/jdk/java/lang/ProcessBuilder/Basic.java (**Enhancement** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1975/head:pull/1975` \
`$ git checkout pull/1975`

Update a local copy of the PR: \
`$ git checkout pull/1975` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1975`

View PR using the GUI difftool: \
`$ git pr show -t 1975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1975.diff">https://git.openjdk.org/jdk21u-dev/pull/1975.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1975#issuecomment-3075059026)
</details>
