### PR TITLE
8363676: [GCC static analyzer] missing return value check of malloc in OGLContext_SetTransform

### DIFF
--- a/src/java.desktop/share/native/common/java2d/opengl/OGLContext.c
+++ b/src/java.desktop/share/native/common/java2d/opengl/OGLContext.c
@@ -484,6 +484,7 @@ OGLContext_SetTransform(OGLContext *oglc,
     if (oglc->xformMatrix == NULL) {
         size_t arrsize = 16 * sizeof(GLdouble);
         oglc->xformMatrix = (GLdouble *)malloc(arrsize);
+        RETURN_IF_NULL(oglc->xformMatrix);
         memset(oglc->xformMatrix, 0, arrsize);
         oglc->xformMatrix[10] = 1.0;
         oglc->xformMatrix[15] = 1.0;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8363676](https://bugs.openjdk.org/browse/JDK-8363676) needs maintainer approval

### Issue
 * [JDK-8363676](https://bugs.openjdk.org/browse/JDK-8363676): [GCC static analyzer] missing return value check of malloc in OGLContext_SetTransform (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2268/head:pull/2268` \
`$ git checkout pull/2268`

Update a local copy of the PR: \
`$ git checkout pull/2268` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2268`

View PR using the GUI difftool: \
`$ git pr show -t 2268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2268.diff">https://git.openjdk.org/jdk21u-dev/pull/2268.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2268#issuecomment-3333584806)
</details>
