### PR TITLE
8360022: ClassRefDupInConstantPoolTest.java fails when running in repeat

### DIFF
--- a/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
+++ b/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8015927
  * @summary Class reference duplicates in constant pool
  * @modules jdk.jdeps/com.sun.tools.classfile
- * @clean ClassRefDupInConstantPoolTest$Duplicates
+ * @clean ClassRefDupInConstantPoolTest ClassRefDupInConstantPoolTest$Duplicates
  * @run main ClassRefDupInConstantPoolTest
  */
 


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

both chunks needed resolve.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8360022](https://bugs.openjdk.org/browse/JDK-8360022) needs maintainer approval

### Issue
 * [JDK-8360022](https://bugs.openjdk.org/browse/JDK-8360022): ClassRefDupInConstantPoolTest.java fails when running in repeat (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2231/head:pull/2231` \
`$ git checkout pull/2231`

Update a local copy of the PR: \
`$ git checkout pull/2231` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2231`

View PR using the GUI difftool: \
`$ git pr show -t 2231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2231.diff">https://git.openjdk.org/jdk21u-dev/pull/2231.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2231#issuecomment-3308981712)
</details>
