### PR TITLE
8320836: jtreg gtest runs should limit heap size

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ public class GTestWrapper {
         command.add(execPath.toAbsolutePath().toString());
         command.add("-jdk");
         command.add(Utils.TEST_JDK);
+        command.add("-Xmx200m");
         command.add("--gtest_output=xml:" + resultFile);
         command.add("--gtest_catch_exceptions=0");
         for (String a : args) {


### PR DESCRIPTION
A clean backport for https://bugs.openjdk.org/browse/JDK-8320836.

This patch limits the gtest max heap size. In the original [JBS](https://bugs.openjdk.org/browse/JDK-8320836), there was already a customer report saying CI pipeline gtest failed due to large heap. Backporting this patch can benefit non tip customers. Running tests. In tip for ~2 months.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320836](https://bugs.openjdk.org/browse/JDK-8320836) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8320836: jtreg gtest runs should limit heap size`

### Issue
 * [JDK-8320836](https://bugs.openjdk.org/browse/JDK-8320836): jtreg gtest runs should limit heap size (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2161/head:pull/2161` \
`$ git checkout pull/2161`

Update a local copy of the PR: \
`$ git checkout pull/2161` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2161`

View PR using the GUI difftool: \
`$ git pr show -t 2161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2161.diff">https://git.openjdk.org/jdk21u-dev/pull/2161.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2161#issuecomment-3268591949)
</details>
