### PR TITLE
Backport c8acab1d913a6c676706fce7ad98a7f831a95682

### DIFF
--- a/src/java.base/share/classes/java/lang/StackStreamFactory.java
+++ b/src/java.base/share/classes/java/lang/StackStreamFactory.java
@@ -543,12 +543,6 @@ final class StackStreamFactory {
             final Class<?> at(int index) {
                 return stackFrames[index].declaringClass();
             }
-
-            @Override
-            final boolean filter(int index) {
-                return stackFrames[index].declaringClass() == Continuation.class
-                        && "yield0".equals(stackFrames[index].getMethodName());
-            }
         }
 
         final Function<? super Stream<StackFrame>, ? extends T> function;  // callback
@@ -685,10 +679,6 @@ final class StackStreamFactory {
             @Override
             final Class<?> at(int index) { return classes[index];}
 
-            @Override
-            final boolean filter(int index) { return false; }
-
-
             // ------ subclass may override the following methods -------
             /**
              * Resizes the buffers for VM to fill in the next batch of stack frames.
@@ -820,12 +810,6 @@ final class StackStreamFactory {
             final Class<?> at(int index) {
                 return stackFrames[index].declaringClass();
             }
-
-            @Override
-            final boolean filter(int index) {
-                return stackFrames[index].declaringClass() == Continuation.class
-                        && "yield0".equals(stackFrames[index].getMethodName());
-            }
         }
 
         LiveStackInfoTraverser(StackWalker walker,
@@ -894,13 +878,6 @@ final class StackStreamFactory {
          * @return the class at the given position in the current batch.
          */
         abstract Class<?> at(int index);
-
-        /**
-         * Filter out frames at the top of a batch
-         * @param index the position of the frame.
-         * @return true if the frame should be skipped
-         */
-        abstract boolean filter(int index);
 
         // ------ subclass may override the following methods -------
 
@@ -1007,8 +984,7 @@ final class StackStreamFactory {
             this.fence = endIndex;
             for (int i = START_POS; i < fence; i++) {
                 if (isDebug) System.err.format("  frame %d: %s%n", i, at(i));
-                if ((depth == 0 && filterStackWalkImpl(at(i))) // filter the frames due to the stack stream implementation
-                        || filter(i)) {
+                if (depth == 0 && filterStackWalkImpl(at(i))) { // filter the frames due to the stack stream implementation
                     origin++;
                 } else {
                     break;

--- a/test/jdk/jdk/internal/vm/Continuation/Basic.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Basic.java
@@ -92,7 +92,7 @@ public class Basic {
             assertEquals(cont.isPreempted(), false);
 
             List<String> frames = cont.stackWalker().walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
-            assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "bar", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+            assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "bar", "foo", "lambda$test1$0", "run", "enter0", "enter"));
         }
         assertEquals(res.get(), 247);
         assertEquals(cont.isPreempted(), false);

--- a/test/jdk/jdk/internal/vm/Continuation/BasicExt.java
+++ b/test/jdk/jdk/internal/vm/Continuation/BasicExt.java
@@ -798,7 +798,7 @@ public class BasicExt {
                 cont.stackWalker()
                 .walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
             assertEquals(frames, cont.isDone() ? List.of()
-                         : Arrays.asList("yield", "ord104_testMethod_dontinline",
+                         : Arrays.asList("yield0", "yield", "ord104_testMethod_dontinline",
                                          "ord103_testMethod_dontinline",
                                          "ord102_testMethod_dontinline",
                                          "ord101_testMethod_dontinline",

--- a/test/jdk/jdk/internal/vm/Continuation/Scoped.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Scoped.java
@@ -74,27 +74,27 @@ public class Scoped {
 
                         frames = cont.stackWalker().walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("No scope: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "yield0", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), A).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("A: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "yield0", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), B).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("B: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), C).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("C: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), K).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("K: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "yield0", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), null).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("null: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "yield0", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
                 }
                 assertEquals(res.get(), 2);
         }


### PR DESCRIPTION
A clean backport of https://bugs.openjdk.org/browse/JDK-8315413.

Those special filtering is no longer needed because to be filtered methods are already marked by `@Hidden`.

Tests in this pr passed. Other jtregs are running.