### PR TITLE
8361328: cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java archive timestamps comparison failed

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java
@@ -556,10 +556,10 @@ public class TestAutoCreateSharedArchive extends DynamicArchiveTestBase {
                        .shouldContain(HELLO_WORLD)
                        .shouldContain("Dumping shared data to file:");
              });
-        ft2 = Files.getLastModifiedTime(Paths.get(versionB));
+        ft2 = Files.getLastModifiedTime(Paths.get(versionF));
         fileModified = !ft1.equals(ft2);
         if (!fileModified) {
-            throw new RuntimeException("Shared archive " + versionB + " should be created at exit");
+            throw new RuntimeException("Shared archive " + versionF + " should be created at exit");
         }
 
         // 22 create an archive with dynamic magic number only


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8361328](https://bugs.openjdk.org/browse/JDK-8361328) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361328](https://bugs.openjdk.org/browse/JDK-8361328): cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java archive timestamps comparison failed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2098/head:pull/2098` \
`$ git checkout pull/2098`

Update a local copy of the PR: \
`$ git checkout pull/2098` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2098`

View PR using the GUI difftool: \
`$ git pr show -t 2098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2098.diff">https://git.openjdk.org/jdk21u-dev/pull/2098.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2098#issuecomment-3189328453)
</details>
