### PR TITLE
8309238: jdk/jfr/tool/TestView.java failed with "exitValue = 134"

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -289,9 +289,6 @@ public final class ChunkParser {
             if (parserState.isClosed()) {
                 return true;
             }
-            if (chunkHeader.getLastNanos() > filterEnd)  {
-              return true;
-            }
             chunkHeader.refresh();
             if (absoluteChunkEnd != chunkHeader.getEnd()) {
                 return false;

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -785,7 +785,6 @@ jdk/jfr/startupargs/TestStartName.java                          8214685 windows-
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
-jdk/jfr/tool/TestView.java                                      8309238 macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

Update: This used to be clean, but I added removal of the entry in ProblemList.
It was only on the ProblemList of 21, not head, so there is no change for this in head.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309238](https://bugs.openjdk.org/browse/JDK-8309238) needs maintainer approval

### Issue
 * [JDK-8309238](https://bugs.openjdk.org/browse/JDK-8309238): jdk/jfr/tool/TestView.java failed with "exitValue = 134" (**Bug** - P3 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/1994/head:pull/1994` \
`$ git checkout pull/1994`

Update a local copy of the PR: \
`$ git checkout pull/1994` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/1994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1994`

View PR using the GUI difftool: \
`$ git pr show -t 1994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/1994.diff">https://git.openjdk.org/jdk21u-dev/pull/1994.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/1994#issuecomment-3092532615)
</details>
