### PR TITLE
8351487: [ubsan] jvmti.h runtime error: load of value which is not a valid value

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,9 @@
  *         JVMTI_ERROR_NULL_POINTER        if name_ptr is NULL.
  * COMMENTS
  *
+ * @comment We test with arguments out of scope of the jvmti enums, which causes
+ *          ubsan issues.
+ * @requires !vm.ubsan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,9 @@
  *     if flag is not a jvmtiVerboseFlag.
  * COMMENTS
  *
+ * @comment We test with arguments out of scope of the jvmti enums, which causes
+ *          ubsan issues.
+ * @requires !vm.ubsan
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm/native


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351487](https://bugs.openjdk.org/browse/JDK-8351487) needs maintainer approval

### Issue
 * [JDK-8351487](https://bugs.openjdk.org/browse/JDK-8351487): [ubsan] jvmti.h runtime error: load of value which is not a valid value (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2133/head:pull/2133` \
`$ git checkout pull/2133`

Update a local copy of the PR: \
`$ git checkout pull/2133` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2133`

View PR using the GUI difftool: \
`$ git pr show -t 2133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2133.diff">https://git.openjdk.org/jdk21u-dev/pull/2133.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2133#issuecomment-3236674376)
</details>
