### PR TITLE
8346875: Test jdk/jdk/jfr/event/os/TestCPULoad.java fails on macOS

### DIFF
--- a/test/jdk/jdk/jfr/event/os/TestCPULoad.java
+++ b/test/jdk/jdk/jfr/event/os/TestCPULoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
-
 /**
  * @test
  * @key jfr
@@ -41,13 +40,32 @@ import jdk.test.lib.jfr.Events;
 public class TestCPULoad {
     private final static String EVENT_NAME = EventNames.CPULoad;
 
+    public static boolean isPrime(int num) {
+        if (num <= 1) return false;
+        for (int i = 2; i <= Math.sqrt(num); i++) {
+            if (num % i == 0) return false;
+        }
+        return true;
+    }
+
+    public static int burnCpuCycles(int limit) {
+        int primeCount = 0;
+        for (int i = 2; i < limit; i++) {
+            if (isPrime(i)) {
+                primeCount++;
+            }
+        }
+        return primeCount;
+    }
+
     public static void main(String[] args) throws Throwable {
         Recording recording = new Recording();
         recording.enable(EVENT_NAME);
         recording.start();
-        // Need to sleep so a time delta can be calculated
-        Thread.sleep(100);
+        // burn some cycles to check increase of CPU related counters
+        int pn = burnCpuCycles(2500000);
         recording.stop();
+        System.out.println("Found " + pn + " primes while burning cycles");
 
         List<RecordedEvent> events = Events.fromRecording(recording);
         if (events.isEmpty()) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a3eef6c2](https://github.com/openjdk/jdk25u/commit/a3eef6c2416eb0e02fbd154d84c98b12bcb66e97) from the [openjdk/jdk25u](https://git.openjdk.org/jdk25u) repository.

The commit being backported was authored by Matthias Baesken on 17 Jan 2025 and was reviewed by Erik Gahlin.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346875](https://bugs.openjdk.org/browse/JDK-8346875) needs maintainer approval

### Issue
 * [JDK-8346875](https://bugs.openjdk.org/browse/JDK-8346875): Test jdk/jdk/jfr/event/os/TestCPULoad.java fails on macOS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2271/head:pull/2271` \
`$ git checkout pull/2271`

Update a local copy of the PR: \
`$ git checkout pull/2271` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2271`

View PR using the GUI difftool: \
`$ git pr show -t 2271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2271.diff">https://git.openjdk.org/jdk21u-dev/pull/2271.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2271#issuecomment-3340258139)
</details>
