### PR TITLE
8366558: Gtests leave /tmp/cgroups-test* files

### DIFF
--- a/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
@@ -342,7 +342,6 @@ TEST(cgroupTest, read_string_tests) {
   ok = controller->read_string(base_with_slash, result, 1024);
   EXPECT_FALSE(ok) << "Empty file should have failed";
   EXPECT_STREQ("", result) << "Expected untouched result";
-  delete_file(test_file);
 
   // File contents larger than 1K
   // We only read in the first 1K - 1 bytes
@@ -359,6 +358,8 @@ TEST(cgroupTest, read_string_tests) {
   EXPECT_TRUE(1023 == strlen(result)) << "Expected only the first 1023 chars to be read in";
   EXPECT_EQ(0, strncmp(too_large, result, 1023));
   EXPECT_EQ(result[1023], '\0') << "The last character must be the null character";
+
+  delete_file(test_file);
 }
 
 TEST(cgroupTest, read_number_tuple_test) {
@@ -394,6 +395,8 @@ TEST(cgroupTest, read_number_tuple_test) {
   ok = controller->read_numerical_tuple_value(base_with_slash, true /* use_first */, &result);
   EXPECT_FALSE(ok) << "Empty file should be an error";
   EXPECT_EQ((jlong)-10, result) << "result value should be unchanged";
+
+  delete_file(test_file);
 }
 
 TEST(cgroupTest, read_numerical_key_beyond_max_path) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [49fd6a0c](https://github.com/openjdk/jdk/commit/49fd6a0cb4ddabaa865155bbfd4290077b7d13ea) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Arno Zeller on 4 Sep 2025 and was reviewed by Matthias Baesken, Thomas Stuefe and Leonid Mesnik.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8366558](https://bugs.openjdk.org/browse/JDK-8366558) needs maintainer approval

### Issue
 * [JDK-8366558](https://bugs.openjdk.org/browse/JDK-8366558): Gtests leave /tmp/cgroups-test* files (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2151/head:pull/2151` \
`$ git checkout pull/2151`

Update a local copy of the PR: \
`$ git checkout pull/2151` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2151`

View PR using the GUI difftool: \
`$ git pr show -t 2151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2151.diff">https://git.openjdk.org/jdk21u-dev/pull/2151.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2151#issuecomment-3252388004)
</details>
