### PR TITLE
8353483: Open source some JProgressBar tests

### DIFF
--- a/test/jdk/javax/swing/JProgressBar/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JProgressBar/RightLeftOrientation.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4230355
+ * @summary
+ *     This test checks if progress bars lay out correctly when their
+ *     ComponentOrientation property is set to RIGHT_TO_LEFT. This test is
+ *     manual. The tester is asked to compare left-to-right and
+ *     right-to-left progress bars and judge whether they are mirror images
+ *     of each other.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RightLeftOrientation
+ */
+
+import java.awt.ComponentOrientation;
+import java.awt.Container;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.LookAndFeel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.UIManager;
+
+public class RightLeftOrientation {
+
+    static final String INSTRUCTIONS = """
+        This test checks progress bars for correct Right-To-Left Component Orientation.
+        The progress bars in the left column should fill up from the left while the bars in
+        the right column should fill up from the right.
+        If this is so, the test PASSES, otherwise it FAILS.
+    """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("Progress Bar Orientation Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .testUI(RightLeftOrientation::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        JFrame frame = new JFrame("Progress Bar Orientation Test");
+        Container contentPane = frame.getContentPane();
+        contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.X_AXIS));
+        contentPane.add(createBarSet(ComponentOrientation.LEFT_TO_RIGHT));
+        contentPane.add(createBarSet(ComponentOrientation.RIGHT_TO_LEFT));
+        frame.pack();
+        return frame;
+    }
+
+    static JPanel createBarSet(ComponentOrientation o) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
+        JLabel header;
+        if (o.isLeftToRight())
+            header = new JLabel("Left To Right");
+        else
+            header = new JLabel("Right To Left");
+        panel.add(header);
+
+        UIManager.LookAndFeelInfo[] lafs = UIManager.getInstalledLookAndFeels();
+        for (int i = 0; i < lafs.length; i++) {
+            if (i > 0)
+                panel.add(Box.createVerticalStrut(10));
+            panel.add(createProgressBars(lafs[i].getName(),
+                                          lafs[i].getClassName(), o));
+        }
+
+        return panel;
+    }
+
+    static JPanel createProgressBars(String name, String plaf,
+                                     ComponentOrientation o) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        JLabel label = new JLabel(name);
+        panel.add(label);
+        try {
+            LookAndFeel save = UIManager.getLookAndFeel();
+            UIManager.setLookAndFeel(plaf);
+
+            panel.add(createProgressBar(true, 0, o));
+            panel.add(Box.createVerticalStrut(5));
+
+            panel.add(createProgressBar(true, 5, o));
+            panel.add(Box.createVerticalStrut(5));
+
+            panel.add(createProgressBar(true, 10, o));
+            panel.add(Box.createVerticalStrut(5));
+
+            panel.add(createProgressBar(true, 20, o));
+            panel.add(Box.createVerticalStrut(5));
+
+            UIManager.put("ProgressBar.cellSpacing", Integer.valueOf(2));
+            UIManager.put("ProgressBar.cellLength", Integer.valueOf(7));
+
+            panel.add(createProgressBar(false, 5, o));
+            panel.add(Box.createVerticalStrut(5));
+
+            panel.add(createProgressBar(false, 20, o));
+
+            UIManager.setLookAndFeel(save);
+        } catch (Exception e) {
+            System.err.println(e);
+        }
+        return panel;
+    }
+
+    static JProgressBar createProgressBar(boolean paintStr, int value,
+                                          ComponentOrientation o) {
+        JProgressBar p = new JProgressBar(JProgressBar.HORIZONTAL, 0, 20);
+        p.setStringPainted(paintStr);
+        p.setValue(value);
+        p.setComponentOrientation(o);
+        return p;
+    }
+
+}

