### PR TITLE
8361751: Test sun/tools/jcmd/TestJcmdSanity.java timed out on Windows

### DIFF
--- a/test/jdk/sun/tools/jcmd/JcmdBase.java
+++ b/test/jdk/sun/tools/jcmd/JcmdBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,6 +102,8 @@ public final class JcmdBase {
                 launcher.addVMArg(vmArg);
             }
         }
+        // Some command output may be lengthy, disable streaming output to avoid deadlocks
+        launcher.addVMArg("-Djdk.attach.allowStreamingOutput=false");
         if (requestToCurrentProcess) {
             launcher.addToolArg(Long.toString(ProcessTools.getProcessId()));
         }


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361751](https://bugs.openjdk.org/browse/JDK-8361751) needs maintainer approval

### Issue
 * [JDK-8361751](https://bugs.openjdk.org/browse/JDK-8361751): Test sun/tools/jcmd/TestJcmdSanity.java timed out on Windows (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2241/head:pull/2241` \
`$ git checkout pull/2241`

Update a local copy of the PR: \
`$ git checkout pull/2241` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2241`

View PR using the GUI difftool: \
`$ git pr show -t 2241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2241.diff">https://git.openjdk.org/jdk21u-dev/pull/2241.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2241#issuecomment-3311563090)
</details>
