### PR TITLE
8367869: Test java/io/FileDescriptor/Sync.java timed out

### DIFF
--- a/test/jdk/java/io/FileDescriptor/Sync.java
+++ b/test/jdk/java/io/FileDescriptor/Sync.java
@@ -39,7 +39,7 @@ import jdk.test.lib.thread.VThreadRunner;
 public class Sync {
 
     static final String TEST_DIR = System.getProperty("test.dir", ".");
-    static final int TRIES = 10_000;
+    static final int TRIES = 1_000;
 
     public static void testWith(File file) throws Exception {
         try (FileOutputStream fos = new FileOutputStream(file)) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [61c5245b](https://github.com/openjdk/jdk/commit/61c5245bf7d6626b0c816612adcb0d94d6863644) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 23 Sep 2025 and was reviewed by Jaikiran Pai, Aleksey Shipilev and Roger Riggs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367869](https://bugs.openjdk.org/browse/JDK-8367869) needs maintainer approval

### Issue
 * [JDK-8367869](https://bugs.openjdk.org/browse/JDK-8367869): Test java/io/FileDescriptor/Sync.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2262/head:pull/2262` \
`$ git checkout pull/2262`

Update a local copy of the PR: \
`$ git checkout pull/2262` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2262`

View PR using the GUI difftool: \
`$ git pr show -t 2262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2262.diff">https://git.openjdk.org/jdk21u-dev/pull/2262.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2262#issuecomment-3322007762)
</details>
