### PR TITLE
8355515: Clarify the purpose of forcePass() and forceFail() methods

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -150,6 +150,17 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  * Before returning from {@code awaitAndCheck}, the framework disposes of
  * all the windows and frames.
  *
+ * <p id="forcePassAndFail">
+ * For semi-automatic tests, use {@code forcePass} or
+ * {@code forceFail} methods to forcibly pass or fail the test
+ * when it's determined that the required conditions are already met
+ * or cannot be met correspondingly.
+ * These methods release {@code awaitAndCheck}, and
+ * the test will complete successfully or fail.
+ * <p>
+ * Refer to examples of using these methods in the description of the
+ * {@link #forcePass() forcePass} and {@link #forceFail() forceFail} methods.
+ *
  * <h2 id="sampleManualTest">Sample Manual Test</h2>
  * A simple test would look like this:
  * {@snippet id='sampleManualTestCode' lang='java':
@@ -1310,14 +1321,34 @@ public final class PassFailJFrame {
     }
 
     /**
-     *  Forcibly fail the test.
+     * Forcibly fail the test.
+     * <p>
+     * Use this method in semi-automatic tests when
+     * it is determined that the conditions for passing the test cannot be met.
+     * <p>
+     * <strong>Do not use</strong> this method in cases where a resource is unavailable or a
+     * feature isn't supported, throw {@code jtreg.SkippedException} instead.
+     *
+     * <p>A sample usage can be found in
+     * <a href="https://github.com/openjdk/jdk/blob/0844745e7bd954a96441365f8010741ec1c29dbf/test/jdk/javax/swing/JScrollPane/AcceleratedWheelScrolling/HorizScrollers.java#L180">{@code
+     * HorizScrollers.java}</a>
      */
     public static void forceFail() {
         forceFail("forceFail called");
     }
 
     /**
-     *  Forcibly fail the test and provide a reason.
+     * Forcibly fail the test and provide a reason.
+     * <p>
+     * Use this method in semi-automatic tests when
+     * it is determined that the conditions for passing the test cannot be met.
+     * <p>
+     * <strong>Do not use</strong> this method in cases where a resource is unavailable or a
+     * feature isn't supported, throw {@code jtreg.SkippedException} instead.
+     *
+     * <p>A sample usage can be found in
+     * <a href="https://github.com/openjdk/jdk/blob/7283c8b075aa289dbb9cb80f6937b3349c8d4769/test/jdk/java/awt/FileDialog/SaveFileNameOverrideTest.java#L86">{@code
+     * SaveFileNameOverrideTest.java}</a>
      *
      * @param reason the reason why the test is failed
      */


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8355515](https://bugs.openjdk.org/browse/JDK-8355515) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355515](https://bugs.openjdk.org/browse/JDK-8355515): Clarify the purpose of forcePass() and forceFail() methods (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1985/head:pull/1985` \
`$ git checkout pull/1985`

Update a local copy of the PR: \
`$ git checkout pull/1985` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1985`

View PR using the GUI difftool: \
`$ git pr show -t 1985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1985.diff">https://git.openjdk.org/jdk21u-dev/pull/1985.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1985#issuecomment-3080330274)
</details>
