### PR TITLE
8212084: G1: Implement UseGCOverheadLimit

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -30,6 +30,7 @@
 #include "code/icBuffer.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/g1/g1Allocator.inline.hpp"
+#include "gc/g1/g1Analytics.hpp"
 #include "gc/g1/g1Arguments.hpp"
 #include "gc/g1/g1BarrierSet.hpp"
 #include "gc/g1/g1BatchedTask.hpp"
@@ -492,6 +493,13 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(uint node_index, size_t word_
       gclocker_retry_count += 1;
     }
 
+    // Has the gc overhead limit been reached in the meantime? If so, this mutator
+    // should receive null even when unsuccessfully scheduling a collection as well
+    // for global consistency.
+    if (gc_overhead_limit_exceeded()) {
+      return nullptr;
+    }
+
     // We can reach here if we were unsuccessful in scheduling a
     // collection (because another thread beat us to it) or if we were
     // stalled due to the GC locker. In either can we should retry the
@@ -760,7 +768,12 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
       GCLocker::stall_until_clear();
       gclocker_retry_count += 1;
     }
-
+    // Has the gc overhead limit been reached in the meantime? If so, this mutator
+    // should receive null even when unsuccessfully scheduling a collection as well
+    // for global consistency.
+    if (gc_overhead_limit_exceeded()) {
+      return nullptr;
+    }
 
     // We can reach here if we were unsuccessful in scheduling a
     // collection (because another thread beat us to it) or if we were
@@ -981,27 +994,64 @@ void G1CollectedHeap::resize_heap_if_necessary() {
   }
 }
 
