### PR TITLE
8219408: Tests should handle ${} in the view of jtreg "smart action"

### DIFF
--- a/test/jdk/com/sun/security/auth/login/ConfigFile/TEST.properties
+++ b/test/jdk/com/sun/security/auth/login/ConfigFile/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false

--- a/test/jdk/java/security/Security/SecurityPropFile/TEST.properties
+++ b/test/jdk/java/security/Security/SecurityPropFile/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false

--- a/test/jdk/javax/security/auth/login/TEST.properties
+++ b/test/jdk/javax/security/auth/login/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false

--- a/test/jdk/sun/security/util/Resources/TEST.properties
+++ b/test/jdk/sun/security/util/Resources/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8219408](https://bugs.openjdk.org/browse/JDK-8219408) needs maintainer approval

### Issue
 * [JDK-8219408](https://bugs.openjdk.org/browse/JDK-8219408): Tests should handle ${} in the view of jtreg "smart action" (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2188/head:pull/2188` \
`$ git checkout pull/2188`

Update a local copy of the PR: \
`$ git checkout pull/2188` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2188`

View PR using the GUI difftool: \
`$ git pr show -t 2188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2188.diff">https://git.openjdk.org/jdk21u-dev/pull/2188.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2188#issuecomment-3281166164)
</details>
