### PR TITLE
8347434: Richer VM operations events logging

### DIFF
--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -409,17 +409,17 @@ void VMThread::inner_execute(VM_Operation* op) {
   HandleMark hm(VMThread::vm_thread());
 
   const char* const cause = op->cause();
-  EventMarkVMOperation em("Executing %sVM operation: %s%s%s%s",
-      prev_vm_operation != nullptr ? "nested " : "",
-      op->name(),
-      cause != nullptr ? " (" : "",
-      cause != nullptr ? cause : "",
-      cause != nullptr ? ")" : "");
+  stringStream ss;
+  ss.print("Executing%s%s VM operation: %s",
+           prev_vm_operation != nullptr ? " nested" : "",
+           op->evaluate_at_safepoint() ? " safepoint" : " non-safepoint",
+           op->name());
+  if (cause != nullptr) {
+    ss.print(" (%s)", cause);
+  }
 
-  log_debug(vmthread)("Evaluating %s %s VM operation: %s",
-                       prev_vm_operation != nullptr ? "nested" : "",
-                      _cur_vm_operation->evaluate_at_safepoint() ? "safepoint" : "non-safepoint",
-                      _cur_vm_operation->name());
+  EventMarkVMOperation em("%s", ss.freeze());
+  log_debug(vmthread)("%s", ss.freeze());
 
   bool end_safepoint = false;
   bool has_timeout_task = (_timeout_task != nullptr);


### PR DESCRIPTION
A clean backport of https://bugs.openjdk.org/browse/JDK-8347434.

This patch adds information of whether the operation is at safepoint. Sample log see: https://github.com/openjdk/jdk/pull/23039#issuecomment-2582924941.

In tip for ~5 months. Log changes. Low risks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347434](https://bugs.openjdk.org/browse/JDK-8347434) needs maintainer approval

### Issue
 * [JDK-8347434](https://bugs.openjdk.org/browse/JDK-8347434): Richer VM operations events logging (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2168/head:pull/2168` \
`$ git checkout pull/2168`

Update a local copy of the PR: \
`$ git checkout pull/2168` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2168`

View PR using the GUI difftool: \
`$ git pr show -t 2168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2168.diff">https://git.openjdk.org/jdk21u-dev/pull/2168.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2168#issuecomment-3272813074)
</details>
