### PR TITLE
8353213: Open source several swing tests batch3

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicInternalFrameTitlePane/bug4331515.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicInternalFrameTitlePane/bug4331515.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4331515
+ * @requires (os.family == "windows")
+ * @summary System menu of an internal frame shouldn't have duplicated items in Win L&F
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4331515
+ */
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.UIManager;
+
+public class bug4331515 {
+    static final String INSTRUCTIONS = """
+        Open the system menu of internal frame "JIF" placed in the frame "Test".
+        If this menu contains duplicates of some items then test FAILS, else
+        test PASSES.
+    """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        PassFailJFrame.builder()
+                .title("bug4331515 Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug4331515::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        JFrame fr = new JFrame("System Menu in JIF Test");
+        JDesktopPane dp = new JDesktopPane();
+        fr.setContentPane(dp);
+        JInternalFrame jif = new JInternalFrame("JIF", true, true, true, true);
+        dp.add(jif);
+        jif.setBounds(20, 20, 120, 100);
+        jif.setVisible(true);
+        fr.setSize(200, 200);
+        return fr;
+    }
+}

--- a/test/jdk/javax/swing/plaf/basic/BasicSplitPaneDivider/AddMouseListenerTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicSplitPaneDivider/AddMouseListenerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4165874
+ * @summary Adds a MouseListener to the splitpane divider.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AddMouseListenerTest
+ */
+
+import java.awt.Component;
+import java.awt.event.MouseAdapter;
+
+import javax.swing.JFrame;
+import javax.swing.JSplitPane;
+
+public class AddMouseListenerTest {
+    static final String INSTRUCTIONS = """
+        Try dragging the split pane divider, if you can, click PASS,
+        else click FAIL.
+    """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("AddMouseListenerTest Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(AddMouseListenerTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        JFrame f = new JFrame("JSplitPane With ActionListener Test");
+        JSplitPane sp = new JSplitPane();
+
+        sp.setContinuousLayout(true);
+        Component[] children = sp.getComponents();
+        for (int counter = children.length - 1; counter >= 0; counter--) {
+            children[counter].addMouseListener(new MouseAdapter() {});
+        }
+        f.getContentPane().add(sp);
+        f.setSize(400, 400);
+        return f;
+    }
+}

--- a/test/jdk/javax/swing/plaf/basic/BasicToolBarUI/bug4305622.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicToolBarUI/bug4305622.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4305622
+ * @summary MetalToolBarUI.installUI invokeLater causes flickering
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4305622
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JToolBar;
+import javax.swing.UIManager;
+import javax.swing.border.LineBorder;
+
+
+public class bug4305622 {
+    private static JFrame fr;
+    static final String INSTRUCTIONS = """
+        Press button "Create ToolBar" at frame "Create ToolBar Test".
+        If you see any flickering during creating of toolbar
+        then the test FAILS, otherwise the test PASSES.
+    """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        PassFailJFrame.builder()
+                .title("bug4305622 Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug4305622::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        fr = new JFrame("Create ToolBar Test");
+        JButton button = new JButton("Create ToolBar");
+        button.addActionListener(ae -> addToolBar());
+        fr.add(button, BorderLayout.SOUTH);
+        fr.setSize(400, 400);
+        return fr;
+    }
+
+    static void addToolBar() {
+        fr.repaint();
+        fr.revalidate();
+        JToolBar toolbar = new JToolBar();
+
+        JButton btn = new JButton("Button 1");
+        btn.setBorder(new LineBorder(Color.red, 30));
+        toolbar.add(btn);
+
+        btn = new JButton("Button 2");
+        btn.setBorder(new LineBorder(Color.red, 30));
+        toolbar.add(btn);
+
+        toolbar.updateUI();
+        fr.add(toolbar, BorderLayout.NORTH);
+    }
+}

--- a/test/jdk/javax/swing/plaf/basic/BasicToolBarUI/bug4331392.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicToolBarUI/bug4331392.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4331392
+ * @summary Tests if BasicToolBarUI has bogus logic that prevents vertical
+ *          toolbars from docking
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4331392
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Container;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JToolBar;
+
+public class bug4331392 {
+   static final String INSTRUCTIONS = """
+        Try to dock the toolbar across all the edges of frame. If you succeed,
+        then the test PASSES. Otherwise, it FAILS.
+    """;
+
+   public static void main(String[] args) throws Exception {
+      PassFailJFrame.builder()
+              .title("bug4331392 Test Instructions")
+              .instructions(INSTRUCTIONS)
+              .columns(40)
+              .testUI(bug4331392::createUI)
+              .build()
+              .awaitAndCheck();
+   }
+
+   static JFrame createUI() {
+      JFrame frame = new JFrame("JToolBar Docking Test");
+      Container c = frame.getContentPane();
+
+      JToolBar tbar = new JToolBar(JToolBar.VERTICAL);
+
+      tbar.add(new JButton("A"));
+      tbar.add(new JButton("B"));
+      tbar.add(new JButton("C"));
+
+      JButton b = new JButton("Hello");
+      c.add(b, BorderLayout.CENTER);
+      c.add(tbar, BorderLayout.EAST);
+      frame.setSize(300, 300);
+      return frame;
+   }
+}


### PR DESCRIPTION
Backporting JDK-8353213: Open source several swing tests batch3. Adds four swing tests to detect regressions. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353213](https://bugs.openjdk.org/browse/JDK-8353213) needs maintainer approval

### Issue
 * [JDK-8353213](https://bugs.openjdk.org/browse/JDK-8353213): Open source several swing tests batch3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2111/head:pull/2111` \
`$ git checkout pull/2111`

Update a local copy of the PR: \
`$ git checkout pull/2111` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2111`

View PR using the GUI difftool: \
`$ git pr show -t 2111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2111.diff">https://git.openjdk.org/jdk21u-dev/pull/2111.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2111#issuecomment-3208118968)
</details>
