### PR TITLE
8346142: [perf] scalability issue for the specjvm2008::xml.validation workload

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
@@ -704,11 +704,13 @@ public class RegularExpression implements java.io.Serializable {
      */
     public boolean matches(char[] target, int start, int end, Match match) {
 
-        synchronized (this) {
-            if (this.operations == null)
-                this.prepare();
-            if (this.context == null)
-                this.context = new Context();
+        if (this.operations == null || this.context == null) {
+            synchronized (this) {
+                if (this.operations == null)
+                    this.prepare();
+                if (this.context == null)
+                    this.context = new Context();
+            }
         }
         Context con = null;
         synchronized (this.context) {
@@ -889,11 +891,13 @@ public class RegularExpression implements java.io.Serializable {
      */
     public boolean matches(String  target, int start, int end, Match match) {
 
-        synchronized (this) {
-            if (this.operations == null)
-                this.prepare();
-            if (this.context == null)
-                this.context = new Context();
+        if (this.operations == null || this.context == null) {
+            synchronized (this) {
+                if (this.operations == null)
+                    this.prepare();
+                if (this.context == null)
+                    this.context = new Context();
+            }
         }
         Context con = null;
         synchronized (this.context) {
@@ -1569,11 +1573,13 @@ public class RegularExpression implements java.io.Serializable {
 
 
 
-        synchronized (this) {
-            if (this.operations == null)
-                this.prepare();
-            if (this.context == null)
-                this.context = new Context();
+        if (this.operations == null || this.context == null) {
+            synchronized (this) {
+                if (this.operations == null)
+                    this.prepare();
+                if (this.context == null)
+                    this.context = new Context();
+            }
         }
         Context con = null;
         synchronized (this.context) {
@@ -1738,9 +1744,9 @@ public class RegularExpression implements java.io.Serializable {
     boolean hasBackReferences = false;
 
     transient int minlength;
-    transient Op operations = null;
+    transient volatile Op operations = null;
     transient int numberOfClosures;
-    transient Context context = null;
+    transient volatile Context context = null;
     transient RangeToken firstChar = null;
 
     transient String fixedString = null;


### PR DESCRIPTION
A clean backport for https://bugs.openjdk.org/browse/JDK-8346142

A perf patch: it adds low cost null prechecks to prevent the flow entering slow synchronized block unnecessarily.

In tip for about 8 months, no issues so far. Low risks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8346142](https://bugs.openjdk.org/browse/JDK-8346142) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346142](https://bugs.openjdk.org/browse/JDK-8346142): [perf] scalability issue for the specjvm2008::xml.validation workload (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2175/head:pull/2175` \
`$ git checkout pull/2175`

Update a local copy of the PR: \
`$ git checkout pull/2175` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2175`

View PR using the GUI difftool: \
`$ git pr show -t 2175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2175.diff">https://git.openjdk.org/jdk21u-dev/pull/2175.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2175#issuecomment-3277077924)
</details>
