### PR TITLE
8352677: Opensource JMenu tests - series2

### DIFF
--- a/test/jdk/javax/swing/JMenu/bug4187996.java
+++ b/test/jdk/javax/swing/JMenu/bug4187996.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4187996
+ * @summary Tests that Metal submenus overlap menu
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4187996
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.UIManager;
+
+public class bug4187996 {
+
+    private static final String INSTRUCTIONS = """
+        Open the menu "Menu", then "Submenu".
+        The submenu should be top-aligned with the menu,
+        and slightly overlap it horizontally. Otherwise test fails.""";
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        PassFailJFrame.builder()
+                .title("bug4187996 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug4187996::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4187996");
+        JMenu submenu = new JMenu("Submenu");
+        submenu.add(new JMenuItem("Sub 1"));
+        submenu.add(new JMenuItem("Sub 2"));
+
+        JMenu menu = new JMenu("Menu");
+        menu.add(submenu);
+        menu.add(new JMenuItem("Item 1"));
+        menu.add(new JMenuItem("Item 2"));
+
+        JMenuBar mbar = new JMenuBar();
+        mbar.add(menu);
+        frame.setJMenuBar(mbar);
+        frame.setSize(300, 100);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug6471949.java
+++ b/test/jdk/javax/swing/JMenu/bug6471949.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6471949
+ * @summary JMenu should stay selected after escape is pressed
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug6471949
+*/
+
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug6471949 {
+
+    private static final String INSTRUCTIONS = """
+        Test the menu and its submenus for different LaF:
+
+        Click on "Menu" and then click on "Inner" submenu
+        and then click on "One more" submenu.
+
+        For Metal, Nimbus and Aqua Laf the Escape key hides the last open submenu,
+        Press Esc till the last menu "Inner" is closed.
+        If the last menu is closed then the menu button (in menubar) gets unselected.
+
+        For Windows Laf the Escape key hides the last open submenu
+        if the last menu is closed then the menu button remains selected,
+        until the Escape key is pressed again or any other key letter pressed.
+
+        For GTK and Motif menu, all open submenus must hide when the Escape key is pressed.
+
+        If everything works as described, the test passes and fails otherwise.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug6471949 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug6471949::createTestUI)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+
+        PassFailJFrame.log("Menu.cancelMode = " +
+                           UIManager.getString("Menu.cancelMode"));
+        PassFailJFrame.log("Menu.preserveTopLevelSelection = " +
+                            UIManager.getBoolean("Menu.preserveTopLevelSelection"));
+        PassFailJFrame.log("");
+
+        JFrame frame = new JFrame("bug6471949");
+        JMenuBar bar = new JMenuBar();
+        JMenu menu = new JMenu("Menu");
+        menu.setMnemonic('m');
+
+        JMenuItem item = new JMenuItem("Item");
+        menu.add(item);
+        JMenu inner = new JMenu("Inner");
+        inner.add(new JMenuItem("Test"));
+        JMenu oneMore = new JMenu("One more");
+        oneMore.add(new JMenuItem("Lala"));
+        inner.add(oneMore);
+        menu.add(inner);
+
+        JMenu lafMenu = new JMenu("Change LaF");
+
+        UIManager.LookAndFeelInfo[] lafs = UIManager.getInstalledLookAndFeels();
+        for (final UIManager.LookAndFeelInfo lafInfo : lafs) {
+            JMenuItem lafItem = new JMenuItem(lafInfo.getName());
+            lafItem.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    setLaf(frame, lafInfo.getClassName());
+                }
+            });
+            lafMenu.add(lafItem);
+        }
+
+        frame.setJMenuBar(bar);
+        bar.add(menu);
+        bar.add(lafMenu);
+
+        JTextArea field = new JTextArea();
+        frame.add(field);
+        field.requestFocusInWindow();
+        frame.pack();
+        return frame;
+    }
+
+    private static void setLaf(JFrame frame, String laf) {
+        try {
+            UIManager.setLookAndFeel(laf);
+            SwingUtilities.updateComponentTreeUI(frame);
+            PassFailJFrame.log("Menu.cancelMode = " +
+                               UIManager.getString("Menu.cancelMode"));
+            PassFailJFrame.log("Menu.preserveTopLevelSelection = " +
+                               UIManager.getBoolean("Menu.preserveTopLevelSelection"));
+            PassFailJFrame.log("");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug6513492.java
+++ b/test/jdk/javax/swing/JMenu/bug6513492.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+* @test
+* @bug 6513492
+* @summary Escape key needs to be pressed twice to remove focus from an empty/diabled Menu.
+* @library /java/awt/regtesthelpers
+* @build PassFailJFrame
+* @run main/manual bug6513492
+*/
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug6513492 {
+
+    private static final String INSTRUCTIONS = """
+        Test Menu for different LaF:
+
+        * For Windows Laf:
+            Click the editor
+            Click EmpyMenu, press Escape -> focus must go to the editor
+            Click EmpyMenu, press right arrow button, press Escape -> focus must go to the editor
+            Click SubMenuTest, highlight the first disabled submenu, press Escape
+                -> focus must stay at the topLevelMenu
+
+        * For Metal, Nimbus and Aqua Laf
+            Click the editor
+            Click SubMenuTest, highlight the EmptySubmenu, press Escape -> focus must go to the editor
+            Click SubMenuTest, highlight the EnabledItem, press Escape -> focus must go to the editor
+
+        * For GTK and Motif
+            Click the editor
+            Open any menu or submenu, press Escape -> focus must go to the editor.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug6513492 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(bug6513492::createTestUI)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        PassFailJFrame.log("Menu.cancelMode = " +
+                            UIManager.getString("Menu.cancelMode"));
+        PassFailJFrame.log("Menu.preserveTopLevelSelection = " +
+                            UIManager.getBoolean("Menu.preserveTopLevelSelection"));
+        PassFailJFrame.log("");
+
+        JFrame frame = new JFrame("bug6513492");
+        JMenuBar bar = new JMenuBar();
+        bar.add(new JMenu("EmptyMenu"));
+
+        JMenu disabledMenu = new JMenu("NotEmpyButDisabled");
+        disabledMenu.add(new JMenuItem("item"));
+        disabledMenu.setEnabled(false);
+        bar.add(disabledMenu);
+
+        JMenu menu = new JMenu("SubMenuTest");
+        JMenu disabledSubmenu = new JMenu("Submenu");
+        disabledSubmenu.add(new JMenuItem("item"));
+        disabledSubmenu.setEnabled(false);
+        menu.add(disabledSubmenu);
+
+        JMenu enabledSubmenu = new JMenu("Submenu");
+        enabledSubmenu.add(new JMenuItem("item"));
+        menu.add(enabledSubmenu);
+
+        JMenu emptySubmenu = new JMenu("EmptySubmenu");
+        menu.add(emptySubmenu);
+
+        menu.add(new JMenuItem("EnabledItem"));
+        JMenuItem item = new JMenuItem("DisabledItem");
+        item.setEnabled(false);
+        menu.add(item);
+        bar.add(menu);
+
+        JMenu lafMenu = new JMenu("Change LaF");
+
+        UIManager.LookAndFeelInfo[] lafs = UIManager.getInstalledLookAndFeels();
+        for (final UIManager.LookAndFeelInfo lafInfo : lafs) {
+            JMenuItem lafItem = new JMenuItem(lafInfo.getName());
+            lafItem.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    setLaf(frame, lafInfo.getClassName());
+                }
+            });
+            lafMenu.add(lafItem);
+        }
+
+        frame.setJMenuBar(bar);
+        bar.add(menu);
+        bar.add(lafMenu);
+
+        JTextArea field = new JTextArea("The editor");
+        frame.add(field);
+        field.requestFocusInWindow();
+        frame.pack();
+        return frame;
+    }
+
+    private static void setLaf(JFrame frame, String laf) {
+        try {
+            UIManager.setLookAndFeel(laf);
+            SwingUtilities.updateComponentTreeUI(frame);
+            PassFailJFrame.log("Menu.cancelMode = " +
+                               UIManager.getString("Menu.cancelMode"));
+            PassFailJFrame.log("Menu.preserveTopLevelSelection = " +
+                                UIManager.getBoolean("Menu.preserveTopLevelSelection"));
+            PassFailJFrame.log("");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8352677: Opensource JMenu tests - series2. Adds three javax/swing tests, testing which menus are focused/displayed when submenus are opened and closed. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352677](https://bugs.openjdk.org/browse/JDK-8352677) needs maintainer approval

### Issue
 * [JDK-8352677](https://bugs.openjdk.org/browse/JDK-8352677): Opensource JMenu tests - series2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2092/head:pull/2092` \
`$ git checkout pull/2092`

Update a local copy of the PR: \
`$ git checkout pull/2092` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2092`

View PR using the GUI difftool: \
`$ git pr show -t 2092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2092.diff">https://git.openjdk.org/jdk21u-dev/pull/2092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2092#issuecomment-3185901189)
</details>
