### PR TITLE
Backport d288ca28be7bfba3abe9f54cefbe53e73c25707e

### DIFF
--- a/test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java
+++ b/test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java
@@ -37,12 +37,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.test.lib.net.SimpleSSLContext;
 
 import static java.lang.System.out;
 
-/**
+/*
  * @test
  * @bug 8262027
  * @summary Verify that it's possible to handle proxy authentication manually
@@ -62,7 +61,7 @@ import static java.lang.System.out;
 //-Djdk.internal.httpclient.debug=true -Dtest.debug=true
 public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
 
-    static final String data[] = {
+    static final String[] data = {
         "Lorem ipsum",
         "dolor sit amet",
         "consectetur adipiscing elit, sed do eiusmod tempor",
@@ -150,7 +149,7 @@ public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        if (proxy != null) close(proxy::stop);
+        if (proxy != null) close(proxy);
         if (http1Server != null) close(http1Server::stop);
         if (https1Server != null) close(https1Server::stop);
         if (https2Server != null) close(https2Server::stop);
@@ -160,7 +159,8 @@ public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
         try {
             closeable.close();
         } catch (Exception x) {
-            // OK.
+            // OK to ignore and just log
+            System.err.println("ignoring failure during close() of " + closeable + " due to: " + x);
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 21.0.10-oracle.