### PR TITLE
Backport 3468c6e5ef7e7592cf9484736ce333fbe0eaf34d

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/SwingUtilities3.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/SwingUtilities3.java
@@ -72,10 +72,6 @@ public class SwingUtilities3 {
     private static final Object DELEGATE_REPAINT_MANAGER_KEY =
         new StringBuilder("DelegateRepaintManagerKey");
 
-    private static Color disabledForeground;
-    private static Color acceleratorSelectionForeground;
-    private static Color acceleratorForeground;
-
     /**
       * Registers delegate RepaintManager for {@code JComponent}.
       */
@@ -210,7 +206,10 @@ public class SwingUtilities3 {
 
 
     public static void paintAccText(Graphics g, MenuItemLayoutHelper lh,
-                             MenuItemLayoutHelper.LayoutResult lr) {
+                             MenuItemLayoutHelper.LayoutResult lr,
+                             Color disabledForeground,
+                             Color acceleratorSelectionForeground,
+                             Color acceleratorForeground) {
         if (!lh.getAccText().isEmpty()) {
             ButtonModel model = lh.getMenuItem().getModel();
             g.setFont(lh.getAccFontMetrics().getFont());
@@ -247,18 +246,6 @@ public class SwingUtilities3 {
                                 lh.getAccFontMetrics().getAscent());
             }
         }
-    }
-
-    public static void setDisabledForeground(Color disabledFg) {
-        disabledForeground = disabledFg;
-    }
-
-    public static void setAcceleratorSelectionForeground(Color acceleratorSelectionFg) {
-        acceleratorSelectionForeground = acceleratorSelectionFg;
-    }
-
-    public static void setAcceleratorForeground(Color acceleratorFg) {
-        acceleratorForeground = acceleratorFg;
     }
 
     public static void paintArrowIcon(Graphics g, MenuItemLayoutHelper lh,

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -716,11 +716,10 @@ public class BasicMenuItemUI extends MenuItemUI
 
     private void paintAccText(Graphics g, MenuItemLayoutHelper lh,
                               MenuItemLayoutHelper.LayoutResult lr) {
-        SwingUtilities3.setDisabledForeground(disabledForeground);
-        SwingUtilities3.setAcceleratorSelectionForeground(
-                        acceleratorSelectionForeground);
-        SwingUtilities3.setAcceleratorForeground(acceleratorForeground);
-        SwingUtilities3.paintAccText(g, lh, lr);
+        SwingUtilities3.paintAccText(g, lh, lr,
+                                     disabledForeground,
+                                     acceleratorSelectionForeground,
+                                     acceleratorForeground);
     }
 
     private void paintText(Graphics g, MenuItemLayoutHelper lh,

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxMenuItemUI.java
@@ -82,7 +82,9 @@ public class WindowsCheckBoxMenuItemUI extends BasicCheckBoxMenuItemUI {
                                  int defaultTextIconGap) {
         if (WindowsMenuItemUI.isVistaPainting()) {
             WindowsMenuItemUI.paintMenuItem(accessor, g, c, checkIcon,
-                    arrowIcon, background, foreground, defaultTextIconGap,
+                    arrowIcon, background, foreground,
+                    disabledForeground, acceleratorSelectionForeground,
+                    acceleratorForeground, defaultTextIconGap,
                     menuItem, getPropertyPrefix());
             return;
         }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuItemUI.java
@@ -66,9 +66,6 @@ public class WindowsMenuItemUI extends BasicMenuItemUI {
      * The instance of {@code PropertyChangeListener}.
      */
     private PropertyChangeListener changeListener;
-    private static Color disabledForeground;
-    private static Color acceleratorSelectionForeground;
-    private static Color acceleratorForeground;
 
     final WindowsMenuItemUIAccessor accessor =
         new  WindowsMenuItemUIAccessor() {
@@ -164,36 +161,6 @@ public class WindowsMenuItemUI extends BasicMenuItemUI {
         changeListener = null;
     }
 
-    private static void applyInsets(Rectangle rect, Insets insets) {
-        SwingUtilities3.applyInsets(rect, insets);
-    }
-
-    private static void paintCheckIcon(Graphics g, MenuItemLayoutHelper lh,
-                                MenuItemLayoutHelper.LayoutResult lr,
-                                Color holdc, Color foreground) {
-        SwingUtilities3.paintCheckIcon(g, lh, lr, holdc, foreground);
-    }
-
-    private static void paintIcon(Graphics g, MenuItemLayoutHelper lh,
-                           MenuItemLayoutHelper.LayoutResult lr, Color holdc) {
-        SwingUtilities3.paintIcon(g, lh, lr, holdc);
-    }
-
-    private static void paintAccText(Graphics g, MenuItemLayoutHelper lh,
-                              MenuItemLayoutHelper.LayoutResult lr) {
-        SwingUtilities3.setDisabledForeground(disabledForeground);
-        SwingUtilities3.setAcceleratorSelectionForeground(
-                        acceleratorSelectionForeground);
-        SwingUtilities3.setAcceleratorForeground(acceleratorForeground);
-        SwingUtilities3.paintAccText(g, lh, lr);
-    }
-
-    private static void paintArrowIcon(Graphics g, MenuItemLayoutHelper lh,
-                                MenuItemLayoutHelper.LayoutResult lr,
-                                Color foreground) {
-        SwingUtilities3.paintArrowIcon(g, lh, lr, foreground);
-    }
-
     protected void paintMenuItem(Graphics g, JComponent c,
                                  Icon checkIcon, Icon arrowIcon,
                                  Color background, Color foreground,
@@ -201,7 +168,8 @@ public class WindowsMenuItemUI extends BasicMenuItemUI {
         if (WindowsMenuItemUI.isVistaPainting()) {
             WindowsMenuItemUI.paintMenuItem(accessor, g, c, checkIcon,
                                             arrowIcon, background, foreground,
-                                            defaultTextIconGap, menuItem,
+                                            disabledForeground, acceleratorSelectionForeground,
+                                            acceleratorForeground, defaultTextIconGap, menuItem,
                                             getPropertyPrefix());
             return;
         }
@@ -212,6 +180,9 @@ public class WindowsMenuItemUI extends BasicMenuItemUI {
     static void paintMenuItem(WindowsMenuItemUIAccessor accessor, Graphics g,
                               JComponent c, Icon checkIcon, Icon arrowIcon,
                               Color background, Color foreground,
+                              Color disabledForeground,
+                              Color acceleratorSelectionForeground,
+                              Color acceleratorForeground,
                               int defaultTextIconGap, JMenuItem menuItem, String prefix) {
         // Save original graphics font and color
         Font holdf = g.getFont();
@@ -221,7 +192,7 @@ public class WindowsMenuItemUI extends BasicMenuItemUI {
         g.setFont(mi.getFont());
 
         Rectangle viewRect = new Rectangle(0, 0, mi.getWidth(), mi.getHeight());
-        applyInsets(viewRect, mi.getInsets());
+        SwingUtilities3.applyInsets(viewRect, mi.getInsets());
 
         String acceleratorDelimiter =
                 UIManager.getString("MenuItem.acceleratorDelimiter");
@@ -239,8 +210,8 @@ public class WindowsMenuItemUI extends BasicMenuItemUI {
         MenuItemLayoutHelper.LayoutResult lr = lh.layoutMenuItem();
 
         paintBackground(accessor, g, mi, background);
-        paintCheckIcon(g, lh, lr, holdc, foreground);
-        paintIcon(g, lh, lr, holdc);
+        SwingUtilities3.paintCheckIcon(g, lh, lr, holdc, foreground);
+        SwingUtilities3.paintIcon(g, lh, lr, holdc);
 
         if (lh.getCheckIcon() != null && lh.useCheckAndArrow()) {
             Rectangle rect = lr.getTextRect();
@@ -264,8 +235,10 @@ public class WindowsMenuItemUI extends BasicMenuItemUI {
             rect.x += lh.getAfterCheckIconGap();
             lr.setAccRect(rect);
         }
-        paintAccText(g, lh, lr);
-        paintArrowIcon(g, lh, lr, foreground);
+        SwingUtilities3.paintAccText(g, lh, lr, disabledForeground,
+                                     acceleratorSelectionForeground,
+                                     acceleratorForeground);
+        SwingUtilities3.paintArrowIcon(g, lh, lr, foreground);
 
         // Restore original graphics font and color
         g.setColor(holdc);

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
@@ -137,7 +137,8 @@ public class WindowsMenuUI extends BasicMenuUI {
         if (WindowsMenuItemUI.isVistaPainting()) {
             WindowsMenuItemUI.paintMenuItem(accessor, g, c, checkIcon, arrowIcon,
                                             background, foreground,
-                                            defaultTextIconGap, menuItem,
+                                            disabledForeground, acceleratorSelectionForeground,
+                                            acceleratorForeground, defaultTextIconGap, menuItem,
                                             getPropertyPrefix());
             return;
         }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonMenuItemUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonMenuItemUI.java
@@ -82,7 +82,9 @@ public class WindowsRadioButtonMenuItemUI extends BasicRadioButtonMenuItemUI {
                                  int defaultTextIconGap) {
         if (WindowsMenuItemUI.isVistaPainting()) {
             WindowsMenuItemUI.paintMenuItem(accessor, g, c, checkIcon,
-                    arrowIcon, background, foreground, defaultTextIconGap,
+                    arrowIcon, background, foreground,
+                    disabledForeground, acceleratorSelectionForeground,
+                    acceleratorForeground, defaultTextIconGap,
                     menuItem, getPropertyPrefix());
             return;
         }


### PR DESCRIPTION
I'd like to bring this late to 21 to assure the regression introduced by [JDK-8348760](https://bugs.openjdk.org/browse/JDK-8348760) doesn't get into the product.
Unfortunately the follow-up change [JDK-8365625](https://bugs.openjdk.org/browse/JDK-8348760) is not yet pushed.
Also, OpenJDK 21 will be ahead of OpenJDK 25, as I doubt this change will make it to 25.0.1.

