### PR TITLE
8364198: NMT should have a better corruption message

### DIFF
--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -104,7 +104,7 @@ inline OutTypeParam MallocHeader::resolve_checked_impl(InTypeParam memblock) {
   OutTypeParam header_pointer = (OutTypeParam)memblock - 1;
   if (!header_pointer->check_block_integrity(msg, sizeof(msg), &corruption)) {
     header_pointer->print_block_on_error(tty, corruption != nullptr ? corruption : (address)header_pointer);
-    fatal("NMT corruption: Block at " PTR_FORMAT ": %s", p2i(memblock), msg);
+    fatal("NMT has detected a memory corruption bug. Block at " PTR_FORMAT ": %s", p2i(memblock), msg);
   }
   return header_pointer;
 }

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -36,7 +36,7 @@
 
 // This prefix shows up on any c heap corruption NMT detects. If unsure which assert will
 // come, just use this one.
-#define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT corruption"
+#define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT has detected a memory corruption bug."
 
 #define DEFINE_TEST(test_function, expected_assertion_message)                            \
   TEST_VM_FATAL_ERROR_MSG(NMT, test_function, ".*" expected_assertion_message ".*") {     \


### PR DESCRIPTION
A clean backport of https://bugs.openjdk.org/browse/JDK-8364198.

This patch improves the error message, quite straight forward as the error message itself - NMT detected a bug somewhere else, but not in itself. Error message change. Low risks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8364198](https://bugs.openjdk.org/browse/JDK-8364198) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364198](https://bugs.openjdk.org/browse/JDK-8364198): NMT should have a better corruption message (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2167/head:pull/2167` \
`$ git checkout pull/2167`

Update a local copy of the PR: \
`$ git checkout pull/2167` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2167`

View PR using the GUI difftool: \
`$ git pr show -t 2167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2167.diff">https://git.openjdk.org/jdk21u-dev/pull/2167.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2167#issuecomment-3272772757)
</details>
