### PR TITLE
8350665: SIZE_FORMAT_HEX macro undefined in gtest

### DIFF
--- a/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
+++ b/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
@@ -60,9 +60,9 @@ namespace {
 
 static void diagnostic_print(ReservedMemoryRegion* rmr) {
   CommittedRegionIterator iter = rmr->iterate_committed_regions();
-  LOG("In reserved region " PTR_FORMAT ", size " SIZE_FORMAT_HEX ":", p2i(rmr->base()), rmr->size());
+  LOG("In reserved region " PTR_FORMAT ", size 0x%zx:", p2i(rmr->base()), rmr->size());
   for (const CommittedMemoryRegion* region = iter.next(); region != nullptr; region = iter.next()) {
-    LOG("   committed region: " PTR_FORMAT ", size " SIZE_FORMAT_HEX, p2i(region->base()), region->size());
+    LOG("   committed region: " PTR_FORMAT ", size 0x%zx", p2i(region->base()), region->size());
   }
 }
 


### PR DESCRIPTION
Backporting JDK-8350665: SIZE_FORMAT_HEX macro undefined in gtest. SIZE_FORMAT_HEX macro is undefined in test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp, and can be replaced by "0x%zx". Ran GHA Sanity Checks, local Tier 1 and 2 and adjusted test directly. Patch is clean. Change has been backported by oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8350665](https://bugs.openjdk.org/browse/JDK-8350665) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350665](https://bugs.openjdk.org/browse/JDK-8350665): SIZE_FORMAT_HEX macro undefined in gtest (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2028/head:pull/2028` \
`$ git checkout pull/2028`

Update a local copy of the PR: \
`$ git checkout pull/2028` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2028`

View PR using the GUI difftool: \
`$ git pr show -t 2028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2028.diff">https://git.openjdk.org/jdk21u-dev/pull/2028.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2028#issuecomment-3145810862)
</details>
