### PR TITLE
8344577: Virtual thread tests are timing out on some macOS systems

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -36,12 +36,13 @@
  * @requires vm.debug == true
  * @modules java.base/java.lang:+open
  * @library /test/lib
- * @run main/othervm/timeout=300 GetStackTraceALotWhenPinned 200000
+ * @run main/othervm/timeout=300 GetStackTraceALotWhenPinned 50000
  */
 
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import jdk.test.lib.Platform;
 import jdk.test.lib.thread.VThreadRunner;
 import jdk.test.lib.thread.VThreadPinner;
 
@@ -53,7 +54,15 @@ public class GetStackTraceALotWhenPinned {
             VThreadRunner.ensureParallelism(2);
         }
 
-        int iterations = Integer.parseInt(args[0]);
+        int iterations;
+        int value = Integer.parseInt(args[0]);
+        if (Platform.isOSX() && Platform.isX64()) {
+            // reduced iterations on macosx-x64
+            iterations = Math.max(value / 4, 1);
+        } else {
+            iterations = value;
+        }
+
         var barrier = new Barrier(2);
 
         // Start a virtual thread that loops doing Thread.yield and parking while pinned.
@@ -78,18 +87,23 @@ public class GetStackTraceALotWhenPinned {
             }
         });
 
-        long lastTimestamp = System.currentTimeMillis();
-        for (int i = 0; i < iterations; i++) {
+        long lastTime = System.nanoTime();
+        for (int i = 1; i <= iterations; i++) {
             // wait for virtual thread to arrive
             barrier.await();
 
             thread.getStackTrace();
             LockSupport.unpark(thread);
 
-            long currentTime = System.currentTimeMillis();
-            if ((currentTime - lastTimestamp) > 500) {
-                System.out.format("%s %d remaining ...%n", Instant.now(), (iterations - i));
-                lastTimestamp = currentTime;
+            long currentTime = System.nanoTime();
+            if (i == iterations || ((currentTime - lastTime) > 1_000_000_000L)) {
+                System.out.format("%s => %d of %d%n", Instant.now(), i, iterations);
+                lastTime = currentTime;
+            }
+
+            if (Thread.currentThread().isInterrupted()) {
+                // fail quickly if interrupted by jtreg
+                throw new RuntimeException("interrupted");
             }
         }
     }

--- a/test/jdk/java/lang/Thread/virtual/stress/SleepALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/SleepALot.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Stress test Thread.sleep
  * @requires vm.debug != true & vm.continuations
- * @run main/othervm SleepALot 500000
+ * @run main SleepALot 500000
  */
 
 /*


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8344577](https://bugs.openjdk.org/browse/JDK-8344577), commit [a032de29](https://github.com/openjdk/jdk/commit/a032de2904baf83143415858ed7191549c659035) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alan Bateman on 25 Nov 2024 and was reviewed by Jaikiran Pai.

I did a minor resolve in test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java and dropped changes to several tests which do not exist in 21.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8344143](https://bugs.openjdk.org/browse/JDK-8344143) needs maintainer approval
- [x] [JDK-8344577](https://bugs.openjdk.org/browse/JDK-8344577) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8344577](https://bugs.openjdk.org/browse/JDK-8344577): Virtual thread tests are timing out on some macOS systems (**Bug** - P4 - Approved)
 * [JDK-8344143](https://bugs.openjdk.org/browse/JDK-8344143): Test jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java timed out on  macosx-x64 (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2297/head:pull/2297` \
`$ git checkout pull/2297`

Update a local copy of the PR: \
`$ git checkout pull/2297` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2297`

View PR using the GUI difftool: \
`$ git pr show -t 2297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2297.diff">https://git.openjdk.org/jdk21u-dev/pull/2297.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2297#issuecomment-3371389263)
</details>
