### PR TITLE
8357173: Split jtreg test group jdk tier3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -1,4 +1,4 @@
-#  Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 #  This code is free software; you can redistribute it and/or modify it
@@ -83,14 +83,24 @@ tier2_part2 = \
 tier2_part3 = \
     :jdk_net
 
+# These sub groups of tier3 allow for running certain tests separately from the
+# rest. When adding tests to tier3, in most cases they should be added to
+# tier3_part1.
 tier3 = \
+    :tier3_part1 \
+    :tier3_jpackage
+
+tier3_part1 = \
     :build \
     :jdk_vector \
     -:jdk_vector_sanity \
     :jdk_rmi \
     :jdk_svc \
     -:jdk_svc_sanity \
-    -:svc_tools \
+    -:svc_tools
+
+# The jpackage tests on Windows require permissions that aren't always present
+tier3_jpackage = \
     :jdk_jpackage
 
 # Everything not in other tiers


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

Trivial resolves because head has jdk_since_checks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8357173](https://bugs.openjdk.org/browse/JDK-8357173) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357173](https://bugs.openjdk.org/browse/JDK-8357173): Split jtreg test group jdk tier3 (**Bug** - P2 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2000/head:pull/2000` \
`$ git checkout pull/2000`

Update a local copy of the PR: \
`$ git checkout pull/2000` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2000`

View PR using the GUI difftool: \
`$ git pr show -t 2000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2000.diff">https://git.openjdk.org/jdk21u-dev/pull/2000.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2000#issuecomment-3094418998)
</details>
