### PR TITLE
8330022: Failure test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/BTreeTest.java: Could not initialize class java.util.concurrent.ThreadLocalRandom

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -245,6 +245,12 @@ public final class GarbageUtils {
              }
          }
 
+        private static Throwable ultimateCause(Throwable t) {
+            while (t.getCause() != null) {
+                t = t.getCause();
+            }
+            return t;
+        }
 
          public static int eatMemory(ExecutionController stresser, GarbageProducer gp, long initialFactor, long minMemoryChunk, long factor, OOM_TYPE type) {
             try {
@@ -253,6 +259,9 @@ public final class GarbageUtils {
             } catch (OutOfMemoryError e) {
                return numberOfOOMEs++;
             } catch (Throwable t) {
+                if (ultimateCause(t) instanceof OutOfMemoryError) {
+                    return numberOfOOMEs++;
+                }
                throw new RuntimeException(t);
             }
          }


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330022](https://bugs.openjdk.org/browse/JDK-8330022) needs maintainer approval

### Issue
 * [JDK-8330022](https://bugs.openjdk.org/browse/JDK-8330022): Failure test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/BTreeTest.java: Could not initialize class java.util.concurrent.ThreadLocalRandom (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1977/head:pull/1977` \
`$ git checkout pull/1977`

Update a local copy of the PR: \
`$ git checkout pull/1977` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1977`

View PR using the GUI difftool: \
`$ git pr show -t 1977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1977.diff">https://git.openjdk.org/jdk21u-dev/pull/1977.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1977#issuecomment-3075283822)
</details>
