### PR TITLE
8311939: Excessive allocation of Matcher.groups array

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Matcher.java
+++ b/src/java.base/share/classes/java/util/regex/Matcher.java
@@ -247,8 +247,7 @@ public final class Matcher implements MatchResult {
         this.text = text;
 
         // Allocate state storage
-        int parentGroupCount = Math.max(parent.capturingGroupCount, 10);
-        groups = new int[parentGroupCount * 2];
+        groups = new int[parent.capturingGroupCount * 2];
         locals = new int[parent.localCount];
         localsPos = new IntHashSet[parent.localTCNCount];
 
@@ -422,8 +421,7 @@ public final class Matcher implements MatchResult {
         namedGroups = null;
 
         // Reallocate state storage
-        int parentGroupCount = Math.max(newPattern.capturingGroupCount, 10);
-        groups = new int[parentGroupCount * 2];
+        groups = new int[newPattern.capturingGroupCount * 2];
         locals = new int[newPattern.localCount];
         for (int i = 0; i < groups.length; i++)
             groups[i] = -1;

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -5187,6 +5187,12 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
             groupIndex = groupCount + groupCount;
         }
         boolean match(Matcher matcher, int i, CharSequence seq) {
+            // reference to not existing group must never match
+            // group does not exist if matcher didn't allocate space for it
+            if (groupIndex >= matcher.groups.length) {
+                return false;
+            }
+
             int j = matcher.groups[groupIndex];
             int k = matcher.groups[groupIndex+1];
 
@@ -5223,6 +5229,12 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
             this.doUnicodeCase = doUnicodeCase;
         }
         boolean match(Matcher matcher, int i, CharSequence seq) {
+            // reference to not existing group must never match
+            // group does not exist if matcher didn't allocate space for it
+            if (groupIndex >= matcher.groups.length) {
+                return false;
+            }
+
             int j = matcher.groups[groupIndex];
             int k = matcher.groups[groupIndex+1];
 

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -2041,6 +2041,58 @@ public class RegExTest {
         check(pattern, toSupplementaries("abcdefghijkk"), true);
     }
 
+    @Test
+    public static void ciBackRefTest() {
+        Pattern pattern = Pattern.compile("(?i)(a*)bc\\1");
+        check(pattern, "zzzaabcazzz", true);
+
+        pattern = Pattern.compile("(?i)(a*)bc\\1");
+        check(pattern, "zzzaabcaazzz", true);
+
+        pattern = Pattern.compile("(?i)(abc)(def)\\1");
+        check(pattern, "abcdefabc", true);
+
+        pattern = Pattern.compile("(?i)(abc)(def)\\3");
+        check(pattern, "abcdefabc", false);
+
+        for (int i = 1; i < 10; i++) {
+            // Make sure backref 1-9 are always accepted
+            pattern = Pattern.compile("(?i)abcdef\\" + i);
+            // and fail to match if the target group does not exit
+            check(pattern, "abcdef", false);
+        }
+
+        pattern = Pattern.compile("(?i)(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\11");
+        check(pattern, "abcdefghija", false);
+        check(pattern, "abcdefghija1", true);
+
+        pattern = Pattern.compile("(?i)(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)\\11");
+        check(pattern, "abcdefghijkk", true);
+
+        pattern = Pattern.compile("(?i)(a)bcdefghij\\11");
+        check(pattern, "abcdefghija1", true);
+
+        // Supplementary character tests
+        pattern = Pattern.compile("(?i)" + toSupplementaries("(a*)bc\\1"));
+        check(pattern, toSupplementaries("zzzaabcazzz"), true);
+
+        pattern = Pattern.compile("(?i)" + toSupplementaries("(a*)bc\\1"));
+        check(pattern, toSupplementaries("zzzaabcaazzz"), true);
+
+        pattern = Pattern.compile("(?i)" + toSupplementaries("(abc)(def)\\1"));
+        check(pattern, toSupplementaries("abcdefabc"), true);
+
+        pattern = Pattern.compile("(?i)" + toSupplementaries("(abc)(def)\\3"));
+        check(pattern, toSupplementaries("abcdefabc"), false);
+
+        pattern = Pattern.compile("(?i)" + toSupplementaries("(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)\\11"));
+        check(pattern, toSupplementaries("abcdefghija"), false);
+        check(pattern, toSupplementaries("abcdefghija1"), true);
+
+        pattern = Pattern.compile("(?i)" + toSupplementaries("(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)\\11"));
+        check(pattern, toSupplementaries("abcdefghijkk"), true);
+    }
+
     /**
      * Unicode Technical Report #18, section 2.6 End of Line
      * There is no empty line to be matched in the sequence \u000D\u000A


### PR DESCRIPTION
A clean backport for https://bugs.openjdk.org/browse/JDK-8311939.

This improves perf by not allocating excessive `groups` array. Tests are running. In tip for over 2 years and no related issues reported. Low risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8311939](https://bugs.openjdk.org/browse/JDK-8311939) needs maintainer approval

### Issue
 * [JDK-8311939](https://bugs.openjdk.org/browse/JDK-8311939): Excessive allocation of Matcher.groups array (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2159/head:pull/2159` \
`$ git checkout pull/2159`

Update a local copy of the PR: \
`$ git checkout pull/2159` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2159`

View PR using the GUI difftool: \
`$ git pr show -t 2159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2159.diff">https://git.openjdk.org/jdk21u-dev/pull/2159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2159#issuecomment-3268556384)
</details>
