### PR TITLE
8356324: JVM crash (SIGSEGV at ClassListParser::resolve_indy_impl) during -Xshare:dump starting from 21.0.5

### DIFF
--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -444,7 +444,14 @@ class ConstantPoolCache: public MetaspaceObj {
 
   Array<ResolvedIndyEntry>* resolved_indy_entries()          { return _resolved_indy_entries; }
   ResolvedIndyEntry* resolved_indy_entry_at(int index) const { return _resolved_indy_entries->adr_at(index); }
-  int resolved_indy_entries_length()                   const { return _resolved_indy_entries->length();      }
+
+  int resolved_indy_entries_length() const {
+    if (_resolved_indy_entries == nullptr) {
+      return 0;
+    }
+    return _resolved_indy_entries->length();
+  }
+
   void print_resolved_indy_entries(outputStream* st)   const {
     for (int i = 0; i < _resolved_indy_entries->length(); i++) {
         _resolved_indy_entries->at(i).print_on(st);


### PR DESCRIPTION
Avoids the JVM crash in a corner case. The patch is very recent, but it is borderline trivial, and we have seen customer crashes in the wild (see original issue). Without the patch, the alternative on this code path is a JVM crash.

Unfortunately, this 21u version is not clean. 21u is missing [JDK-8309878](https://bugs.openjdk.org/browse/JDK-8309878), so I had to re-apply the fix to the older place.

Additional testing:
 - [x] Linux AArch64 server fastdebug, original reproducer no longer fails
 - [x] Linux AArch64 server fastdebug, `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8356324](https://bugs.openjdk.org/browse/JDK-8356324) needs maintainer approval

### Issue
 * [JDK-8356324](https://bugs.openjdk.org/browse/JDK-8356324): JVM crash (SIGSEGV at ClassListParser::resolve_indy_impl) during -Xshare:dump starting from 21.0.5 (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2123/head:pull/2123` \
`$ git checkout pull/2123`

Update a local copy of the PR: \
`$ git checkout pull/2123` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2123`

View PR using the GUI difftool: \
`$ git pr show -t 2123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2123.diff">https://git.openjdk.org/jdk21u-dev/pull/2123.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2123#issuecomment-3219651282)
</details>
