### PR TITLE
Backport c8a30c2aaba04c11b70a4f74ee74452250be6e59

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java
@@ -31,7 +31,7 @@
  * @requires vm.opt.final.ClassUnloading
  * @library /vmTestbase /test/lib
  * @run main/othervm
- *      -XX:MetaspaceSize=10m
+ *      -XX:MetaspaceSize=20m
  *      -XX:MaxMetaspaceSize=20m
  *      -Xlog:gc*:gc.log
  *      metaspace.shrink_grow.ShrinkGrowTest.ShrinkGrowTest


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle

One of the two flags edited is already at 20m. 

8338526: Don't store abstract and interface Klasses in class metaspace
is missing in 21.