### PR TITLE
8360178: TestArguments.atojulong gtest has incorrect format string

### DIFF
--- a/test/hotspot/gtest/runtime/test_arguments.cpp
+++ b/test/hotspot/gtest/runtime/test_arguments.cpp
@@ -23,13 +23,14 @@
 
 #include "precompiled.hpp"
 #include "jvm.h"
-#include "unittest.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/flags/jvmFlag.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 #include <errno.h>
+
+#include "unittest.hpp"
 
 class ArgumentsTest : public ::testing::Test {
 public:
@@ -58,7 +59,7 @@ public:
 
 TEST_F(ArgumentsTest, atojulong) {
   char ullong_max[32];
-  int ret = jio_snprintf(ullong_max, sizeof(ullong_max), JULONG_FORMAT, ULLONG_MAX);
+  int ret = jio_snprintf(ullong_max, sizeof(ullong_max), "%llu", ULLONG_MAX);
   ASSERT_NE(-1, ret);
 
   julong value;


### PR DESCRIPTION
A clean backport for JDK-8360178.

Backport this for parity with oracle. This patch fixes formatting problem. Testing: make test-only TEST="gtest:ArgumentsTest".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8360178](https://bugs.openjdk.org/browse/JDK-8360178) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360178](https://bugs.openjdk.org/browse/JDK-8360178): TestArguments.atojulong gtest has incorrect format string (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2285/head:pull/2285` \
`$ git checkout pull/2285`

Update a local copy of the PR: \
`$ git checkout pull/2285` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2285`

View PR using the GUI difftool: \
`$ git pr show -t 2285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2285.diff">https://git.openjdk.org/jdk21u-dev/pull/2285.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2285#issuecomment-3349693453)
</details>
