### PR TITLE
Backport a827ff05dba0c9b7c74d83053a35c8041c1ac5cc

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -116,8 +116,9 @@ public class TestParallelGCWithCDS {
                 } else {
                     String pattern = "((Too small maximum heap)" +
                                      "|(GC triggered before VM initialization completed)" +
-                                     "|(java.lang.OutOfMemoryError: Java heap space)" +
-                                     "|(Initial heap size set to a larger value than the maximum heap size))";
+                                     "|(Initial heap size set to a larger value than the maximum heap size)" +
+                                     "|(java.lang.OutOfMemoryError)" +
+                                     "|(Error: A JNI error has occurred, please check your installation and try again))";
                     out.shouldMatch(pattern);
                     out.shouldNotHaveFatalError();
                 }


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle