### PR TITLE
8350858: [IR Framework] Some tests failed on Cascade Lake

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/VMInfo.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/VMInfo.java
@@ -42,7 +42,7 @@ public class VMInfo {
     private final Map<String, String> keyValueMap;
 
     private static final Pattern CPU_SKYLAKE_PATTERN =
-            Pattern.compile("family 6 model 85 stepping (\\d) ");
+            Pattern.compile("family 6 model 85 stepping (\\d+) ");
 
     public VMInfo(Map<String, String> map) {
         this.keyValueMap = map;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3c9d64eb](https://github.com/openjdk/jdk/commit/3c9d64eb07c5bc9006ef05b0ab81bdc318cccc20) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Kuai Wei on 27 Feb 2025 and was reviewed by Christian Hagedorn and Emanuel Peter.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350858](https://bugs.openjdk.org/browse/JDK-8350858) needs maintainer approval

### Issue
 * [JDK-8350858](https://bugs.openjdk.org/browse/JDK-8350858): [IR Framework] Some tests failed on Cascade Lake (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2013/head:pull/2013` \
`$ git checkout pull/2013`

Update a local copy of the PR: \
`$ git checkout pull/2013` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2013`

View PR using the GUI difftool: \
`$ git pr show -t 2013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2013.diff">https://git.openjdk.org/jdk21u-dev/pull/2013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2013#issuecomment-3107326537)
</details>
