### PR TITLE
8369078: Fix faulty test conversion in IllegalCharsetName.java

### DIFF
--- a/test/jdk/java/nio/charset/Charset/IllegalCharsetName.java
+++ b/test/jdk/java/nio/charset/Charset/IllegalCharsetName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class IllegalCharsetName {
         assertThrows(IllegalCharsetNameException.class,
                 () -> Charset.forName(name));
         assertThrows(IllegalCharsetNameException.class,
-                () -> Charset.forName(name));
+                () -> Charset.isSupported(name));
     }
 
     // Charset.forName, Charset.isSupported, and the Charset constructor should
@@ -60,7 +60,7 @@ public class IllegalCharsetName {
         assertThrows(IllegalCharsetNameException.class,
                 () -> Charset.forName(""));
         assertThrows(IllegalCharsetNameException.class,
-                () -> Charset.forName(""));
+                () -> Charset.isSupported(""));
         assertThrows(IllegalCharsetNameException.class,
                 () -> new Charset("", new String[]{}) {
                     @Override


### PR DESCRIPTION
I backport this as follow up of [JDK-8310049](https://bugs.openjdk.org/browse/JDK-8310049).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8369078](https://bugs.openjdk.org/browse/JDK-8369078) needs maintainer approval

### Issue
 * [JDK-8369078](https://bugs.openjdk.org/browse/JDK-8369078): Fix faulty test conversion in IllegalCharsetName.java (**Bug** - P4 - Approved)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - no project role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2301/head:pull/2301` \
`$ git checkout pull/2301`

Update a local copy of the PR: \
`$ git checkout pull/2301` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2301`

View PR using the GUI difftool: \
`$ git pr show -t 2301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2301.diff">https://git.openjdk.org/jdk21u-dev/pull/2301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2301#issuecomment-3380124316)
</details>
