### PR TITLE
Backport e3a5e265a7747b02b8f828fbedea0dda7246fc51

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public class TestVMProcess {
         String bootClassPath = "-Xbootclasspath/a:.";
         if (testClassesOnBootClassPath) {
             // Add test classes themselves to boot classpath to make them privileged.
-            bootClassPath += File.pathSeparator + Utils.TEST_CLASSES;
+            bootClassPath += File.pathSeparator + Utils.TEST_CLASS_PATH;
         }
         cmds.add(bootClassPath);
         cmds.add("-XX:+UnlockDiagnosticVMOptions");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e3a5e265](https://github.com/openjdk/jdk/commit/e3a5e265a7747b02b8f828fbedea0dda7246fc51) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 14 Aug 2024 and was reviewed by Christian Hagedorn and Aleksey Shipilev.

Thanks!