### PR TITLE
8357285: JSR166 Test case testShutdownNow_delayedTasks failed

### DIFF
--- a/test/jdk/java/util/concurrent/tck/ScheduledExecutorTest.java
+++ b/test/jdk/java/util/concurrent/tck/ScheduledExecutorTest.java
@@ -700,11 +700,13 @@ public class ScheduledExecutorTest extends JSR166TestCase {
     public void testShutdownNow_delayedTasks() throws InterruptedException {
         final ScheduledThreadPoolExecutor p = new ScheduledThreadPoolExecutor(1);
         List<ScheduledFuture<?>> tasks = new ArrayList<>();
+        final int DELAY = 100;
+
         for (int i = 0; i < 3; i++) {
             Runnable r = new NoOpRunnable();
-            tasks.add(p.schedule(r, 9, SECONDS));
-            tasks.add(p.scheduleAtFixedRate(r, 9, 9, SECONDS));
-            tasks.add(p.scheduleWithFixedDelay(r, 9, 9, SECONDS));
+            tasks.add(p.schedule(r, DELAY, SECONDS));
+            tasks.add(p.scheduleAtFixedRate(r, DELAY, DELAY, SECONDS));
+            tasks.add(p.scheduleWithFixedDelay(r, DELAY, DELAY, SECONDS));
         }
         if (testImplementationDetails)
             assertEquals(new HashSet<Object>(tasks), new HashSet<Object>(p.getQueue()));


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8357285](https://bugs.openjdk.org/browse/JDK-8357285) needs maintainer approval

### Issue
 * [JDK-8357285](https://bugs.openjdk.org/browse/JDK-8357285): JSR166 Test case testShutdownNow_delayedTasks failed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2084/head:pull/2084` \
`$ git checkout pull/2084`

Update a local copy of the PR: \
`$ git checkout pull/2084` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2084`

View PR using the GUI difftool: \
`$ git pr show -t 2084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2084.diff">https://git.openjdk.org/jdk21u-dev/pull/2084.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2084#issuecomment-3183051064)
</details>
