### PR TITLE
8362548: [21u] Add bugId to test missed in backport of JDK-8343804

### DIFF
--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 /*
  * @test
- * @bug 6994753 7123582 8305950 8281658 8310201
+ * @bug 6994753 7123582 8305950 8281658 8310201 8343804
  * @summary tests -XshowSettings options
  * @modules jdk.compiler
  *          jdk.zipfs


### PR DESCRIPTION
I somehow missed this in the corresponding backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362548](https://bugs.openjdk.org/browse/JDK-8362548) needs maintainer approval

### Issue
 * [JDK-8362548](https://bugs.openjdk.org/browse/JDK-8362548): [21u] Add bugId to test missed in backport of JDK-8343804 (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1989/head:pull/1989` \
`$ git checkout pull/1989`

Update a local copy of the PR: \
`$ git checkout pull/1989` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1989`

View PR using the GUI difftool: \
`$ git pr show -t 1989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1989.diff">https://git.openjdk.org/jdk21u-dev/pull/1989.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1989#issuecomment-3085395337)
</details>
