### PR TITLE
8338939: Simplify processing of hidden class names

### DIFF
--- a/src/hotspot/share/jfr/support/jfrSymbolTable.hpp
+++ b/src/hotspot/share/jfr/support/jfrSymbolTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,15 +100,12 @@ class JfrSymbolTable : public JfrCHeapObj {
   traceid mark(const Symbol* sym, bool leakp = false);
   traceid mark(const char* str, bool leakp = false);
   traceid mark(uintptr_t hash, const char* str, bool leakp);
+  traceid mark_hidden_klass_name(const Klass* k, bool leakp);
   traceid bootstrap_name(bool leakp);
 
   bool has_entries() const { return has_symbol_entries() || has_string_entries(); }
   bool has_symbol_entries() const { return _symbol_list != nullptr; }
   bool has_string_entries() const { return _string_list != nullptr; }
-
-  traceid mark_hidden_klass_name(const InstanceKlass* k, bool leakp);
-  bool is_hidden_klass(const Klass* k);
-  uintptr_t hidden_klass_name_hash(const InstanceKlass* ik);
 
   // hashtable(s) callbacks
   void on_link(const SymbolEntry* entry);


### PR DESCRIPTION
Makes JFR more durable by avoiding Java mirror accesses for the classes that might be unloading. We were seeing the problems (crashes) at least with Shenandoah in both mainline and JDK 21u. There seem to be no bugtail for this change since JDK 24 integration 11 months ago.

Additional testing:
 - [x] Linux AArch64 server fastdebug, `jdk/jfr`
 - [x] Linux AArch64 server fastdebug, `jdk/jfr` + `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338939](https://bugs.openjdk.org/browse/JDK-8338939) needs maintainer approval

### Issue
 * [JDK-8338939](https://bugs.openjdk.org/browse/JDK-8338939): Simplify processing of hidden class names (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2018/head:pull/2018` \
`$ git checkout pull/2018`

Update a local copy of the PR: \
`$ git checkout pull/2018` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2018`

View PR using the GUI difftool: \
`$ git pr show -t 2018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2018.diff">https://git.openjdk.org/jdk21u-dev/pull/2018.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2018#issuecomment-3128082506)
</details>
