### PR TITLE
8342238: Test javax/crypto/CryptoPermissions/InconsistentEntries.java writes files in tested JDK dir

### DIFF
--- a/test/jdk/javax/crypto/CryptoPermissions/InconsistentEntries.java
+++ b/test/jdk/javax/crypto/CryptoPermissions/InconsistentEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @run testng/othervm InconsistentEntries
  */
 
+import java.util.List;
+import jdk.test.lib.Utils;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.ProcessTools;
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import javax.crypto.*;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,42 +47,35 @@ import java.security.Security;
 
 public class InconsistentEntries {
 
-    private static final String JDK_HOME = System.getProperty("test.jdk");
-    private static final String TEST_SRC = System.getProperty("test.src");
-    private static final Path POLICY_DIR = Paths.get(JDK_HOME, "conf", "security",
-            "policy", "testlimited");
-    private static final Path POLICY_FILE = Paths.get(TEST_SRC, "default_local.policy");
-
-    Path targetFile = null;
+    private static final String JDK_HOME = System.getProperty("test.jdk", ".");
+    private static final String TEST_SRC = System.getProperty("test.src", ".");
+    private static final Path TEMP_JDK_HOME = Path.of("java");
+    private static final Path POLICY_DIR = TEMP_JDK_HOME.resolve(Path.of("conf", "security",
+            "policy", "testlimited"));
+    private static final Path POLICY_FILE_SRC = Paths.get(TEST_SRC, "default_local.policy");
+    private static final Path POLICY_FILE_TARGET = POLICY_DIR
+        .resolve(POLICY_FILE_SRC.getFileName());
 
     @BeforeTest
-    public void setUp() throws IOException {
+    public void setUp() throws Exception {
+        // Clone the tested JDK to the scratch directory
+        CDSTestUtils.clone(new File(JDK_HOME), new File(TEMP_JDK_HOME.toString()));
+
+        // create policy directory in the cloned JDK
         if (!POLICY_DIR.toFile().exists()) {
             Files.createDirectory(POLICY_DIR);
         }
 
-        targetFile = POLICY_DIR.resolve(POLICY_FILE.getFileName());
-        Files.copy(POLICY_FILE, targetFile, StandardCopyOption.REPLACE_EXISTING);
+        // copy policy file into policy directory
+        Files.copy(POLICY_FILE_SRC, POLICY_FILE_TARGET, StandardCopyOption.REPLACE_EXISTING);
     }
 
-    @AfterTest
-    public void cleanUp() throws IOException {
-        Files.delete(targetFile);
-    }
-
-    @Test
-    public void test() throws Exception {
-        String JAVA_HOME = System.getProperty("java.home");
-        String FS = System.getProperty("file.separator");
-        Path testlimited = Path.of(JAVA_HOME + FS + "conf" + FS + "security" +
-                FS + "policy" + FS + "testlimited");
-        if (!Files.exists(testlimited)) {
+    public static void main(String[] args) throws Throwable {
+        if (!Files.exists(POLICY_DIR)) {
             throw new RuntimeException(
                     "custom policy subdirectory: testlimited does not exist");
         }
-
-        File testpolicy = new File(JAVA_HOME + FS + "conf" + FS + "security" +
-                FS + "policy" + FS + "testlimited" + FS + "default_local.policy");
+        File testpolicy = new File(POLICY_FILE_TARGET.toString());
         if (testpolicy.length() == 0) {
             throw new RuntimeException(
                     "policy: default_local.policy does not exist or is empty");
@@ -90,5 +85,17 @@ public class InconsistentEntries {
 
         Assert.assertThrows(ExceptionInInitializerError.class,
                 () -> Cipher.getMaxAllowedKeyLength("AES"));
+    }
+
+    @Test
+    public void test() throws Exception {
+        String tmpJava = TEMP_JDK_HOME.resolve("bin").resolve("java").toString();
+        String[] args = Utils.prependTestJavaOpts(InconsistentEntries.class.getName());
+        ProcessBuilder pb = new ProcessBuilder(tmpJava);
+        pb.command().addAll(List.of(args));
+
+        ProcessTools
+            .executeProcess(pb)
+            .shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
Backporting JDK-8342238: Test javax/crypto/CryptoPermissions/InconsistentEntries.java writes files in tested JDK dir. Fixing test to not modify the JDK home directory under test, as that could impact the results of other tests, or could fail if the JDK home dir is read-only. Ran GHA Sanity Checks, local Tier 1 and 2, and adjusted test directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342238](https://bugs.openjdk.org/browse/JDK-8342238) needs maintainer approval

### Issue
 * [JDK-8342238](https://bugs.openjdk.org/browse/JDK-8342238): Test javax/crypto/CryptoPermissions/InconsistentEntries.java writes files in tested JDK dir (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2020/head:pull/2020` \
`$ git checkout pull/2020`

Update a local copy of the PR: \
`$ git checkout pull/2020` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2020`

View PR using the GUI difftool: \
`$ git pr show -t 2020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2020.diff">https://git.openjdk.org/jdk21u-dev/pull/2020.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2020#issuecomment-3134321508)
</details>
