### PR TITLE
8368335: Refactor the rest of Locale TestNG based tests to JUnit

### DIFF
--- a/test/jdk/java/util/Locale/LocaleMatchingTest.java
+++ b/test/jdk/java/util/Locale/LocaleMatchingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,12 @@
  * @test
  * @bug 7069824 8042360 8032842 8175539 8210443 8242010 8276302
  * @summary Verify implementation for Locale matching.
- * @run testng/othervm LocaleMatchingTest
+ * @run junit/othervm LocaleMatchingTest
  */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,15 +44,14 @@ import java.util.Map;
 
 import static java.util.Locale.FilteringMode.*;
 import static java.util.Locale.LanguageRange.*;
-import static org.testng.Assert.*;
-
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LocaleMatchingTest {
 
-    @DataProvider(name = "LRConstructorData")
-    Object[][] LRConstructorData() {
+    static Object[][] LRConstructorData() {
         return new Object[][] {
                 // Range, Weight
                 {"elvish", MAX_WEIGHT},
@@ -62,8 +65,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LRConstructorNPEData")
-    Object[][] LRConstructorNPEData() {
+    static Object[][] LRConstructorNPEData() {
         return new Object[][] {
                 // Range, Weight
                 {null, MAX_WEIGHT},
@@ -71,8 +73,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LRConstructorIAEData")
-    Object[][] LRConstructorIAEData() {
+    static Object[][] LRConstructorIAEData() {
         return new Object[][] {
                 // Range, Weight
                 {"ja", -0.8},
@@ -93,8 +94,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LRParseData")
-    Object[][] LRParseData() {
+    static Object[][] LRParseData() {
         return new Object[][] {
                 // Ranges, Expected result
                 {"Accept-Language: fr-FX, de-DE;q=0.5, fr-tp-x-FOO;q=0.1, "
@@ -139,8 +139,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LRParseIAEData")
-    Object[][] LRParseIAEData() {
+    static Object[][] LRParseIAEData() {
         return new Object[][] {
                 // Ranges
                 {""},
@@ -148,8 +147,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LRMapEquivalentsData")
-    Object[][] LRMapEquivalentsData() {
+    static Object[][] LRMapEquivalentsData() {
         return new Object[][] {
                 // Ranges, Map, Expected result
                 {LanguageRange.parse("zh, zh-TW;q=0.8, ar;q=0.9, EN, zh-HK, ja-JP;q=0.2, es;q=0.4"),
@@ -181,8 +179,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LFilterData")
-    Object[][] LFilterData() {
+    static Object[][] LFilterData() {
         return new Object[][] {
                 // Range, LanguageTags, FilteringMode, Expected locales
                 {"ja-JP, fr-FR", "de-DE, en, ja-JP-hepburn, fr, he, ja-Latn-JP",
@@ -203,8 +200,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LFilterNPEData")
-    Object[][] LFilterNPEData() {
+    static Object[][] LFilterNPEData() {
         return new Object[][] {
                 // Range, LanguageTags, FilteringMode
                 {"en;q=0.2, ja-*-JP, fr-JP", null, REJECT_EXTENDED_RANGES},
@@ -212,8 +208,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LFilterTagsData")
-    Object[][] LFilterTagsData() {
+    static Object[][] LFilterTagsData() {
         return new Object[][] {
                 // Range, LanguageTags, FilteringMode, Expected language tags
                 {"fr-FR, fr-BG;q=0.8, *;q=0.5, en;q=0", "en-US, fr-FR, fr-CA, fr-BG",
@@ -274,8 +269,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LLookupData")
-    Object[][] LLookupData() {
+    static Object[][] LLookupData() {
         return new Object[][] {
                 // Range, LanguageTags, Expected locale
                 {"en;q=0.2, *-JP;q=0.6, iw", "de-DE, en, ja-JP-hepburn, fr-JP, he", "he"},
@@ -284,8 +278,7 @@ public class LocaleMatchingTest {
         };
     }
 
-    @DataProvider(name = "LLookupTagData")
-    Object[][] LLookupTagData() {
+    static Object[][] LLookupTagData() {
         return new Object[][] {
                 // Range, LanguageTags, Expected language tag
                 {"en, *", "es, de, ja-JP", null},
@@ -298,117 +291,135 @@ public class LocaleMatchingTest {
     }
 
     @Test
-    public void testLRConstants() {
-        assertEquals(MIN_WEIGHT, 0.0, "    MIN_WEIGHT should be 0.0 but got "
+    void testLRConstants() {
+        assertEquals(0.0, MIN_WEIGHT, "    MIN_WEIGHT should be 0.0 but got "
                 + MIN_WEIGHT);
-        assertEquals(MAX_WEIGHT, 1.0, "    MAX_WEIGHT should be 1.0 but got "
+        assertEquals(1.0, MAX_WEIGHT, "    MAX_WEIGHT should be 1.0 but got "
                 + MAX_WEIGHT);
     }
 
-    @Test(dataProvider = "LRConstructorData")
-    public void testLRConstructors(String range, double weight) {
+    @MethodSource("LRConstructorData")
+    @ParameterizedTest
+    void testLRConstructors(String range, double weight) {
         LanguageRange lr;
         if (weight == MAX_WEIGHT) {
             lr = new LanguageRange(range);
         } else {
             lr = new LanguageRange(range, weight);
         }
-        assertEquals(lr.getRange(), range.toLowerCase(Locale.ROOT),
+        assertEquals(range.toLowerCase(Locale.ROOT), lr.getRange(),
                 "    LR.getRange() returned unexpected value. Expected: "
                         + range.toLowerCase(Locale.ROOT) + ", got: " + lr.getRange());
-        assertEquals(lr.getWeight(), weight,
+        assertEquals(weight, lr.getWeight(),
                 "    LR.getWeight() returned unexpected value. Expected: "
                         + weight + ", got: " + lr.getWeight());
     }
 
-    @Test(dataProvider = "LRConstructorNPEData", expectedExceptions = NullPointerException.class)
-    public void testLRConstructorNPE(String range, double weight) {
+    @MethodSource("LRConstructorNPEData")
+    @ParameterizedTest
+    void testLRConstructorNPE(String range, double weight) {
         if (weight == MAX_WEIGHT) {
-            new LanguageRange(range);
+            assertThrows(NullPointerException.class, () -> new LanguageRange(range));
         } else {
-            new LanguageRange(range, weight);
+            assertThrows(NullPointerException.class, () -> new LanguageRange(range, weight));
         }
     }
 
-    @Test(dataProvider = "LRConstructorIAEData", expectedExceptions = IllegalArgumentException.class)
-    public void testLRConstructorIAE(String range, double weight) {
+    @MethodSource("LRConstructorIAEData")
+    @ParameterizedTest
+    void testLRConstructorIAE(String range, double weight) {
         if (weight == MAX_WEIGHT) {
-            new LanguageRange(range);
+            assertThrows(IllegalArgumentException.class, () -> new LanguageRange(range));
         } else {
-            new LanguageRange(range, weight);
+            assertThrows(IllegalArgumentException.class, () -> new LanguageRange(range, weight));
         }
     }
 
     @Test
-    public void testLREquals() {
+    void testLREquals() {
         LanguageRange lr1 = new LanguageRange("ja", 1.0);
         LanguageRange lr2 = new LanguageRange("ja");
         LanguageRange lr3 = new LanguageRange("ja", 0.1);
         LanguageRange lr4 = new LanguageRange("en", 1.0);
 
-        assertEquals(lr1, lr2, "    LR(ja, 1.0).equals(LR(ja)) should return true.");
-        assertNotEquals(lr1, lr3, "    LR(ja, 1.0).equals(LR(ja, 0.1)) should return false.");
-        assertNotEquals(lr1, lr4, "    LR(ja, 1.0).equals(LR(en, 1.0)) should return false.");
+        assertEquals(lr2, lr1, "    LR(ja, 1.0).equals(LR(ja)) should return true.");
+        assertNotEquals(lr3, lr1, "    LR(ja, 1.0).equals(LR(ja, 0.1)) should return false.");
+        assertNotEquals(lr4, lr1, "    LR(ja, 1.0).equals(LR(en, 1.0)) should return false.");
         assertNotNull(lr1, "    LR(ja, 1.0).equals(null) should return false.");
-        assertNotEquals(lr1, "", "    LR(ja, 1.0).equals(\"\") should return false.");
+        assertNotEquals("", lr1, "    LR(ja, 1.0).equals(\"\") should return false.");
     }
 
-    @Test(dataProvider = "LRParseData")
-    public void testLRParse(String ranges, List<LanguageRange> expected) {
-        assertEquals(LanguageRange.parse(ranges), expected,
+    @MethodSource("LRParseData")
+    @ParameterizedTest
+    void testLRParse(String ranges, List<LanguageRange> expected) {
+        assertEquals(expected, LanguageRange.parse(ranges),
                 "    LR.parse(" + ranges + ") test failed.");
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testLRParseNPE() {
-        LanguageRange.parse(null);
+    @Test
+    void testLRParseNPE() {
+        assertThrows(NullPointerException.class, () -> LanguageRange.parse(null));
     }
 
-    @Test(dataProvider = "LRParseIAEData", expectedExceptions = IllegalArgumentException.class)
-    public void testLRParseIAE(String ranges) {
-        LanguageRange.parse(ranges);
+    @MethodSource("LRParseIAEData")
+    @ParameterizedTest
+    void testLRParseIAE(String ranges) {
+        assertThrows(IllegalArgumentException.class, () -> LanguageRange.parse(ranges));
     }
 
-    @Test(dataProvider = "LRMapEquivalentsData")
-    public void testLRMapEquivalents(List<Locale.LanguageRange> priorityList,
+    @MethodSource("LRMapEquivalentsData")
+    @ParameterizedTest
+    void testLRMapEquivalents(List<Locale.LanguageRange> priorityList,
             Map<String,List<String>> map, List<LanguageRange> expected) {
-        assertEquals(LanguageRange.mapEquivalents(priorityList, map), expected,
+        assertEquals(expected, LanguageRange.mapEquivalents(priorityList, map),
                 "    LR.mapEquivalents() test failed.");
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testLRMapEquivalentsNPE() {
-        LanguageRange.mapEquivalents(null, Map.of("ja", List.of("ja", "ja-Hira")));
+    @Test
+    void testLRMapEquivalentsNPE() {
+        assertThrows(NullPointerException.class,
+                () -> LanguageRange.mapEquivalents(null, Map.of("ja", List.of("ja", "ja-Hira"))));
     }
 
-    @Test(dataProvider = "LFilterData")
-    public void testLFilter(String ranges, String tags, FilteringMode mode, String expectedLocales) {
+    @MethodSource("LFilterData")
+    @ParameterizedTest
+    void testLFilter(String ranges, String tags, FilteringMode mode, String expectedLocales) {
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<Locale> tagList = generateLocales(tags);
         String actualLocales =
                 showLocales(Locale.filter(priorityList, tagList, mode));
-        assertEquals(actualLocales, expectedLocales, showErrorMessage("    L.Filter(" + mode + ")",
+        assertEquals(expectedLocales, actualLocales, showErrorMessage("    L.Filter(" + mode + ")",
                 ranges, tags, expectedLocales, actualLocales));
     }
 
-    @Test(dataProvider = "LFilterNPEData", expectedExceptions = NullPointerException.class)
-    public void testLFilterNPE(String ranges, String tags, FilteringMode mode) {
-        List<LanguageRange> priorityList = LanguageRange.parse(ranges);
-        List<Locale> tagList = generateLocales(tags);
-        showLocales(Locale.filter(priorityList, tagList, mode));
+    @MethodSource("LFilterNPEData")
+    @ParameterizedTest
+    void testLFilterNPE(String ranges, String tags, FilteringMode mode) {
+        if (ranges == null) {
+            // Ranges are null
+            assertThrows(NullPointerException.class, () -> LanguageRange.parse(ranges));
+        } else {
+            // Tags are null
+            List<LanguageRange> priorityList = LanguageRange.parse(ranges);
+            List<Locale> tagList = generateLocales(tags);
+            assertThrows(NullPointerException.class,
+                    () -> showLocales(Locale.filter(priorityList, tagList, mode)));
+        }
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testLFilterIAE() {
+    @Test
+    void testLFilterIAE() {
         String ranges = "en;q=0.2, ja-*-JP, fr-JP";
         String tags = "de-DE, en, ja-JP-hepburn, fr, he, ja-Latn-JP";
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<Locale> tagList = generateLocales(tags);
-        showLocales(Locale.filter(priorityList, tagList, REJECT_EXTENDED_RANGES));
+        assertThrows(IllegalArgumentException.class,
+                () -> showLocales(Locale.filter(priorityList, tagList, REJECT_EXTENDED_RANGES)));
     }
 
-    @Test(dataProvider = "LFilterTagsData")
-    public void testLFilterTags(String ranges, String tags, FilteringMode mode, String expectedTags) {
+    @MethodSource("LFilterTagsData")
+    @ParameterizedTest
+    void testLFilterTags(String ranges, String tags, FilteringMode mode, String expectedTags) {
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<String> tagList = generateLanguageTags(tags);
         String actualTags;
@@ -417,36 +428,39 @@ public class LocaleMatchingTest {
         } else {
             actualTags = showLanguageTags(Locale.filterTags(priorityList, tagList, mode));
         }
-        assertEquals(actualTags, expectedTags,
+        assertEquals(expectedTags, actualTags,
                 showErrorMessage("    L.FilterTags(" + (mode != null ? mode : "") + ")",
                         ranges, tags, expectedTags, actualTags));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testLFilterTagsIAE() {
+    @Test
+    void testLFilterTagsIAE() {
         String ranges = "de-*-DE";
         String tags = "de-DE, de-de, de-Latn-DE, de-Latf-DE, de-DE-x-goethe, "
                 + "de-Latn-DE-1996, de-Deva-DE, de, de-x-DE, de-Deva";
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
-        showLanguageTags(Locale.filterTags(priorityList, generateLanguageTags(tags), REJECT_EXTENDED_RANGES));
+        assertThrows(IllegalArgumentException.class,
+                () -> showLanguageTags(Locale.filterTags(priorityList, generateLanguageTags(tags), REJECT_EXTENDED_RANGES)));
     }
 
-    @Test(dataProvider = "LLookupData")
-    public void testLLookup(String ranges, String tags, String expectedLocale) {
+    @MethodSource("LLookupData")
+    @ParameterizedTest
+    void testLLookup(String ranges, String tags, String expectedLocale) {
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<Locale> localeList = generateLocales(tags);
         String actualLocale =
                 Locale.lookup(priorityList, localeList).toLanguageTag();
-        assertEquals(actualLocale, expectedLocale, showErrorMessage("    L.Lookup()",
+        assertEquals(expectedLocale, actualLocale, showErrorMessage("    L.Lookup()",
                 ranges, tags, expectedLocale, actualLocale));
     }
 
-    @Test(dataProvider = "LLookupTagData")
-    public void testLLookupTag(String ranges, String tags, String expectedTag) {
+    @MethodSource("LLookupTagData")
+    @ParameterizedTest
+    void testLLookupTag(String ranges, String tags, String expectedTag) {
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<String> tagList = generateLanguageTags(tags);
         String actualTag = Locale.lookupTag(priorityList, tagList);
-        assertEquals(actualTag, expectedTag, showErrorMessage("    L.LookupTag()",
+        assertEquals(expectedTag, actualTag, showErrorMessage("    L.LookupTag()",
                 ranges, tags, expectedTag, actualTag));
     }
 

--- a/test/jdk/java/util/Locale/RequiredAvailableLocalesTest.java
+++ b/test/jdk/java/util/Locale/RequiredAvailableLocalesTest.java
@@ -20,34 +20,42 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/**
+
+/*
  * @test
  * @bug 8276186
  * @summary Checks whether getAvailableLocales() returns at least Locale.ROOT and
  *      Locale.US instances.
- * @run testng/othervm -Djava.locale.providers=COMPAT RequiredAvailableLocalesTest
- * @run testng/othervm -Djava.locale.providers=CLDR RequiredAvailableLocalesTest
+ * @run junit/othervm -Djava.locale.providers=COMPAT RequiredAvailableLocalesTest
+ * @run junit/othervm -Djava.locale.providers=CLDR RequiredAvailableLocalesTest
  */
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.text.*;
+import java.text.BreakIterator;
+import java.text.Collator;
+import java.text.DateFormat;
+import java.text.DateFormatSymbols;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
 import java.time.format.DecimalStyle;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.Set;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@Test
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class RequiredAvailableLocalesTest {
 
     private static final Set<Locale> REQUIRED_LOCALES = Set.of(Locale.ROOT, Locale.US);
     private static final MethodType ARRAY_RETURN_TYPE = MethodType.methodType(Locale.class.arrayType());
     private static final MethodType SET_RETURN_TYPE = MethodType.methodType(Set.class);
 
-    @DataProvider
-    public Object[][] availableLocalesClasses() {
+    static Object[][] availableLocalesClasses() {
         return new Object[][] {
             {BreakIterator.class, ARRAY_RETURN_TYPE},
             {Calendar.class, ARRAY_RETURN_TYPE},
@@ -61,8 +69,9 @@ public class RequiredAvailableLocalesTest {
         };
     }
 
-    @Test (dataProvider = "availableLocalesClasses")
-    public void checkRequiredLocales(Class<?> c, MethodType mt) throws Throwable {
+    @MethodSource("availableLocalesClasses")
+    @ParameterizedTest
+    void checkRequiredLocales(Class<?> c, MethodType mt) throws Throwable {
         var ret = MethodHandles.lookup().findStatic(c, "getAvailableLocales", mt).invoke();
 
         if (ret instanceof Locale[] a) {

--- a/test/jdk/java/util/Locale/TestOf.java
+++ b/test/jdk/java/util/Locale/TestOf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,29 +20,30 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/**
+
+/*
  * @test
  * @bug 8282819
  * @summary Unit tests for Locale.of() method. Those tests check the equality
  *      of obtained objects with ones that are gotten from other means with both
  *      well-formed and ill-formed arguments. Also checks the possible NPEs
  *      for error cases.
- * @run testng TestOf
+ * @run junit TestOf
  */
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Locale;
 
-import org.testng.annotations.Test;
-import org.testng.annotations.DataProvider;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("deprecation")
-@Test
 public class TestOf {
 
-    @DataProvider
-    public Object[][] data_1Arg() {
+    static Object[][] data_1Arg() {
         return new Object[][]{
                 // well-formed
                 {Locale.ENGLISH, "en"},
@@ -55,8 +56,7 @@ public class TestOf {
         };
     }
 
-    @DataProvider
-    public Object[][] data_2Args() {
+    static Object[][] data_2Args() {
         return new Object[][]{
                 // well-formed
                 {Locale.US, "en", "US"},
@@ -69,8 +69,7 @@ public class TestOf {
         };
     }
 
-    @DataProvider
-    public Object[][] data_3Args() {
+    static Object[][] data_3Args() {
         return new Object[][]{
                 // well-formed
                 {Locale.forLanguageTag("en-US-POSIX"), "en", "US", "POSIX"},
@@ -87,23 +86,26 @@ public class TestOf {
         };
     }
 
-    @Test (dataProvider = "data_1Arg")
-    public void test_1Arg(Locale expected, String lang) {
-        assertEquals(Locale.of(lang), expected);
+    @MethodSource("data_1Arg")
+    @ParameterizedTest
+    void test_1Arg(Locale expected, String lang) {
+        assertEquals(expected, Locale.of(lang));
     }
 
-    @Test (dataProvider = "data_2Args")
-    public void test_2Args(Locale expected, String lang, String ctry) {
-        assertEquals(Locale.of(lang, ctry), expected);
+    @MethodSource("data_2Args")
+    @ParameterizedTest
+    void test_2Args(Locale expected, String lang, String ctry) {
+        assertEquals(expected, Locale.of(lang, ctry));
     }
 
-    @Test (dataProvider = "data_3Args")
-    public void test_3Args(Locale expected, String lang, String ctry, String vrnt) {
-        assertEquals(Locale.of(lang, ctry, vrnt), expected);
+    @MethodSource("data_3Args")
+    @ParameterizedTest
+    void test_3Args(Locale expected, String lang, String ctry, String vrnt) {
+        assertEquals(expected, Locale.of(lang, ctry, vrnt));
     }
 
     @Test
-    public void test_NPE() {
+    void test_NPE() {
         assertThrows(NullPointerException.class, () -> Locale.of(null));
         assertThrows(NullPointerException.class, () -> Locale.of("", null));
         assertThrows(NullPointerException.class, () -> Locale.of("", "", null));

--- a/test/jdk/java/util/Locale/bcp47u/CalendarTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/CalendarTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,25 +28,24 @@
  * @summary Tests Calendar class deals with Unicode extensions
  *      correctly.
  * @modules jdk.localedata
- * @run testng/othervm CalendarTests
+ * @run junit/othervm CalendarTests
  */
-
-import static org.testng.Assert.assertEquals;
 
 import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Calendar with BCP47 U extensions
  */
-@Test
 public class CalendarTests {
     private static TimeZone defaultTZ;
 
@@ -64,19 +63,18 @@ public class CalendarTests {
     private static final Locale FW_FRI = Locale.forLanguageTag("en-US-u-fw-fri");
     private static final Locale FW_SAT = Locale.forLanguageTag("en-US-u-fw-sat");
 
-    @BeforeTest
-    public void beforeTest() {
+    @BeforeAll
+    static void beforeTest() {
         defaultTZ = TimeZone.getDefault();
         TimeZone.setDefault(AMLA);
     }
 
-    @AfterTest
-    public void afterTest() {
+    @AfterAll
+    static void afterTest() {
         TimeZone.setDefault(defaultTZ);
     }
 
-    @DataProvider(name="tz")
-    Object[][] tz() {
+    static Object[][] tz() {
         return new Object[][] {
             // Locale, Expected Zone,
             {JPTYO, ASIATOKYO},
@@ -87,8 +85,7 @@ public class CalendarTests {
         };
     }
 
-    @DataProvider(name="firstDayOfWeek")
-    Object[][] firstDayOfWeek () {
+    static Object[][] firstDayOfWeek () {
         return new Object[][] {
             // Locale, Expected DayOfWeek,
             {Locale.US, Calendar.SUNDAY},
@@ -114,8 +111,7 @@ public class CalendarTests {
         };
     }
 
-    @DataProvider(name="minDaysInFirstWeek")
-    Object[][] minDaysInFrstWeek () {
+    static Object[][] minDaysInFirstWeek () {
         return new Object[][] {
             // Locale, Expected minDay,
             {Locale.US, 1},
@@ -126,33 +122,36 @@ public class CalendarTests {
         };
     }
 
-    @Test(dataProvider="tz")
-    public void test_tz(Locale locale, TimeZone zoneExpected) {
+    @MethodSource("tz")
+    @ParameterizedTest
+    void test_tz(Locale locale, TimeZone zoneExpected) {
         DateFormat df = DateFormat.getTimeInstance(DateFormat.FULL, locale);
-        assertEquals(df.getTimeZone(), zoneExpected);
+        assertEquals(zoneExpected, df.getTimeZone());
 
         Calendar c = Calendar.getInstance(locale);
-        assertEquals(c.getTimeZone(), zoneExpected);
+        assertEquals(zoneExpected, c.getTimeZone());
 
         c = new Calendar.Builder().setLocale(locale).build();
-        assertEquals(c.getTimeZone(), zoneExpected);
+        assertEquals(zoneExpected, c.getTimeZone());
     }
 
-    @Test(dataProvider="firstDayOfWeek")
-    public void test_firstDayOfWeek(Locale locale, int dowExpected) {
+    @MethodSource("firstDayOfWeek")
+    @ParameterizedTest
+    void test_firstDayOfWeek(Locale locale, int dowExpected) {
         Calendar c = Calendar.getInstance(locale);
-        assertEquals(c.getFirstDayOfWeek(), dowExpected);
+        assertEquals(dowExpected, c.getFirstDayOfWeek());
 
         c = new Calendar.Builder().setLocale(locale).build();
-        assertEquals(c.getFirstDayOfWeek(), dowExpected);
+        assertEquals(dowExpected, c.getFirstDayOfWeek());
     }
 
-    @Test(dataProvider="minDaysInFirstWeek")
-    public void test_minDaysInFirstWeek(Locale locale, int minDaysExpected) {
+    @MethodSource("minDaysInFirstWeek")
+    @ParameterizedTest
+    void test_minDaysInFirstWeek(Locale locale, int minDaysExpected) {
         Calendar c = Calendar.getInstance(locale);
-        assertEquals(c.getMinimalDaysInFirstWeek(), minDaysExpected);
+        assertEquals(minDaysExpected, c.getMinimalDaysInFirstWeek());
 
         c = new Calendar.Builder().setLocale(locale).build();
-        assertEquals(c.getMinimalDaysInFirstWeek(), minDaysExpected);
+        assertEquals(minDaysExpected, c.getMinimalDaysInFirstWeek());
     }
 }

--- a/test/jdk/java/util/Locale/bcp47u/CurrencyFormatTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/CurrencyFormatTests.java
@@ -27,26 +27,24 @@
  * @bug 8215181 8230284 8231273 8284840
  * @summary Tests the "u-cf" extension
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=CLDR CurrencyFormatTests
+ * @run junit/othervm -Djava.locale.providers=CLDR CurrencyFormatTests
  */
 
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.NumberFormat;
 import java.util.Locale;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test NumberFormat with BCP47 u-cf extensions. Note that this test depends
  * on the particular CLDR release. Results may vary on other CLDR releases.
  */
-@Test
 public class CurrencyFormatTests {
 
-    @DataProvider(name="getInstanceData")
-    Object[][] getInstanceData() {
+    static Object[][] getInstanceData() {
         return new Object[][] {
             // Locale, amount, expected
             // US dollar
@@ -97,8 +95,9 @@ public class CurrencyFormatTests {
         };
     }
 
-    @Test(dataProvider="getInstanceData")
-    public void test_getInstance(Locale locale, int amount, String expected) {
-        assertEquals(NumberFormat.getCurrencyInstance(locale).format(amount), expected);
+    @MethodSource("getInstanceData")
+    @ParameterizedTest
+    void test_getInstance(Locale locale, int amount, String expected) {
+        assertEquals(expected, NumberFormat.getCurrencyInstance(locale).format(amount));
     }
 }

--- a/test/jdk/java/util/Locale/bcp47u/CurrencyTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/CurrencyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,28 +28,26 @@
  * @summary Tests Currency class instantiates correctly with Unicode
  *      extensions
  * @modules jdk.localedata
- * @run testng/othervm CurrencyTests
+ * @run junit/othervm CurrencyTests
  */
 
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Currency;
 import java.util.Locale;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Currency with BCP47 U extensions
  */
-@Test
 public class CurrencyTests {
     private static final Currency USD = Currency.getInstance("USD");
     private static final Currency CAD = Currency.getInstance("CAD");
     private static final Currency JPY = Currency.getInstance("JPY");
 
-    @DataProvider(name="getInstanceData")
-    Object[][] getInstanceData() {
+    static Object[][] getInstanceData() {
         return new Object[][] {
             // Locale, Expected Currency
             // "cu"
@@ -76,8 +74,7 @@ public class CurrencyTests {
         };
     }
 
-    @DataProvider(name="getSymbolData")
-    Object[][] getSymbolData() {
+    static Object[][] getSymbolData() {
         return new Object[][] {
             // Currency, DisplayLocale, expected Symbol
             {USD, Locale.forLanguageTag("en-US-u-rg-jpzzzz"), "$"},
@@ -94,13 +91,15 @@ public class CurrencyTests {
         };
     }
 
-    @Test(dataProvider="getInstanceData")
-    public void test_getInstance(Locale locale, Currency currencyExpected) {
-        assertEquals(Currency.getInstance(locale), currencyExpected);
+    @MethodSource("getInstanceData")
+    @ParameterizedTest
+    void test_getInstance(Locale locale, Currency currencyExpected) {
+        assertEquals(currencyExpected, Currency.getInstance(locale));
     }
 
-    @Test(dataProvider="getSymbolData")
-    public void test_getSymbol(Currency c, Locale locale, String expected) {
-        assertEquals(c.getSymbol(locale), expected);
+    @MethodSource("getSymbolData")
+    @ParameterizedTest
+    void test_getSymbol(Currency c, Locale locale, String expected) {
+        assertEquals(expected, c.getSymbol(locale));
     }
 }

--- a/test/jdk/java/util/Locale/bcp47u/DisplayNameTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/DisplayNameTests.java
@@ -27,21 +27,20 @@
  * @bug 8176841 8202537
  * @summary Tests the display names for BCP 47 U extensions
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=CLDR DisplayNameTests
+ * @run junit/othervm -Djava.locale.providers=CLDR DisplayNameTests
  */
 
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Locale;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Locale.getDisplayName() with BCP47 U extensions. Note that the
  * result may change depending on the CLDR releases.
  */
-@Test
 public class DisplayNameTests {
     private static final Locale loc1 = Locale.forLanguageTag("en-Latn-US-u" +
                                                              "-ca-japanese" +
@@ -75,8 +74,7 @@ public class DisplayNameTests {
                                             .build();
     private static final Locale loc6 = Locale.forLanguageTag( "zh-CN-u-ca-dddd-nu-ddd-cu-ddd-fw-moq-tz-unknown-rg-twzz");
 
-    @DataProvider(name="locales")
-    Object[][] tz() {
+    static Object[][] locales() {
         return new Object[][] {
             // Locale for display, Test Locale, Expected output,
             {Locale.US, loc1,
@@ -101,9 +99,10 @@ public class DisplayNameTests {
         };
     }
 
-    @Test(dataProvider="locales")
-    public void test_locales(Locale inLocale, Locale testLocale, String expected) {
+    @MethodSource("locales")
+    @ParameterizedTest
+    void test_locales(Locale inLocale, Locale testLocale, String expected) {
         String result = testLocale.getDisplayName(inLocale);
-        assertEquals(result, expected);
+        assertEquals(expected, result);
     }
 }

--- a/test/jdk/java/util/Locale/bcp47u/FormatTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/FormatTests.java
@@ -28,10 +28,13 @@
  * @summary Tests *Format class deals with Unicode extensions
  *      correctly.
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=CLDR FormatTests
+ * @run junit/othervm -Djava.locale.providers=CLDR FormatTests
  */
 
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.DateFormat;
 import java.text.NumberFormat;
@@ -40,15 +43,11 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test *Format classes with BCP47 U extensions
  */
-@Test
 public class FormatTests {
     private static TimeZone defaultTZ;
 
@@ -80,19 +79,18 @@ public class FormatTests {
                                         .build()
                                         .getTime();
 
-    @BeforeTest
-    public void beforeTest() {
+    @BeforeAll
+    static void beforeTest() {
         defaultTZ = TimeZone.getDefault();
         TimeZone.setDefault(AMLA);
     }
 
-    @AfterTest
-    public void afterTest() {
+    @AfterAll
+    static void afterTest() {
         TimeZone.setDefault(defaultTZ);
     }
 
-    @DataProvider(name="dateFormatData")
-    Object[][] dateFormatData() {
+    static Object[][] dateFormatData() {
         return new Object[][] {
             // Locale, Expected calendar, Expected timezone, Expected formatted string
 
@@ -116,8 +114,7 @@ public class FormatTests {
         };
     }
 
-    @DataProvider(name="numberFormatData")
-    Object[][] numberFormatData() {
+    static Object[][] numberFormatData() {
         return new Object[][] {
             // Locale, number, expected format
 
@@ -136,33 +133,35 @@ public class FormatTests {
         };
     }
 
-    @Test(dataProvider="dateFormatData")
-    public void test_DateFormat(Locale locale, String calClass, TimeZone tz,
+    @MethodSource("dateFormatData")
+    @ParameterizedTest
+    void test_DateFormat(Locale locale, String calClass, TimeZone tz,
                                 String formatExpected) throws Exception {
         DateFormat df = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, locale);
         if (calClass != null) {
             try {
                 Class expected = Class.forName(calClass);
-            assertEquals(df.getCalendar().getClass(), expected);
+            assertEquals(expected, df.getCalendar().getClass());
             } catch (Exception e) {
                 throw e;
             }
         }
         if (tz != null) {
-            assertEquals(df.getTimeZone(), tz);
+            assertEquals(tz, df.getTimeZone());
         }
         String formatted = df.format(testDate);
-        assertEquals(formatted, formatExpected);
-        assertEquals(df.parse(formatted), testDate);
+        assertEquals(formatExpected, formatted);
+        assertEquals(testDate, df.parse(formatted));
     }
 
-    @Test(dataProvider="numberFormatData")
-    public void test_NumberFormat(Locale locale, double num,
+    @MethodSource("numberFormatData")
+    @ParameterizedTest
+    void test_NumberFormat(Locale locale, double num,
                                 String formatExpected) throws Exception {
         NumberFormat nf = NumberFormat.getNumberInstance(locale);
         nf.setMaximumFractionDigits(4);
         String formatted = nf.format(num);
-        assertEquals(nf.format(num), formatExpected);
-        assertEquals(nf.parse(formatted), num);
+        assertEquals(formatExpected, nf.format(num));
+        assertEquals(num, nf.parse(formatted));
     }
 }

--- a/test/jdk/java/util/Locale/bcp47u/SymbolsTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/SymbolsTests.java
@@ -28,30 +28,28 @@
  * @summary Tests *FormatSymbols class deals with Unicode extensions
  *      correctly.
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=CLDR SymbolsTests
+ * @run junit/othervm -Djava.locale.providers=CLDR SymbolsTests
  */
 
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.DateFormatSymbols;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test *FormatSymbols classes with BCP47 U extensions
  */
-@Test
 public class SymbolsTests {
 
     private static final Locale RG_GB = Locale.forLanguageTag("en-US-u-rg-gbzzzz");
     private static final Locale RG_IE = Locale.forLanguageTag("en-US-u-rg-iezzzz");
     private static final Locale RG_AT = Locale.forLanguageTag("en-US-u-rg-atzzzz");
 
-    @DataProvider(name="dateFormatSymbolsData")
-    Object[][] dateFormatSymbolsData() {
+    static Object[][] dateFormatSymbolsData() {
         return new Object[][] {
             // Locale, expected AM string, expected PM string
 
@@ -61,8 +59,7 @@ public class SymbolsTests {
         };
     }
 
-    @DataProvider(name="decimalFormatSymbolsData")
-    Object[][] decimalFormatSymbolsData() {
+    static Object[][] decimalFormatSymbolsData() {
         return new Object[][] {
             // Locale, expected decimal separator, expected grouping separator
 
@@ -74,18 +71,20 @@ public class SymbolsTests {
         };
     }
 
-    @Test(dataProvider="dateFormatSymbolsData")
-    public void test_DateFormatSymbols(Locale locale, String amExpected, String pmExpected) {
+    @MethodSource("dateFormatSymbolsData")
+    @ParameterizedTest
+    void test_DateFormatSymbols(Locale locale, String amExpected, String pmExpected) {
         DateFormatSymbols dfs = DateFormatSymbols.getInstance(locale);
         String[] ampm = dfs.getAmPmStrings();
-        assertEquals(ampm[0], amExpected);
-        assertEquals(ampm[1], pmExpected);
+        assertEquals(amExpected, ampm[0]);
+        assertEquals(pmExpected, ampm[1]);
     }
 
-    @Test(dataProvider="decimalFormatSymbolsData")
-    public void test_DecimalFormatSymbols(Locale locale, char decimal, char grouping) {
+    @MethodSource("decimalFormatSymbolsData")
+    @ParameterizedTest
+    void test_DecimalFormatSymbols(Locale locale, char decimal, char grouping) {
         DecimalFormatSymbols dfs = DecimalFormatSymbols.getInstance(locale);
-        assertEquals(dfs.getDecimalSeparator(), decimal);
-        assertEquals(dfs.getGroupingSeparator(), grouping);
+        assertEquals(decimal, dfs.getDecimalSeparator());
+        assertEquals(grouping, dfs.getGroupingSeparator());
     }
 }

--- a/test/jdk/java/util/Locale/bcp47u/SystemPropertyTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/SystemPropertyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,30 +28,26 @@
  * @summary Tests the system properties
  * @modules jdk.localedata
  * @build DefaultLocaleTest
- * @run testng/othervm SystemPropertyTests
+ * @run junit/othervm SystemPropertyTests
  */
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import static jdk.test.lib.process.ProcessTools.executeTestJava;
-import static org.testng.Assert.assertTrue;
-
-import java.util.Locale;
-
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Locale.getDefault() reflects the system property. Note that the
  * result may change depending on the CLDR releases.
  */
-@Test
 public class SystemPropertyTests {
 
     private static String LANGPROP = "-Duser.language=en";
     private static String SCPTPROP = "-Duser.script=";
     private static String CTRYPROP = "-Duser.country=US";
 
-    @DataProvider(name="data")
-    Object[][] data() {
+    static Object[][] data() {
         return new Object[][] {
             // system property, expected default, expected format, expected display
             {"-Duser.extensions=u-ca-japanese",
@@ -86,8 +82,9 @@ public class SystemPropertyTests {
         };
     }
 
-    @Test(dataProvider="data")
-    public void runTest(String extprop, String defLoc,
+    @MethodSource("data")
+    @ParameterizedTest
+    void runTest(String extprop, String defLoc,
                         String defFmtLoc, String defDspLoc) throws Exception {
         int exitValue = executeTestJava(LANGPROP, SCPTPROP, CTRYPROP,
                                     extprop, "DefaultLocaleTest", defLoc, defFmtLoc, defDspLoc)
@@ -95,6 +92,6 @@ public class SystemPropertyTests {
                             .errorTo(System.out)
                             .getExitValue();
 
-        assertTrue(exitValue == 0);
+        assertEquals(0, exitValue);
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.12-oracle.

Needed to resolve several files as [8354276: Strict HTTP header validation](https://github.com/openjdk/jdk25u-dev/commit/c94a7ae11e588250cd0eb064c3280afd580530ea) is not in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368335](https://bugs.openjdk.org/browse/JDK-8368335) needs maintainer approval

### Issue
 * [JDK-8368335](https://bugs.openjdk.org/browse/JDK-8368335): Refactor the rest of Locale TestNG based tests to JUnit (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2799/head:pull/2799` \
`$ git checkout pull/2799`

Update a local copy of the PR: \
`$ git checkout pull/2799` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2799`

View PR using the GUI difftool: \
`$ git pr show -t 2799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2799.diff">https://git.openjdk.org/jdk21u-dev/pull/2799.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2799#issuecomment-4170690051)
</details>
