### PR TITLE
8311220: Optimization for StringLatin UpperLower

### DIFF
--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -420,10 +420,9 @@ final class StringLatin1 {
         }
         int first;
         final int len = value.length;
-        // Now check if there are any characters that need to be changed, or are surrogate
+        // Now check if there are any characters that need to be changed
         for (first = 0 ; first < len; first++) {
-            int cp = value[first] & 0xff;
-            if (cp != CharacterDataLatin1.instance.toLowerCase(cp)) {  // no need to check Character.ERROR
+            if (CharacterDataLatin1.instance.isUpperCase(value[first] & 0xff)) {
                 break;
             }
         }
@@ -437,12 +436,7 @@ final class StringLatin1 {
         System.arraycopy(value, 0, result, 0, first);  // Just copy the first few
                                                        // lowerCase characters.
         for (int i = first; i < len; i++) {
-            int cp = value[i] & 0xff;
-            cp = CharacterDataLatin1.instance.toLowerCase(cp);
-            if (!canEncode(cp)) {                      // not a latin1 character
-                return toLowerCaseEx(str, value, first, locale, false);
-            }
-            result[i] = (byte)cp;
+            result[i] = (byte)CharacterDataLatin1.instance.toLowerCase(value[i] & 0xff);
         }
         return new String(result, LATIN1);
     }
@@ -494,10 +488,11 @@ final class StringLatin1 {
         int first;
         final int len = value.length;
 
-        // Now check if there are any characters that need to be changed, or are surrogate
+        // Now check if there are any characters that need to be changed
         for (first = 0 ; first < len; first++ ) {
             int cp = value[first] & 0xff;
-            if (cp != CharacterDataLatin1.instance.toUpperCaseEx(cp)) {   // no need to check Character.ERROR
+            boolean notUpperCaseEx = cp >= 'a' && (cp <= 'z' || cp == 0xb5 || (cp >= 0xdf && cp != 0xf7));
+            if (notUpperCaseEx) {
                 break;
             }
         }
@@ -512,8 +507,7 @@ final class StringLatin1 {
         System.arraycopy(value, 0, result, 0, first);  // Just copy the first few
                                                        // upperCase characters.
         for (int i = first; i < len; i++) {
-            int cp = value[i] & 0xff;
-            cp = CharacterDataLatin1.instance.toUpperCaseEx(cp);
+            int cp = CharacterDataLatin1.instance.toUpperCaseEx(value[i] & 0xff);
             if (!canEncode(cp)) {                      // not a latin1 character
                 return toUpperCaseEx(str, value, first, locale, false);
             }


### PR DESCRIPTION
This is backport of "[JDK-8311220](https://bugs.openjdk.org/browse/JDK-8311220) Optimization for StringLatin UpperLower"

It seems good to have it backported as I see improvements even locally on my i7-12700H (benchmarks command line was taken from original PR):
```
sh make/devkit/createJMHBundle.sh
bash configure --with-jmh=build/jmh/jars
make test TEST="micro:java.lang.StringUpperLower.*"

----- Baseline JDK21
Benchmark                      Mode  Cnt   Score   Error  Units
StringUpperLower.lowerToLower  avgt   15  24.146 ± 0.216  ns/op
StringUpperLower.lowerToUpper  avgt   15  43.720 ± 2.689  ns/op
StringUpperLower.mixedToLower  avgt   15  27.335 ± 1.120  ns/op
StringUpperLower.mixedToUpper  avgt   15  43.239 ± 3.731  ns/op
StringUpperLower.upperToLower  avgt   15  28.310 ± 1.557  ns/op
StringUpperLower.upperToUpper  avgt   15  35.032 ± 1.840  ns/op

----- Backported
Benchmark                      Mode  Cnt   Score   Error  Units
StringUpperLower.lowerToLower  avgt   15  13.890 ± 0.786  ns/op
StringUpperLower.lowerToUpper  avgt   15  38.636 ± 2.103  ns/op
StringUpperLower.mixedToLower  avgt   15  28.087 ± 1.639  ns/op
StringUpperLower.mixedToUpper  avgt   15  33.970 ± 0.502  ns/op
StringUpperLower.upperToLower  avgt   15  28.394 ± 1.443  ns/op
StringUpperLower.upperToUpper  avgt   15  17.347 ± 0.578  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8311220](https://bugs.openjdk.org/browse/JDK-8311220) needs maintainer approval

### Issue
 * [JDK-8311220](https://bugs.openjdk.org/browse/JDK-8311220): Optimization for StringLatin UpperLower (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1988/head:pull/1988` \
`$ git checkout pull/1988`

Update a local copy of the PR: \
`$ git checkout pull/1988` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1988`

View PR using the GUI difftool: \
`$ git pr show -t 1988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1988.diff">https://git.openjdk.org/jdk21u-dev/pull/1988.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1988#issuecomment-3083807587)
</details>
