### PR TITLE
8364996: java/awt/font/FontNames/LocaleFamilyNames.java times out on Windows

### DIFF
--- a/test/jdk/java/awt/font/FontNames/LocaleFamilyNames.java
+++ b/test/jdk/java/awt/font/FontNames/LocaleFamilyNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,19 +26,21 @@
  * @bug 4935798 6521210 6901159
  * @summary Tests that all family names that are reported in all locales
  * correspond to some font returned from getAllFonts().
- * @run main LocaleFamilyNames
+ * @run main/othervm/timeout=360 LocaleFamilyNames
  */
 import java.awt.*;
 import java.util.*;
 
 public class LocaleFamilyNames {
     public static void main(String[] args) throws Exception {
+        System.out.println("Start time: " + java.time.LocalDateTime.now());
 
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-
         Font[] all_fonts = ge.getAllFonts();
-
         Locale[] all_locales = Locale.getAvailableLocales();
+
+        System.out.println("Number of fonts: " + all_fonts.length);
+        System.out.println("Number of locales: " + all_locales.length);
 
         HashSet all_families = new HashSet();
         for (int i=0; i<all_fonts.length; i++) {
@@ -46,9 +48,10 @@ public class LocaleFamilyNames {
             for (int j=0; j<all_locales.length;j++) {
               all_families.add(all_fonts[i].getFamily(all_locales[j]));
             }
-
         }
 
+        System.out.println("Number of font families: " + all_families.size());
+        System.out.println("Time after preparing the font families HashSet: " + java.time.LocalDateTime.now());
 
         for (int i=0; i<all_locales.length; i++) {
             String[] families_for_locale =


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8364996](https://bugs.openjdk.org/browse/JDK-8364996) needs maintainer approval

### Issue
 * [JDK-8364996](https://bugs.openjdk.org/browse/JDK-8364996): java/awt/font/FontNames/LocaleFamilyNames.java times out on Windows (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2257/head:pull/2257` \
`$ git checkout pull/2257`

Update a local copy of the PR: \
`$ git checkout pull/2257` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2257`

View PR using the GUI difftool: \
`$ git pr show -t 2257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2257.diff">https://git.openjdk.org/jdk21u-dev/pull/2257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2257#issuecomment-3319318233)
</details>
