### PR TITLE
8325731: Installation instructions for Debian/Ubuntu don't mention autoconf

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -476,7 +476,7 @@ header files as provided by your distribution.</p>
 <p>The basic tooling is provided as part of the core operating system,
 but you will most likely need to install developer packages.</p>
 <p>For apt-based distributions (Debian, Ubuntu, etc), try this:</p>
-<pre><code>sudo apt-get install build-essential</code></pre>
+<pre><code>sudo apt-get install build-essential autoconf</code></pre>
 <p>For rpm-based distributions (Fedora, Red Hat, etc), try this:</p>
 <pre><code>sudo yum groupinstall &quot;Development Tools&quot;</code></pre>
 <p>For Alpine Linux, aside from basic tooling, install the GNU versions

--- a/doc/building.md
+++ b/doc/building.md
@@ -289,7 +289,7 @@ will most likely need to install developer packages.
 
 For apt-based distributions (Debian, Ubuntu, etc), try this:
 ```
-sudo apt-get install build-essential
+sudo apt-get install build-essential autoconf
 ```
 
 For rpm-based distributions (Fedora, Red Hat, etc), try this:


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325731](https://bugs.openjdk.org/browse/JDK-8325731) needs maintainer approval

### Issue
 * [JDK-8325731](https://bugs.openjdk.org/browse/JDK-8325731): Installation instructions for Debian/Ubuntu don't mention autoconf (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2181/head:pull/2181` \
`$ git checkout pull/2181`

Update a local copy of the PR: \
`$ git checkout pull/2181` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2181`

View PR using the GUI difftool: \
`$ git pr show -t 2181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2181.diff">https://git.openjdk.org/jdk21u-dev/pull/2181.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2181#issuecomment-3280526200)
</details>
