### PR TITLE
8332586: Avoid cloning empty arrays in java.lang.reflect.{Method,Constructor}

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -266,7 +266,7 @@ public final class Constructor<T> extends Executable {
      */
     @Override
     public Class<?>[] getParameterTypes() {
-        return parameterTypes.clone();
+        return parameterTypes.length == 0 ? parameterTypes : parameterTypes.clone();
     }
 
     /**
@@ -292,9 +292,8 @@ public final class Constructor<T> extends Executable {
      */
     @Override
     public Class<?>[] getExceptionTypes() {
-        return exceptionTypes.clone();
+        return exceptionTypes.length == 0 ? exceptionTypes : exceptionTypes.clone();
     }
-
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -315,7 +315,7 @@ public final class Method extends Executable {
      */
     @Override
     public Class<?>[] getParameterTypes() {
-        return parameterTypes.clone();
+        return parameterTypes.length == 0 ? parameterTypes: parameterTypes.clone();
     }
 
     /**
@@ -342,7 +342,7 @@ public final class Method extends Executable {
      */
     @Override
     public Class<?>[] getExceptionTypes() {
-        return exceptionTypes.clone();
+        return exceptionTypes.length == 0 ? exceptionTypes : exceptionTypes.clone();
     }
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/reflect/ConstructorBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/ConstructorBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.reflect;
+
+import java.lang.reflect.Constructor;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark measuring the speed of Method/Constructor.getExceptionTypes() and
+ * getParameterTypes(), in cases where the result array is length zero.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+public class ConstructorBenchmark {
+    Constructor<?> emptyExceptionsConstructor;
+    Constructor<?> emptyParametersConstructor;
+    Constructor<?> oneExceptionConstructor;
+    Constructor<?> oneParameterConstructor;
+
+    public ConstructorBenchmark() {
+        try {
+            emptyParametersConstructor = Object.class.getConstructor();
+            oneParameterConstructor = String.class.getConstructor(String.class);
+
+            emptyExceptionsConstructor = emptyParametersConstructor;
+            oneExceptionConstructor = String.class.getConstructor(byte[].class, String.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Benchmark
+    public Object[] getExceptionTypes() throws Exception {
+        return oneExceptionConstructor.getExceptionTypes();
+    }
+
+    @Benchmark
+    public Object[] getExceptionTypesEmpty() throws Exception {
+        return emptyExceptionsConstructor.getExceptionTypes();
+    }
+
+    @Benchmark
+    public Object[] getParameterTypes() throws Exception {
+        return oneParameterConstructor.getParameterTypes();
+    }
+
+    @Benchmark
+    public Object[] getParameterTypesEmpty() throws Exception {
+        return emptyParametersConstructor.getParameterTypes();
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/reflect/MethodBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/MethodBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.reflect;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark measuring the speed of Method/Method.getExceptionTypes() and
+ * getParameterTypes(), in cases where the result array is length zero.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+public class MethodBenchmark {
+    Method emptyExceptionsMethod;
+    Method emptyParametersMethod;
+    Method oneExceptionMethod;
+    Method oneParameterMethod;
+
+    public MethodBenchmark() {
+        try {
+            emptyParametersMethod = Object.class.getDeclaredMethod("hashCode");
+            oneParameterMethod = String.class.getDeclaredMethod("getBytes", String.class);
+
+            emptyExceptionsMethod = emptyParametersMethod;
+            oneExceptionMethod = oneParameterMethod;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Benchmark
+    public Object[] getExceptionTypes() throws Exception {
+        return oneExceptionMethod.getExceptionTypes();
+    }
+
+    @Benchmark
+    public Object[] getExceptionTypesEmpty() throws Exception {
+        return emptyExceptionsMethod.getExceptionTypes();
+    }
+
+    @Benchmark
+    public Object[] getParameterTypes() throws Exception {
+        return oneParameterMethod.getParameterTypes();
+    }
+
+    @Benchmark
+    public Object[] getParameterTypesEmpty() throws Exception {
+        return emptyParametersMethod.getParameterTypes();
+    }
+}


### PR DESCRIPTION
A clean backport of https://bugs.openjdk.org/browse/JDK-8332586. 

A perf improvement: when members are empty arrays, return them as it is (empty arrays are non modifiable) rather than clone an new empty array. 

Logic is straightforward. Low risk. On tip for over a year.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8332586](https://bugs.openjdk.org/browse/JDK-8332586) needs maintainer approval

### Issue
 * [JDK-8332586](https://bugs.openjdk.org/browse/JDK-8332586): Avoid cloning empty arrays in java.lang.reflect.{Method,Constructor} (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2145/head:pull/2145` \
`$ git checkout pull/2145`

Update a local copy of the PR: \
`$ git checkout pull/2145` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2145`

View PR using the GUI difftool: \
`$ git pr show -t 2145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2145.diff">https://git.openjdk.org/jdk21u-dev/pull/2145.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2145#issuecomment-3247562361)
</details>
