### PR TITLE
8330108: Increase CipherInputStream buffer size

### DIFF
--- a/src/java.base/share/classes/javax/crypto/CipherInputStream.java
+++ b/src/java.base/share/classes/javax/crypto/CipherInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,8 +84,8 @@ public class CipherInputStream extends FilterInputStream {
 
     /* the buffer holding data that have been read in from the
        underlying stream, but have not been processed by the cipher
-       engine. the size 512 bytes is somewhat randomly chosen */
-    private final byte[] ibuffer = new byte[512];
+       engine. */
+    private final byte[] ibuffer = new byte[8192];
 
     // having reached the end of the underlying input stream
     private boolean done = false;


### PR DESCRIPTION
Clean backport of [JDK-8330108](https://bugs.openjdk.org/browse/JDK-8330108), to increase CipherInputStream buffer size from 512 to 8192 bytes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8330108](https://bugs.openjdk.org/browse/JDK-8330108) needs maintainer approval

### Issue
 * [JDK-8330108](https://bugs.openjdk.org/browse/JDK-8330108): Increase CipherInputStream buffer size (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2022/head:pull/2022` \
`$ git checkout pull/2022`

Update a local copy of the PR: \
`$ git checkout pull/2022` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2022`

View PR using the GUI difftool: \
`$ git pr show -t 2022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2022.diff">https://git.openjdk.org/jdk21u-dev/pull/2022.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2022#issuecomment-3134437749)
</details>
