### PR TITLE
8353592: Open source several scrollbar tests

### DIFF
--- a/test/jdk/java/awt/Scrollbar/ListScrollbarTest.java
+++ b/test/jdk/java/awt/Scrollbar/ListScrollbarTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4029465
+ * @summary Win95 Multiselect List doesn't display scrollbar
+ * @key headful
+ * @run main ListScrollbarTest
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+
+public class ListScrollbarTest {
+
+    private static final Color BG_COLOR = Color.RED;
+    private static Robot robot;
+    private static Frame frame;
+    private static List list;
+    private static int counter = 0;
+    private static volatile Rectangle listBounds;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(ListScrollbarTest::createAndShowUI);
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void test() throws Exception {
+        robot = new Robot();
+        robot.waitForIdle();
+        robot.delay(500);
+
+        EventQueue.invokeAndWait(() -> {
+            Point locationOnScreen = list.getLocationOnScreen();
+            Dimension size = list.getSize();
+            listBounds = new Rectangle(locationOnScreen, size);
+        });
+
+        Point point = new Point(listBounds.x + listBounds.width - 5,
+                listBounds.y + listBounds.height / 2);
+
+
+        for (int i = 0; i < 4; i++) {
+            scrollbarCheck(point, false);
+            addListItem();
+        }
+        scrollbarCheck(point, true);
+    }
+
+    public static boolean areColorsSimilar(Color c1, Color c2, int tolerance) {
+        return Math.abs(c1.getRed() - c2.getRed()) <= tolerance
+                && Math.abs(c1.getGreen() - c2.getGreen()) <= tolerance
+                && Math.abs(c1.getBlue() - c2.getBlue()) <= tolerance;
+    }
+
+    private static void scrollbarCheck(Point point, boolean isScrollbarExpected) {
+        Color pixelColor = robot.getPixelColor(point.x, point.y);
+        boolean areColorsSimilar = areColorsSimilar(BG_COLOR, pixelColor, 5);
+
+        if (isScrollbarExpected && areColorsSimilar) {
+            throw new RuntimeException(("""
+                    Scrollbar is expected, but pixel color \
+                    is similar to the background color
+                    %s pixel color
+                    %s bg color""")
+                    .formatted(pixelColor, BG_COLOR));
+        }
+
+        if (!isScrollbarExpected && !areColorsSimilar) {
+            throw new RuntimeException(("""
+                    Scrollbar is not expected, but pixel color \
+                    is not similar to the background color
+                    %s pixel color
+                    %s bg color""")
+                    .formatted(pixelColor, BG_COLOR));
+        }
+    }
+
+    private static void addListItem() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            counter++;
+            System.out.println("Adding list item " + counter);
+            list.add("List Item " + counter);
+            frame.validate();
+        });
+        robot.waitForIdle();
+        robot.delay(150);
+    }
+
+    private static void createAndShowUI() {
+        frame = new Frame("ListScrollbarTest");
+        list = new List(3, true);
+        list.setBackground(BG_COLOR);
+
+        // do not draw border around items, it can affect screen capture
+        list.setFocusable(false);
+
+        frame.add(list);
+
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/Scrollbar/ScrollbarCtrlClickTest.java
+++ b/test/jdk/java/awt/Scrollbar/ScrollbarCtrlClickTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4075950
+ * @summary Test for functionality of Control Click on Scrollbar
+ * @key headful
+ * @run main ScrollbarCtrlClickTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Scrollbar;
+import java.awt.TextArea;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class ScrollbarCtrlClickTest {
+    private static Frame frame;
+    private static TextArea ta;
+    private static Scrollbar scrollbar;
+    private static final CountDownLatch latch = new CountDownLatch(1);
+    private static volatile Rectangle sbBounds;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(ScrollbarCtrlClickTest::initAndShowGUI);
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void initAndShowGUI() {
+        frame = new Frame("ScrollbarDimensionTest");
+        ta = new TextArea("", 30, 100);
+
+
+        scrollbar = new Scrollbar(Scrollbar.VERTICAL,
+                0, 10, 0, 20);
+
+        // Just setting layout so scrollbar thumb will be big enough to use
+        frame.setLayout(new BorderLayout());
+        frame.add("East", scrollbar);
+        frame.add("West", ta);
+
+        scrollbar.addAdjustmentListener(e -> {
+            System.out.println(e.paramString());
+            ta.append(e.paramString() + "\n");
+            latch.countDown();
+        });
+
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void test() throws Exception {
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        robot.setAutoDelay(25);
+        robot.delay(500);
+
+        EventQueue.invokeAndWait(() -> {
+            Point locationOnScreen = scrollbar.getLocationOnScreen();
+            Dimension size = scrollbar.getSize();
+            sbBounds = new Rectangle(locationOnScreen, size);
+        });
+
+        robot.mouseMove(sbBounds.x + sbBounds.width / 2,
+                sbBounds.y + sbBounds.height - 50);
+
+        robot.keyPress(KeyEvent.VK_CONTROL);
+        robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+        robot.keyRelease(KeyEvent.VK_CONTROL);
+
+        if (!latch.await(1, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for latch");
+        }
+    }
+}

--- a/test/jdk/java/awt/Scrollbar/UnitIncrementTest.java
+++ b/test/jdk/java/awt/Scrollbar/UnitIncrementTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4169461
+ * @summary Test for Motif Scrollbar unit increment
+ * @key headful
+ * @run main UnitIncrementTest
+ */
+
+import javax.swing.UIManager;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Scrollbar;
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+
+public class UnitIncrementTest {
+    private static Frame frame;
+    private static Scrollbar scrollbar;
+    private static final java.util.List<AdjustmentEvent> eventsList = new ArrayList<>();
+    private static final int UNIT_INCREMENT_VALUE = 5;
+    private static final int INCREMENTS_COUNT = 10;
+    private static volatile Rectangle scrollbarBounds;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+
+        try {
+            EventQueue.invokeAndWait(UnitIncrementTest::createAndShowUI);
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new Frame("UnitIncrementTest");
+
+        scrollbar = new Scrollbar(Scrollbar.HORIZONTAL);
+
+        scrollbar.setUnitIncrement(UNIT_INCREMENT_VALUE);
+        scrollbar.setBlockIncrement(20);
+
+        scrollbar.addAdjustmentListener(e -> {
+            eventsList.add(e);
+            System.out.println(e);
+        });
+
+        frame.add(scrollbar);
+
+        frame.setSize(300, 100);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void test() throws Exception {
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        robot.setAutoDelay(25);
+        robot.delay(500);
+
+        EventQueue.invokeAndWait(() -> {
+            Point locationOnScreen = scrollbar.getLocationOnScreen();
+            Dimension size = scrollbar.getSize();
+            scrollbarBounds = new Rectangle(locationOnScreen, size);
+        });
+
+        robot.mouseMove(scrollbarBounds.x + scrollbarBounds.width - 10,
+                scrollbarBounds.y + scrollbarBounds.height / 2);
+
+        for (int i = 0; i < INCREMENTS_COUNT; i++) {
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.delay(150);
+        }
+
+        robot.waitForIdle();
+        robot.delay(250);
+
+        if (eventsList.size() != INCREMENTS_COUNT) {
+            throw new RuntimeException("Wrong number of events: " + eventsList.size());
+        }
+
+        int oldValue = 0;
+        for (AdjustmentEvent event : eventsList) {
+            System.out.println("\nChecking event " + event);
+
+            int diff = event.getValue() - oldValue;
+            System.out.printf("diff: %d - %d = %d\n", event.getValue(), oldValue, diff);
+
+            if (diff != UNIT_INCREMENT_VALUE) {
+                throw new RuntimeException("Unexpected adjustment value: %d".formatted(diff));
+            }
+
+            oldValue = event.getValue();
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353592: Open source several scrollbar tests. Adds three scroll bar tests. Ran GHA Sanity Checks and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8353592](https://bugs.openjdk.org/browse/JDK-8353592) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353592](https://bugs.openjdk.org/browse/JDK-8353592): Open source several scrollbar tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2298/head:pull/2298` \
`$ git checkout pull/2298`

Update a local copy of the PR: \
`$ git checkout pull/2298` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2298`

View PR using the GUI difftool: \
`$ git pr show -t 2298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2298.diff">https://git.openjdk.org/jdk21u-dev/pull/2298.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2298#issuecomment-3375180457)
</details>
