### PR TITLE
8353589: Open source a few Swing menu-related tests

### DIFF
--- a/test/jdk/javax/swing/JPopupMenu/bug4119993.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4119993.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4119993
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Check that mouse button 3 is reserved for popup invocation not selection.
+ * @run main/manual bug4119993
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.border.BevelBorder;
+
+/*
+ * This is a sort of negative test. Mouse Button 3 is not supposed to cause selections.
+ * If it did, then it would not be useable to invoke popup menus.
+ * So this popup menu test .. does not popup menus.
+ */
+
+public class bug4119993 {
+
+    static final String INSTRUCTIONS = """
+<html>
+        The test window contains a text area, a table, and a list.
+        <p>
+        For each component, try to select text/cells/rows/items as appropriate
+        using the <font size=+2 color=red>RIGHT</font> mouse button (Mouse Button 3).
+        <p>
+        If the selection changes, then press <em><b>FAIL</b></em>.
+        <p>
+        If the selection does not change, press <em><b>PASS</b></em></html
+ </html>
+    """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .testUI(bug4119993::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        JFrame frame = new JFrame("bug4119993");
+        JPanel p = new JPanel();
+        p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
+        frame.add(p);
+
+        String text = "This is some text that you should try to select using the right mouse button";
+        JTextArea area = new JTextArea(text, 5, 40);
+        JScrollPane scrollpane0 = new JScrollPane(area);
+        scrollpane0.setBorder(new BevelBorder(BevelBorder.LOWERED));
+        scrollpane0.setPreferredSize(new Dimension(430, 200));
+        p.add(scrollpane0);
+
+        String[][] data = new String[5][5];
+        String[] cols = new String[5];
+        for (int r = 0; r < 5; r ++) {
+            cols[r] = "col " + r;
+            for (int c = 0; c < 5; c ++) {
+               data[r][c] = "(" + r + "," + c + ")";
+            }
+        }
+
+        JTable tableView = new JTable(data, cols);
+        JScrollPane scrollpane = new JScrollPane(tableView);
+        scrollpane.setBorder(new BevelBorder(BevelBorder.LOWERED));
+        scrollpane.setPreferredSize(new Dimension(430, 200));
+        p.add(scrollpane);
+
+        String[] s = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
+        JList listView = new JList(s);
+        JScrollPane scrollpane2 = new JScrollPane(listView);
+        scrollpane2.setBorder(new BevelBorder(BevelBorder.LOWERED));
+        scrollpane2.setPreferredSize(new Dimension(430, 200));
+        p.add(scrollpane2);
+
+       frame.pack();
+       return frame;
+    }
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug4187004.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4187004.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4187004
+   @summary test that title/label is show on menu for Motif L&F
+   @key headful
+*/
+
+import java.awt.Dimension;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug4187004 {
+
+    static volatile JPopupMenu m;
+    static volatile Dimension d1, d2;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(bug4187004::createUI);
+
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+            d1 = m.getSize();
+            SwingUtilities.invokeAndWait(bug4187004::hideMenu);
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(bug4187004::updateUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(bug4187004::showMenu);
+            robot.waitForIdle();
+            robot.delay(1000);
+            d2 = m.getSize();
+        } finally {
+            SwingUtilities.invokeAndWait(bug4187004::hideMenu);
+        }
+        System.out.println(d1);
+        System.out.println(d2);
+        if (d1.width <= d2.width) {
+            throw new RuntimeException("Menu not updated");
+        }
+    }
+
+   static void createUI() {
+        try {
+            UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        m = new JPopupMenu("One really long menu title");
+        m.add("Item 1");
+        m.add("Item 2");
+        m.add("Item 3");
+        m.add("Item 4");
+        m.pack();
+        m.setVisible(true);
+    }
+
+    static void hideMenu() {
+        m.setVisible(false);
+    }
+
+    static void showMenu() {
+        m.setVisible(true);
+    }
+
+    static void updateUI() {
+        m.setLabel("short");
+        m.pack();
+    }
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug4530303.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4530303.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4530303
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests JPopupMenu.pack()
+ * @run main/manual bug4530303
+ */
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+
+public class bug4530303 {
+
+    static final String INSTRUCTIONS = """
+        The test window has a menu bar.
+        Open the menu "Menu" and place the mouse pointer over the first menu item, "Point here".
+        The second menu item, "Ghost", should be replaced with another item, "Fixed!".
+        If the item just disappears and no new item appears in the empty space, the test FAILS.
+    """;
+
+    static volatile JMenu menu;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .testUI(bug4530303::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        JFrame frame = new JFrame("bug4530303");
+        menu = new JMenu("Menu");
+        JMenuItem item = new JMenuItem("Point here");
+        item.addMouseListener(new MenuBuilder());
+        menu.add(item);
+        menu.add(new JMenuItem("Ghost"));
+
+        JMenuBar mbar = new JMenuBar();
+        mbar.add(menu);
+        frame.setJMenuBar(mbar);
+        frame.setSize(300, 300);
+        return frame;
+    }
+
+    static class MenuBuilder extends MouseAdapter {
+        public void mouseEntered(MouseEvent ev) {
+            menu.remove(1);
+            menu.add(new JMenuItem("Fixed!"));
+
+            JPopupMenu pm = menu.getPopupMenu();
+            pm.pack();
+            pm.paintImmediately(pm.getBounds());
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353589: Open source a few Swing menu-related tests. Adds three menu related tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353589](https://bugs.openjdk.org/browse/JDK-8353589) needs maintainer approval

### Issue
 * [JDK-8353589](https://bugs.openjdk.org/browse/JDK-8353589): Open source a few Swing menu-related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2143/head:pull/2143` \
`$ git checkout pull/2143`

Update a local copy of the PR: \
`$ git checkout pull/2143` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2143`

View PR using the GUI difftool: \
`$ git pr show -t 2143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2143.diff">https://git.openjdk.org/jdk21u-dev/pull/2143.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2143#issuecomment-3247490969)
</details>
