### PR TITLE
8322992: Javac fails with StackOverflowError when compiling deeply nested synchronized blocks

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1100,29 +1100,38 @@ public class Gen extends JCTree.Visitor {
     }
 
     public void visitBlock(JCBlock tree) {
+        /* this method is heavily invoked, as expected, for deeply nested blocks, if blocks doesn't happen to have
+         * patterns there will be an unnecessary tax on memory consumption every time this method is executed, for this
+         * reason we have created helper methods and here at a higher level we just discriminate depending on the
+         * presence, or not, of patterns in a given block
+         */
         if (tree.patternMatchingCatch != null) {
-            Set<JCMethodInvocation> prevInvocationsWithPatternMatchingCatch = invocationsWithPatternMatchingCatch;
-            ListBuffer<int[]> prevRanges = patternMatchingInvocationRanges;
-            State startState = code.state.dup();
-            try {
-                invocationsWithPatternMatchingCatch = tree.patternMatchingCatch.calls2Handle();
-                patternMatchingInvocationRanges = new ListBuffer<>();
-                doVisitBlock(tree);
-            } finally {
-                Chain skipCatch = code.branch(goto_);
-                JCCatch handler = tree.patternMatchingCatch.handler();
-                code.entryPoint(startState, handler.param.sym.type);
-                genPatternMatchingCatch(handler, env, patternMatchingInvocationRanges.toList());
-                code.resolve(skipCatch);
-                invocationsWithPatternMatchingCatch = prevInvocationsWithPatternMatchingCatch;
-                patternMatchingInvocationRanges = prevRanges;
-            }
+            visitBlockWithPatterns(tree);
         } else {
-            doVisitBlock(tree);
+            internalVisitBlock(tree);
         }
     }
 
-    private void doVisitBlock(JCBlock tree) {
+    private void visitBlockWithPatterns(JCBlock tree) {
+        Set<JCMethodInvocation> prevInvocationsWithPatternMatchingCatch = invocationsWithPatternMatchingCatch;
+        ListBuffer<int[]> prevRanges = patternMatchingInvocationRanges;
+        State startState = code.state.dup();
+        try {
+            invocationsWithPatternMatchingCatch = tree.patternMatchingCatch.calls2Handle();
+            patternMatchingInvocationRanges = new ListBuffer<>();
+            internalVisitBlock(tree);
+        } finally {
+            Chain skipCatch = code.branch(goto_);
+            JCCatch handler = tree.patternMatchingCatch.handler();
+            code.entryPoint(startState, handler.param.sym.type);
+            genPatternMatchingCatch(handler, env, patternMatchingInvocationRanges.toList());
+            code.resolve(skipCatch);
+            invocationsWithPatternMatchingCatch = prevInvocationsWithPatternMatchingCatch;
+            patternMatchingInvocationRanges = prevRanges;
+        }
+    }
+
+    private void internalVisitBlock(JCBlock tree) {
         int limit = code.nextreg;
         Env<GenContext> localEnv = env.dup(tree, new GenContext());
         genStats(tree.stats, localEnv);

--- a/test/langtools/tools/javac/patterns/SOEDeeplyNestedBlocksTest.java
+++ b/test/langtools/tools/javac/patterns/SOEDeeplyNestedBlocksTest.java
@@ -1,0 +1,1187 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8322992
+ * @summary Javac fails with StackOverflowError when compiling deeply nested synchronized blocks
+ * @compile SOEDeeplyNestedBlocksTest.java
+ */
+
+public class SOEDeeplyNestedBlocksTest {
+
+    public static void test() {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+    }
+}


### PR DESCRIPTION
I backport this to fix this obvious problem and as prereq of JDK-8332106.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322992](https://bugs.openjdk.org/browse/JDK-8322992) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322992](https://bugs.openjdk.org/browse/JDK-8322992): Javac fails with StackOverflowError when compiling deeply nested synchronized blocks (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1992/head:pull/1992` \
`$ git checkout pull/1992`

Update a local copy of the PR: \
`$ git checkout pull/1992` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1992`

View PR using the GUI difftool: \
`$ git pr show -t 1992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1992.diff">https://git.openjdk.org/jdk21u-dev/pull/1992.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1992#issuecomment-3092523833)
</details>
