### PR TITLE
8362602: Add test.timeout.factor to CompileFactory to avoid test timeouts

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/compile_framework/Compile.java
+++ b/test/hotspot/jtreg/compiler/lib/compile_framework/Compile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import jdk.test.lib.JDKToolFinder;
  */
 class Compile {
     private static final int COMPILE_TIMEOUT = 60;
+    private static final float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
 
     private static final String JAVA_PATH = JDKToolFinder.getJDKTool("java");
     private static final String JAVAC_PATH = JDKToolFinder.getJDKTool("javac");
@@ -178,7 +179,8 @@ class Compile {
         int exitCode;
         try {
             Process process = builder.start();
-            boolean exited = process.waitFor(COMPILE_TIMEOUT, TimeUnit.SECONDS);
+            long timeout = COMPILE_TIMEOUT * (long)timeoutFactor;
+            boolean exited = process.waitFor(timeout, TimeUnit.SECONDS);
             if (!exited) {
                 process.destroyForcibly();
                 System.out.println("Timeout: compile command: " + String.join(" ", command));


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8362602](https://bugs.openjdk.org/browse/JDK-8362602) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362602](https://bugs.openjdk.org/browse/JDK-8362602): Add test.timeout.factor to CompileFactory to avoid test timeouts (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2243/head:pull/2243` \
`$ git checkout pull/2243`

Update a local copy of the PR: \
`$ git checkout pull/2243` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2243`

View PR using the GUI difftool: \
`$ git pr show -t 2243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2243.diff">https://git.openjdk.org/jdk21u-dev/pull/2243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2243#issuecomment-3311603853)
</details>
