### PR TITLE
backport 12ee80cac754c1a6dd37191a9f80c01de8b659ad

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,6 @@ public class PlatformGraphicsInfo {
 
             No X11 DISPLAY variable was set,
             or no headful library support was found,
-            but this program performed an operation which requires it,
-            """;
+            but this program performed an operation which requires it.""";
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle,

Resolved Copyright, probably clean.