### PR TITLE
8320049: PKCS10 would not discard the cause when throw SignatureException on invalid key

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs10/PKCS10.java
+++ b/src/java.base/share/classes/sun/security/pkcs10/PKCS10.java
@@ -23,7 +23,6 @@
  * questions.
  */
 
-
 package sun.security.pkcs10;
 
 import java.io.PrintStream;
@@ -173,7 +172,7 @@ public class PKCS10 {
                 throw new SignatureException("Invalid PKCS #10 signature");
             }
         } catch (InvalidKeyException e) {
-            throw new SignatureException("Invalid key");
+            throw new SignatureException("Invalid key", e);
         } catch (InvalidAlgorithmParameterException e) {
             throw new SignatureException("Invalid signature parameters", e);
         } catch (ProviderException e) {


### PR DESCRIPTION
A clean backport for https://bugs.openjdk.org/browse/JDK-8320049.

This patch passes cause in SignatureException on invalid key. Pretty small and straightforward. Low risks. Tests are running.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320049](https://bugs.openjdk.org/browse/JDK-8320049) needs maintainer approval

### Issue
 * [JDK-8320049](https://bugs.openjdk.org/browse/JDK-8320049): PKCS10 would not discard the cause when throw SignatureException on invalid key (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2176/head:pull/2176` \
`$ git checkout pull/2176`

Update a local copy of the PR: \
`$ git checkout pull/2176` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2176`

View PR using the GUI difftool: \
`$ git pr show -t 2176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2176.diff">https://git.openjdk.org/jdk21u-dev/pull/2176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2176#issuecomment-3277087536)
</details>
