### PR TITLE
8341370: Test java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java fails intermittently on macOS-aarch64

### DIFF
--- a/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
+++ b/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
@@ -33,6 +33,7 @@ import java.awt.Toolkit;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import javax.imageio.ImageIO;
@@ -42,7 +43,7 @@ import javax.imageio.ImageIO;
  * @key headful
  * @bug 6988428
  * @summary Tests whether shape is always set
- * @run main/othervm -Dsun.java2d.uiScale=1 ShapeNotSetSometimes
+ * @run main/othervm/timeout=300 -Dsun.java2d.uiScale=1 ShapeNotSetSometimes
  */
 
 public class ShapeNotSetSometimes {
@@ -147,15 +148,20 @@ public class ShapeNotSetSometimes {
         robot.waitForIdle();
         robot.delay(500);
 
+        Rectangle screenBounds = window.getGraphicsConfiguration().getBounds();
+        BufferedImage screenCapture = robot.createScreenCapture(screenBounds);
         try {
-            colorCheck(innerPoint.x, innerPoint.y, SHAPE_COLOR, true);
+            colorCheck(innerPoint.x, innerPoint.y, SHAPE_COLOR,
+                    true, screenCapture);
 
             for (Point point : pointsOutsideToCheck) {
-                colorCheck(point.x, point.y, BACKGROUND_COLOR, true);
+                colorCheck(point.x, point.y, BACKGROUND_COLOR,
+                        true, screenCapture);
             }
 
             for (Point point : shadedPointsToCheck) {
-                colorCheck(point.x, point.y, SHAPE_COLOR, false);
+                colorCheck(point.x, point.y, SHAPE_COLOR,
+                        false, screenCapture);
             }
         } finally {
             EventQueue.invokeAndWait(() -> {
@@ -169,15 +175,12 @@ public class ShapeNotSetSometimes {
         }
     }
 
-    private void colorCheck(int x, int y, Color expectedColor, boolean mustBeExpectedColor) {
+    private void colorCheck(int x, int y, Color expectedColor,
+                            boolean mustBeExpectedColor, BufferedImage screenCapture) {
         int screenX = window.getX() + x;
         int screenY = window.getY() + y;
 
-        robot.mouseMove(screenX, screenY);
-        robot.waitForIdle();
-        robot.delay(50);
-
-        Color actualColor = robot.getPixelColor(screenX, screenY);
+        Color actualColor = new Color(screenCapture.getRGB(screenX, screenY));
 
         System.out.printf(
                 "Checking %3d, %3d, %35s should %sbe %35s\n",


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

Resolved ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8341370](https://bugs.openjdk.org/browse/JDK-8341370) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341370](https://bugs.openjdk.org/browse/JDK-8341370): Test java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java fails intermittently on macOS-aarch64 (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2077/head:pull/2077` \
`$ git checkout pull/2077`

Update a local copy of the PR: \
`$ git checkout pull/2077` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2077`

View PR using the GUI difftool: \
`$ git pr show -t 2077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2077.diff">https://git.openjdk.org/jdk21u-dev/pull/2077.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2077#issuecomment-3179119312)
</details>
