### PR TITLE
8341178: TypeRawPtr::add_offset may be "miscompiled" due to UB

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3125,8 +3125,8 @@ const TypeRawPtr *TypeRawPtr::make( enum PTR ptr ) {
   return (TypeRawPtr*)(new TypeRawPtr(ptr,0))->hashcons();
 }
 
-const TypeRawPtr *TypeRawPtr::make( address bits ) {
-  assert( bits, "Use TypePtr for null" );
+const TypeRawPtr *TypeRawPtr::make(address bits) {
+  assert(bits != nullptr, "Use TypePtr for null");
   return (TypeRawPtr*)(new TypeRawPtr(Constant,bits))->hashcons();
 }
 
@@ -3215,15 +3215,21 @@ const TypePtr* TypeRawPtr::add_offset(intptr_t offset) const {
   case TypePtr::BotPTR:
   case TypePtr::NotNull:
     return this;
-  case TypePtr::Null:
   case TypePtr::Constant: {
-    address bits = _bits+offset;
-    if ( bits == 0 ) return TypePtr::NULL_PTR;
-    return make( bits );
+    uintptr_t bits = (uintptr_t)_bits;
+    uintptr_t sum = bits + offset;
+    if (( offset < 0 )
+        ? ( sum > bits )        // Underflow?
+        : ( sum < bits )) {     // Overflow?
+      return BOTTOM;
+    } else if ( sum == 0 ) {
+      return TypePtr::NULL_PTR;
+    } else {
+      return make( (address)sum );
+    }
   }
   default:  ShouldNotReachHere();
   }
-  return nullptr;                  // Lint noise
 }
 
 //------------------------------eq---------------------------------------------


### PR DESCRIPTION
Backporting JDK-8341178: TypeRawPtr::add_offset may be "miscompiled" due to UB. Change catches case where compiler infers things based on prior pointer arithmetic not invoking UB. Fix preserves intended functionality by changing to integral arithmetic, adds over/underflow, and bit of cleanup. Ran GHA Sanity Checks, local tier 1 and 2. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341178](https://bugs.openjdk.org/browse/JDK-8341178) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341178](https://bugs.openjdk.org/browse/JDK-8341178): TypeRawPtr::add_offset may be "miscompiled" due to UB (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2075/head:pull/2075` \
`$ git checkout pull/2075`

Update a local copy of the PR: \
`$ git checkout pull/2075` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2075`

View PR using the GUI difftool: \
`$ git pr show -t 2075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2075.diff">https://git.openjdk.org/jdk21u-dev/pull/2075.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2075#issuecomment-3176672471)
</details>
