### PR TITLE
8199149: Improve the exception message thrown by VarHandle of unsupported operation

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -101,7 +101,7 @@ import java.util.function.BiFunction;
     @Override
     MethodHandle getMethodHandleUncached(int mode) {
         MethodHandle targetHandle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
-        return handleFactory.apply(AccessMode.values()[mode], targetHandle);
+        return handleFactory.apply(AccessMode.valueFromOrdinal(mode), targetHandle);
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/invoke/VarForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarForm.java
@@ -26,6 +26,7 @@ package java.lang.invoke;
 
 import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.Hidden;
 import jdk.internal.vm.annotation.Stable;
 
 import java.lang.invoke.VarHandle.AccessMode;
@@ -108,6 +109,7 @@ final class VarForm {
     }
 
     @ForceInline
+    @Hidden
     final MemberName getMemberName(int mode) {
         // Can be simplified by calling getMemberNameOrNull, but written in this
         // form to improve interpreter/coldpath performance.
@@ -115,7 +117,7 @@ final class VarForm {
         if (mn == null) {
             mn = resolveMemberName(mode);
             if (mn == null) {
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException(AccessMode.valueFromOrdinal(mode).methodName());
             }
         }
         return mn;
@@ -132,7 +134,7 @@ final class VarForm {
 
     @DontInline
     MemberName resolveMemberName(int mode) {
-        AccessMode value = AccessMode.values()[mode];
+        AccessMode value = AccessMode.valueFromOrdinal(mode);
         String methodName = value.methodName();
         MethodType type = methodType_table[value.at.ordinal()].insertParameterTypes(0, VarHandle.class);
         return memberName_table[mode] = MethodHandles.Lookup.IMPL_LOOKUP

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1989,6 +1989,11 @@ public abstract sealed class VarHandle implements Constable
                 default -> throw new IllegalArgumentException("No AccessMode value for method name " + methodName);
             };
         }
+
+        private static final @Stable AccessMode[] VALUES = values();
+        static AccessMode valueFromOrdinal(int mode) {
+            return VALUES[mode];
+        }
     }
 
     static final class AccessDescriptor {
@@ -2187,7 +2192,7 @@ public abstract sealed class VarHandle implements Constable
     }
 
     MethodHandle getMethodHandleUncached(int mode) {
-        MethodType mt = accessModeType(AccessMode.values()[mode]).
+        MethodType mt = accessModeType(AccessMode.valueFromOrdinal(mode)).
                 insertParameterTypes(0, VarHandle.class);
         MemberName mn = vform.getMemberName(mode);
         DirectMethodHandle dmh = DirectMethodHandle.make(mn);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A clean backport.

The current UnsupportedOperationException message isn't clear on what method isn't unsupported, as described at [here](https://mail.openjdk.org/pipermail/core-libs-dev/2020-December/072500.html). This change adds the unsupported method name in the exception message.

Low risk. On tip for 2 years.

Tested using the example provided [here](https://mail.openjdk.org/pipermail/core-libs-dev/2020-December/072500.html). Can see the unsupported method name in the exception message. Output:

```
x64 (8318072) % ./build/linux-x86_64-server-release/jdk/bin/java ThereIsABugButWhere.java
Exception in thread "main" java.lang.UnsupportedOperationException: compareAndSet
	at ThereIsABugButWhere.update(ThereIsABugButWhere.java:22)
	at ThereIsABugButWhere.main(ThereIsABugButWhere.java:26)
```

Jtreg tests are running.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8199149](https://bugs.openjdk.org/browse/JDK-8199149) needs maintainer approval

### Issue
 * [JDK-8199149](https://bugs.openjdk.org/browse/JDK-8199149): Improve the exception message thrown by VarHandle of unsupported operation (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2130/head:pull/2130` \
`$ git checkout pull/2130`

Update a local copy of the PR: \
`$ git checkout pull/2130` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2130`

View PR using the GUI difftool: \
`$ git pr show -t 2130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2130.diff">https://git.openjdk.org/jdk21u-dev/pull/2130.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2130#issuecomment-3234705481)
</details>
