### PR TITLE
8359182: Use @requires instead of SkippedException for MaxPath.java

### DIFF
--- a/test/jdk/java/io/File/MaxPath.java
+++ b/test/jdk/java/io/File/MaxPath.java
@@ -24,21 +24,14 @@
 /* @test
    @bug 6481955
    @summary Path length less than MAX_PATH (260) works on Windows
-   @library /test/lib
+   @requires (os.family == "windows")
  */
 
 import java.io.File;
 import java.io.IOException;
 
-import jtreg.SkippedException;
-
 public class MaxPath {
     public static void main(String[] args) throws Exception {
-        String osName = System.getProperty("os.name");
-        if (!osName.startsWith("Windows")) {
-            throw new SkippedException("This test is run only on Windows");
-        }
-
         int MAX_PATH = 260;
         String dir = new File(".").getAbsolutePath() + "\\";
         String padding = "1234567890123456789012345678901234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890012345678900123456789001234567890";


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359182](https://bugs.openjdk.org/browse/JDK-8359182) needs maintainer approval

### Issue
 * [JDK-8359182](https://bugs.openjdk.org/browse/JDK-8359182): Use @<!---->requires instead of SkippedException for MaxPath.java (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2212/head:pull/2212` \
`$ git checkout pull/2212`

Update a local copy of the PR: \
`$ git checkout pull/2212` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2212`

View PR using the GUI difftool: \
`$ git pr show -t 2212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2212.diff">https://git.openjdk.org/jdk21u-dev/pull/2212.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2212#issuecomment-3292591926)
</details>
