### PR TITLE
8353445: Open source several AWT Menu tests - Batch 1

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -835,3 +835,4 @@ java/awt/Checkbox/CheckboxIndicatorSizeTest.java 8340870 windows-all
 java/awt/Checkbox/CheckboxNullLabelTest.java 8340870 windows-all
 java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
 java/awt/Focus/MinimizeNonfocusableWindowTest.java 8024487 windows-all
+java/awt/Menu/MenuVisibilityTest.java 8161110 macosx-all

--- a/test/jdk/java/awt/Menu/MenuActionEventTest.java
+++ b/test/jdk/java/awt/Menu/MenuActionEventTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4094620
+ * @summary MenuItem.enableEvents does not work
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuActionEventTest
+ */
+
+import java.awt.AWTEvent;
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ActionEvent;
+
+public class MenuActionEventTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Click on the Menu and then on Menuitem on the frame.
+                2. If you find the following message being printed in
+                   the test log area:,
+                   _MenuItem: action event",
+                   click PASS, else click FAIL"
+                 """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(MenuActionEventTest::initialize)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame f = new Frame("Menu Action Event Test");
+        f.setLayout(new BorderLayout());
+        f.setMenuBar(new MenuBar());
+        Menu m = new _Menu("Menu");
+        MenuBar mb = f.getMenuBar();
+        mb.add(m);
+        MenuItem mi = new _MenuItem("Menuitem");
+        m.add(mi);
+        f.setBounds(204, 152, 396, 300);
+        return f;
+    }
+
+    static class _Menu extends Menu {
+        public _Menu(String text) {
+            super(text);
+            enableEvents(AWTEvent.ACTION_EVENT_MASK);
+        }
+
+        @Override
+        protected void processActionEvent(ActionEvent e) {
+            PassFailJFrame.log("_Menu: action event");
+            super.processActionEvent(e);
+        }
+    }
+
+    static class _MenuItem extends MenuItem {
+        public _MenuItem(String text) {
+            super(text);
+            enableEvents(AWTEvent.ACTION_EVENT_MASK);
+        }
+
+        @Override
+        protected void processActionEvent(ActionEvent e) {
+            PassFailJFrame.log("_MenuItem: action event");
+            super.processActionEvent(e);
+        }
+    }
+
+}

--- a/test/jdk/java/awt/Menu/MenuVisibilityTest.java
+++ b/test/jdk/java/awt/Menu/MenuVisibilityTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5046491 6423258
+ * @summary CheckboxMenuItem: menu text is missing from test frame
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuVisibilityTest
+*/
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+public class MenuVisibilityTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Press on a MenuBar with a long name.
+                2. Select "First item" in an opened menu.
+                   If you see that "First menu item was pressed" in
+                   the test log area, press PASS
+                   Otherwise press FAIL"
+                 """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(MenuVisibilityTest::initialize)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame initialize() {
+        Frame frame = new Frame("Menu visibility test");
+        String menuTitle = "I_have_never_seen_so_long_Menu_Title_" +
+                "!_ehe-eha-ehu-ehi_ugu-gu!!!_;)_BANG_BANG...";
+        MenuBar menubar = new MenuBar();
+        Menu menu = new Menu(menuTitle);
+        MenuItem menuItem = new MenuItem("First item");
+        menuItem.addActionListener(e ->
+                PassFailJFrame.log("First menu item was pressed."));
+        menu.add(menuItem);
+        menubar.add(menu);
+        frame.setMenuBar(menubar);
+        frame.setSize(100, 200);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Menu/RmInHideTest.java
+++ b/test/jdk/java/awt/Menu/RmInHideTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4039387
+ * @summary Checks that calling Frame.remove() within hide() doesn't
+ *          cause SEGV
+ * @key headful
+ * @run main RmInHideTest
+ */
+
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+
+public class RmInHideTest {
+    static volatile Point point;
+    static RmInHideTestFrame frame;
+    static volatile Dimension dimension;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new RmInHideTestFrame();
+                frame.setSize(200, 200);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> {
+                point = frame.getButtonLocation();
+                dimension = frame.getButtonDimension();
+            });
+            robot.mouseMove(point.x + dimension.width / 2, point.y + dimension.height / 2);
+            robot.mousePress(MouseEvent.BUTTON2_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON2_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(100);
+            System.out.println("Test pass");
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    static class RmInHideTestFrame extends Frame implements ActionListener {
+        MenuBar menubar = null;
+        Button b;
+
+        public RmInHideTestFrame() {
+            super("RmInHideTest");
+            b = new Button("Hide");
+            b.setActionCommand("hide");
+            b.addActionListener(this);
+            add("Center", b);
+
+            MenuBar bar = new MenuBar();
+
+            Menu menu = new Menu("Test1", true);
+            menu.add(new MenuItem("Test1A"));
+            menu.add(new MenuItem("Test1B"));
+            menu.add(new MenuItem("Test1C"));
+            bar.add(menu);
+
+            menu = new Menu("Test2", true);
+            menu.add(new MenuItem("Test2A"));
+            menu.add(new MenuItem("Test2B"));
+            menu.add(new MenuItem("Test2C"));
+            bar.add(menu);
+            setMenuBar(bar);
+        }
+
+        @Override
+        public Dimension minimumSize() {
+            return new Dimension(200, 200);
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            String cmd = e.getActionCommand();
+            if (cmd.equals("hide")) {
+                hide();
+                try {
+                    Thread.currentThread().sleep(2000);
+                } catch (InterruptedException ex) {
+                    // do nothing
+                }
+                show();
+            }
+        }
+
+        @Override
+        public void hide() {
+            menubar = getMenuBar();
+            if (menubar != null) {
+                remove(menubar);
+            }
+            super.hide();
+        }
+
+
+        @Override
+        public void show() {
+            if (menubar != null) {
+                setMenuBar(menubar);
+            }
+            super.show();
+        }
+
+        public Point getButtonLocation() {
+            return b.getLocationOnScreen();
+        }
+
+        public Dimension getButtonDimension() {
+            return b.getSize();
+        }
+    }
+}

--- a/test/jdk/java/awt/Menu/SetShortCutTest.java
+++ b/test/jdk/java/awt/Menu/SetShortCutTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4203208
+ * @summary setShortcut method does not display proper text on Menu component
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetShortCutTest
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+
+import static java.awt.event.KeyEvent.VK_META;
+import static java.awt.event.KeyEvent.VK_SHIFT;
+
+public class SetShortCutTest {
+    public static void main(String[] args) throws Exception {
+        boolean isMac = System.getProperty("os.name").startsWith("Mac");
+        String shortcut = "Ctrl+Shift+";
+        if (isMac) {
+            shortcut = KeyEvent.getKeyText(VK_SHIFT) + "+" + KeyEvent.getKeyText(VK_META);
+        }
+
+        String INSTRUCTIONS = """
+                1. Select menuitem 'Stuff -> Second' once to remove 'File -> First'.
+                2. Select menuitem 'Stuff -> Second' again to add 'File -> First'.
+                3. If menuitem 'File -> First' reads First """ + shortcut + """
+                       'C', press PASS. Otherwise press FAIL.
+                """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(SetShortCutTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        return new TestMenuShortCut();
+    }
+
+    static class TestMenuShortCut extends Frame implements ActionListener {
+        Menu menu1;
+        MenuItem item1;
+        MenuItem item2;
+        boolean beenHere;
+
+        public TestMenuShortCut() {
+            setTitle("Set ShortCut test");
+            beenHere = false;
+            MenuBar mTopMenu = buildMenu();
+            setSize(300, 300);
+            this.setMenuBar(mTopMenu);
+        }
+
+        public MenuBar buildMenu() {
+            MenuBar bar;
+            bar = new MenuBar();
+            menu1 = new Menu("File");
+            item1 = new MenuItem("First");
+            menu1.add(item1);
+            item1.setShortcut(new MenuShortcut(KeyEvent.VK_C, true));
+            bar.add(menu1);
+
+            // Stuff menu
+            item2 = new MenuItem("Second");
+            Menu menu2 = new Menu("Stuff");
+            menu2.add(item2);
+            item2.setShortcut(new MenuShortcut(KeyEvent.VK_C, false));
+            bar.add(menu2);
+
+            item1.addActionListener(this);
+            item2.addActionListener(this);
+            return bar;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent event) {
+            if (event.getSource() == item1) {
+                Frame temp = new Frame("Accelerator key is working for 'First'");
+                temp.setSize(300, 50);
+                temp.setVisible(true);
+            }
+
+            // Click on the "Stuff" menu to remove the "first" menu item
+            else if (event.getSource() == item2) {
+                // If the item has not been removed from the menu,
+                // then remove "First" from the "File" menu
+                if (beenHere == false) {
+                    item1.removeActionListener(this);
+                    menu1.remove(item1);
+                    beenHere = true;
+                } else {
+                    item1 = new MenuItem("First");
+                    menu1.add(item1);
+                    item1.addActionListener(this);
+                    item1.setShortcut(new MenuShortcut(KeyEvent.VK_C, true));
+                    beenHere = false;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353445: Open source several AWT Menu tests - Batch 1. Adds four AWT menu tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353445](https://bugs.openjdk.org/browse/JDK-8353445) needs maintainer approval

### Issue
 * [JDK-8353445](https://bugs.openjdk.org/browse/JDK-8353445): Open source several AWT Menu tests - Batch 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2251/head:pull/2251` \
`$ git checkout pull/2251`

Update a local copy of the PR: \
`$ git checkout pull/2251` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2251`

View PR using the GUI difftool: \
`$ git pr show -t 2251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2251.diff">https://git.openjdk.org/jdk21u-dev/pull/2251.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2251#issuecomment-3313777622)
</details>
