### PR TITLE
8354532: Open source JFileChooser Tests - Set 7

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/bug4357012.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4357012.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4357012
+ * @requires (os.family == "windows")
+ * @summary JFileChooser.showSaveDialog inconsistent with Windows Save Dialog
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4357012
+ */
+
+import java.io.File;
+import java.io.IOException;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.UIManager;
+
+public class bug4357012 {
+    private static File workDir = null;
+    private static File dir = null;
+    private static File file = null;
+    private static final String INSTRUCTIONS = """
+            <html>
+            Test is for Windows LAF only
+            <p>In JFileChooser's files list :
+            <ol>
+            <li>Select directory. Verify that the directory name doesn't
+            appear in "file name" field.</li>
+            <li>Select file. Verify that the file name appears in
+            "file name" field.</li>
+            <li>Select directory again. Verify that the previous file name
+            remains in file name field.</li>
+            </ol>
+            </p>
+            </html>
+            """;
+
+    public static void main(String[] argv) throws Exception {
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+            createTestDir();
+            PassFailJFrame.builder()
+                    .instructions(INSTRUCTIONS)
+                    .rows(10)
+                    .columns(40)
+                    .testUI(bug4357012::createTestUI)
+                    .build()
+                    .awaitAndCheck();
+        } finally {
+            if (workDir != null) {
+                System.out.println("Deleting '" + file + "': " + file.delete());
+                System.out.println("Deleting '" + dir + "': " + dir.delete());
+                System.out.println("Deleting '" + workDir + "': " + workDir.delete());
+            }
+        }
+    }
+
+    private static void createTestDir() throws IOException {
+        String tempDir = ".";
+        String fs = System.getProperty("file.separator");
+
+        workDir = new File(tempDir + fs + "bug4357012");
+        System.out.println("Creating '" + workDir + "': " + workDir.mkdir());
+
+        dir = new File(workDir + fs + "Directory");
+        System.out.println("Creating '" + dir + "': " + dir.mkdir());
+
+        file = new File(workDir + fs + "File.txt");
+        System.out.println("Creating '" + file + "': " + file.createNewFile());
+    }
+
+    private static JComponent createTestUI() {
+        JFileChooser fc = new JFileChooser(workDir);
+        fc.setDialogType(JFileChooser.SAVE_DIALOG);
+        return fc;
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4926884.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4926884.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4926884
+ * @requires (os.family == "windows")
+ * @summary Win L&F: JFileChooser problems with "My Documents" folder
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4926884
+ */
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import javax.swing.JFileChooser;
+import javax.swing.UIManager;
+
+public class bug4926884 {
+    private static final String INSTRUCTIONS = """
+            Validate next statements step by step:
+
+            1. In the file list there are several dirs and files (like "ski",
+               "Snowboard" etc.)
+            2. Select "Details" view mode.
+            3. Make file list in focus (e.g. by pressing mouse button)
+            4. Press key "w" several times with delay LESS than 1 second.
+              Selection should be changed across files started with letter "w"
+              (without case sensitive).
+            5. Press key "w" several times with delay MORE than 1 second.
+              Selection should be changed across files started with letter "w"
+              (without case sensitive).
+            6. Type "winnt" (with delay less than 1 second between letters) -
+               directory "winnt" should be selected.
+            7. Change conditions:
+              - Move column "Name" to the second position
+              - Change sort mode by clicking column "Size"
+            8. Repeat items 4-6
+
+            If above is true press PASS else FAIL
+            """;
+
+    private static final String[] DIRS = {"www", "winnt", "ski"};
+    private static final String[] FILES = {"Window", "weel", "mice",
+                                           "Wall", "Snowboard", "wood"};
+    private static final File testDir = new File(".");
+
+    public static void main(String[] argv) throws Exception {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        try {
+            createTestDir();
+            PassFailJFrame.builder()
+                    .instructions(INSTRUCTIONS)
+                    .columns(40)
+                    .testUI(() -> new JFileChooser(testDir))
+                    .build()
+                    .awaitAndCheck();
+        } finally {
+            deleteTempDir();
+        }
+    }
+
+    private static void createTestDir() throws IOException {
+        testDir.mkdir();
+
+        for (String dir : DIRS) {
+            new File(testDir, dir).mkdir();
+        }
+
+        for (int i = 0; i < FILES.length; i++) {
+
+            try (OutputStream outputStream = new FileOutputStream(
+                    new File(testDir, FILES[i]))) {
+                for (int j = 0; j < i * 1024; j++) {
+                    outputStream.write('#');
+                }
+            }
+        }
+    }
+
+    private static void deleteTempDir() {
+        File[] files = testDir.listFiles();
+
+        for (File file : files) {
+            if (file != null) {
+                file.delete();
+            }
+        }
+
+        testDir.delete();
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug5045464.java
+++ b/test/jdk/javax/swing/JFileChooser/bug5045464.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5045464
+ * @requires (os.family == "linux")
+ * @summary Regression: GTK L&F, JFileChooser shows "null/" in folder list
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug5045464
+ */
+
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug5045464 {
+    private static final String INSTRUCTIONS = """
+            When the filechooser appears check the directory list (the left list).
+            If it starts with two items: "./" (current directory)
+            and "../" (parent directory) press PASS.
+            If something else is here (e.g. "null/" instead of "./")
+            press FAIL.
+            """;
+
+    public static void main(String[] argv) throws Exception {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug5045464::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JComponent createTestUI() {
+        JFileChooser fc = new JFileChooser();
+        fc.setControlButtonsAreShown(false);
+        try {
+         UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        } catch (Exception ex) {
+        throw new RuntimeException("Test Failed!", ex);
+        }
+        SwingUtilities.updateComponentTreeUI(fc);
+        return fc;
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug6515169.java
+++ b/test/jdk/javax/swing/JFileChooser/bug6515169.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6515169
+ * @requires (os.family == "windows")
+ * @summary wrong grid header in JFileChooser
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug6515169
+ */
+
+import javax.swing.ButtonGroup;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug6515169 {
+    private static JFrame frame;
+    private static final String INSTRUCTIONS = """
+            This test is to verify JFileChooser on Windows and Metal LAF.
+            Use the "Change LaF" menu to switch between the 2 LaF
+            and verify the following.
+
+            a. Change view mode to "Details"
+            b. Check that 4 columns appear: Name, Size, Type and Date Modified
+            c. Change current directory by pressing any available subdirectory
+               or by pressing button "Up One Level".
+            d. Check that still four columns exist.
+
+            Change LaF and repeat the steps a-d.
+            If all conditions are true press PASS, else FAIL.
+            """;
+
+    public static void main(String[] argv) throws Exception {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug6515169::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        frame = new JFrame("bug6515169");
+        JMenuBar bar = new JMenuBar();
+        JMenu lafMenu = new JMenu("Change LaF");
+        ButtonGroup lafGroup = new ButtonGroup();
+        JCheckBoxMenuItem lafItem1 = new JCheckBoxMenuItem("Window LaF");
+        lafItem1.addActionListener(e ->
+                setLaF(UIManager.getSystemLookAndFeelClassName()));
+        lafGroup.add(lafItem1);
+        lafMenu.add(lafItem1);
+
+        JCheckBoxMenuItem lafItem2 = new JCheckBoxMenuItem("Metal LaF");
+        lafItem2.addActionListener(e ->
+                setLaF(UIManager.getCrossPlatformLookAndFeelClassName()));
+        lafGroup.add(lafItem2);
+        lafMenu.add(lafItem2);
+
+        bar.add(lafMenu);
+        frame.setJMenuBar(bar);
+
+        String dir = ".";
+        JFileChooser fc = new JFileChooser(dir);
+        fc.setControlButtonsAreShown(false);
+        frame.add(fc);
+        frame.pack();
+
+        return frame;
+    }
+
+    private static void setLaF(String laf) {
+        try {
+            UIManager.setLookAndFeel(laf);
+            SwingUtilities.updateComponentTreeUI(frame);
+        } catch (Exception e) {
+           throw new RuntimeException("Test Failed!", e);
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8354532: Open source JFileChooser Tests - Set 7. Adds four file selector tests, three for windows and one linux. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354532](https://bugs.openjdk.org/browse/JDK-8354532) needs maintainer approval

### Issue
 * [JDK-8354532](https://bugs.openjdk.org/browse/JDK-8354532): Open source JFileChooser Tests - Set 7 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2174/head:pull/2174` \
`$ git checkout pull/2174`

Update a local copy of the PR: \
`$ git checkout pull/2174` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2174`

View PR using the GUI difftool: \
`$ git pr show -t 2174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2174.diff">https://git.openjdk.org/jdk21u-dev/pull/2174.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2174#issuecomment-3276587494)
</details>