+void G1CollectedHeap::update_gc_overhead_counter() {
+  assert(SafepointSynchronize::is_at_safepoint(), "precondition");
+
+  if (!UseGCOverheadLimit) {
+    return;
+  }
+
+  bool gc_time_over_limit = (_policy->analytics()->long_term_pause_time_ratio() * 100) >= GCTimeLimit;
+  double free_space_percent = percent_of(num_available_regions() * G1HeapRegion::GrainBytes, max_capacity());
+  bool free_space_below_limit = free_space_percent < GCHeapFreeLimit;
+
+  log_debug(gc)("GC Overhead Limit: GC Time %f Free Space %f Counter %zu",
+                (_policy->analytics()->long_term_pause_time_ratio() * 100),
+                free_space_percent,
+                _gc_overhead_counter);
+
+  if (gc_time_over_limit && free_space_below_limit) {
+    _gc_overhead_counter++;
+  } else {
+    _gc_overhead_counter = 0;
+  }
+}
+
+bool G1CollectedHeap::gc_overhead_limit_exceeded() {
+  return _gc_overhead_counter >= GCOverheadLimitThreshold;
+}
+
 HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
                                                             bool do_gc,
                                                             bool maximal_compaction,
                                                             bool expect_null_mutator_alloc_region,
                                                             bool* gc_succeeded) {
   *gc_succeeded = true;
-  // Let's attempt the allocation first.
-  HeapWord* result =
-    attempt_allocation_at_safepoint(word_size,
-                                    expect_null_mutator_alloc_region);
-  if (result != nullptr) {
-    return result;
-  }
+  // Skip allocation if GC overhead limit has been exceeded to let the mutator run
+  // into an OOME. It can either exit "gracefully" or try to free up memory asap.
+  // For the latter situation, keep running GCs. If the mutator frees up enough
+  // memory quickly enough, the overhead(s) will go below the threshold(s) again
+  // and the VM may continue running.
+  // If we did not continue garbage collections, the (gc overhead) limit may decrease
+  // enough by itself to not count as exceeding the limit any more, in the worst
+  // case bouncing back-and-forth all the time.
+  if (!gc_overhead_limit_exceeded()) {
+    // Let's attempt the allocation first.
+    HeapWord* result =
+      attempt_allocation_at_safepoint(word_size,
+                                      expect_null_mutator_alloc_region);
+    if (result != nullptr) {
+      return result;
+    }
 
-  // In a G1 heap, we're supposed to keep allocation from failing by
-  // incremental pauses.  Therefore, at least for now, we'll favor
-  // expansion over collection.  (This might change in the future if we can
-  // do something smarter than full collection to satisfy a failed alloc.)
-  result = expand_and_allocate(word_size);
-  if (result != nullptr) {
-    return result;
+    // In a G1 heap, we're supposed to keep allocation from failing by
+    // incremental pauses.  Therefore, at least for now, we'll favor
+    // expansion over collection.  (This might change in the future if we can
+    // do something smarter than full collection to satisfy a failed alloc.)
+    result = expand_and_allocate(word_size);
+    if (result != nullptr) {
+      return result;
+    }
   }
 
   if (do_gc) {
@@ -1024,6 +1074,10 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation_helper(size_t word_size,
 HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size,
                                                      bool* succeeded) {
   assert_at_safepoint_on_vm_thread();
+
+  // Update GC overhead limits after the initial garbage collection leading to this
+  // allocation attempt.
+  update_gc_overhead_counter();
 
   // Attempts to allocate followed by Full GC.
   HeapWord* result =
@@ -1061,6 +1115,10 @@ HeapWord* G1CollectedHeap::satisfy_failed_allocation(size_t word_size,
 
   assert(!soft_ref_policy()->should_clear_all_soft_refs(),
          "Flag should have been handled and cleared prior to this point");
+
+  if (gc_overhead_limit_exceeded()) {
+    log_info(gc)("GC Overhead Limit exceeded too often (%zu).", GCOverheadLimitThreshold);
+  }
 
   // What else?  We might try synchronous finalization later.  If the total
   // space available is large enough for the allocation, then a more
@@ -1230,6 +1288,7 @@ public:
 
 G1CollectedHeap::G1CollectedHeap() :
   CollectedHeap(),
+  _gc_overhead_counter(0),
   _service_thread(nullptr),
   _periodic_gc_task(nullptr),
   _free_arena_memory_task(nullptr),

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1002,7 +1002,7 @@ void G1CollectedHeap::update_gc_overhead_counter() {
   }
 
   bool gc_time_over_limit = (_policy->analytics()->long_term_pause_time_ratio() * 100) >= GCTimeLimit;
-  double free_space_percent = percent_of(num_available_regions() * G1HeapRegion::GrainBytes, max_capacity());
+  double free_space_percent = percent_of(num_free_or_available_regions() * HeapRegion::GrainBytes, max_capacity());
   bool free_space_below_limit = free_space_percent < GCHeapFreeLimit;
 
   log_debug(gc)("GC Overhead Limit: GC Time %f Free Space %f Counter %zu",

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -169,6 +169,17 @@ class G1CollectedHeap : public CollectedHeap {
   friend class G1CheckRegionAttrTableClosure;
 
 private:
+  // GC Overhead Limit functionality related members.
+  //
+  // The goal is to return null for allocations prematurely (before really going
+  // OOME) in case both GC CPU usage (>= GCTimeLimit) and not much available free
+  // memory (<= GCHeapFreeLimit) so that applications can exit gracefully or try
+  // to keep running by easing off memory.
+  uintx _gc_overhead_counter;        // The number of consecutive garbage collections we were over the limits.
+
+  void update_gc_overhead_counter();
+  bool gc_overhead_limit_exceeded();
+
   G1ServiceThread* _service_thread;
   G1ServiceTask* _periodic_gc_task;
   G1MonotonicArenaFreeMemoryTask* _free_arena_memory_task;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -477,7 +477,7 @@
           "Estimate of footprint other than Java Heap")                     \
           range(0, max_uintx)                                               \
                                                                             \
-  product(bool, UseGCOverheadLimit, true,                                   \
+  product(bool, UseGCOverheadLimit, falseInDebug,                           \
           "Use policy to limit of proportion of time spent in GC "          \
           "before an OutOfMemory error is thrown")                          \
                                                                             \

--- a/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
+++ b/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
+++ b/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc;
+
+/*
+ * @test id=Parallel
+ * @requires vm.gc.Parallel & false
+ * @requires !vm.debug
+ * @summary Verifies that the UseGCOverheadLimit functionality works in Parallel GC.
+ * @library /test/lib
+ * @run driver gc.TestUseGCOverheadLimit Parallel
+ */
+
+/*
+ * @test id=G1
+ * @requires vm.gc.G1
+ * @requires !vm.debug
+ * @summary Verifies that the UseGCOverheadLimit functionality works in G1 GC.
+ * @library /test/lib
+ * @run driver gc.TestUseGCOverheadLimit G1
+ */
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestUseGCOverheadLimit {
+  public static void main(String args[]) throws Exception {
+    String[] parallelArgs = {
+      "-XX:+UseParallelGC",
+      "-XX:NewSize=122m",
+      "-XX:SurvivorRatio=99",
+      "-XX:GCHeapFreeLimit=10"
+    };
+    String[] g1Args = {
+      "-XX:+UseG1GC",
+      "-XX:GCHeapFreeLimit=5"
+    };
+
+    String[] selectedArgs = args[0].equals("G1") ? g1Args : parallelArgs;
+
+    final String[] commonArgs = {
+      "-XX:-UseCompactObjectHeaders", // Object sizes are calculated such that the heap is tight.
+      "-XX:ParallelGCThreads=1",      // Make GCs take longer.
+      "-XX:+UseGCOverheadLimit",
+      "-Xlog:gc=debug",
+      "-XX:GCTimeLimit=90",           // Ease the CPU requirement a little.
+      "-Xmx128m",
+      Allocating.class.getName()
+    };
+
+    String[] vmArgs = Stream.concat(Arrays.stream(selectedArgs), Arrays.stream(commonArgs)).toArray(String[]::new);
+    OutputAnalyzer output = ProcessTools.executeLimitedTestJava(vmArgs);
+    output.shouldNotHaveExitValue(0);
+
+    System.out.println(output.getStdout());
+
+    output.stdoutShouldContain("GC Overhead Limit exceeded too often (5).");
+  }
+
+  static class Allocating {
+    public static void main(String[] args) {
+      Object[] cache = new Object[1024 * 1024 * 2];
+
+      // Allocate random objects, keeping around data, causing garbage
+      // collections.
+      for (int i = 0; i < 1024* 1024 * 30; i++) {
+        Object[] obj = new Object[10];
+        cache[i % cache.length] = obj;
+      }
+
+      System.out.println(cache);
+    }
+  }
+}

--- a/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
+++ b/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
@@ -63,7 +63,6 @@ public class TestUseGCOverheadLimit {
     String[] selectedArgs = args[0].equals("G1") ? g1Args : parallelArgs;
 
     final String[] commonArgs = {
-      "-XX:-UseCompactObjectHeaders", // Object sizes are calculated such that the heap is tight.
       "-XX:ParallelGCThreads=1",      // Make GCs take longer.
       "-XX:+UseGCOverheadLimit",
       "-Xlog:gc=debug",

--- a/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
+++ b/test/hotspot/jtreg/gc/TestUseGCOverheadLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Backport JDK-8212084 to JDK-21.

I am new to backporting JDK fixes. I have contributed small fixes to OpenJDK upstream in the past but this is my first backport, so any help is appreciated, especially as I do not have JBS access.

JDK-8212084 has been backported to OpenJDK 25 in JDK-8374125. So far it has only made it into the Oracle versions of JDK 21 and JDK 17. I believe this confirms that backporting JDK-8212084 provides value with acceptable risk.

Why am I backporting this? We are using G1 on OpenJDK 21 and are observing an issue that we believe is caused by GC overhead (high CPU usage on all cores, application becomes unresponsive and is eventually terminated due to failing liveness probes). Unfortunately we do not yet have the tools in place to confirm this, although we are working on this. With UseGCOverheadLimit the application would terminate earlier with a clear error message and we could make use of HeapDumpOnOutOfMemoryError for diagnosing.

I split this PR into 5 commits for easier reviewing:

- Apply the commit from JDK-8374125 and fix the merge conflicts, these are just positioning issues due to white space, log statements and comments.
- Make the code compile for older G1 before https://github.com/openjdk/jdk/pull/25408/changes, I am almost, but not 100%, certain that num_available_regions is the replacement for num_free_or_available_regions.
- Remove -XX:-UseCompactObjectHeaders from TestUseGCOverheadLimit as this feature is not in OpenJDK 21. Therefore the test behaves the same in JDK 21 without the option as in JDK 25 with the compact object headers disabled.
- Update the copyright years.
- Revert update the copyright years.

I ran both the tier1 and tier2 test suites, the both pass, specifically TestUseGCOverheadLimit.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8212084](https://bugs.openjdk.org/browse/JDK-8212084) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8212084](https://bugs.openjdk.org/browse/JDK-8212084): G1: Implement UseGCOverheadLimit (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2682/head:pull/2682` \
`$ git checkout pull/2682`

Update a local copy of the PR: \
`$ git checkout pull/2682` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2682`

View PR using the GUI difftool: \
`$ git pr show -t 2682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2682.diff">https://git.openjdk.org/jdk21u-dev/pull/2682.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2682#issuecomment-4077900697)
</details>
