### PR TITLE
8311076: RedefineClasses doesn't check for ConstantPool overflow

### DIFF
--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1859,6 +1859,12 @@ jvmtiError VM_RedefineClasses::merge_cp_and_rewrite(
   if (!result) {
     // The merge can fail due to memory allocation failure or due
     // to robustness checks.
+    return JVMTI_ERROR_INTERNAL;
+  }
+
+  // ensure merged constant pool size does not overflow u2
+  if (merge_cp_length > 0xFFFF) {
+    log_warning(redefine, class, constantpool)("Merged constant pool overflow: %d entries", merge_cp_length);
     return JVMTI_ERROR_INTERNAL;
   }
 


### PR DESCRIPTION
A clean patch for https://bugs.openjdk.org/browse/JDK-8311076

This patch adds u2 overflow check when merging constant pools. Tests are running. In tip for over a year.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8311076](https://bugs.openjdk.org/browse/JDK-8311076) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311076](https://bugs.openjdk.org/browse/JDK-8311076): RedefineClasses doesn't check for ConstantPool overflow (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2160/head:pull/2160` \
`$ git checkout pull/2160`

Update a local copy of the PR: \
`$ git checkout pull/2160` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2160`

View PR using the GUI difftool: \
`$ git pr show -t 2160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2160.diff">https://git.openjdk.org/jdk21u-dev/pull/2160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2160#issuecomment-3268574206)
</details>
