### PR TITLE
Backport 58e7581527208dfd6dd694793e4790dcad8fc3ef

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/JfrEvents.java
+++ b/test/jdk/java/lang/Thread/virtual/JfrEvents.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import jdk.jfr.EventType;
@@ -72,12 +73,13 @@ class JfrEvents {
 
             // execute 100 tasks, each in their own virtual thread
             recording.start();
-            ThreadFactory factory = Thread.ofVirtual().factory();
-            try (var executor = Executors.newThreadPerTaskExecutor(factory)) {
-                for (int i = 0; i < 100; i++) {
-                    executor.submit(() -> { });
+            try {
+                List<Thread> threads = IntStream.range(0, 100)
+                        .mapToObj(_ -> Thread.startVirtualThread(() -> { }))
+                        .toList();
+                for (Thread t : threads) {
+                    t.join();
                 }
-                Thread.sleep(1000); // give time for thread end events to be recorded
             } finally {
                 recording.stop();
             }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [58e75815](https://github.com/openjdk/jdk/commit/58e7581527208dfd6dd694793e4790dcad8fc3ef) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alan Bateman on 24 Aug 2025 and was reviewed by Jaikiran Pai.

Thanks!