### PR TITLE
8340554: Improve MessageFormat readObject checks

### DIFF
--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1662,7 +1662,7 @@ public class MessageFormat extends Format {
 
         // Check the correctness of arguments and offsets
         if (isValid) {
-            int lastOffset = patt.length() + 1;
+            int lastOffset = patt.length();
             for (int i = maxOff; i >= 0; --i) {
                 if (argNums[i] < 0 || argNums[i] >= MAX_ARGUMENT_INDEX
                         || offs[i] < 0 || offs[i] > lastOffset) {

--- a/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8331446
+ * @bug 8331446 8340554
  * @summary Check correctness of deserialization
  * @run junit SerializationTest
  */
@@ -70,7 +70,13 @@ public class SerializationTest {
                 // With null locale. (NPE not thrown, if no format defined)
                 new MessageFormat("{1} {0} foo", null),
                 // With formats
-                new MessageFormat("{0,number,short} {0} {1,date,long} foo")
+                new MessageFormat("{0,number,short} {0} {1,date,long} foo"),
+                // Offset equal to pattern length (0)
+                new MessageFormat("{0}"),
+                // Offset equal to pattern length (1)
+                new MessageFormat("X{0}"),
+                // Offset 1 under pattern length
+                new MessageFormat("X{0}X")
         );
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340554](https://bugs.openjdk.org/browse/JDK-8340554) needs maintainer approval

### Issue
 * [JDK-8340554](https://bugs.openjdk.org/browse/JDK-8340554): Improve MessageFormat readObject checks (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1987/head:pull/1987` \
`$ git checkout pull/1987`

Update a local copy of the PR: \
`$ git checkout pull/1987` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1987`

View PR using the GUI difftool: \
`$ git pr show -t 1987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1987.diff">https://git.openjdk.org/jdk21u-dev/pull/1987.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1987#issuecomment-3082918199)
</details>
