### PR TITLE
8376684: Compile OpenJDK in headless mode without required X11 libraries

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1339,10 +1339,9 @@ dpkg-deb -x /tmp/libasound2-dev_1.0.25-4_armhf.deb .</code></pre>
 point it out by <code>--with-alsa</code>.</li>
 </ul>
 <h4 id="x11-1">X11</h4>
-<p>You will need X11 libraries suitable for your <em>target</em> system.
-For most cases, using Debian's pre-built libraries work fine.</p>
-<p>Note that X11 is needed even if you only want to build a headless
-JDK.</p>
+<p>When not building a headless JDK, you will need X11 libraries
+suitable for your <em>target</em> system. In most cases, using Debian's
+pre-built libraries work fine.</p>
 <ul>
 <li><p>Go to <a href="https://www.debian.org/distrib/packages">Debian
 Package Search</a>, search for the following packages for your

--- a/doc/building.md
+++ b/doc/building.md
@@ -1108,10 +1108,8 @@ dpkg-deb -x /tmp/libasound2-dev_1.0.25-4_armhf.deb .
 
 #### X11
 
-You will need X11 libraries suitable for your *target* system. For most cases,
-using Debian's pre-built libraries work fine.
-
-Note that X11 is needed even if you only want to build a headless JDK.
+When not building a headless JDK, you will need X11 libraries suitable for your
+*target* system. In most cases, using Debian's pre-built libraries work fine.
 
   * Go to [Debian Package Search](https://www.debian.org/distrib/packages),
     search for the following packages for your *target* system, and download them

--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -42,12 +42,12 @@ m4_include([lib-tests.m4])
 AC_DEFUN_ONCE([LIB_DETERMINE_DEPENDENCIES],
 [
   # Check if X11 is needed
-  if test "x$OPENJDK_TARGET_OS" = xwindows || test "x$OPENJDK_TARGET_OS" = xmacosx; then
-    # No X11 support on windows or macosx
+  if test "x$OPENJDK_TARGET_OS" = xwindows ||
+     test "x$OPENJDK_TARGET_OS" = xmacosx ||
+     test "x$ENABLE_HEADLESS_ONLY" = xtrue; then
     NEEDS_LIB_X11=false
   else
-    # All other instances need X11, even if building headless only, libawt still
-    # needs X11 headers.
+    # All other instances need X11 for libawt.
     NEEDS_LIB_X11=true
   fi
 

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -77,6 +77,10 @@ ifeq ($(call isTargetOs, windows), true)
       #
 endif
 
+ifeq ($(ENABLE_HEADLESS_ONLY), true)
+  LIBAWT_CFLAGS += -DHEADLESS
+endif
+
 ifeq ($(call isTargetOs, linux macosx aix), true)
   LIBAWT_EXFILES += awt_Font.c CUPSfuncs.c fontpath.c X11Color.c
 endif
@@ -379,13 +383,20 @@ ifeq ($(call isTargetOs, windows macosx), false)
       $(TOPDIR)/src/$(MODULE)/$(OPENJDK_TARGET_OS_TYPE)/native/common/awt \
       #
 
-  LIBAWT_HEADLESS_EXCLUDES := medialib
+  LIBAWT_HEADLESS_EXCLUDES := medialib opengl
+
+  LIBAWT_HEADLESS_EXCLUDE_FILES := \
+      GLXGraphicsConfig.c \
+      GLXSurfaceData.c \
+      X11PMBlitLoops.c \
+      X11Renderer.c \
+      X11SurfaceData.c \
+      #
 
   LIBAWT_HEADLESS_EXTRA_HEADER_DIRS := \
       $(LIBAWT_DEFAULT_HEADER_DIRS) \
       common/awt/debug \
       common/font \
-      common/java2d/opengl \
       #
 
   LIBAWT_HEADLESS_CFLAGS := $(CUPS_CFLAGS) $(FONTCONFIG_CFLAGS) $(X_CFLAGS) \
@@ -395,6 +406,7 @@ ifeq ($(call isTargetOs, windows macosx), false)
       NAME := awt_headless, \
       EXTRA_SRC := $(LIBAWT_HEADLESS_EXTRA_SRC), \
       EXCLUDES := $(LIBAWT_HEADLESS_EXCLUDES), \
+      EXCLUDE_FILES := $(LIBAWT_HEADLESS_EXCLUDE_FILES), \
       OPTIMIZATION := LOW, \
       CFLAGS := $(CFLAGS_JDKLIB) \
           $(LIBAWT_HEADLESS_CFLAGS), \

--- a/src/java.desktop/unix/native/common/awt/utility/rect.h
+++ b/src/java.desktop/unix/native/common/awt/utility/rect.h
@@ -28,7 +28,7 @@
 #ifndef _AWT_RECT_H
 #define _AWT_RECT_H
 
-#ifndef MACOSX
+#if !defined(HEADLESS) && !defined(MACOSX)
 #include <X11/Xlib.h>
 typedef XRectangle RECT_T;
 #else
@@ -39,7 +39,7 @@ typedef struct {
     int width;
     int height;
 } RECT_T;
-#endif /* !MACOSX */
+#endif /* !HEADLESS && !MACOSX */
 
 #define RECT_EQ_X(r1,r2)        ((r1).x==(r2).x && (r1).width==(r2).width)
 


### PR DESCRIPTION
https://github.com/openjdk/jdk/commit/1069ccebcc32e02055985e2babfa2986a2e295ca

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8376684](https://bugs.openjdk.org/browse/JDK-8376684) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8376684](https://bugs.openjdk.org/browse/JDK-8376684): Compile OpenJDK in headless mode without required X11 libraries (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2604/head:pull/2604` \
`$ git checkout pull/2604`

Update a local copy of the PR: \
`$ git checkout pull/2604` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2604`

View PR using the GUI difftool: \
`$ git pr show -t 2604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2604.diff">https://git.openjdk.org/jdk21u-dev/pull/2604.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2604#issuecomment-3855625812)
</details>
