### PR TITLE
8320189: vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t001 memory corruption when using -Xcheck:jni

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t001/bi02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t001/bi02t001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ const char* CLASS_NAME = "nsk/jvmti/scenarios/bcinstr/BI02/bi02t001a";
 /** callback functions **/
 
 static void JNICALL
-ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
+ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
         jclass class_being_redefined, jobject loader,
         const char* name, jobject protection_domain,
         jint class_data_len, const unsigned char* class_data,
@@ -61,18 +61,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
         if (class_being_redefined == nullptr) {
             /* sent by class load */
-
-            if (!NSK_JNI_VERIFY(jni_env, (*new_class_data_len =
-                    jni_env->GetArrayLength(classBytes)) > 0)) {
-                nsk_jvmti_setFailStatus();
-                return;
-            }
-
-            if (!NSK_JNI_VERIFY(jni_env, (*new_class_data = (unsigned char*)
-                    jni_env->GetByteArrayElements(classBytes, nullptr)) != nullptr)) {
-                nsk_jvmti_setFailStatus();
-                return;
-            }
+            *new_class_data = jni_array_to_jvmti_allocated(jvmti, jni, classBytes, new_class_data_len);
         }
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI03/bi03t001/bi03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI03/bi03t001/bi03t001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ const char* CLASS_NAME = "nsk/jvmti/scenarios/bcinstr/BI03/bi03t001a";
 /** callback functions **/
 
 static void JNICALL
-ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
+ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
         jclass class_being_redefined, jobject loader,
         const char* name, jobject protection_domain,
         jint class_data_len, const unsigned char* class_data,
@@ -62,17 +62,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
         if (class_being_redefined == nullptr) {
             /* sent by class load */
 
-            if (!NSK_JNI_VERIFY(jni_env, (*new_class_data_len =
-                    jni_env->GetArrayLength(classBytes)) > 0)) {
-                nsk_jvmti_setFailStatus();
-                return;
-            }
-
-            if (!NSK_JNI_VERIFY(jni_env, (*new_class_data = (unsigned char*)
-                    jni_env->GetByteArrayElements(classBytes, nullptr)) != nullptr)) {
-                nsk_jvmti_setFailStatus();
-                return;
-            }
+            *new_class_data = jni_array_to_jvmti_allocated(jvmti, jni, classBytes, new_class_data_len);
         }
     }
 }

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -429,7 +429,27 @@ static jthread get_current_thread(jvmtiEnv *jvmti, JNIEnv* jni) {
   return thread;
 }
 
+/* Used in a couple of nsk/jvmti/scenarios tests to convert jbyteArray to a JVMTI allocated */
+static unsigned char* jni_array_to_jvmti_allocated(jvmtiEnv *jvmti, JNIEnv *jni, jbyteArray arr, jint* len_ptr) {
+    unsigned char* new_arr = nullptr;
 
+    jint len = jni->GetArrayLength(arr);
+    if (len <= 0) {
+      fatal(jni, "JNI GetArrayLength returned a non-positive value");
+    }
+    jbyte* jni_arr = jni->GetByteArrayElements(arr, nullptr);
+    if (jni_arr == nullptr) {
+      fatal(jni, "JNI GetByteArrayElements returned nullptr");
+    }
+    jvmtiError err = jvmti->Allocate(len, &new_arr);
+    check_jvmti_status(jni, err, "JVMTI Allocate returned an error code");
+
+    memcpy(new_arr, jni_arr, (size_t)len);
+    jni->ReleaseByteArrayElements(arr, jni_arr, JNI_ABORT);
+
+    *len_ptr = len;
+    return new_arr;
+}
 
 /* Commonly used helper functions */
 const char*


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320189](https://bugs.openjdk.org/browse/JDK-8320189) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320189](https://bugs.openjdk.org/browse/JDK-8320189): vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t001 memory corruption when using -Xcheck:jni (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2095/head:pull/2095` \
`$ git checkout pull/2095`

Update a local copy of the PR: \
`$ git checkout pull/2095` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2095`

View PR using the GUI difftool: \
`$ git pr show -t 2095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2095.diff">https://git.openjdk.org/jdk21u-dev/pull/2095.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2095#issuecomment-3189283392)
</details>
