### PR TITLE
8353126: Open source events tests batch1

### DIFF
--- a/test/jdk/java/awt/event/MouseEvent/DragToLightweightTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/DragToLightweightTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4417964
+ * @summary tests that drag events continue to arrive to heavyweight
+ *          when the mouse is moved to lightweight while dragging.
+ * @key headful
+ * @library /lib/client /java/awt/regtesthelpers
+ * @build ExtendedRobot Util
+ * @run main DragToLightweightTest
+*/
+
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.HeadlessException;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import test.java.awt.regtesthelpers.Util;
+
+public class DragToLightweightTest {
+
+    private static final CountDownLatch latch = new CountDownLatch(1);
+    private static volatile MouseTest mouseTest;
+
+    public static void main(String[] args) throws Exception {
+
+        EventQueue.invokeAndWait(() -> mouseTest = new MouseTest());
+
+        try {
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (mouseTest != null) {
+                    mouseTest.dispose();
+                }
+            });
+        }
+    }
+
+    private static void test() throws Exception {
+        ExtendedRobot robot = new ExtendedRobot();
+        robot.waitForIdle();
+        robot.delay(500);
+
+        Rectangle componentBounds = mouseTest.getLightweightComponentBounds();
+
+        robot.dragAndDrop(
+                componentBounds.x + componentBounds.width / 2, componentBounds.y + componentBounds.height + 30,
+                componentBounds.x + componentBounds.width / 2, componentBounds.y + 2 * componentBounds.height / 3
+        );
+
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("The test failed: no mouse release event received");
+        }
+
+        System.out.println("Mouse release event received, the test PASSED");
+    }
+
+    private static class MouseTest extends Frame {
+
+        final Foo foo;
+
+        public MouseTest() throws HeadlessException {
+            super("DragToLightweightTest");
+
+            setLayout(new FlowLayout());
+
+            addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseReleased(MouseEvent e) {
+                    System.out.println("mouseReleased");
+                    latch.countDown();
+                }
+            });
+
+            // Create a Component that will be a child of the Frame and add
+            // a MouseListener to it.
+            foo = new Foo();
+            foo.setBackground(Color.red);
+
+            System.out.println(foo.getPreferredSize());
+            foo.setPreferredSize(new Dimension(350, 200));
+            System.out.println(foo.getPreferredSize());
+
+            foo.addMouseListener(new DummyAdapter());
+
+            add(foo);
+
+            setSize(400, 400);
+            setLocationRelativeTo(null);
+            setVisible(true);
+        }
+
+        public Rectangle getLightweightComponentBounds() throws Exception {
+            return Util.invokeOnEDT(() -> {
+                Point locationOnScreen = foo.getLocationOnScreen();
+                Dimension size = foo.getSize();
+                return new Rectangle(locationOnScreen.x, locationOnScreen.y, size.width, size.height);
+            });
+        }
+
+        private static class Foo extends Container {
+            public void paint(Graphics g) {
+                g.setColor(getBackground());
+                g.fillRect(0, 0, getWidth(), getHeight());
+                g.setColor(Color.white);
+                g.drawString(getBounds().toString(), 5, 20);
+                super.paint(g);
+            }
+        }
+
+        private static class DummyAdapter extends MouseAdapter {}
+    }
+}

