### PR TITLE
8354701: Open source few JToolTip tests

### DIFF
--- a/test/jdk/javax/swing/JToolTip/TooltipTest.java
+++ b/test/jdk/javax/swing/JToolTip/TooltipTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4207474 4218495 4375928
+ * @summary Tests various tooltip issues: HTML tooltips, long tooltip text
+ *          and mnemonic keys displayed in tooltips
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TooltipTest
+ */
+
+import java.awt.FlowLayout;
+import java.awt.event.KeyEvent;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+
+public class TooltipTest {
+    private static final String INSTRUCTIONS = """
+        1.  Move the mouse over the button labeled "Red tip" and let it stay
+            still in order to test HTML in JToolTip. If the tooltip has some
+            text which is red then test passes, otherwise it fails (bug 4207474).
+
+        2.  Move the mouse over the button labeled "Long tip".
+            If the last letter of the tooltip appears clipped,
+            then the test fails. If you can see the entire last character,
+            then the test passes (bug 4218495).
+
+        3.  Verify that "M" is underlined on the button labeled "Mnemonic"
+            Move the mouse pointer over the button labeled "Mnemonic" and look
+            at tooltip when it appears. It should read "hint".
+            If the above is true test passes else test fails (bug 4375928).
+        """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+
+        PassFailJFrame.builder()
+                .title("TooltipTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(TooltipTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JComponent createTestUI() {
+        JPanel panel = new JPanel();
+        panel.setLayout(new FlowLayout());
+
+        JButton b = new JButton("Red tip");
+        b.setToolTipText("<html><center>Here is some <font color=red>" +
+                "red</font> text.</center></html>");
+        panel.add(b);
+
+        b = new JButton("Long tip");
+        b.setToolTipText("Is the last letter clipped?");
+        panel.add(b);
+
+        b = new JButton("Mnemonic");
+        b.setMnemonic(KeyEvent.VK_M);
+        b.setToolTipText("hint");
+        panel.add(b);
+
+        return panel;
+    }
+}

--- a/test/jdk/javax/swing/JToolTip/bug4225314.java
+++ b/test/jdk/javax/swing/JToolTip/bug4225314.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4225314
+ * @summary Tests that tooltip is painted properly when it has thick border
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4225314
+ */
+
+import java.awt.Color;
+import java.awt.FlowLayout;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JToolTip;
+import javax.swing.border.LineBorder;
+
+public class bug4225314 {
+    private static final String INSTRUCTIONS = """
+            The word "Tooltip" in both tooltips should not be clipped by the
+            black border and be fully visible for this test to pass.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4225314 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug4225314::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JComponent createTestUI() {
+        JToolTip tt1 = new JToolTip();
+        tt1.setTipText("Tooltip");
+        tt1.setBorder(new LineBorder(Color.BLACK, 10));
+
+        JToolTip tt2 = new JToolTip();
+        tt2.setTipText("<html><b><i>Tooltip</i></b></html>");
+        tt2.setBorder(new LineBorder(Color.BLACK, 10));
+
+        JPanel panel = new JPanel();
+        panel.setLayout(new FlowLayout());
+        panel.add(tt1);
+        panel.add(tt2);
+
+        return panel;
+    }
+}

--- a/test/jdk/javax/swing/JToolTip/bug4255441.java
+++ b/test/jdk/javax/swing/JToolTip/bug4255441.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4255441
+ * @summary Tests that tooltip appears inside AWT Frame
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4255441
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import javax.swing.JButton;
+
+public class bug4255441 {
+    private static final String INSTRUCTIONS = """
+            Move mouse pointer inside the button.
+            If a tooltip with "Tooltip text" appears, the test passes.
+            """;
+
+    private static Frame createTestUI() {
+        Frame fr = new Frame("bug4255441");
+        fr.setLayout(new FlowLayout());
+
+        JButton bt = new JButton("Button");
+        bt.setToolTipText("Tooltip text");
+        fr.add(bt);
+
+        fr.setSize(200, 200);
+        return fr;
+    }
+
+    public static void main(String[] argv) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug4255441 Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug4255441::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
Backporting JDK-8354701: Open source few JToolTip tests. Adds three tooltip tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8354701](https://bugs.openjdk.org/browse/JDK-8354701) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354701](https://bugs.openjdk.org/browse/JDK-8354701): Open source few JToolTip tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2274/head:pull/2274` \
`$ git checkout pull/2274`

Update a local copy of the PR: \
`$ git checkout pull/2274` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2274`

View PR using the GUI difftool: \
`$ git pr show -t 2274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2274.diff">https://git.openjdk.org/jdk21u-dev/pull/2274.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2274#issuecomment-3348076927)
</details>
