### PR TITLE
8356897: Update NSS library to 3.111

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -82,7 +82,7 @@ public abstract class PKCS11Test {
 
     // Version of the NSS artifact. This coincides with the version of
     // the NSS version
-    private static final String NSS_BUNDLE_VERSION = "3.107";
+    private static final String NSS_BUNDLE_VERSION = "3.111";
     private static final String NSSLIB = "jpg.tests.jdk.nsslib";
 
     static double nss_version = -1;


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8356897](https://bugs.openjdk.org/browse/JDK-8356897) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356897](https://bugs.openjdk.org/browse/JDK-8356897): Update NSS library to 3.111 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2225/head:pull/2225` \
`$ git checkout pull/2225`

Update a local copy of the PR: \
`$ git checkout pull/2225` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2225`

View PR using the GUI difftool: \
`$ git pr show -t 2225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2225.diff">https://git.openjdk.org/jdk21u-dev/pull/2225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2225#issuecomment-3303276154)
</details>
