### PR TITLE
8361871: [GCC static analyzer] complains about use of uninitialized value ckpObject in p11_util.c

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -1191,7 +1191,7 @@ CK_VOID_PTR jObjectToPrimitiveCKObjectPtr(JNIEnv *env, jobject jObject, CK_ULONG
     jclass jBooleanArrayClass, jIntArrayClass, jLongArrayClass;
     jclass jStringClass;
     jclass jObjectClass, jClassClass;
-    CK_VOID_PTR ckpObject;
+    CK_VOID_PTR ckpObject = NULL;
     jmethodID jMethod;
     jobject jClassObject;
     jstring jClassNameString;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8361871](https://bugs.openjdk.org/browse/JDK-8361871) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361871](https://bugs.openjdk.org/browse/JDK-8361871): [GCC static analyzer] complains about use of uninitialized value ckpObject in p11_util.c (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2264/head:pull/2264` \
`$ git checkout pull/2264`

Update a local copy of the PR: \
`$ git checkout pull/2264` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2264`

View PR using the GUI difftool: \
`$ git pr show -t 2264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2264.diff">https://git.openjdk.org/jdk21u-dev/pull/2264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2264#issuecomment-3324075704)
</details>
