### PR TITLE
8361754: New test runtime/jni/checked/TestCharArrayReleasing.java can cause disk full errors

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/checked/TestCharArrayReleasing.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCharArrayReleasing.java
@@ -84,7 +84,7 @@ public class TestCharArrayReleasing {
     }
 
     public static void main(String[] args) throws Throwable {
-        int ABRT = Platform.isWindows() ? 1 : 134;
+        int ABRT = 1;
         int[][] errorCodes = new int[][] {
             { ABRT, 0, ABRT, ABRT, ABRT },
             { ABRT, ABRT, 0, ABRT, ABRT },
@@ -118,6 +118,7 @@ public class TestCharArrayReleasing {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
              "-Djava.library.path=" + System.getProperty("test.nativepath"),
              "--enable-native-access=ALL-UNNAMED",
+             "-XX:-CreateCoredumpOnCrash",
              "-Xcheck:jni",
              "TestCharArrayReleasing$Driver",
              args[0], args[1]);


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361754](https://bugs.openjdk.org/browse/JDK-8361754) needs maintainer approval

### Issue
 * [JDK-8361754](https://bugs.openjdk.org/browse/JDK-8361754): New test runtime/jni/checked/TestCharArrayReleasing.java can cause disk full errors (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2209/head:pull/2209` \
`$ git checkout pull/2209`

Update a local copy of the PR: \
`$ git checkout pull/2209` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2209`

View PR using the GUI difftool: \
`$ git pr show -t 2209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2209.diff">https://git.openjdk.org/jdk21u-dev/pull/2209.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2209#issuecomment-3292381723)
</details>
