### PR TITLE
8360664: Null pointer dereference in src/hotspot/share/prims/jvmtiTagMap.cpp in IterateOverHeapObjectClosure::do_object()

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -921,6 +921,7 @@ class IterateOverHeapObjectClosure: public ObjectClosure {
 
 // invoked for each object in the heap
 void IterateOverHeapObjectClosure::do_object(oop o) {
+  assert(o != nullptr, "Heap iteration should never produce null!");
   // check if iteration has been halted
   if (is_iteration_aborted()) return;
 
@@ -930,7 +931,7 @@ void IterateOverHeapObjectClosure::do_object(oop o) {
   }
 
   // skip if object is a dormant shared object whose mirror hasn't been loaded
-  if (o != nullptr && o->klass()->java_mirror() == nullptr) {
+  if (o->klass()->java_mirror() == nullptr) {
     log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s)", p2i(o),
                          o->klass()->external_name());
     return;
@@ -1009,6 +1010,7 @@ class IterateThroughHeapObjectClosure: public ObjectClosure {
 
 // invoked for each object in the heap
 void IterateThroughHeapObjectClosure::do_object(oop obj) {
+  assert(obj != nullptr, "Heap iteration should never produce null!");
   // check if iteration has been halted
   if (is_iteration_aborted()) return;
 
@@ -1016,7 +1018,7 @@ void IterateThroughHeapObjectClosure::do_object(oop obj) {
   if (is_filtered_by_klass_filter(obj, klass())) return;
 
   // skip if object is a dormant shared object whose mirror hasn't been loaded
-  if (obj != nullptr &&   obj->klass()->java_mirror() == nullptr) {
+  if (obj->klass()->java_mirror() == nullptr) {
     log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s)", p2i(obj),
                          obj->klass()->external_name());
     return;


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [e9a43416](https://github.com/openjdk/jdk/commit/e9a434165a6ec07cde0429c7f9823bbc5dab7857) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Artem Semenov on 7 Jul 2025 and was reviewed by Serguei Spitsyn, Alex Menkov and Chris Plummer.

This patch adds an assert that demonstrates that NULL cannot be passed to this function. This change will simplify code analysis during bug hunting and investigation.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8360664](https://bugs.openjdk.org/browse/JDK-8360664) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360664](https://bugs.openjdk.org/browse/JDK-8360664): Null pointer dereference in src/hotspot/share/prims/jvmtiTagMap.cpp in IterateOverHeapObjectClosure::do_object() (**Bug** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1982/head:pull/1982` \
`$ git checkout pull/1982`

Update a local copy of the PR: \
`$ git checkout pull/1982` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1982`

View PR using the GUI difftool: \
`$ git pr show -t 1982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1982.diff">https://git.openjdk.org/jdk21u-dev/pull/1982.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1982#issuecomment-3078617369)
</details>
