### PR TITLE
8332020: jwebserver tool prints invalid URL in case of IPv6 address binding

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import com.sun.net.httpserver.SimpleFileServer;
 import com.sun.net.httpserver.SimpleFileServer.OutputLevel;
 
 import java.io.PrintWriter;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -168,6 +169,13 @@ final class SimpleFileServerImpl {
             var addr = isAnyLocal ? InetAddress.getLocalHost().getHostAddress() : inetAddr.getHostAddress();
             if (!addrSpecified) {
                 writer.println(ResourceBundleHelper.getMessage("loopback.info"));
+            }
+            if (inetAddr instanceof Inet6Address && addr.contains(":") && !addr.startsWith("[")) {
+                // we use the "addr" when printing the URL, so make sure it
+                // conforms to RFC-2732, section 2:
+                // To use a literal IPv6 address in a URL, the literal
+                // address should be enclosed in "[" and "]" characters.
+                addr = "[" + addr + "]";
             }
             if (isAnyLocal) {
                 writer.println(ResourceBundleHelper.getMessage("msg.start.anylocal", root, addr, port));

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import jdk.internal.util.OperatingSystem;
+import jdk.test.lib.net.IPSupport;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8332020
+ * @summary verifies that when jwebserver is launched with a IPv6 bind address
+ *          then the URL printed contains the correct host literal
+ * @modules jdk.httpserver java.base/jdk.internal.util
+ * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
+ * @run driver IPv6BoundHost
+ */
+public class IPv6BoundHost {
+
+    private static final Path JDK_BIN_DIR = Path.of(System.getProperty("java.home")).resolve("bin");
+    private static final Path JWEBSERVER_BINARY = OperatingSystem.isWindows()
+            ? JDK_BIN_DIR.resolve("jwebserver.exe") : JDK_BIN_DIR.resolve("jwebserver");
+
+    public static void main(final String[] args) throws Exception {
+        IPSupport.printPlatformSupport(System.err); // for debug purposes
+        if (!IPSupport.hasIPv6()) {
+            throw new SkippedException("Skipping test - IPv6 is not supported");
+        }
+        final String output = launchJwebserverAndExit(List.of("-b", "::1", "-p", "0"));
+        if (output.contains("URL http://[::1]:")
+                || output.contains("URL http://[0:0:0:0:0:0:0:1]:")) {
+            // found expected content
+            System.out.println("found expected URL in jwebserver output");
+        } else {
+            throw new AssertionError("missing IPv6 address in jwebserver process output");
+        }
+    }
+
+    private static String launchJwebserverAndExit(final List<String> args) throws Exception {
+        final Predicate<String> waitForLine = (s) -> s.startsWith("URL http://");
+        final StringBuilder sb = new StringBuilder();  // stdout & stderr
+        final List<String> cmd = new ArrayList<>();
+        cmd.add(JWEBSERVER_BINARY.toString());
+        cmd.addAll(args);
+        // start the process and await the waitForLine before returning
+        final Process p = ProcessTools.startProcess("8332020-test", new ProcessBuilder(cmd),
+                line -> sb.append(line).append("\n"),
+                waitForLine,
+                30,  // suitably high default timeout, not expected to timeout
+                TimeUnit.SECONDS);
+        System.out.println(sb.toString()); // print the process' stdout/stderr
+        // the process has started and it is confirmed that the process output has the line
+        // we were waiting for. now kill the process.
+        p.destroy();
+        final int exitCode = p.waitFor();
+        if (!isNormalExitCode(exitCode)) {
+            throw new AssertionError("jwebserver exited with unexpected exit code: " + exitCode);
+        }
+        return sb.toString();
+    }
+
+    private static boolean isNormalExitCode(final int exitCode) {
+        final int SIGTERM = 15;
+        if (OperatingSystem.isWindows()) {
+            return exitCode == 1; // we expect exit code == 1 on Windows for Process.destroy()
+        } else {
+            // signal terminated exit code on Unix is 128 + signal value
+            return exitCode == (128 + SIGTERM);
+        }
+    }
+}


### PR DESCRIPTION
Hi,

This is a backoport of JDK-8332020: jwebserver tool prints invalid URL in case of IPv6 address binding

Original patch applies cleanly to 21u.

This is dependent PR for https://github.com/openjdk/jdk21u-dev/pull/1981 (PR for JDK-8353698). First, because the bug of JDK-8353698 can be reproduced in 21u, I thought about backporting JDK-8353698 to 21u. However, the patch of JDK-8353698 could not be applied cleanly because IPv6BoundHost.java added in JDK-8332020 does not exist in 21u. Therefore, since I confirmed that the bug of JDK-8332020 can be reproduced in 21u, I considered this PR as a PR that https://github.com/openjdk/jdk21u-dev/pull/1981 depends on.

Testing: test/jdk/com/sun/net/httpserver/simpleserver passes on Windows Server 2022

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332020](https://bugs.openjdk.org/browse/JDK-8332020) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332020: jwebserver tool prints invalid URL in case of IPv6 address binding`

### Issue
 * [JDK-8332020](https://bugs.openjdk.org/browse/JDK-8332020): jwebserver tool prints invalid URL in case of IPv6 address binding (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1980/head:pull/1980` \
`$ git checkout pull/1980`

Update a local copy of the PR: \
`$ git checkout pull/1980` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1980`

View PR using the GUI difftool: \
`$ git pr show -t 1980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1980.diff">https://git.openjdk.org/jdk21u-dev/pull/1980.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1980#issuecomment-3077919210)
</details>
