### PR TITLE
8325397: sun/java2d/Disposer/TestDisposerRace.java fails in linux-aarch64

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -657,6 +657,40 @@ public abstract class AbstractQueuedSynchronizer
     }
 
     /**
+     * Repeatedly invokes acquire, if its execution throws an Error or a Runtime Exception,
+     * using an Unsafe.park-based backoff
+     * @param node which to reacquire
+     * @param arg the acquire argument
+     */
+    private final void reacquire(Node node, int arg) {
+        try {
+            acquire(node, arg, false, false, false, 0L);
+        } catch (Error | RuntimeException firstEx) {
+            // While we currently do not emit an JFR events in this situation, mainly
+            // because the conditions under which this happens are such that it
+            // cannot be presumed to be possible to actually allocate an event, and
+            // using a preconstructed one would have limited value in serviceability.
+            // Having said that, the following place would be the more appropriate
+            // place to put such logic:
+            //     emit JFR event
+
+            for (long nanos = 1L;;) {
+                U.park(false, nanos); // must use Unsafe park to sleep
+                if (nanos < 1L << 30)            // max about 1 second
+                    nanos <<= 1;
+
+                try {
+                    acquire(node, arg, false, false, false, 0L);
+                } catch (Error | RuntimeException ignored) {
+                    continue;
+                }
+
+                throw firstEx;
+            }
+        }
+    }
+
+    /**
      * Main acquire method, invoked by all exported acquire methods.
      *
      * @param node null unless a reacquiring Condition
@@ -1673,7 +1707,7 @@ public abstract class AbstractQueuedSynchronizer
             }
             LockSupport.setCurrentBlocker(null);
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (interrupted)
                 Thread.currentThread().interrupt();
         }
@@ -1720,7 +1754,7 @@ public abstract class AbstractQueuedSynchronizer
             }
             LockSupport.setCurrentBlocker(null);
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (interrupted) {
                 if (cancelled) {
                     unlinkCancelledWaiters(node);
@@ -1763,7 +1797,7 @@ public abstract class AbstractQueuedSynchronizer
                     LockSupport.parkNanos(this, nanos);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)
@@ -1807,7 +1841,7 @@ public abstract class AbstractQueuedSynchronizer
                     LockSupport.parkUntil(this, abstime);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)
@@ -1852,7 +1886,7 @@ public abstract class AbstractQueuedSynchronizer
                     LockSupport.parkNanos(this, nanos);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)

--- a/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
+++ b/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
@@ -23,6 +23,7 @@
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import javax.swing.SwingUtilities;
 
 import sun.java2d.Disposer;
@@ -39,14 +40,21 @@ public final class TestDisposerRace {
     private static final AtomicInteger recordsCount = new AtomicInteger();
     private static volatile boolean disposerDone = false;
 
+    private static final String KO_OVERFLOW = "Some records have not been disposed!";
+    private static final String KO_UNDERFLOW = "Disposed more records than were added!";
+
     public static void main(String[] args) throws Exception {
-        TestDisposerRace test = new TestDisposerRace();
-        test.run();
+        new TestDisposerRace().run();
 
         checkRecordsCountIsSane();
         if (recordsCount.get() > 0) {
+            System.err.println(KO_OVERFLOW); // In case the next line fails to allocate due to OOME
             throw new RuntimeException("Some records (" + recordsCount + ") have not been disposed");
         }
+    }
+
+    interface ThrowingRunnable<E extends Exception> {
+        void run() throws E;
     }
 
     TestDisposerRace() {
@@ -56,14 +64,14 @@ public final class TestDisposerRace {
     void run() throws Exception {
         generateOOME();
         for (int i = 0; i < 1000; ++i) {
-            SwingUtilities.invokeAndWait(Disposer::pollRemove);
-            if (i % 10 == 0) {
-                // Adding records will race with the diposer trying to remove them
+            retryOnOOME(() -> SwingUtilities.invokeAndWait(Disposer::pollRemove));
+
+            // Adding records will race with the diposer trying to remove them
+            if (i % 10 == 0)
                 addRecordsToDisposer(1000);
-            }
         }
 
-        Disposer.addObjectRecord(new Object(), new FinalDisposerRecord());
+        retryOnOOME(() -> Disposer.addObjectRecord(new Object(), new FinalDisposerRecord()));
 
         while (!disposerDone) {
              generateOOME();
@@ -72,18 +80,45 @@ public final class TestDisposerRace {
 
     private static void checkRecordsCountIsSane() {
         if (recordsCount.get() < 0) {
-            throw new RuntimeException("Disposed more records than were added");
+            throw new RuntimeException(KO_UNDERFLOW);
+        }
+    }
+
+    private static <T> T retryOnOOME(Supplier<T> allocator) {
+        for(;;) {
+            try {
+                return allocator.get();
+            } catch (OutOfMemoryError ignored1) {
+                try {
+                    Thread.sleep(1); // Give GC a little chance to run
+                } catch (InterruptedException ignored2) {}
+            }
+        }
+    }
+
+    private static <E extends Exception> void retryOnOOME(ThrowingRunnable<E> tr) throws E {
+        for(;;) {
+            try {
+                tr.run();
+                break;
+            } catch (OutOfMemoryError ignored1) {
+                try {
+                    Thread.sleep(1); // Give GC a little chance to run
+                } catch (InterruptedException ignored2) {}
+            }
         }
     }
 
     private void addRecordsToDisposer(int count) {
         checkRecordsCountIsSane();
 
-        recordsCount.addAndGet(count);
+        MyDisposerRecord disposerRecord = retryOnOOME(MyDisposerRecord::new);
 
-        MyDisposerRecord disposerRecord = new MyDisposerRecord();
-        for (int i = 0; i < count; i++) {
-            Disposer.addObjectRecord(new Object(), disposerRecord);
+        while(count > 0) {
+            recordsCount.incrementAndGet(); // pre-add to make sure it doesn't go negative
+            var o = retryOnOOME(Object::new);
+            retryOnOOME(() -> Disposer.addObjectRecord(o, disposerRecord));
+            --count;
         }
     }
 
@@ -106,8 +141,8 @@ public final class TestDisposerRace {
     }
 
     private static void generateOOME() throws Exception {
-        final List<Object> leak = new LinkedList<>();
         try {
+            final List<Object> leak = new LinkedList<>();
             while (true) {
                 leak.add(new byte[1024 * 1024]);
             }


### PR DESCRIPTION
I would like to backport this as we see this failing in our CI regularly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8325397](https://bugs.openjdk.org/browse/JDK-8325397) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325397](https://bugs.openjdk.org/browse/JDK-8325397): sun/java2d/Disposer/TestDisposerRace.java fails in linux-aarch64 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2103/head:pull/2103` \
`$ git checkout pull/2103`

Update a local copy of the PR: \
`$ git checkout pull/2103` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2103`

View PR using the GUI difftool: \
`$ git pr show -t 2103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2103.diff">https://git.openjdk.org/jdk21u-dev/pull/2103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2103#issuecomment-3190990586)
</details>
