### PR TITLE
8353958: Open source several AWT ScrollPane tests - Batch 2

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -445,6 +445,7 @@ java/awt/FileDialog/ModalFocus/FileDialogModalFocusTest.java 8194751 linux-all
 java/awt/image/VolatileImage/BitmaskVolatileImage.java 8133102 linux-all
 java/awt/SplashScreen/MultiResolutionSplash/unix/UnixMultiResolutionSplashTest.java 8203004 linux-all
 java/awt/ScrollPane/ScrollPositionTest.java 8040070 linux-all
+java/awt/ScrollPane/ScrollPaneScrollType/ScrollPaneEventType.java 8296516 macosx-all
 java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java 7107528 linux-all,macosx-all
 java/awt/Mouse/MouseDragEvent/MouseDraggedTest.java 8080676 linux-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersInKeyEvent.java 8157147 linux-all,windows-all,macosx-all

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneAsNeededTest.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneAsNeededTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4152524
+ * @summary ScrollPane AS_NEEDED always places scrollbars first time component
+ *          is laid out
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollPaneAsNeededTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.ScrollPane;
+
+public class ScrollPaneAsNeededTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. You will see a frame titled 'ScrollPane as needed'
+                   of minimum possible size in the middle of the screen.
+                2. If for the first resize of frame(using mouse) to
+                   a very big size(may be, to half the area of the screen)
+                   the scrollbars(any - horizontal, vertical or both)
+                   appear, click FAIL else, click PASS.
+                                           """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ScrollPaneAsNeededTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame f = new Frame("ScrollPane as needed");
+        f.setLayout(new BorderLayout());
+        ScrollPane sp = new ScrollPane(ScrollPane.SCROLLBARS_AS_NEEDED);
+        sp.add(new Button("TEST"));
+        f.add("Center", sp);
+        f.setSize(200, 200);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneComponentTest.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneComponentTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4100671
+ * @summary removing and adding back ScrollPane component does not work
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollPaneComponentTest
+ */
+
+import java.awt.Adjustable;
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Panel;
+import java.awt.ScrollPane;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class ScrollPaneComponentTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Notice the scrollbars (horizontal and vertical)
+                   in the Frame titled 'ScrollPane Component Test'
+                2. Click the button labeled 'Remove and add back
+                   ScrollPane Contents'
+                3. If the Scrollbars (horizontal or vertical or both)
+                   disappears in the Frame, then press FAIL, else press PASS.
+                                   """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ScrollPaneComponentTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame fr = new Frame("ScrollPane Component Test");
+        fr.setLayout(new BorderLayout());
+        ScrollTester test = new ScrollTester();
+
+        fr.add(test);
+        fr.pack();
+        fr.setSize(200, 200);
+
+        Adjustable vadj = test.pane.getVAdjustable();
+        Adjustable hadj = test.pane.getHAdjustable();
+        vadj.setUnitIncrement(5);
+        hadj.setUnitIncrement(5);
+        return fr;
+    }
+}
+
+class Box extends Component {
+    public Dimension getPreferredSize() {
+        System.out.println("asked for size");
+        return new Dimension(300, 300);
+    }
+
+    public void paint(Graphics gr) {
+        super.paint(gr);
+        gr.setColor(Color.red);
+        gr.drawLine(5, 5, 295, 5);
+        gr.drawLine(295, 5, 295, 295);
+        gr.drawLine(295, 295, 5, 295);
+        gr.drawLine(5, 295, 5, 5);
+        System.out.println("Painted!!");
+    }
+}
+
+class ScrollTester extends Panel {
+    public ScrollPane pane;
+    private final Box child;
+
+    class Handler implements ActionListener {
+        public void actionPerformed(ActionEvent e) {
+            System.out.println("Removing scrollable component");
+            pane.remove(child);
+            System.out.println("Adding back scrollable component");
+            pane.add(child);
+            System.out.println("Done Adding back scrollable component");
+        }
+    }
+
+    public ScrollTester() {
+        pane = new ScrollPane();
+        pane.setSize(200, 200);
+        child = new Box();
+        pane.add(child);
+        setLayout(new BorderLayout());
+        Button changeScrollContents = new Button("Remove and add back ScrollPane Contents");
+        changeScrollContents.setBackground(Color.red);
+        changeScrollContents.addActionListener(new Handler());
+        add("North", changeScrollContents);
+        add("Center", pane);
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneEventType.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneEventType.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4075484
+ * @summary Tests that events of different types are generated for the
+ *          corresponding scroll actions.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollPaneEventType
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.ScrollPane;
+import java.awt.event.AdjustmentListener;
+
+public class ScrollPaneEventType {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. This test verifies that when user performs some scrolling operation on
+                   ScrollPane the correct AdjustmentEvent is being generated.
+                2. To test this, press on:
+                   - scrollbar's arrows and verify that UNIT event is generated,
+                   - scrollbar's grey area(non-thumb) and verify that BLOCK event is
+                    generated,
+                   - drag scrollbar's thumb and verify that TRACK event is generated
+                   If you see correct events for both scroll bars then test is PASSED.
+                   Otherwise it is FAILED.
+                   """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ScrollPaneEventType::initialize)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame frame = new Frame("ScrollPane event type test");
+        frame.setLayout(new BorderLayout());
+        ScrollPane pane = new ScrollPane(ScrollPane.SCROLLBARS_ALWAYS);
+        pane.add(new Button("press") {
+            public Dimension getPreferredSize() {
+                return new Dimension(1000, 1000);
+            }
+        });
+
+        AdjustmentListener listener = e -> PassFailJFrame.log(e.toString());
+        pane.getHAdjustable().addAdjustmentListener(listener);
+        pane.getVAdjustable().addAdjustmentListener(listener);
+        frame.add(pane);
+        frame.setSize(200, 200);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneSize.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneSize.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4117404
+ * @summary Tests that child component is always at least large as scrollpane
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollPaneSize
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Insets;
+import java.awt.Panel;
+import java.awt.ScrollPane;
+import java.util.List;
+
+public class ScrollPaneSize {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Three frames representing the three different ScrollPane scrollbar
+                   policies will appear.
+                2. Verify that when you resize the windows, the child component in the
+                   scrollpane always expands to fill the scrollpane. The scrollpane
+                   background is colored red to show any improper bleed through.
+                   """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(ScrollPaneSize::initialize)
+                .positionTestUIRightColumn()
+                .build()
+                .awaitAndCheck();
+    }
+
+    static List<Frame> initialize() {
+        return List.of(new ScrollFrame("SCROLLBARS_AS_NEEDED", ScrollPane.SCROLLBARS_AS_NEEDED),
+                new ScrollFrame("SCROLLBARS_ALWAYS", ScrollPane.SCROLLBARS_ALWAYS),
+                new ScrollFrame("SCROLLBARS_NEVER", ScrollPane.SCROLLBARS_NEVER));
+    }
+}
+
+class ScrollFrame extends Frame {
+    ScrollFrame(String title, int policy) {
+        super(title);
+        setLayout(new GridLayout(1, 1));
+        ScrollPane c = new ScrollPane(policy);
+        c.setBackground(Color.red);
+        Panel panel = new TestPanel();
+        c.add(panel);
+        add(c);
+        pack();
+        Dimension size = panel.getPreferredSize();
+        Insets insets = getInsets();
+        setSize(size.width + 45 + insets.right + insets.left,
+                size.height + 20 + insets.top + insets.bottom);
+    }
+}
+
+class TestPanel extends Panel {
+    TestPanel() {
+        setLayout(new FlowLayout());
+        setBackground(Color.white);
+
+        Button b1, b2, b3;
+        add(b1 = new Button("Button1"));
+        add(b2 = new Button("Button2"));
+        add(b3 = new Button("Button3"));
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPanechildViewportTest.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPanechildViewportTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4094581
+ * @summary ScrollPane does not refresh properly when child is just smaller than viewport
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollPanechildViewportTest
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.ScrollPane;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class ScrollPanechildViewportTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Click "Slightly Large" and ensure scrollbars are VISIBLE
+                2. Click "Slightly Small" and ensure there are NO scrollbars
+                3. Click "Smaller" and ensure there are NO scrollbars
+                4. If everything is ok, click PASS, else click FAIL.
+                                          """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ScrollPanechildViewportTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        return new Test();
+    }
+}
+
+class Test extends Frame implements ActionListener {
+    Button b1, b2, b3;
+    MyPanel p;
+    int state; // 0 = slightly large, 1 = slightly smaller, 2 = smaller
+
+    public Test() {
+        ScrollPane sp = new ScrollPane();
+        p = new MyPanel();
+        p.setBackground(Color.yellow);
+        state = 1;
+        sp.add(p);
+        add(sp, "Center");
+
+        Panel p1 = new Panel();
+        b1 = new Button("Slightly Large");
+        b1.addActionListener(this);
+        p1.add(b1);
+        b2 = new Button("Slightly Small");
+        b2.addActionListener(this);
+        p1.add(b2);
+        b3 = new Button("Smaller");
+        b3.addActionListener(this);
+        p1.add(b3);
+
+        add(p1, "South");
+
+        setSize(400, 200);
+        //added to test to move test frame away from instructions
+        setLocation(0, 350);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        Object source = e.getSource();
+
+        // set size to small and re-validate the panel to get correct size of
+        // scrollpane viewport without scrollbars
+
+        state = 2;
+        p.invalidate();
+        validate();
+
+        Dimension pd = ((ScrollPane) p.getParent()).getViewportSize();
+
+        if (source.equals(b1)) {
+            p.setBackground(Color.green);
+            state = 0;
+        } else if (source.equals(b2)) {
+            p.setBackground(Color.yellow);
+            state = 1;
+        } else if (source.equals(b3)) {
+            p.setBackground(Color.red);
+            state = 2;
+        }
+
+        p.invalidate();
+        validate();
+        System.out.println("Panel Size = " + p.getSize());
+        System.out.println("ScrollPane Viewport Size = " + pd);
+        System.out.println(" ");
+    }
+
+    class MyPanel extends Panel {
+        public Dimension getPreferredSize() {
+            Dimension d = null;
+            Dimension pd = ((ScrollPane) getParent()).getViewportSize();
+            switch (state) {
+                case 0 -> {
+                    d = new Dimension(pd.width + 2, pd.height + 2);
+                    System.out.println("Preferred size: " + d);
+                }
+                case 1 -> {
+                    d = new Dimension(pd.width - 2, pd.height - 2);
+                    System.out.println("Preferred size: " + d);
+                }
+                case 2 -> {
+                    d = new Dimension(50, 50);
+                    System.out.println("Preferred size: " + d);
+                }
+            }
+            return d;
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353958: Open source several AWT ScrollPane tests - Batch 2. Adds five scroll tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353958](https://bugs.openjdk.org/browse/JDK-8353958) needs maintainer approval

### Issue
 * [JDK-8353958](https://bugs.openjdk.org/browse/JDK-8353958): Open source several AWT ScrollPane tests - Batch 2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2275/head:pull/2275` \
`$ git checkout pull/2275`

Update a local copy of the PR: \
`$ git checkout pull/2275` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2275`

View PR using the GUI difftool: \
`$ git pr show -t 2275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2275.diff">https://git.openjdk.org/jdk21u-dev/pull/2275.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2275#issuecomment-3348143975)
</details>
