### PR TITLE
8353319: Open source Swing tests - Set 3

### DIFF
--- a/test/jdk/javax/swing/JFrame/bug4419914.java
+++ b/test/jdk/javax/swing/JFrame/bug4419914.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,55 +28,141 @@
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual bug4419914
-*/
+ */
 
 import java.awt.BorderLayout;
 import java.awt.ComponentOrientation;
-import javax.swing.JButton;
-import javax.swing.JFrame;
+import java.awt.Frame;
+import java.awt.Window;
+import java.util.List;
 import java.util.Locale;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JWindow;
 
 public class bug4419914 {
+    private static JFrame frame;
     private static final String INSTRUCTIONS = """
-        1. You will see a frame with five buttons.
-        2. Confirm that each button is placed as follows:
-             NORTH
-        END  CENTER  START
-             SOUTH
-        3. Press the "NORTH" button and confirm the button is focused.
-        4. Press TAB repeatedly and confirm that the TAB focus moves from right to left.
-             (NORTH - START - CENTER - END - SOUTH - NORTH - START - CENTER - ...)
+        This test verifies tab movement on RTL component orientation
+        in JWindow, JFrame and JDialog.
 
-            If there's anything different from the above items, click Fail else click Pass.""";
+        When test starts 3 test windows are displayed - JFrame, JWindow and JDialog.
+        Follow the instructions below and if any condition does not hold
+        press FAIL.
+
+        1. Confirm that each button in the child window is placed as follows:
+
+            For JFrame:
+                 NORTH
+            END  CENTER  START
+                 SOUTH
+
+            For JWindow:
+            END  CENTER  START
+                  QUIT
+
+            For JDialog:
+            END  CENTER  START
+
+        3. Press on the "START" button in case of JWindow & JDialog and "NORTH"
+           in case of JFrame, confirm that the respective button is focused.
+
+        4. Press TAB repeatedly and confirm that the TAB focus moves
+           from right to left.
+
+            For JFrame:
+            (NORTH - START - CENTER - END - SOUTH - NORTH - START - CENTER - ...)
+
+            For JWindow:
+            (START - CENTER - END - QUIT - START - CENTER - END - QUIT - ...)
+
+            For JDialog:
+            (START - CENTER - END - START - CENTER - END - ...)
+
+        If all of the above conditions are true press PASS else FAIL.
+        """;
 
     public static void main(String[] args) throws Exception {
         PassFailJFrame.builder()
-                .title("Tab movement Instructions")
                 .instructions(INSTRUCTIONS)
-                .rows((int) INSTRUCTIONS.lines().count() + 2)
-                .columns(48)
-                .testUI(bug4419914::createTestUI)
+                .columns(45)
+                .testTimeOut(10)
+                .testUI(bug4419914::createAndShowUI)
+                .positionTestUI(WindowLayouts::rightOneColumn)
                 .build()
                 .awaitAndCheck();
     }
 
-    private static JFrame createTestUI() {
-        JFrame frame = new JFrame("bug4419914");
+    private static List<Window> createAndShowUI() {
+        return List.of(createJFrame(), createJWindow(), createJDialog());
+    }
+
+    private static JFrame createJFrame() {
+        frame = new JFrame("bug4419914 JFrame");
         frame.setFocusCycleRoot(true);
+        // Tab movement set to RTL
         frame.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
         frame.setLocale(Locale.ENGLISH);
         frame.enableInputMethods(false);
 
+        // Component placement within content pane set to RTL
         frame.getContentPane().setComponentOrientation(
-                               ComponentOrientation.RIGHT_TO_LEFT);
+                ComponentOrientation.RIGHT_TO_LEFT);
         frame.getContentPane().setLocale(Locale.ENGLISH);
-        frame.getContentPane().setLayout(new BorderLayout());
+        frame.setLayout(new BorderLayout());
         frame.add(new JButton("SOUTH"), BorderLayout.SOUTH);
         frame.add(new JButton("CENTER"), BorderLayout.CENTER);
         frame.add(new JButton("END"), BorderLayout.LINE_END);
         frame.add(new JButton("START"), BorderLayout.LINE_START);
         frame.add(new JButton("NORTH"), BorderLayout.NORTH);
-        frame.setSize(300, 150);
+        frame.setSize(300, 160);
         return frame;
+    }
+
+    private static JWindow createJWindow() {
+        JWindow window = new JWindow(frame);
+        window.setFocusableWindowState(true);
+        // Tab movement set to RTL
+        window.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+        window.setLocale(new Locale("en"));
+        window.enableInputMethods(false);
+
+        // Component placement within content pane set to RTL
+        window.getContentPane().setComponentOrientation(
+                ComponentOrientation.RIGHT_TO_LEFT);
+        window.getContentPane().setLocale(new Locale("en"));
+        window.setLayout(new BorderLayout());
+        window.add(new JLabel("bug4419914 JWindow"), BorderLayout.NORTH);
+        window.add(new JButton("START"), BorderLayout.LINE_START);
+        window.add(new JButton("CENTER"), BorderLayout.CENTER);
+        window.add(new JButton("END"), BorderLayout.LINE_END);
+
+        JButton quitButton = new JButton("QUIT");
+        quitButton.addActionListener(e1 -> window.dispose());
+        window.add(quitButton, BorderLayout.SOUTH);
+        window.setSize(300, 153);
+        window.requestFocus();
+        return window;
+    }
+
+    private static JDialog createJDialog() {
+        JDialog dialog = new JDialog((Frame) null, "bug4419914 JDialog");
+        // Tab movement set to RTL
+        dialog.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+        dialog.setLocale(new Locale("en"));
+        dialog.enableInputMethods(false);
+
+        // Component placement within content pane set to RTL
+        dialog.getContentPane().setComponentOrientation(
+                ComponentOrientation.RIGHT_TO_LEFT);
+        dialog.getContentPane().setLocale(new Locale("en"));
+        dialog.setLayout(new BorderLayout());
+        dialog.add(new JButton("CENTER"), BorderLayout.CENTER);
+        dialog.add(new JButton("END"), BorderLayout.LINE_END);
+        dialog.add(new JButton("START"), BorderLayout.LINE_START);
+        dialog.setSize(300, 160);
+        return dialog;
     }
 }

--- a/test/jdk/javax/swing/JRootPane/bug4614623.java
+++ b/test/jdk/javax/swing/JRootPane/bug4614623.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4614623
+ * @requires (os.family == "windows")
+ * @summary Tests that w2k mnemonic underlining works when there's no
+            focus owner
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4614623
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.UIManager;
+
+public class bug4614623 {
+    private static final String INSTRUCTIONS = """
+            This test verifies if the short-cut character
+            (menu mnemonic) is underlined when the ALT key is held down.
+
+            Check if the following is true.
+            1) Press Alt key. The letter 'F' (menu mnemonic) of
+            the "File" menu should now be underlined.
+            2) Release the Alt key, the selection background (light grey)
+            should appear around the "File" menu. Compare "About" menu
+            with "File" menu to see the light grey selection background.
+
+            If the above is true, press PASS else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(62)
+                .rows(12)
+                .testUI(bug4614623::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("bug4614623 - File menu test");
+        JMenuBar menuBar = new JMenuBar();
+
+        JMenu fileMenu = new JMenu("File");
+        fileMenu.setMnemonic('F');
+        menuBar.add(fileMenu);
+
+        JMenu about = new JMenu("About");
+        menuBar.add(about);
+        menuBar.setSize(300, 100);
+
+        frame.setJMenuBar(menuBar);
+        menuBar.requestFocus();
+        frame.setSize(300, 200);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JTabbedPane/bug4613811.java
+++ b/test/jdk/javax/swing/JTabbedPane/bug4613811.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4613811
+ * @summary Scrollable Buttons of JTabbedPane don't
+ *          get enabled or disabled on selecting tab
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4613811
+ */
+
+import java.awt.BorderLayout;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JTabbedPane;
+
+public class bug4613811 {
+    private static final String INSTRUCTIONS = """
+            Select different tabs and check that the scrollable
+            buttons are correctly enabled and disabled.
+
+            When the very first tab (Tab 1) is fully visible
+            On macOS:
+            the left arrow button should NOT be visible.
+
+            On other platforms:
+            the left arrow button should be disabled.
+
+            If the last tab (Tab 5) is fully visible
+            On macOS:
+            the right arrow button should NOT be visible.
+
+            On other platforms:
+            the right arrow button should be disabled.
+
+            If the above is true press PASS else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(30)
+                .testUI(bug4613811::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("bug4613811 - JTabbedPane Test");
+        final JTabbedPane tabPane = new JTabbedPane(JTabbedPane.TOP,
+                                                    JTabbedPane.SCROLL_TAB_LAYOUT);
+        for (int i = 1; i <= 5; i++) {
+            tabPane.addTab("TabbedPane: Tab " + i, null, new JLabel("Tab " + i));
+        }
+        frame.add(tabPane, BorderLayout.CENTER);
+        frame.setResizable(false);
+        frame.setSize(400, 200);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JWindow/bug4251781.java
+++ b/test/jdk/javax/swing/JWindow/bug4251781.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4251781
+ * @summary Tests that JWindow repaint is optimized (background is not
+            cleared).
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4251781
+ */
+
+import java.awt.Color;
+import java.awt.Container;
+import javax.swing.JButton;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JWindow;
+
+public class bug4251781 {
+    private static final String INSTRUCTIONS = """
+            Press the button at the bottom-right corner of the gray
+            window with the mouse.
+            If the window DOES NOT flicker when you press and/or release
+            the mouse button press PASS else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug4251781::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JWindow createAndShowUI() {
+        JWindow w = new JWindow();
+        final Container pane = w.getContentPane();
+        pane.setLayout(null);
+        pane.setBackground(Color.GRAY.darker());
+
+        final JPopupMenu popup = new JPopupMenu();
+        popup.add(new JMenuItem("item 1"));
+        popup.add(new JMenuItem("exit"));
+
+        JButton b = new JButton("menu");
+        b.setBounds(350, 250, 50, 50);
+        b.addActionListener(ev -> popup.show(pane, 0, 0));
+        pane.add(b);
+
+        w.setSize(400, 300);
+        return w;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353319: Open source Swing tests - Set 3. Adds four swing tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353319](https://bugs.openjdk.org/browse/JDK-8353319) needs maintainer approval

### Issue
 * [JDK-8353319](https://bugs.openjdk.org/browse/JDK-8353319): Open source Swing tests - Set 3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2158/head:pull/2158` \
`$ git checkout pull/2158`

Update a local copy of the PR: \
`$ git checkout pull/2158` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2158`

View PR using the GUI difftool: \
`$ git pr show -t 2158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2158.diff">https://git.openjdk.org/jdk21u-dev/pull/2158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2158#issuecomment-3268105839)
</details>
