### PR TITLE
8335131: Test "javax/swing/JColorChooser/Test6977726.java" failed on ubuntu x64 because "Preview" title is missing for GTK L&F

### DIFF
--- a/test/jdk/javax/swing/JColorChooser/Test6977726.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6977726.java
@@ -41,7 +41,14 @@ public class Test6977726 {
         String instructions = """
                 Check that there is a panel with "Text Preview Panel" text
                 and with title "Preview" in the JColorChooser.
-                Test passes if the panel is as described, test fails otherwise.""";
+                Test passes if the panel is as described, test fails otherwise.
+
+                Note: "Preview" title is not applicable for GTK Look and Feel.""";
+
+        // In case this test is run with GTK L&F, the preview panel title
+        // is missing due to the "ColorChooser.showPreviewPanelText" property
+        // which is set to "Boolean.FALSE" for GTK L&F. Test instructions are
+        // modified to reflect that "Preview" title is not applicable for GTK L&F.
 
         PassFailJFrame.builder()
                 .title("Test6977726")


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335131](https://bugs.openjdk.org/browse/JDK-8335131) needs maintainer approval

### Issue
 * [JDK-8335131](https://bugs.openjdk.org/browse/JDK-8335131): Test "javax/swing/JColorChooser/Test6977726.java" failed on ubuntu x64 because "Preview" title is missing for GTK L&amp;F (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1993/head:pull/1993` \
`$ git checkout pull/1993`

Update a local copy of the PR: \
`$ git checkout pull/1993` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1993`

View PR using the GUI difftool: \
`$ git pr show -t 1993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1993.diff">https://git.openjdk.org/jdk21u-dev/pull/1993.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1993#issuecomment-3092528731)
</details>
