### PR TITLE
8319932: [JVMCI] class unloading related tests can fail on libgraal

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassInitErrors/InitExceptionUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/InitExceptionUnloadTest.java
@@ -37,6 +37,8 @@
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Set;
+import java.util.List;
 
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
@@ -122,10 +124,9 @@ public class InitExceptionUnloadTest {
             }
         }
         cl = null;
-        ClassUnloadCommon.triggerUnloading();  // should unload these classes
-        for (String className : classNames) {
-          ClassUnloadCommon.failIf(wb.isClassAlive(className), "should be unloaded");
-        }
+
+        Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(classNames));
+        ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should be unloaded: " + aliveClasses);
     }
     public static void main(java.lang.String[] unused) throws Throwable {
         test();

--- a/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
+++ b/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
@@ -39,6 +39,9 @@ import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class ClassUnloadCommon {
@@ -69,6 +72,41 @@ public class ClassUnloadCommon {
     public static void triggerUnloading() {
         WhiteBox wb = WhiteBox.getWhiteBox();
         wb.fullGC();  // will do class unloading
+    }
+
+    /**
+     * Calls triggerUnloading() in a retry loop for 2 seconds or until WhiteBox.isClassAlive
+     * determines that no classes named in classNames are alive.
+     *
+     * This variant of triggerUnloading() accommodates the inherent raciness
+     * of class unloading. For example, it's possible for a JIT compilation to hold
+     * strong roots to types (e.g. in virtual call or instanceof profiles) that
+     * are not released or converted to weak roots until the compilation completes.
+     *
+     * @param classNames the set of classes that are expected to be unloaded
+     * @return the set of classes that have not been unloaded after exiting the retry loop
+     */
+    public static Set<String> triggerUnloading(List<String> classNames) {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        Set<String> aliveClasses = new HashSet<>(classNames);
+        int attempt = 0;
+        while (!aliveClasses.isEmpty() && attempt < 20) {
+            ClassUnloadCommon.triggerUnloading();
+            for (String className : classNames) {
+                if (aliveClasses.contains(className)) {
+                    if (wb.isClassAlive(className)) {
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException ex) {
+                        }
+                    } else {
+                        aliveClasses.remove(className);
+                    }
+                }
+            }
+            attempt++;
+        }
+        return aliveClasses;
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

Resolved Copyright.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319932](https://bugs.openjdk.org/browse/JDK-8319932) needs maintainer approval

### Issue
 * [JDK-8319932](https://bugs.openjdk.org/browse/JDK-8319932): [JVMCI] class unloading related tests can fail on libgraal (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1986/head:pull/1986` \
`$ git checkout pull/1986`

Update a local copy of the PR: \
`$ git checkout pull/1986` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1986`

View PR using the GUI difftool: \
`$ git pr show -t 1986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1986.diff">https://git.openjdk.org/jdk21u-dev/pull/1986.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1986#issuecomment-3082863653)
</details>
