### PR TITLE
8351567: Jar Manifest test ValueUtf8Coding produces misleading diagnostic output

### DIFF
--- a/test/jdk/java/util/jar/Manifest/ValueUtf8Coding.java
+++ b/test/jdk/java/util/jar/Manifest/ValueUtf8Coding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import static org.testng.Assert.*;
 
 /**
  * @test
- * @bug 8066619
+ * @bug 8066619 8351567
  * @run testng ValueUtf8Coding
  * @summary Tests encoding and decoding manifest header values to and from
  * UTF-8 with the complete Unicode character set.
@@ -200,10 +200,6 @@ public class ValueUtf8Coding {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         mf.write(out);
         byte[] mfBytes = out.toByteArray();
-
-        System.out.println("-".repeat(72));
-        System.out.print(new String(mfBytes, UTF_8));
-        System.out.println("-".repeat(72));
 
         ByteArrayInputStream in = new ByteArrayInputStream(mfBytes);
         return new Manifest(in);


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351567](https://bugs.openjdk.org/browse/JDK-8351567) needs maintainer approval

### Issue
 * [JDK-8351567](https://bugs.openjdk.org/browse/JDK-8351567): Jar Manifest test ValueUtf8Coding produces misleading diagnostic output (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2187/head:pull/2187` \
`$ git checkout pull/2187`

Update a local copy of the PR: \
`$ git checkout pull/2187` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2187`

View PR using the GUI difftool: \
`$ git pr show -t 2187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2187.diff">https://git.openjdk.org/jdk21u-dev/pull/2187.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2187#issuecomment-3281112917)
</details>
