### PR TITLE
8318662: Refactor some jdk/java/net/httpclient/http2 tests to JUnit

### DIFF
--- a/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
+++ b/test/jdk/java/net/httpclient/http2/BadHeadersTest.java
@@ -26,7 +26,7 @@
  * @bug 8303965
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm -Djdk.internal.httpclient.debug=true BadHeadersTest
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true BadHeadersTest
  */
 
 import jdk.internal.net.http.common.HttpHeadersBuilder;
@@ -35,10 +35,10 @@ import jdk.internal.net.http.frame.HeaderFrame;
 import jdk.internal.net.http.frame.HeadersFrame;
 import jdk.internal.net.http.frame.Http2Frame;
 import jdk.test.lib.net.SimpleSSLContext;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
+
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
@@ -65,8 +66,9 @@ import jdk.httpclient.test.lib.http2.BodyOutputStream;
 import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
 import static java.util.List.of;
 import static java.util.Map.entry;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // Code copied from ContinuationFrameTest
 public class BadHeadersTest {
@@ -79,11 +81,11 @@ public class BadHeadersTest {
         of(entry("hello", "world!"), entry(":status", "200"))                      // Pseudo header is not the first one
     );
 
-    SSLContext sslContext;
-    Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
-    Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
-    String http2URI;
-    String https2URI;
+    private static SSLContext sslContext;
+    private static Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
+    private static Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
+    private static String http2URI;
+    private static String https2URI;
 
     /**
      * A function that returns a list of 1) a HEADERS frame ( with an empty
@@ -121,8 +123,7 @@ public class BadHeadersTest {
                 return frames;
             };
 
-    @DataProvider(name = "variants")
-    public Object[][] variants() {
+    static Object[][] variants() {
         return new Object[][] {
                 { http2URI,  false, oneContinuation },
                 { https2URI, false, oneContinuation },
@@ -136,8 +137,8 @@ public class BadHeadersTest {
         };
     }
 
-
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     void test(String uri,
               boolean sameClient,
               BiFunction<Integer,List<ByteBuffer>,List<Http2Frame>> headerFramesSupplier)
@@ -166,7 +167,8 @@ public class BadHeadersTest {
         }
     }
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     void testAsync(String uri,
                    boolean sameClient,
                    BiFunction<Integer,List<ByteBuffer>,List<Http2Frame>> headerFramesSupplier)
@@ -204,8 +206,7 @@ public class BadHeadersTest {
     // sync with implementation.
     static void assertDetailMessage(Throwable throwable, int iterationIndex) {
         try {
-            assertTrue(throwable instanceof IOException,
-                    "Expected IOException, got, " + throwable);
+            assertInstanceOf(IOException.class, throwable, "Expected IOException, got " + throwable);
             assertTrue(throwable.getMessage().contains("malformed response"),
                     "Expected \"malformed response\" in: " + throwable.getMessage());
 
@@ -226,8 +227,8 @@ public class BadHeadersTest {
         }
     }
 
-    @BeforeTest
-    public void setup() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         sslContext = new SimpleSSLContext().get();
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
@@ -251,8 +252,8 @@ public class BadHeadersTest {
         https2TestServer.start();
     }
 
-    @AfterTest
-    public void teardown() throws Exception {
+    @AfterAll
+    static void teardown() throws Exception {
         http2TestServer.stop();
         https2TestServer.stop();
     }

--- a/test/jdk/java/net/httpclient/http2/BasicTest.java
+++ b/test/jdk/java/net/httpclient/http2/BasicTest.java
@@ -32,7 +32,7 @@
  *        jdk.test.lib.Asserts
  *        jdk.test.lib.Utils
  *        jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm -Djdk.httpclient.HttpClient.log=ssl,requests,responses,errors BasicTest
+ * @run junit/othervm -Djdk.httpclient.HttpClient.log=ssl,requests,responses,errors BasicTest
  */
 
 import java.io.IOException;
@@ -53,14 +53,13 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2EchoHandler;
 import jdk.test.lib.net.SimpleSSLContext;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static jdk.test.lib.Asserts.assertFileContentsEqual;
 import static jdk.test.lib.Utils.createTempFile;
 import static jdk.test.lib.Utils.createTempFileOfSize;
 
-@Test
 public class BasicTest {
 
     private static final String TEMP_FILE_PREFIX =
@@ -127,7 +126,7 @@ public class BasicTest {
     }
 
     @Test
-    public static void test() throws Exception {
+    void test() throws Exception {
         try {
             initialize();
             warmup(false);

--- a/test/jdk/java/net/httpclient/http2/ConnectionFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/ConnectionFlowControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary checks connection flow control
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm  -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm   -Djdk.internal.httpclient.debug=true
  *                      -Djdk.httpclient.connectionWindowSize=65535
  *                      -Djdk.httpclient.windowsize=16384
  *                      ConnectionFlowControlTest
@@ -43,23 +43,13 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.net.http.HttpResponse.BodySubscriber;
-import java.net.http.HttpResponse.ResponseInfo;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
@@ -72,44 +62,34 @@ import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
 import jdk.internal.net.http.common.HttpHeadersBuilder;
-import jdk.internal.net.http.frame.ContinuationFrame;
-import jdk.internal.net.http.frame.HeaderFrame;
-import jdk.internal.net.http.frame.HeadersFrame;
-import jdk.internal.net.http.frame.Http2Frame;
 import jdk.internal.net.http.frame.SettingsFrame;
 import jdk.test.lib.Utils;
 import jdk.test.lib.net.SimpleSSLContext;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static java.util.List.of;
-import static java.util.Map.entry;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConnectionFlowControlTest {
 
-    SSLContext sslContext;
-    HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
-    HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
-    String http2URI;
-    String https2URI;
-    final AtomicInteger reqid = new AtomicInteger();
+    private static SSLContext sslContext;
+    private static HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
+    private static HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
+    private static String http2URI;
+    private static String https2URI;
+    private final AtomicInteger reqid = new AtomicInteger();
 
-
-    @DataProvider(name = "variants")
-    public Object[][] variants() {
+    static Object[][] variants() {
         return new Object[][] {
                 { http2URI },
                 { https2URI },
         };
     }
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     void test(String uri) throws Exception {
         System.out.printf("%ntesting %s%n", uri);
         ConcurrentHashMap<String, CompletableFuture<String>> responseSent = new ConcurrentHashMap<>();
@@ -148,7 +128,7 @@ public class ConnectionFlowControlTest {
                         if (i < max - 1) {
                             // the connection window might be exceeded at i == max - 2, which
                             // means that the last request could go on a new connection.
-                            assertEquals(ckey, label, "Unexpected key for " + query);
+                            assertEquals(label, ckey, "Unexpected key for " + query);
                         }
                     } catch (AssertionError ass) {
                         // since we won't pull all responses, the client
@@ -174,7 +154,7 @@ public class ConnectionFlowControlTest {
                         if (i < max - 1) {
                             // the connection window might be exceeded at i == max - 2, which
                             // means that the last request could go on a new connection.
-                            assertEquals(ckey, label, "Unexpected key for " + query);
+                            assertEquals(label, ckey, "Unexpected key for " + query);
                         }
                         int wait = uri.startsWith("https://") ? 500 : 250;
                         try (InputStream is = response.body()) {
@@ -227,7 +207,7 @@ public class ConnectionFlowControlTest {
             var response = client.send(request, BodyHandlers.ofString());
             if (label != null) {
                 String ckey = response.headers().firstValue("X-Connection-Key").get();
-                assertNotEquals(ckey, label);
+                assertNotEquals(label, ckey);
                 System.out.printf("last request %s sent on different connection as expected:" +
                         "\n\tlast: %s\n\tprevious: %s%n", query, ckey, label);
             }
@@ -258,33 +238,33 @@ public class ConnectionFlowControlTest {
         }
     }
 
-    @BeforeTest
-    public void setup() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         sslContext = new SimpleSSLContext().get();
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        var http2TestServer = new Http2TestServer("localhost", false, 0);
-        http2TestServer.addHandler(new Http2TestHandler(), "/http2/");
-        this.http2TestServer = HttpTestServer.of(http2TestServer);
-        http2URI = "http://" + this.http2TestServer.serverAuthority() + "/http2/x";
+        var http2TestServerLocal = new Http2TestServer("localhost", false, 0);
+        http2TestServerLocal.addHandler(new Http2TestHandler(), "/http2/");
+        http2TestServer = HttpTestServer.of(http2TestServerLocal);
+        http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/x";
 
-        var https2TestServer = new Http2TestServer("localhost", true, sslContext);
-        https2TestServer.addHandler(new Http2TestHandler(), "/https2/");
-        this.https2TestServer = HttpTestServer.of(https2TestServer);
-        https2URI = "https://" + this.https2TestServer.serverAuthority() + "/https2/x";
+        var https2TestServerLocal = new Http2TestServer("localhost", true, sslContext);
+        https2TestServerLocal.addHandler(new Http2TestHandler(), "/https2/");
+        https2TestServer = HttpTestServer.of(https2TestServerLocal);
+        https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/x";
 
         // Override the default exchange supplier with a custom one to enable
         // particular test scenarios
-        http2TestServer.setExchangeSupplier(FCHttp2TestExchange::new);
-        https2TestServer.setExchangeSupplier(FCHttp2TestExchange::new);
+        http2TestServerLocal.setExchangeSupplier(FCHttp2TestExchange::new);
+        https2TestServerLocal.setExchangeSupplier(FCHttp2TestExchange::new);
 
-        this.http2TestServer.start();
-        this.https2TestServer.start();
+        http2TestServer.start();
+        https2TestServer.start();
     }
 
-    @AfterTest
-    public void teardown() throws Exception {
+    @AfterAll
+    static void teardown() throws Exception {
         http2TestServer.stop();
         https2TestServer.stop();
     }
@@ -364,6 +344,5 @@ public class ConnectionFlowControlTest {
             System.out.println("Server: response sent for " + query);
             responseSentCB.accept(query);
         }
-
     }
 }

--- a/test/jdk/java/net/httpclient/http2/ContinuationFrameTest.java
+++ b/test/jdk/java/net/httpclient/http2/ContinuationFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
  * @compile ../ReferenceTracker.java
- * @run testng/othervm ContinuationFrameTest
+ * @run junit/othervm ContinuationFrameTest
  */
 
 import java.io.IOException;
@@ -59,25 +59,24 @@ import jdk.httpclient.test.lib.http2.BodyOutputStream;
 import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
 
 import jdk.test.lib.net.SimpleSSLContext;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Version.HTTP_2;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ContinuationFrameTest {
 
-    SSLContext sslContext;
-    Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
-    Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
-    String http2URI;
-    String https2URI;
-    String noBodyhttp2URI;
-    String noBodyhttps2URI;
-    final ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
+    private static SSLContext sslContext;
+    private static Http2TestServer http2TestServer;   // HTTP/2 ( h2c )
+    private static Http2TestServer https2TestServer;  // HTTP/2 ( h2  )
+    private static String http2URI;
+    private static String https2URI;
+    private static String noBodyhttp2URI;
+    private static String noBodyhttps2URI;
+    private final static ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
 
     /**
      * A function that returns a list of 1) a HEADERS frame ( with an empty
@@ -132,8 +131,7 @@ public class ContinuationFrameTest {
             return frames;
         };
 
-    @DataProvider(name = "variants")
-    public Object[][] variants() {
+    static Object[][] variants() {
         return new Object[][] {
                 { http2URI,        false, oneContinuation },
                 { https2URI,       false, oneContinuation },
@@ -154,7 +152,8 @@ public class ContinuationFrameTest {
 
     static final int ITERATION_COUNT = 20;
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     void test(String uri,
               boolean sameClient,
               BiFunction<Integer,List<ByteBuffer>,List<Http2Frame>> headerFramesSupplier)
@@ -184,22 +183,20 @@ public class ContinuationFrameTest {
 
             if(uri.contains("nobody")) {
                 out.println("Got response: " + resp);
-                assertTrue(resp.statusCode() == 204,
-                    "Expected 204, got:" + resp.statusCode());
-                assertEquals(resp.version(), HTTP_2);
+                assertEquals(204, resp.statusCode(), "Expected 204, got:" + resp.statusCode());
+                assertEquals(HTTP_2, resp.version());
                 continue;
             }
             out.println("Got response: " + resp);
             out.println("Got body: " + resp.body());
-            assertTrue(resp.statusCode() == 200,
-                       "Expected 200, got:" + resp.statusCode());
-            assertEquals(resp.body(), "Hello there!");
-            assertEquals(resp.version(), HTTP_2);
+            assertEquals(200, resp.statusCode(), "Expected 200, got:" + resp.statusCode());
+            assertEquals("Hello there!", resp.body());
+            assertEquals(HTTP_2, resp.version());
         }
     }
 
-    @BeforeTest
-    public void setup() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         sslContext = new SimpleSSLContext().get();
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
@@ -227,8 +224,8 @@ public class ContinuationFrameTest {
         https2TestServer.start();
     }
 
-    @AfterTest
-    public void teardown() throws Exception {
+    @AfterAll
+    static void teardown() throws Exception {
         AssertionError fail = TRACKER.check(500);
         try {
             http2TestServer.stop();


### PR DESCRIPTION
I backport this for parity with 21.0.12-oracle.

Resolved as "8354276: Strict HTTP header validation" is not in 21.
and omitted test/jdk/java/net/httpclient/http2/BadPushPromiseTest.java as it was only introduced by that change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318662](https://bugs.openjdk.org/browse/JDK-8318662) needs maintainer approval

### Issue
 * [JDK-8318662](https://bugs.openjdk.org/browse/JDK-8318662): Refactor some jdk/java/net/httpclient/http2 tests to JUnit (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2798/head:pull/2798` \
`$ git checkout pull/2798`

Update a local copy of the PR: \
`$ git checkout pull/2798` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2798`

View PR using the GUI difftool: \
`$ git pr show -t 2798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2798.diff">https://git.openjdk.org/jdk21u-dev/pull/2798.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2798#issuecomment-4170555631)
</details>
