### PR TITLE
8355512: Test compiler/vectorization/TestVectorZeroCount.java times out with -XX:TieredStopAtLevel=3

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 8349637
+ * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @summary Ensure that vectorization of numberOfLeadingZeros and numberOfTrailingZeros outputs correct values
  * @library /test/lib /
  * @run main/othervm compiler.vectorization.TestVectorZeroCount


### PR DESCRIPTION
Backporting JDK-8355512: Test compiler/vectorization/TestVectorZeroCount.java times out with -XX:TieredStopAtLevel=3. Small patch to TestVectorZeroCount test to make it only execute when C2 is enabled. Backporting for parity with oracle. Ran GHA Sanity Checks, local Tier 1 and 2, and adjusted test directly. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8355512](https://bugs.openjdk.org/browse/JDK-8355512) needs maintainer approval

### Issue
 * [JDK-8355512](https://bugs.openjdk.org/browse/JDK-8355512): Test compiler/vectorization/TestVectorZeroCount.java times out with -XX:TieredStopAtLevel=3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2009/head:pull/2009` \
`$ git checkout pull/2009`

Update a local copy of the PR: \
`$ git checkout pull/2009` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2009`

View PR using the GUI difftool: \
`$ git pr show -t 2009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2009.diff">https://git.openjdk.org/jdk21u-dev/pull/2009.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2009#issuecomment-3099415125)
</details>
