### PR TITLE
8350813: Rendering of bulky sound bank from MIDI sequence can cause OutOfMemoryError

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/AudioFileSoundbankReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AudioFileSoundbankReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,13 @@ public final class AudioFileSoundbankReader extends SoundbankReader {
             if (totalSize >= Integer.MAX_VALUE - 2) {
                 throw new InvalidMidiDataException(
                         "Can not allocate enough memory to read audio data.");
+            }
+
+            long maximumHeapSize = (long) ((Runtime.getRuntime().maxMemory() -
+                    (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())) * 0.9);
+            if (totalSize > maximumHeapSize) {
+                throw new InvalidMidiDataException(
+                        "Insufficient heap size to render audio data.");
             }
 
             if (ais.getFrameLength() == -1 || totalSize > MEGABYTE) {

--- a/test/jdk/javax/sound/midi/BulkSoundBank/BulkSoundBank.java
+++ b/test/jdk/javax/sound/midi/BulkSoundBank/BulkSoundBank.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.sound.midi.InvalidMidiDataException;
+import javax.sound.midi.MidiSystem;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/**
+ * @test
+ * @bug 8350813
+ * @summary Rendering of bulky sound bank from MIDI sequence can cause OutOfMemoryError.
+ * @run main/othervm -Xmx1g BulkSoundBank
+ */
+
+public class BulkSoundBank {
+    static final byte[] midi = {77, 84, 104, 100, 0, 0, 0, 6, 0, 0, 0, 1, 1,
+            -32, 77, 84, 114, 107, 0, 0, 0, 50, 0, -1, 88, 4, 4, 2, 24, 8, 0, -1,
+            81, 3, 7, -95, 32, 0, -112, 60, 64, -125, 96, -128, 60, 64, -125, -44,
+            -51, 32, -112, 48, 64, 1, -128, 48, 64, -127, -64, -45, 127, -112, 60,
+            64, 1, -128, 60, 64, 0, -1, 47, 0};
+
+    public static void main(String[] args) throws IOException {
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(midi)) {
+            MidiSystem.getSoundbank(bis);
+            throw new RuntimeException("Test should throw InvalidMidiDataException"
+                                       + " but it did not.");
+        } catch (InvalidMidiDataException imda) {
+            System.out.println("Caught InvalidMidiDataException as expected");
+        }
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350813](https://bugs.openjdk.org/browse/JDK-8350813) needs maintainer approval

### Issue
 * [JDK-8350813](https://bugs.openjdk.org/browse/JDK-8350813): Rendering of bulky sound bank from MIDI sequence can cause OutOfMemoryError (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2172/head:pull/2172` \
`$ git checkout pull/2172`

Update a local copy of the PR: \
`$ git checkout pull/2172` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2172`

View PR using the GUI difftool: \
`$ git pr show -t 2172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2172.diff">https://git.openjdk.org/jdk21u-dev/pull/2172.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2172#issuecomment-3275130308)
</details>
