### PR TITLE
8336702: C2 compilation fails with "all memory state should have been processed" assert

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -701,14 +701,24 @@ SafePointNode* PhaseIdealLoop::find_safepoint(Node* back_control, Node* x, Ideal
 
     // We can only use that safepoint if there's no side effect between the backedge and the safepoint.
 
-    // mm is used for book keeping
+    // mm is the memory state at the safepoint (when it's a MergeMem)
+    // no_side_effect_since_safepoint() goes over the memory state at the backedge. It resets the mm input for each
+    // component of the memory state it encounters so it points to the base memory. Once no_side_effect_since_safepoint()
+    // is done, if no side effect after the safepoint was found, mm should transform to the base memory: the states at
+    // the backedge and safepoint are the same so all components of the memory state at the safepoint should have been
+    // reset.
     MergeMemNode* mm = nullptr;
 #ifdef ASSERT
     if (mem->is_MergeMem()) {
       mm = mem->clone()->as_MergeMem();
       _igvn._worklist.push(mm);
       for (MergeMemStream mms(mem->as_MergeMem()); mms.next_non_empty(); ) {
-        if (mms.alias_idx() != Compile::AliasIdxBot && loop != get_loop(ctrl_or_self(mms.memory()))) {
+        // Loop invariant memory state won't be reset by no_side_effect_since_safepoint(). Do it here.
+        // Escape Analysis can add state to mm that it doesn't add to the backedge memory Phis, breaking verification
+        // code that relies on mm. Clear that extra state here.
+        if (mms.alias_idx() != Compile::AliasIdxBot &&
+            (loop != get_loop(ctrl_or_self(mms.memory())) ||
+             (mms.adr_type()->isa_oop_ptr() && mms.adr_type()->is_known_instance()))) {
           mm->set_memory_at(mms.alias_idx(), mem->as_MergeMem()->base_memory());
         }
       }

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestSafePointWithEAState.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestSafePointWithEAState.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8336702
+ * @summary C2 compilation fails with "all memory state should have been processed" assert
+ *
+ * @run main/othervm TestSafePointWithEAState
+ *
+ */
+
+public class TestSafePointWithEAState {
+    int[] b = new int[400];
+
+    void c() {
+        int e;
+        float f;
+        for (long d = 0; d < 5000; d++) {
+            e = 1;
+            while ((e += 3) < 200) {
+                if (d < b.length) {
+                    for (int g = 0; g < 10000; ++g) ;
+                }
+            }
+            synchronized (TestSafePointWithEAState.class) {
+                f = new h(e).n;
+            }
+        }
+    }
+
+    public static void main(String[] m) {
+        TestSafePointWithEAState o = new TestSafePointWithEAState();
+        o.c();
+    }
+}
+
+class h {
+    float n;
+    h(float n) {
+        this.n = n;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8336702: C2 compilation fails with "all memory state should have been processed" assert. Change adjusts condition for converting a `LongCountedLoop` into a loop nest to handle edge case compilation failure outlined in original [PR](https://github.com/openjdk/jdk/pull/21009). Ran GHA Sanity Checks, local tier 1 and 2, and new test. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8336702](https://bugs.openjdk.org/browse/JDK-8336702) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336702](https://bugs.openjdk.org/browse/JDK-8336702): C2 compilation fails with "all memory state should have been processed" assert (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2074/head:pull/2074` \
`$ git checkout pull/2074`

Update a local copy of the PR: \
`$ git checkout pull/2074` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2074`

View PR using the GUI difftool: \
`$ git pr show -t 2074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2074.diff">https://git.openjdk.org/jdk21u-dev/pull/2074.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2074#issuecomment-3176673402)
</details>
