### PR TITLE
8353847: Remove extra args to System.out.printf in open/test/jdk/java/net/httpclient tests

### DIFF
--- a/test/jdk/java/net/httpclient/AsyncShutdownNow.java
+++ b/test/jdk/java/net/httpclient/AsyncShutdownNow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,7 +208,7 @@ public class AsyncShutdownNow implements HttpServerAdapters {
                     Thread.sleep(sleep);
                 }
                 if (i == step) {
-                    out.printf("%d: shutting down client now%n", i, sleep);
+                    out.printf("%d: shutting down client now%n", i);
                     client.shutdownNow();
                 }
                 var cf = bodyCF.exceptionally((t) -> {
@@ -304,7 +304,7 @@ public class AsyncShutdownNow implements HttpServerAdapters {
                     Thread.sleep(sleep);
                 }
                 if (i == step) {
-                    out.printf("%d: shutting down client now%n", i, sleep);
+                    out.printf("%d: shutting down client now%n", i);
                     client.shutdownNow();
                 }
                 bodyCF.handle((r, t) -> {

--- a/test/jdk/java/net/httpclient/HttpClientShutdown.java
+++ b/test/jdk/java/net/httpclient/HttpClientShutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,7 +192,7 @@ public class HttpClientShutdown implements HttpServerAdapters {
                 out.println(now() + step + ":  Got response: " + response);
                 assertEquals(response.statusCode(), 200);
             } catch (AssertionError error) {
-                out.printf(now() + "%s:  Closing body due to assertion - %s", error);
+                out.printf(now() + "%s:  Closing body due to assertion - %s", step, error);
                 ensureClosed(this);
                 throw error;
             }
@@ -276,7 +276,7 @@ public class HttpClientShutdown implements HttpServerAdapters {
                     continue;
                 }
                 if (i == step) {
-                    out.printf(now() + "%d: shutting down client%n", i, sleep);
+                    out.printf(now() + "%d: shutting down client%n", i);
                     client.shutdown();
                 }
                 var cf = bodyCF.exceptionally((t) -> {
@@ -375,7 +375,7 @@ public class HttpClientShutdown implements HttpServerAdapters {
                     continue;
                 }
                 if (i == step) {
-                    out.printf(now() + "%d: shutting down client%n", i, sleep);
+                    out.printf(now() + "%d: shutting down client%n", i);
                     client.shutdown();
                 }
                 bodyCF.handle((r, t) -> {

--- a/test/jdk/java/net/httpclient/ShutdownNow.java
+++ b/test/jdk/java/net/httpclient/ShutdownNow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,7 @@ public class ShutdownNow implements HttpServerAdapters {
                     Thread.sleep(sleep);
                 }
                 if (i == step) {
-                    out.printf("%d: shutting down client now%n", i, sleep);
+                    out.printf("%d: shutting down client now%n", i);
                     client.shutdownNow();
                 }
                 final int si = i;
@@ -238,7 +238,7 @@ public class ShutdownNow implements HttpServerAdapters {
                     Thread.sleep(sleep);
                 }
                 if (i == step) {
-                    out.printf("%d: shutting down client now%n", i, sleep);
+                    out.printf("%d: shutting down client now%n", i);
                     client.shutdownNow();
                 }
                 final int si = i;


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle

Resolved Copyright because [8338569](https://bugs.openjdk.org/browse/JDK-8338569)

HTTP/1.1 CleanupTrigger may be triggerred after the next exchange started is not in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353847](https://bugs.openjdk.org/browse/JDK-8353847) needs maintainer approval

### Issue
 * [JDK-8353847](https://bugs.openjdk.org/browse/JDK-8353847): Remove extra args to System.out.printf in open/test/jdk/java/net/httpclient tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2089/head:pull/2089` \
`$ git checkout pull/2089`

Update a local copy of the PR: \
`$ git checkout pull/2089` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2089`

View PR using the GUI difftool: \
`$ git pr show -t 2089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2089.diff">https://git.openjdk.org/jdk21u-dev/pull/2089.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2089#issuecomment-3183937169)
</details>
