### PR TITLE
8365811: test/jdk/java/net/CookieHandler/B6644726.java failure - "Should have 5 cookies. Got only 4, expires probably didn't parse correctly"

### DIFF
--- a/test/jdk/java/net/CookieHandler/B6644726.java
+++ b/test/jdk/java/net/CookieHandler/B6644726.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,8 @@ public class B6644726 {
         // Let's test the default path
         lst.add("myCookie1=foo");
         // Then some alternate expires format
-        lst.add("myCookie2=bar; path=/dir; expires=Tue, 19 Aug 2025 16:00:00 GMT");
-        lst.add("myCookie3=test; path=/dir; expires=Tue Aug 19 2025 16:00:00 GMT-0100");
+        lst.add("myCookie2=bar; path=/dir; expires=Fri, 19 Aug 4242 16:00:00 GMT");
+        lst.add("myCookie3=test; path=/dir; expires=Fri Aug 19 4242 16:00:00 GMT-0100");
         // Then Netscape draft cookies and domains
         lst.add("myCookie4=test; domain=.sun.com; path=/dir/foo");
         HashMap<String, List<String>> map = new HashMap<String, List<String>>();
@@ -64,7 +64,8 @@ public class B6644726 {
         List<HttpCookie> cookies = cs.getCookies();
         // There should be 5 cookies if all dates parsed correctly
         if (cookies.size() != 5) {
-            fail("Should have 5 cookies. Got only "+ cookies.size() + ", expires probably didn't parse correctly");
+            fail("unexpected cookies: " + cookies + ", should have 5 cookies. Got only "
+                    + cookies.size() + ", expires probably didn't parse correctly");
         }
         // Check Path for first Cookie
         for (HttpCookie c : cookies) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b453eb63](https://github.com/openjdk/jdk/commit/b453eb63c641e1e69b4aef57a220ebe45b9d1693) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jaikiran Pai on 20 Aug 2025 and was reviewed by SendaoYan and Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365811](https://bugs.openjdk.org/browse/JDK-8365811) needs maintainer approval

### Issue
 * [JDK-8365811](https://bugs.openjdk.org/browse/JDK-8365811): test/jdk/java/net/CookieHandler/B6644726.java failure - "Should have 5 cookies. Got only 4, expires probably didn't parse correctly" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2107/head:pull/2107` \
`$ git checkout pull/2107`

Update a local copy of the PR: \
`$ git checkout pull/2107` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2107`

View PR using the GUI difftool: \
`$ git pr show -t 2107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2107.diff">https://git.openjdk.org/jdk21u-dev/pull/2107.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2107#issuecomment-3204387724)
</details>
