### PR TITLE
8364514: [asan] runtime/jni/checked/TestCharArrayReleasing.java heap-buffer-overflow

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/checked/TestCharArrayReleasing.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestCharArrayReleasing.java
@@ -25,6 +25,8 @@
  * @test
  * @bug 8357601
  * @requires vm.flagless
+ * @comment The check of the array allocated with raw malloc triggers ASAN as we peek into the malloc header space.
+ * @requires !vm.asan
  * @library /test/lib
  * @run main/othervm/native TestCharArrayReleasing 0 0
  * @run main/othervm/native TestCharArrayReleasing 1 0


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8364514](https://bugs.openjdk.org/browse/JDK-8364514) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364514](https://bugs.openjdk.org/browse/JDK-8364514): [asan] runtime/jni/checked/TestCharArrayReleasing.java heap-buffer-overflow (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2288/head:pull/2288` \
`$ git checkout pull/2288`

Update a local copy of the PR: \
`$ git checkout pull/2288` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2288`

View PR using the GUI difftool: \
`$ git pr show -t 2288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2288.diff">https://git.openjdk.org/jdk21u-dev/pull/2288.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2288#issuecomment-3356603605)
</details>