--- a/test/jdk/javax/swing/JProgressBar/bug4230391.java
+++ b/test/jdk/javax/swing/JProgressBar/bug4230391.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4230391
+ * @summary Tests that JProgressBar draws correctly when Insets are not zero
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4230391
+*/
+
+import java.awt.ComponentOrientation;
+import java.awt.Container;
+import java.awt.Insets;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.LookAndFeel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.UIManager;
+
+public class bug4230391 {
+
+    static final String INSTRUCTIONS = """
+        Tests that progress bars honor insets in different L&Fs.
+        Different L&Fs render the progress bar differently, and may or may
+        not have a different colored background around the progress bar,
+        and may or may not draw a border around the bar+background.
+        The progress bars should be of equal width and the progress
+        rendering line/bar should not extend past/overlap any border.
+        If it is as described, the test PASSES.
+    """;
+
+    static class InsetProgressBar extends JProgressBar {
+        private Insets insets = new Insets(12, 12, 12, 12);
+
+        public InsetProgressBar(boolean horiz, int low, int hi) {
+            super((horiz)?JProgressBar.HORIZONTAL:JProgressBar.VERTICAL, low, hi);
+        }
+
+        public Insets getInsets() {
+            return insets;
+        }
+    }
+
+    static JPanel createBarSet() {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(BorderFactory.createEmptyBorder(20,20,20,20));
+        UIManager.LookAndFeelInfo[] lafs = UIManager.getInstalledLookAndFeels();
+        for (int i = 0; i < lafs.length; i++) {
+           if (i > 0) {
+               panel.add(Box.createVerticalStrut(10));
+            }
+            panel.add(createProgressBars(lafs[i].getName(), lafs[i].getClassName()));
+        }
+        return panel;
+    }
+
+    static JPanel createProgressBars(String name, String plaf) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        try {
+            LookAndFeel save = UIManager.getLookAndFeel();
+            UIManager.setLookAndFeel(plaf);
+
+            ComponentOrientation ltr = ComponentOrientation.LEFT_TO_RIGHT;
+
+            Box b = Box.createVerticalBox();
+            panel.add(b);
+            panel.add(Box.createHorizontalStrut(5));
+            panel.add(createProgressBar(false, true, ltr));
+            UIManager.setLookAndFeel(save);
+        } catch (Exception e) {
+            System.err.println(e);
+        }
+        return panel;
+    }
+
+    static JProgressBar createProgressBar(boolean solid, boolean horiz,
+                                          ComponentOrientation o) {
+        if (solid) {
+            UIManager.put("ProgressBar.cellSpacing", Integer.valueOf(0));
+            UIManager.put("ProgressBar.cellLength", Integer.valueOf(1));
+        } else {
+            UIManager.put("ProgressBar.cellSpacing", Integer.valueOf(2));
+            UIManager.put("ProgressBar.cellLength", Integer.valueOf(7));
+        }
+
+        JProgressBar p = new InsetProgressBar(horiz, 0, 20);
+        p.setStringPainted(solid);
+        p.setValue(20);
+        p.setComponentOrientation(o);
+
+        return p;
+    }
+
+    static JFrame createUI() {
+        JFrame frame = new JFrame("Progress Bar Insets Test");
+        Container contentPane = frame.getContentPane();
+        contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.X_AXIS));
+        contentPane.add(createBarSet());
+        frame.setSize(400, 300);
+        return frame;
+    }
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("Progress Bar Insets Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .testUI(bug4230391::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/JProgressBar/bug4393042.java
+++ b/test/jdk/javax/swing/JProgressBar/bug4393042.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4393042
+ * @summary JProgressBar should update painting when maximum value is very large
+ * @key headful
+ */
+
+import java.awt.Graphics;
+import javax.swing.JFrame;
+import javax.swing.JProgressBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug4393042 extends JProgressBar {
+
+    static final int MAXIMUM = Integer.MAX_VALUE - 100;
+    static volatile int value = 0;
+    static volatile bug4393042 progressBar;
+    static JFrame frame;
+    static volatile int paintCount = 0;
+
+    public void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        System.out.println("paint count=" + (++paintCount));
+    }
+
+    public bug4393042(int min, int max) {
+       super(min, max);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+       UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+
+       try {
+           SwingUtilities.invokeAndWait(bug4393042::createUI);
+
+           value = 0;
+           for (int i = 0; i <= 10; i++) {
+               Thread.sleep(1000);
+               SwingUtilities.invokeAndWait(() -> {
+                  progressBar.setValue(value);
+               });
+               value += MAXIMUM / 10;
+           }
+
+       } finally {
+           SwingUtilities.invokeAndWait(() -> {
+              if (frame != null) {
+                  frame.dispose();
+              }
+           });
+        }
+        if (paintCount < 10 || paintCount > 100) {
+            throw new RuntimeException("Unexpected paint count : " + paintCount);
+        }
+    }
+
+    static void createUI() {
+        frame = new JFrame("bug4393042");
+        progressBar = new bug4393042(0, MAXIMUM);
+        progressBar.setStringPainted(true);
+        progressBar.setValue(0);
+        frame.add(progressBar);
+        frame.setSize(400, 200);
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JProgressBar/bug5003022.java
+++ b/test/jdk/javax/swing/JProgressBar/bug5003022.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5003022
+ * @summary Test that setting zero value on JProgressBar works in GTK L&F
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug5003022
+*/
+
+import java.awt.FlowLayout;
+import javax.swing.JFrame;
+import javax.swing.JProgressBar;
+import javax.swing.UIManager;
+
+public class bug5003022 {
+
+    static final String INSTRUCTIONS = """
+         There are two progress bars, they should display progress strings.
+         The first progress bar should display 0% and the bar should show no progress color fill.
+         The second progress bar should display 30% and the bar should show 30% progress color fill.
+         If it is as described, the test PASSES, otherwise it FAILS.
+    """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("bug5003022 Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .testUI(bug5003022::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    static JFrame createUI() {
+        try {
+            /* This will only succeed on Linux, but the test is valid for other platforms and L&Fs */
+            UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        JFrame frame = new JFrame("bug5003022");
+        JProgressBar pb1 = new JProgressBar();
+        pb1.setValue(0);
+        pb1.setStringPainted(true);
+
+        JProgressBar pb2 = new JProgressBar();
+        pb2.setValue(30);
+        pb2.setStringPainted(true);
+
+        frame.setLayout(new FlowLayout());
+        frame.add(pb1);
+        frame.add(pb2);
+
+        frame.setSize(300, 300);
+        return frame;
+    }
+
+}


### PR DESCRIPTION
Backporting JDK-8353483: Open source some JProgressBar tests. Adds four progress bar tests. Ran GHA Sanity Checks and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8353483](https://bugs.openjdk.org/browse/JDK-8353483) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353483](https://bugs.openjdk.org/browse/JDK-8353483): Open source some JProgressBar tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2299/head:pull/2299` \
`$ git checkout pull/2299`

Update a local copy of the PR: \
`$ git checkout pull/2299` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2299`

View PR using the GUI difftool: \
`$ git pr show -t 2299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2299.diff">https://git.openjdk.org/jdk21u-dev/pull/2299.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2299#issuecomment-3375176847)
</details>
