### PR TITLE
8362204: test/jdk/sun/awt/font/TestDevTransform.java fails on Ubuntu 24.04

### DIFF
--- a/test/jdk/sun/awt/font/TestDevTransform.java
+++ b/test/jdk/sun/awt/font/TestDevTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,31 @@
  */
 
 /*
- * @test
+ * @test id=dialog_double
  * @bug 4269775 8341535
  * @summary Check that different text rendering APIs agree
+ * @run main/othervm TestDevTransform DIALOG DOUBLE
+ */
+
+/*
+ * @test id=dialog_float
+ * @bug 4269775 8341535
+ * @summary Check that different text rendering APIs agree
+ * @run main/othervm TestDevTransform DIALOG FLOAT
+ */
+
+/*
+ * @test id=monospaced_double
+ * @bug 4269775 8341535
+ * @summary Check that different text rendering APIs agree
+ * @run main/othervm TestDevTransform MONOSPACED DOUBLE
+ */
+
+/*
+ * @test id=monospaced_float
+ * @bug 4269775 8341535
+ * @summary Check that different text rendering APIs agree
+ * @run main/othervm TestDevTransform MONOSPACED FLOAT
  */
 
 /**
@@ -66,6 +88,8 @@ public class TestDevTransform {
     static String test = "This is only a test";
     static double angle = Math.PI / 6.0;  // Rotate 30 degrees
     static final int W = 400, H = 400;
+    static boolean useDialog;
+    static boolean useDouble;
 
     static void draw(Graphics2D g2d, TextLayout layout,
                       float x, float y, float scalex) {
@@ -101,9 +125,19 @@ public class TestDevTransform {
          g2d.setColor(Color.white);
          g2d.fillRect(0, 0, W, H);
          g2d.setColor(Color.black);
-         g2d.scale(1.481f, 1.481);   // Convert to 108 dpi
+         if (useDouble) {
+             g2d.scale(1.481, 1.481);   // Convert to 108 dpi
+         } else {
+             g2d.scale(1.481f, 1.481f);   // Convert to 108 dpi
+         }
          g2d.addRenderingHints(hints);
-         Font font = new Font(Font.DIALOG, Font.PLAIN, 12);
+         String name;
+         if (useDialog) {
+             name = Font.DIALOG;
+         } else {
+             name = Font.MONOSPACED;
+         }
+         Font font = new Font(name, Font.PLAIN, 12);
          g2d.setFont(font);
     }
 
@@ -135,6 +169,12 @@ public class TestDevTransform {
     }
 
     public static void main(String args[]) throws Exception {
+      if (args[0].equals("DIALOG")) {
+          useDialog = true;
+      }
+      if (args[1].equals("DOUBLE")) {
+          useDouble = true;
+      }
 
       BufferedImage tl_Image = new BufferedImage(W, H, BufferedImage.TYPE_INT_RGB);
       {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [89af6e13](https://github.com/openjdk/jdk/commit/89af6e13f2354d6e32872791d157144cd478a88f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 30 Sep 2025 and was reviewed by Alexey Ushakov and Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8362204](https://bugs.openjdk.org/browse/JDK-8362204) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362204](https://bugs.openjdk.org/browse/JDK-8362204): test/jdk/sun/awt/font/TestDevTransform.java fails on Ubuntu 24.04 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2286/head:pull/2286` \
`$ git checkout pull/2286`

Update a local copy of the PR: \
`$ git checkout pull/2286` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2286`

View PR using the GUI difftool: \
`$ git pr show -t 2286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2286.diff">https://git.openjdk.org/jdk21u-dev/pull/2286.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2286#issuecomment-3354164270)
</details>
