### PR TITLE
8331389: runtime/ErrorHandling/TestDwarf.java fails with "Crash JVM should not exit gracefully"

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,13 +108,12 @@ public class TestDwarf {
     // Crash the VM in different ways in order to verify that DWARF parsing is able to print the source information
     // in the hs_err_files for each VM and C stack frame.
     private static void test() throws Exception {
-        runAndCheck(new Flags("-Xcomp", "-XX:CICrashAt=1", "--version"));
+        runAndCheck(new Flags("-Xcomp", "-XX:+CICountNative", "-XX:CICrashAt=1", "--version"));
         runAndCheck(new Flags("-Xmx100M", "-XX:ErrorHandlerTest=15", "-XX:TestCrashInErrorHandler=14", "--version"));
         runAndCheck(new Flags("-XX:+CrashGCForDumpingJavaThread", "--version"));
         runAndCheck(new Flags("-Xmx10m", "-XX:+CrashOnOutOfMemoryError", TestDwarf.class.getCanonicalName(), "outOfMemory"));
-        // Use -XX:-TieredCompilation as C1 is currently not aborting the VM (JDK-8264899).
         runAndCheck(new Flags(TestDwarf.class.getCanonicalName(), "unsafeAccess"));
-        runAndCheck(new Flags("-XX:-TieredCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:AbortVMOnException=MyException",
+        runAndCheck(new Flags("-XX:+UnlockDiagnosticVMOptions", "-XX:AbortVMOnException=MyException",
                               TestDwarf.class.getCanonicalName(), "abortVMOnException"));
         if (Platform.isX64() || Platform.isX86()) {
             // Not all platforms raise SIGFPE but x86_32 and x86_64 do.


### PR DESCRIPTION
Backporting JDK-8331389: runtime/ErrorHandling/TestDwarf.java fails with "Crash JVM should not exit gracefully". Similar to [JDK-8269342](https://bugs.openjdk.org/browse/JDK-8269342), using -XX:CICrashAt=1 does not guarantee a crash - adding the -XX:+CICountNative flag fixes this test reliability. Ran GHA Sanity Checks, local Tier 1 and 2 and adjusted test directly. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331389](https://bugs.openjdk.org/browse/JDK-8331389) needs maintainer approval

### Issue
 * [JDK-8331389](https://bugs.openjdk.org/browse/JDK-8331389): runtime/ErrorHandling/TestDwarf.java fails with "Crash JVM should not exit gracefully" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2062/head:pull/2062` \
`$ git checkout pull/2062`

Update a local copy of the PR: \
`$ git checkout pull/2062` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2062`

View PR using the GUI difftool: \
`$ git pr show -t 2062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2062.diff">https://git.openjdk.org/jdk21u-dev/pull/2062.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2062#issuecomment-3161828045)
</details>
