### PR TITLE
8351359: OperatingSystemMXBean: values from getCpuLoad and getProcessCpuLoad are stale after 24.8 days (Windows)

### DIFF
--- a/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi,

It's a clean backport of JDK-8351359.
Changes are related to Windows only.

Testing:
- manual testing code that calls `getProcessCpuLoad()` on windows server 2025, intel cpu
- OpenJDK GHA Sanity Checks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8351359](https://bugs.openjdk.org/browse/JDK-8351359) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351359](https://bugs.openjdk.org/browse/JDK-8351359): OperatingSystemMXBean: values from getCpuLoad and getProcessCpuLoad are stale after 24.8 days (Windows) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2263/head:pull/2263` \
`$ git checkout pull/2263`

Update a local copy of the PR: \
`$ git checkout pull/2263` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2263`

View PR using the GUI difftool: \
`$ git pr show -t 2263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2263.diff">https://git.openjdk.org/jdk21u-dev/pull/2263.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2263#issuecomment-3453268707)
</details>
