### PR TITLE
8350456: Test javax/crypto/CryptoPermissions/InconsistentEntries.java crashed: EXCEPTION_ACCESS_VIOLATION

### DIFF
--- a/test/jdk/javax/crypto/CryptoPermissions/InconsistentEntries.java
+++ b/test/jdk/javax/crypto/CryptoPermissions/InconsistentEntries.java
@@ -31,8 +31,8 @@
 
 import java.util.List;
 import jdk.test.lib.Utils;
-import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.util.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -59,7 +59,7 @@ public class InconsistentEntries {
     @BeforeTest
     public void setUp() throws Exception {
         // Clone the tested JDK to the scratch directory
-        CDSTestUtils.clone(new File(JDK_HOME), new File(TEMP_JDK_HOME.toString()));
+        FileUtils.copyDirectory(Path.of(JDK_HOME), TEMP_JDK_HOME);
 
         // create policy directory in the cloned JDK
         if (!POLICY_DIR.toFile().exists()) {

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -48,6 +49,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import jdk.test.lib.Platform;
 
 import com.sun.management.UnixOperatingSystemMXBean;
@@ -362,6 +365,30 @@ public final class FileUtils {
                 throw new UncheckedIOException("error listing file descriptors", ioe);
             }
         });
+    }
+
+    /**
+     * Copies a directory and all entries in the directory to a destination path.
+     * Makes the access permission of the destination entries writable.
+     *
+     * @param src the path of the source directory
+     * @param dst the path of the destination directory
+     * @throws IOException      if an I/O error occurs while walking the file tree
+     * @throws RuntimeException if an I/O error occurs during the copy operation
+     *                          or if the source or destination paths are invalid
+     */
+    public static void copyDirectory(Path src, Path dst) throws IOException {
+        try (Stream<Path> stream = Files.walk(src)) {
+            stream.forEach(sourcePath -> {
+                try {
+                    Path destPath = dst.resolve(src.relativize(sourcePath));
+                    Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING);
+                    destPath.toFile().setWritable(true);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
     }
 
     // Return the current process handle count


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350456](https://bugs.openjdk.org/browse/JDK-8350456) needs maintainer approval

### Issue
 * [JDK-8350456](https://bugs.openjdk.org/browse/JDK-8350456): Test javax/crypto/CryptoPermissions/InconsistentEntries.java crashed: EXCEPTION_ACCESS_VIOLATION (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2071/head:pull/2071` \
`$ git checkout pull/2071`

Update a local copy of the PR: \
`$ git checkout pull/2071` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2071`

View PR using the GUI difftool: \
`$ git pr show -t 2071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2071.diff">https://git.openjdk.org/jdk21u-dev/pull/2071.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2071#issuecomment-3174193637)
</details>
