### PR TITLE
8337102: JITTester: Fix breaks in static initialization blocks

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/conf/default.properties
+++ b/test/hotspot/jtreg/testlibrary/jittester/conf/default.properties
@@ -8,6 +8,6 @@ classes-file=conf/classes.lst
 exclude-methods-file=conf/exclude.methods.lst
 print-complexity=true
 print-hierarchy=true
-disable-static=true
+disable-static=false
 generatorsFactories=jdk.test.lib.jittester.TestGeneratorsFactory
 generators=JavaCode,ByteCode

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/StaticConstructorDefinitionFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/StaticConstructorDefinitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ class StaticConstructorDefinitionFactory extends Factory<StaticConstructorDefini
                     .setOperatorLimit(operatorLimit)
                     .setLevel(level)
                     .setSubBlock(true)
-                    .setCanHaveBreaks(true)
+                    .setCanHaveBreaks(false)
                     .setCanHaveContinues(false)
                     .setCanHaveReturn(false)
                     .getBlockFactory()


### PR DESCRIPTION
The backport verified on MacOS/Linux/Windows by manually running JITTester.

Verification involved modifying JITTester code to terminate with non-zero exit code when encountering specific compilation error (a break statement in a static initializer) in the generated code and enabling static initializer generation in configuration file in non-fixed version.

Without the fix in most cases the error is reproduced  during the first generation round.
With the fix, there is no error for 10s of rounds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8337102](https://bugs.openjdk.org/browse/JDK-8337102) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337102](https://bugs.openjdk.org/browse/JDK-8337102): JITTester: Fix breaks in static initialization blocks (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2214/head:pull/2214` \
`$ git checkout pull/2214`

Update a local copy of the PR: \
`$ git checkout pull/2214` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2214`

View PR using the GUI difftool: \
`$ git pr show -t 2214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2214.diff">https://git.openjdk.org/jdk21u-dev/pull/2214.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2214#issuecomment-3462856439)
</details>
