### PR TITLE
8363720: Follow up to JDK-8360411 with post review comments

### DIFF
--- a/test/jdk/java/io/File/MaxPathLength.java
+++ b/test/jdk/java/io/File/MaxPathLength.java
@@ -24,30 +24,31 @@
 /* @test
    @bug 4759207 4403166 4165006 4403166 6182812 6274272 7160013
    @summary Test to see if win32 path length can be greater than 260
+   @library .. /test/lib
  */
 
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.DirectoryNotEmptyException;
+import jdk.test.lib.Platform;
 
 public class MaxPathLength {
     private static String sep = File.separator;
     private static String pathComponent = sep +
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     private static String fileName =
-                 "areallylongfilenamethatsforsur";
-    private static boolean isWindows = false;
+            "areallylongfilenamethatsforsur";
 
     private static final int MAX_LENGTH = 256;
+
+    private static final int FILE_EXISTS_SLEEP = 100;
+
+    private static final int MAX_PATH_COMPONENTS_WINDOWS = 20;
 
     private static int counter = 0;
 
     public static void main(String[] args) throws Exception {
-        String osName = System.getProperty("os.name");
-        if (osName.startsWith("Windows")) {
-            isWindows = true;
-        }
 
         for (int i = 4; i < 7; i++) {
             String name = fileName;
@@ -59,8 +60,10 @@ public class MaxPathLength {
         }
 
         // test long paths on windows
-        // And these long pathes cannot be handled on Solaris and Mac platforms
-        testLongPathOnWindows();
+        // And these long paths cannot be handled on Linux and Mac platforms
+        if (Platform.isWindows()) {
+            testLongPath();
+        }
     }
 
     private static String getNextName(String fName) {
@@ -139,7 +142,7 @@ public class MaxPathLength {
             if (flist == null || !fn.equals(flist[0].getName()))
                 throw new RuntimeException ("File.listFiles() failed");
 
-            if (isWindows &&
+            if (Platform.isWindows() &&
                 !fu.getCanonicalPath().equals(f.getCanonicalPath()))
                 throw new RuntimeException ("getCanonicalPath() failed");
 
@@ -155,7 +158,7 @@ public class MaxPathLength {
                 String abPath = f.getAbsolutePath();
                 if (!abPath.startsWith("\\\\") ||
                     abPath.length() < 1093) {
-                    throw new RuntimeException ("File.renameTo() failed for lenth="
+                    throw new RuntimeException ("File.renameTo() failed for length="
                                                 + abPath.length());
                 }
             } else {
@@ -182,7 +185,7 @@ public class MaxPathLength {
                     Files.deleteIfExists(p);
                     // Test if the file is really deleted and wait for 1 second at most
                     for (int j = 0; j < 10 && Files.exists(p); j++) {
-                        Thread.sleep(100);
+                        Thread.sleep(FILE_EXISTS_SLEEP);
                     }
                 } catch (DirectoryNotEmptyException ex) {
                     // Give up the clean-up, let jtreg handle it.
@@ -193,14 +196,12 @@ public class MaxPathLength {
         }
     }
 
-    private static void testLongPathOnWindows () throws Exception {
-        if (isWindows) {
-            String name = fileName;
-            while (name.length() < MAX_LENGTH) {
-                testLongPath (20, name, false);
-                testLongPath (20, name, true);
-                name = getNextName(name);
-            }
+    private static void testLongPath () throws Exception {
+        String name = fileName;
+        while (name.length() < MAX_LENGTH) {
+            testLongPath(MAX_PATH_COMPONENTS_WINDOWS, name, false);
+            testLongPath(MAX_PATH_COMPONENTS_WINDOWS, name, true);
+            name = getNextName(name);
         }
     }
 }


### PR DESCRIPTION
A clean backport for JDK-8363720. 

The prerequisite JDK-8360411 is already in 21. The updated test passed locally. Backporting it for parity with oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8363720](https://bugs.openjdk.org/browse/JDK-8363720) needs maintainer approval

### Issue
 * [JDK-8363720](https://bugs.openjdk.org/browse/JDK-8363720): Follow up to JDK-8360411 with post review comments (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2283/head:pull/2283` \
`$ git checkout pull/2283`

Update a local copy of the PR: \
`$ git checkout pull/2283` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2283`

View PR using the GUI difftool: \
`$ git pr show -t 2283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2283.diff">https://git.openjdk.org/jdk21u-dev/pull/2283.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2283#issuecomment-3349584881)
</details>
