### PR TITLE
8367372: Test `test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java` fails on 32 bit systems

### DIFF
--- a/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
+++ b/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package gc;
 /* @test TestObjectAlignmentCardSize.java
  * @summary Test to check correct handling of ObjectAlignmentInBytes and GCCardSizeInBytes combinations
  * @requires vm.gc != "Z"
+ * @requires vm.bits == "64"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @run driver gc.TestObjectAlignmentCardSize


### PR DESCRIPTION
Backporting JDK-8367372: Test test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java fails on 32 bit systems. Trivial fix to require test only run on 64 bit systems. Ran GHA Sanity Checks and adjusted tests directly on both 64 and 32 bit systems (automatically skipped on the latter). Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367372](https://bugs.openjdk.org/browse/JDK-8367372) needs maintainer approval

### Issue
 * [JDK-8367372](https://bugs.openjdk.org/browse/JDK-8367372): Test `test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java` fails on 32 bit systems (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2203/head:pull/2203` \
`$ git checkout pull/2203`

Update a local copy of the PR: \
`$ git checkout pull/2203` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2203`

View PR using the GUI difftool: \
`$ git pr show -t 2203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2203.diff">https://git.openjdk.org/jdk21u-dev/pull/2203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2203#issuecomment-3286265676)
</details>
