### PR TITLE
8335619: Add an @apiNote to j.l.i.ClassFileTransformer to warn about recursive class loading and ClassCircularityErrors

### DIFF
--- a/src/java.instrument/share/classes/java/lang/instrument/ClassFileTransformer.java
+++ b/src/java.instrument/share/classes/java/lang/instrument/ClassFileTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,10 +155,27 @@ import java.security.ProtectionDomain;
  * logging or debugging of format corruptions.
  *
  * <P>
- * Note the term <i>class file</i> is used as defined in section 3.1 of
- * <cite>The Java Virtual Machine Specification</cite>, to mean a
- * sequence of bytes in class file format, whether or not they reside in a
+ * Note the term <i>class file</i> is used as defined in chapter {@jvms 4} The
+ * {@code class} File Format of <cite>The Java Virtual Machine Specification</cite>,
+ * to mean a sequence of bytes in class file format, whether or not they reside in a
  * file.
+ *
+ * @apiNote
+ * Great care must be taken when transforming core JDK classes which are at the
+ * same time required during the transformation process as this can lead to class
+ * circularity or linkage errors.
+ *
+ * <P>
+ * If for example the invocation of {@link #transform transform()} for a class
+ * {@code C} requires loading or resolving the same class {@code C},
+ * an error is thrown that is an instance of {@link LinkageError} (or a subclass).
+ * If the {@link LinkageError} occurs during reference resolution (see section
+ * {@jvms 5.4.3} Resolution of <cite>The Java Virtual Machine Specification</cite>)
+ * for a class {@code D}, the resolution of the corresponding reference in class
+ * {@code D} will permanently fail with the same error at any subsequent attempt.
+ * This means that a {@link LinkageError} triggered during transformation of
+ * {@code C} in a class {@code D} not directly related to {@code C} can repeatedly
+ * occur later in arbitrary user code which uses {@code D}.
  *
  * @see     java.lang.instrument.Instrumentation
  * @since   1.5


### PR DESCRIPTION
Almost clean backport of JDK-8335619, except for a conflict in the copyright header (year). Adds useful information for users of `java.lang.instrument`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8335619](https://bugs.openjdk.org/browse/JDK-8335619) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335619](https://bugs.openjdk.org/browse/JDK-8335619): Add an @<!---->apiNote to j.l.i.ClassFileTransformer to warn about recursive class loading and ClassCircularityErrors (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2012/head:pull/2012` \
`$ git checkout pull/2012`

Update a local copy of the PR: \
`$ git checkout pull/2012` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2012`

View PR using the GUI difftool: \
`$ git pr show -t 2012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2012.diff">https://git.openjdk.org/jdk21u-dev/pull/2012.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2012#issuecomment-3106842186)
</details>
