### PR TITLE
8319570: Change to GCC 13.2.0 for building on Linux at Oracle

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -539,7 +539,7 @@ to compile successfully without issues.</p>
 <tbody>
 <tr class="odd">
 <td>Linux</td>
-<td>gcc 11.2.0</td>
+<td>gcc 13.2.0</td>
 </tr>
 <tr class="even">
 <td>macOS</td>
@@ -560,7 +560,7 @@ limited to using C99 features that it does support.</p>
 generate a warning by <code>configure</code> and are unlikely to
 work.</p>
 <p>The JDK is currently known to be able to compile with at least
-version 11.2 of gcc.</p>
+version 13.2 of gcc.</p>
 <p>In general, any version between these two should be usable.</p>
 <h3 id="clang">clang</h3>
 <p>The minimum accepted version of clang is 3.5. Older versions will not

--- a/doc/building.md
+++ b/doc/building.md
@@ -336,7 +336,7 @@ issues.
 
 | Operating system   | Toolchain version                          |
 | ------------------ | ------------------------------------------ |
-| Linux              | gcc 11.2.0                                 |
+| Linux              | gcc 13.2.0                                 |
 | macOS              | Apple Xcode 10.1 (using clang 10.0.0)      |
 | Windows            | Microsoft Visual Studio 2022 update 17.1.0 |
 
@@ -350,7 +350,7 @@ features that it does support.
 The minimum accepted version of gcc is 5.0. Older versions will generate a warning
 by `configure` and are unlikely to work.
 
-The JDK is currently known to be able to compile with at least version 11.2 of
+The JDK is currently known to be able to compile with at least version 13.2 of
 gcc.
 
 In general, any version between these two should be usable.

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1080,10 +1080,10 @@ var getJibProfilesProfiles = function (input, common, data) {
 var getJibProfilesDependencies = function (input, common) {
 
     var devkit_platform_revisions = {
-        linux_x64: "gcc11.2.0-OL6.4+1.0",
+        linux_x64: "gcc13.2.0-OL6.4+1.0",
         macosx: "Xcode12.4+1.1",
         windows_x64: "VS2022-17.1.0+1.1",
-        linux_aarch64: input.build_cpu == "x64" ? "gcc11.2.0-OL7.6+1.1" : "gcc11.2.0-OL7.6+1.0",
+        linux_aarch64: "gcc13.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
         linux_ppc64le: "gcc8.2.0-Fedora27+1.0",
         linux_s390x: "gcc8.2.0-Fedora27+1.0",

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -55,11 +55,11 @@ KERNEL_HEADERS_RPM := kernel-headers
 
 ifeq ($(BASE_OS), OL)
   ifeq ($(ARCH), aarch64)
-    BASE_URL := http://yum.oracle.com/repo/OracleLinux/OL7/6/base/$(ARCH)/
+    BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL7/6/base/$(ARCH)/
     LINUX_VERSION := OL7.6
     KERNEL_HEADERS_RPM := kernel-uek-headers
   else
-    BASE_URL := http://yum.oracle.com/repo/OracleLinux/OL6/4/base/$(ARCH)/
+    BASE_URL := https://yum.oracle.com/repo/OracleLinux/OL6/4/base/$(ARCH)/
     LINUX_VERSION := OL6.4
   endif
 else ifeq ($(BASE_OS), Fedora)
@@ -96,8 +96,17 @@ endif
 # Define external dependencies
 
 # Latest that could be made to work.
-GCC_VER := 11.3.0
-ifeq ($(GCC_VER), 11.3.0)
+GCC_VER := 13.2.0
+ifeq ($(GCC_VER), 13.2.0)
+  gcc_ver := gcc-13.2.0
+  binutils_ver := binutils-2.41
+  ccache_ver := ccache-3.7.12
+  mpfr_ver := mpfr-4.2.0
+  gmp_ver := gmp-6.3.0
+  mpc_ver := mpc-1.3.1
+  gdb_ver := gdb-13.2
+  REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
+else ifeq ($(GCC_VER), 11.3.0)
   gcc_ver := gcc-11.3.0
   binutils_ver := binutils-2.39
   ccache_ver := ccache-3.7.12
@@ -671,7 +680,11 @@ $(PREFIX)/Tools.gmk: ./Tools.gmk
 	rm -rf $@
 	cp $< $@
 
-THESE_MAKEFILES := $(PREFIX)/Makefile $(PREFIX)/Tools.gmk
+$(PREFIX)/Tars.gmk: ./Tars.gmk
+	rm -rf $@
+	cp $< $@
+
+THESE_MAKEFILES := $(PREFIX)/Makefile $(PREFIX)/Tools.gmk $(PREFIX)/Tars.gmk
 
 ##########################################################################################
 


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.

Resolved some chunks due to context.

This should not change any existing build setup, just bring the possibility 
to generate a devkit with gcc 13.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319570](https://bugs.openjdk.org/browse/JDK-8319570) needs maintainer approval

### Issue
 * [JDK-8319570](https://bugs.openjdk.org/browse/JDK-8319570): Change to GCC 13.2.0 for building on Linux at Oracle (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2253/head:pull/2253` \
`$ git checkout pull/2253`

Update a local copy of the PR: \
`$ git checkout pull/2253` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2253`

View PR using the GUI difftool: \
`$ git pr show -t 2253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2253.diff">https://git.openjdk.org/jdk21u-dev/pull/2253.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2253#issuecomment-3317387807)
</details>
