### PR TITLE
8355444: [java.io] Use @requires tag instead of exiting based on "os.name" property value

### DIFF
--- a/test/jdk/java/io/File/MacPathTest.java
+++ b/test/jdk/java/io/File/MacPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,11 @@
  * questions.
  */
 
+/*
+ * This test is launched via a ProcessBuilder in the main test MacPath which
+ * includes a @requires (os.family == "mac") tag so no operating system
+ * conditional is applied here.
+ */
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -29,10 +34,6 @@ import java.text.Normalizer;
 public class MacPathTest {
 
     public static void main(String args[]) throws Throwable {
-        String osname = System.getProperty("os.name");
-        if (!osname.contains("OS X") && !osname.contains("Darwin"))
-            return;
-
         // English
         test("TestDir_apple",                                    // test dir
              "dir_macosx",                                       // dir

--- a/test/jdk/java/io/File/MaxPath.java
+++ b/test/jdk/java/io/File/MaxPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,16 +24,21 @@
 /* @test
    @bug 6481955
    @summary Path length less than MAX_PATH (260) works on Windows
+   @library /test/lib
  */
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+
+import jtreg.SkippedException;
 
 public class MaxPath {
     public static void main(String[] args) throws Exception {
         String osName = System.getProperty("os.name");
         if (!osName.startsWith("Windows")) {
-            return;
+            throw new SkippedException("This test is run only on Windows");
         }
+
         int MAX_PATH = 260;
         String dir = new File(".").getAbsolutePath() + "\\";
         String padding = "1234567890123456789012345678901234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890";

--- a/test/jdk/java/io/File/WinDeviceName.java
+++ b/test/jdk/java/io/File/WinDeviceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
    @bug 6176051 4858457
    @summary Check whether reserved names are handled correctly on Windows
+   @requires (os.family == "windows")
  */
 
 import java.io.File;
@@ -38,10 +39,6 @@ public class WinDeviceName {
     };
     public static void main(String[] args) {
         String osName = System.getProperty("os.name");
-        if (!osName.startsWith("Windows")) {
-            return;
-        }
-
         for (int i = 0; i < devnames.length; i++) {
             String names[] = { devnames[i], devnames[i] + ".TXT",
                                devnames[i].toLowerCase(),

--- a/test/jdk/java/io/File/WinMaxPath.java
+++ b/test/jdk/java/io/File/WinMaxPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,12 @@
    @bug 6384833
    @summary Check if appropriate exception FileNotFoundException gets
             thrown when the pathlengh exceeds the limit.
+   @requires (os.family == "windows")
  */
 
 import java.io.*;
 public class WinMaxPath {
     public static void main(String[] args) throws Exception {
-        String osName = System.getProperty("os.name");
-        if (!osName.startsWith("Windows")) {
-            return;
-        }
         try {
             char[] as = new char[65000];
             java.util.Arrays.fill(as, 'a');

--- a/test/jdk/java/io/File/WinSpecialFiles.java
+++ b/test/jdk/java/io/File/WinSpecialFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,12 @@
    @bug 6192331 6348207 8202076
    @summary Check if File.exists()/length() works correctly on Windows
             special files hiberfil.sys and pagefile.sys
+   @requires (os.family == "windows")
  */
 
 import java.io.File;
 public class WinSpecialFiles {
     public static void main(String[] args) throws Exception {
-        String osName = System.getProperty("os.name");
-        if (!osName.startsWith("Windows")) {
-            return;
-        }
         File root = new File("C:\\");
         File[] dir = root.listFiles();
         for (int i = 0; i < dir.length; i++) {

--- a/test/jdk/java/io/FileOutputStream/ManyFiles.java
+++ b/test/jdk/java/io/FileOutputStream/ManyFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,15 +37,6 @@ public class ManyFiles {
     static int NUM_FILES = 2050;
 
     public static void main(String args[]) throws Exception {
-        // Linux does not yet allow opening this many files; Solaris
-        // 8 requires an explicit allocation of more file descriptors
-        // to succeed. Since this test is written to check for a
-        // Windows capability it is much simpler to only run it
-        // on that platform.
-        String osName = System.getProperty("os.name");
-        if (osName.startsWith("Linux"))
-            return;
-
         for (int n = 0; n < NUM_FILES; n++) {
             File f = new File("file" + count++);
             files.add(f);


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8355444](https://bugs.openjdk.org/browse/JDK-8355444) needs maintainer approval

### Issue
 * [JDK-8355444](https://bugs.openjdk.org/browse/JDK-8355444): [java.io] Use @<!---->requires tag instead of exiting based on "os.name" property value (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2193/head:pull/2193` \
`$ git checkout pull/2193`

Update a local copy of the PR: \
`$ git checkout pull/2193` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2193`

View PR using the GUI difftool: \
`$ git pr show -t 2193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2193.diff">https://git.openjdk.org/jdk21u-dev/pull/2193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2193#issuecomment-3281496647)
</details>
