### PR TITLE
8324491: Keyboard layout didn't keep its state if it was changed when dialog was active

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -319,6 +319,10 @@ final class WInputMethod extends InputMethodAdapter
             isLastFocussedActiveClient = isAc;
         }
         isActive = true;
+
+        // Sync currentLocale with the Windows keyboard layout which could be changed
+        // while the component was inactive.
+        getLocale();
         if (currentLocale != null) {
             setLocale(currentLocale, true);
         }


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324491](https://bugs.openjdk.org/browse/JDK-8324491) needs maintainer approval

### Issue
 * [JDK-8324491](https://bugs.openjdk.org/browse/JDK-8324491): Keyboard layout didn't keep its state if it was changed when dialog was active (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2201/head:pull/2201` \
`$ git checkout pull/2201`

Update a local copy of the PR: \
`$ git checkout pull/2201` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2201`

View PR using the GUI difftool: \
`$ git pr show -t 2201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2201.diff">https://git.openjdk.org/jdk21u-dev/pull/2201.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2201#issuecomment-3287638784)
</details>
