### PR TITLE
8352793: Open source several AWT TextComponent tests - Batch 1

### DIFF
--- a/test/jdk/java/awt/TextComponent/BackgroundTest.java
+++ b/test/jdk/java/awt/TextComponent/BackgroundTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4258667 4405602
+ * @summary  Make sure TextComponents are grayed out when non-editable
+ *           if the background color has not been set by client code.
+ *           Make sure TextComponents are not grayed out when non-editable
+ *           if the background color has been set by client code.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual BackgroundTest
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.TextArea;
+import java.awt.TextField;
+
+public class BackgroundTest {
+    private static final String enableString = "EnableText";
+    private static final String disableString = "DisableText";
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. When the frame appears, it should have a blue background.
+                2. The first TextField and TextArea will be the default color.
+                   The second TextField and TextArea will be green.
+                3. Press the "DisableText" button.
+                   The first TextField and TextArea should change colors to the
+                   default disabled color.  On Windows, this is usually gray.
+                   On linux and macos it will match the environment settings.
+                   If the TextField or the TextArea do not change colors as described,
+                   the test FAILS.
+                4. The second TextField and TextArea should still be green.
+                   If either of them are not green, the test FAILS.
+                   Press the "EnableText" button (same button as before).
+                   The first TextField and TextArea should return to their
+                   original colors as described in the first paragraph. If they
+                   do not, the test FAILS.
+                5. The second TextField and TextArea should still be green.
+                   If either of them are not green, the test FAILS.
+                   Otherwise, the test PASSES.
+                """;
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(BackgroundTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame initialize() {
+        Frame frame = new Frame("Background Test");
+        frame.setLayout(new FlowLayout());
+        TextField tf = new TextField(30);
+        TextArea ta = new TextArea(4, 30);
+        TextField setTf = new TextField(30);
+        TextArea setTa = new TextArea(4, 30);
+        Button enableButton = new Button(disableString);
+
+        enableButton.setBackground(Color.red);
+        frame.setSize(500, 250);
+
+        frame.setBackground(Color.blue);
+
+        tf.setText("Background not set - should be default");
+        tf.setEditable(true);
+        frame.add(tf);
+        ta.setText("Background not set - should be default");
+        ta.setEditable(true);
+        frame.add(ta);
+
+        setTf.setText("Background is set - should be Green");
+        setTf.setBackground(Color.green);
+        setTf.setEditable(true);
+        frame.add(setTf);
+        setTa.setText("Background is set - should be Green");
+        setTa.setBackground(Color.green);
+        setTa.setEditable(true);
+        frame.add(setTa);
+
+        enableButton.addActionListener(e -> {
+            boolean currentlyEditable = tf.isEditable();
+
+            if (currentlyEditable) {
+                tf.setEditable(false);
+                ta.setEditable(false);
+                setTf.setEditable(false);
+                setTa.setEditable(false);
+                enableButton.setLabel(enableString);
+            } else {
+                tf.setEditable(true);
+                ta.setEditable(true);
+                setTf.setEditable(true);
+                setTa.setEditable(true);
+                enableButton.setLabel(disableString);
+            }
+        });
+        frame.add(enableButton);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/TextComponent/DisableTest.java
+++ b/test/jdk/java/awt/TextComponent/DisableTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5042122
+ * @summary Verifies the TextComponent is grayed out when disabled
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DisableTest
+ */
+
+import javax.swing.BoxLayout;
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.event.ActionListener;
+import java.util.Vector;
+import java.util.Iterator;
+
+public class DisableTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Click "Enable" and "Disable" buttons and verify the text
+                   components are disabled and enabled correctly.
+                2. Verify that the disabled text components are grayed
+                   out and are uneditable.
+                3. Click PASS or FAIL accordingly.
+                """;
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(DisableTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame initialize() {
+        Frame frame = new Frame("TextComponent Disabled test");
+        frame.setLayout(new BorderLayout());
+        frame.setSize(200, 200);
+        final Vector comps = new Vector();
+        comps.add(new TextField("TextField"));
+        TextArea ta = new TextArea("TextArea", 2, 100, TextArea.SCROLLBARS_NONE);
+        comps.add(ta);
+        Panel pc = new Panel();
+        pc.setLayout(new BoxLayout(pc, BoxLayout.Y_AXIS));
+        Iterator iter = comps.iterator();
+        while (iter.hasNext()) {
+            Component c = (Component) iter.next();
+            c.setEnabled(false);
+            pc.add(c);
+        }
+        frame.add(pc, BorderLayout.CENTER);
+        Panel p = new Panel();
+        final Button be = new Button("Enable");
+        final Button bd = new Button("Disable");
+        p.add(be);
+        p.add(bd);
+        ActionListener al = ev -> {
+            boolean enable = (ev.getSource() == be);
+            Iterator iterator = comps.iterator();
+            while (iterator.hasNext()) {
+                Component c = (Component) iterator.next();
+                c.setEnabled(enable);
+            }
+        };
+        be.addActionListener(al);
+        bd.addActionListener(al);
+        frame.add(p, BorderLayout.SOUTH);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/TextComponent/ModifiersTest.java
+++ b/test/jdk/java/awt/TextComponent/ModifiersTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4035364
+ * @summary Checks that Caps Lock key works
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ModifiersTest
+ */
+
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.TextArea;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+
+public class ModifiersTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Type some text in the TextArea in upper and lowercase,
+                   using the Caps Lock ON/OFF.
+                2. If Caps Lock toggles correctly and you are able to type in
+                     both cases, the test PASS. Else Test FAILS.
+                """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ModifiersTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame initialize() {
+        Frame frame = new Frame("Modifiers Test");
+        frame.setLayout(new GridLayout(1, 1));
+        frame.addKeyListener(new KeyChecker());
+        frame.setLayout(new GridLayout(2, 1));
+        Label label = new Label("See if you can type in upper and lowercase using Caps Lock:");
+        frame.add(label);
+        TextArea ta = new TextArea();
+        frame.add(ta);
+        ta.addKeyListener(new KeyChecker());
+        ta.requestFocus();
+        frame.setSize(400, 300);
+        return frame;
+    }
+}
+
+// a KeyListener for debugging purposes
+class KeyChecker extends KeyAdapter {
+    public void keyPressed(KeyEvent ev) {
+        System.out.println(ev);
+    }
+
+    public void keyReleased(KeyEvent ev) {
+        System.out.println(ev);
+    }
+
+    public void keyTyped(KeyEvent ev) {
+        System.out.println(ev);
+    }
+}

--- a/test/jdk/java/awt/TextComponent/TextFieldMargin.java
+++ b/test/jdk/java/awt/TextComponent/TextFieldMargin.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4129511
+ * @summary Tests that TextField margins are not exceedingly wide
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextFieldMargin
+ */
+
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.TextArea;
+import java.awt.TextField;
+
+public class TextFieldMargin {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Examine the TextField, Label, and TextArea to see
+                   that the text is vertically aligned along the left
+                2. If all are aligned along the left, then test PASS,
+                   else test FAILS.
+                """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(TextFieldMargin::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame initialize() {
+        Frame frame = new Frame("Frame with a text field & a label");
+        frame.setLayout(new GridLayout(5, 1));
+        TextField text_field = new TextField("Left Textfield");
+        frame.add(text_field);
+        Label label = new Label("Left Label");
+        frame.add(label);
+        TextArea text_area = new TextArea("Left Textfield");
+        frame.add(text_area);
+        frame.setBounds(50, 50, 300, 300);
+        return frame;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8352793: Open source several AWT TextComponent tests - Batch 1. Adds four AWT TextComponent related tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352793](https://bugs.openjdk.org/browse/JDK-8352793) needs maintainer approval

### Issue
 * [JDK-8352793](https://bugs.openjdk.org/browse/JDK-8352793): Open source several AWT TextComponent tests - Batch 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2233/head:pull/2233` \
`$ git checkout pull/2233`

Update a local copy of the PR: \
`$ git checkout pull/2233` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2233`

View PR using the GUI difftool: \
`$ git pr show -t 2233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2233.diff">https://git.openjdk.org/jdk21u-dev/pull/2233.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2233#issuecomment-3309781414)
</details>