--- a/test/jdk/java/awt/event/MouseEvent/MouseEnterTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseEnterTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4095172
+ * @summary Test for no proper mouse coordinates on MOUSE_ENTER/MOUSE_EXIT events for Win boxes.
+ * @key headful
+ * @library /lib/client /java/awt/regtesthelpers
+ * @build ExtendedRobot Util
+ * @run main MouseEnterTest
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+
+import test.java.awt.regtesthelpers.Util;
+
+public class MouseEnterTest {
+    private static Frame frame;
+    private static final TestMouseAdapter mouseAdapter = new TestMouseAdapter();
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(MouseEnterTest::initAndShowGUI);
+        try {
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void initAndShowGUI() {
+        frame = new Frame("MouseEnterTest");
+        frame.setLayout(null);
+        frame.setSize(300, 200);
+        frame.setLocationRelativeTo(null);
+        frame.addMouseListener(mouseAdapter);
+        frame.setVisible(true);
+    }
+
+    private static void test() throws Exception {
+        ExtendedRobot robot = new ExtendedRobot();
+        robot.waitForIdle();
+        robot.delay(500);
+
+        Rectangle bounds = Util.invokeOnEDT(frame::getBounds);
+
+        java.util.List<Point> points = getBorderGlidePoints(bounds);
+        for (int i = 0; i < points.size(); i += 2) {
+            Point p1 = points.get(i);
+            Point p2 = points.get(i + 1);
+
+            System.out.println("\n------------------\n");
+
+            System.out.printf("%s > %s > %s\n", p1, p2, p1);
+            robot.glide(p1, p2);
+            robot.waitForIdle();
+            robot.glide(p2, p1);
+            robot.waitForIdle();
+            robot.delay(200);
+            mouseAdapter.testEvents();
+
+            System.out.println("\n------------------\n");
+
+            System.out.printf("%s > %s > %s\n", p2, p1, p2);
+            robot.glide(p2, p1);
+            robot.waitForIdle();
+            robot.glide(p1, p2);
+            robot.waitForIdle();
+            robot.delay(200);
+            mouseAdapter.testEvents();
+        }
+    }
+
+    private static java.util.List<Point> getBorderGlidePoints(Rectangle bounds) {
+        java.util.List<Point> list = new ArrayList<>();
+
+        int d = 10;
+
+        // left
+        list.add(new Point(bounds.x - d, bounds.y + bounds.height / 2));
+        list.add(new Point(bounds.x + d, bounds.y + bounds.height / 2));
+
+        // right
+        list.add(new Point(bounds.x + bounds.width - d, bounds.y + bounds.height / 2));
+        list.add(new Point(bounds.x + bounds.width + d, bounds.y + bounds.height / 2));
+
+        // top
+        list.add(new Point(bounds.x + bounds.width / 2, bounds.y - d));
+        list.add(new Point(bounds.x + bounds.width / 2, bounds.y + d));
+
+        // bottom
+        list.add(new Point(bounds.x + bounds.width / 2, bounds.y + bounds.height - d));
+        list.add(new Point(bounds.x + bounds.width / 2, bounds.y + bounds.height + d));
+
+        return list;
+    }
+
+    private static final class TestMouseAdapter extends MouseAdapter {
+        private static final int THRESHOLD = 5;
+        private volatile MouseEvent lastEnteredEvent = null;
+        private volatile MouseEvent lastExitedEvent = null;
+
+        @Override
+        public void mouseEntered(MouseEvent e) {
+            System.out.println("MouseEntered " + e);
+            lastEnteredEvent = e;
+        }
+
+        @Override
+        public void mouseExited(MouseEvent e) {
+            System.out.println("MouseExited " + e);
+            lastExitedEvent = e;
+        }
+
+        public void testEvents() {
+            if (lastEnteredEvent == null || lastExitedEvent == null) {
+                throw new RuntimeException("Missing lastEnteredEvent or lastExitedEvent");
+            }
+
+            System.out.println("\nTesting:");
+            System.out.println(lastEnteredEvent);
+            System.out.println(lastExitedEvent);
+            System.out.println();
+
+            int diffX = Math.abs(lastEnteredEvent.getX() - lastExitedEvent.getX());
+            int diffScreenX = Math.abs(lastEnteredEvent.getY() - lastExitedEvent.getY());
+            int diffY = Math.abs(lastEnteredEvent.getXOnScreen() - lastExitedEvent.getXOnScreen());
+            int diffScreenY = Math.abs(lastEnteredEvent.getYOnScreen() - lastExitedEvent.getYOnScreen());
+
+            System.out.printf("THRESHOLD %d, diffX %d diffScreenX %d " +
+                            "diffY %d diffScreenY %d\n",
+                    THRESHOLD,
+                    diffX, diffScreenX,
+                    diffY, diffScreenY
+            );
+
+            if (diffX > THRESHOLD
+                || diffScreenX > THRESHOLD
+                || diffY > THRESHOLD
+                || diffScreenY > THRESHOLD) {
+                throw new RuntimeException("Mouse enter vs exit event is too different");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353126: Open source events tests batch1. Adds two event tests - one drag events, and the other testing entering a window events. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8353126](https://bugs.openjdk.org/browse/JDK-8353126) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353126](https://bugs.openjdk.org/browse/JDK-8353126): Open source events tests batch1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2100/head:pull/2100` \
`$ git checkout pull/2100`

Update a local copy of the PR: \
`$ git checkout pull/2100` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2100`

View PR using the GUI difftool: \
`$ git pr show -t 2100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2100.diff">https://git.openjdk.org/jdk21u-dev/pull/2100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2100#issuecomment-3189896508)
</details>
