### PR TITLE
8366092: [GCC static analyzer] UnixOperatingSystem.c warning: use of uninitialized value 'systemTicks'

### DIFF
--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,7 +195,7 @@ static int get_jvmticks(ticks *pticks) {
     uint64_t userTicks;
     uint64_t systemTicks;
 
-    if (read_ticks("/proc/self/stat", &userTicks, &systemTicks) < 0) {
+    if (read_ticks("/proc/self/stat", &userTicks, &systemTicks) != 2) {
         return -1;
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8366092](https://bugs.openjdk.org/browse/JDK-8366092) needs maintainer approval

### Issue
 * [JDK-8366092](https://bugs.openjdk.org/browse/JDK-8366092): [GCC static analyzer] UnixOperatingSystem.c warning: use of uninitialized value 'systemTicks' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2290/head:pull/2290` \
`$ git checkout pull/2290`

Update a local copy of the PR: \
`$ git checkout pull/2290` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2290`

View PR using the GUI difftool: \
`$ git pr show -t 2290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2290.diff">https://git.openjdk.org/jdk21u-dev/pull/2290.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2290#issuecomment-3356766638)
</details>
