### PR TITLE
8321279: Implement hashCode() in Heap-X-Buffer.java.template

### DIFF
--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -29,6 +29,7 @@ package java.nio;
 
 import java.lang.foreign.MemorySegment;
 import java.util.Objects;
+import jdk.internal.util.ArraysSupport;
 
 /**
 #if[rw]
@@ -705,6 +706,9 @@ class Heap$Type$Buffer$RW$
                                                                    addr, segment)));
     }
 
+    public int hashCode() {
+        return ArraysSupport.vectorizedHashCode(hb, ix(position()), remaining(), 1, ArraysSupport.T_BYTE);
+    }
 
 #end[byte]
 
@@ -733,6 +737,9 @@ class Heap$Type$Buffer$RW$
                                       offset, segment);
     }
 
+    public int hashCode() {
+        return ArraysSupport.vectorizedHashCode(hb, ix(position()), remaining(), 1, ArraysSupport.T_CHAR);
+    }
 #end[char]
 
 

--- a/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -922,5 +922,10 @@ public class ByteBuffers {
             r += directByteBuffer.getDouble(i);
         }
         return r;
+    }
+
+    @Benchmark
+    public int testHeapHashCode() {
+        return heapByteBuffer.hashCode();
     }
 }


### PR DESCRIPTION
A clean backport for https://bugs.openjdk.org/browse/JDK-8321279.

This patch reduces the time to get hashcode with vectorization. In tip for over a year. Low risk. Tests are running.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8321279](https://bugs.openjdk.org/browse/JDK-8321279) needs maintainer approval

### Issue
 * [JDK-8321279](https://bugs.openjdk.org/browse/JDK-8321279): Implement hashCode() in Heap-X-Buffer.java.template (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2156/head:pull/2156` \
`$ git checkout pull/2156`

Update a local copy of the PR: \
`$ git checkout pull/2156` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2156`

View PR using the GUI difftool: \
`$ git pr show -t 2156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2156.diff">https://git.openjdk.org/jdk21u-dev/pull/2156.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2156#issuecomment-3267164273)
</details>
