### PR TITLE
8230016: re-visit test sun/security/pkcs11/Serialize/SerializeProvider.java

### DIFF
--- a/test/jdk/sun/security/pkcs11/Serialize/SerializeProvider.java
+++ b/test/jdk/sun/security/pkcs11/Serialize/SerializeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,9 +41,9 @@ import java.security.Security;
 public class SerializeProvider extends PKCS11Test {
 
     public void main(Provider p) throws Exception {
+
         if (Security.getProvider(p.getName()) != p) {
-            System.out.println("Provider not installed in Security, skipping");
-            return;
+            Security.addProvider(p);
         }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -57,7 +57,7 @@ public class SerializeProvider extends PKCS11Test {
         InputStream in = new ByteArrayInputStream(data);
         ObjectInputStream oin = new ObjectInputStream(in);
 
-        Provider p2 = (Provider)oin.readObject();
+        Provider p2 = (Provider) oin.readObject();
 
         System.out.println("Reconstituted: " + p2);
 


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8230016](https://bugs.openjdk.org/browse/JDK-8230016) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230016](https://bugs.openjdk.org/browse/JDK-8230016): re-visit test sun/security/pkcs11/Serialize/SerializeProvider.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2216/head:pull/2216` \
`$ git checkout pull/2216`

Update a local copy of the PR: \
`$ git checkout pull/2216` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2216`

View PR using the GUI difftool: \
`$ git pr show -t 2216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2216.diff">https://git.openjdk.org/jdk21u-dev/pull/2216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2216#issuecomment-3299131766)
</details>
