### PR TITLE
8362207: Add more test cases for possible double-rounding in fma

### DIFF
--- a/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
+++ b/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4851642 8253409
+ * @bug 4851642 8253409 8362207
  * @summary Tests for Math.fusedMac and StrictMath.fusedMac.
  * @build Tests
  * @build FusedMultiplyAddTests
@@ -352,8 +352,9 @@ public class FusedMultiplyAddTests {
             {1.0f+Math.ulp(1.0f), 1.0f+Math.ulp(1.0f), -1.0f-2.0f*Math.ulp(1.0f),
              Math.ulp(1.0f)*Math.ulp(1.0f)},
 
-            // Double-rounding if done in double precision
-            {0x1.fffffep23f, 0x1.000004p28f, 0x1.fep5f, 0x1.000002p52f}
+            // Double-rounding if done in double precision and/or double fma
+            {0x1.fffffep23f, 0x1.000004p28f, 0x1.fep5f, 0x1.000002p52f},
+            {0x1.001p0f,     0x1.001p0f,     0x1p-100f, 0x1.002002p0f},
         };
 
         for (float[] testCase: testCases)


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

Omitted b/test/jdk/jdk/incubator/vector/BasicFloat16ArithTests.java
which was added by https://bugs.openjdk.org/browse/JDK-8341260 Add Float16 to jdk.incubator.vector

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362207](https://bugs.openjdk.org/browse/JDK-8362207) needs maintainer approval

### Issue
 * [JDK-8362207](https://bugs.openjdk.org/browse/JDK-8362207): Add more test cases for possible double-rounding in fma (**Enhancement** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2240/head:pull/2240` \
`$ git checkout pull/2240`

Update a local copy of the PR: \
`$ git checkout pull/2240` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2240`

View PR using the GUI difftool: \
`$ git pr show -t 2240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2240.diff">https://git.openjdk.org/jdk21u-dev/pull/2240.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2240#issuecomment-3311165918)
</details>
