### PR TITLE
8334457: Test javax/swing/JTabbedPane/bug4666224.java fail on macOS with because pressing the ‘C’ key does not switch the layout to WRAP_TAB_LAYOUT

### DIFF
--- a/test/jdk/javax/swing/JTabbedPane/bug4666224.java
+++ b/test/jdk/javax/swing/JTabbedPane/bug4666224.java
@@ -49,7 +49,7 @@ public class bug4666224 {
     private static JFrame frame;
 
     private static final String INSTRUCTIONS = """
-                ON ALL PLATFORMS
+                ON ALL PLATFORMS except macos where pt.6 is not applicable
                     1. Click on any of the tabs, focus indicator is visible.
                     2. Lose focus on the window by clicking on some other window.
                     3. Focus indicator should disappear


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334457](https://bugs.openjdk.org/browse/JDK-8334457) needs maintainer approval

### Issue
 * [JDK-8334457](https://bugs.openjdk.org/browse/JDK-8334457): Test javax/swing/JTabbedPane/bug4666224.java fail on macOS with because pressing the ‘C’ key does not switch the layout to WRAP_TAB_LAYOUT (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2078/head:pull/2078` \
`$ git checkout pull/2078`

Update a local copy of the PR: \
`$ git checkout pull/2078` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2078`

View PR using the GUI difftool: \
`$ git pr show -t 2078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2078.diff">https://git.openjdk.org/jdk21u-dev/pull/2078.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2078#issuecomment-3179120591)
</details>
