### PR TITLE
8375294: (fs) Files.copy can fail with EOPNOTSUPP when copy_file_range not supported

### DIFF
--- a/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ Java_sun_nio_ch_FileDispatcherImpl_transferFrom0(JNIEnv *env, jobject this,
     if (n < 0) {
         if (errno == EAGAIN)
             return IOS_UNAVAILABLE;
-        if (errno == ENOSYS)
+        if (errno == ENOSYS || errno == EOPNOTSUPP)
             return IOS_UNSUPPORTED_CASE;
         if ((errno == EBADF || errno == EINVAL || errno == EXDEV) &&
             ((ssize_t)count >= 0))
@@ -103,6 +103,7 @@ Java_sun_nio_ch_FileDispatcherImpl_transferTo0(JNIEnv *env, jobject this,
                 case EINVAL:
                 case ENOSYS:
                 case EXDEV:
+                case EOPNOTSUPP:
                     // ignore and try sendfile()
                     break;
                 default:

--- a/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
+++ b/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,6 +199,7 @@ Java_sun_nio_fs_LinuxNativeDispatcher_directCopy0
                     case EINVAL:
                     case ENOSYS:
                     case EXDEV:
+                    case EOPNOTSUPP:
                         // ignore and try sendfile()
                         break;
                     default:


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [30cda000](https://github.com/openjdk/jdk/commit/30cda00010888b6e9a2bf8cdeaedbb3eb4b6a222) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Brian Burkhalter on 15 Jan 2026 and was reviewed by Alan Bateman and Jaikiran Pai.

Thanks!

This backport was clean, except of the copyright header.
Compared to clean backport to jdk25 and 26, jdk21 is missng
 *  [JDK-8336966](https://bugs.openjdk.org/browse/JDK-8336966): Alpine Linux x86_64 compilation error: sendfile64
   * trivial, applicable
   * https://git.openjdk.org/jdk/commit/db168d9e10c4a302b743ee208e24ba7303fec582
 * [JDK-8327444](https://bugs.openjdk.org/browse/JDK-8327444): simplify RESTARTABLE macro usage in JDK codebase
   * bigger, but should be ok
   * https://git.openjdk.org/jdk/commit/fb4610e6b7a339d0a95a99d6e113e3ddda291561
 * [JDK-8324539](https://bugs.openjdk.org/browse/JDK-8324539): Do not use LFS64 symbols in JDK libs
  * pretty big
  *  https://git.openjdk.org/jdk/commit/e5cb78cc88761cd27964e9fe77fc9c6f9073e888

As per myself, they are not necessary for this PR to do what it should. If you want any of them to go with/before/after, let me know

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8375294](https://bugs.openjdk.org/browse/JDK-8375294) needs maintainer approval

### Issue
 * [JDK-8375294](https://bugs.openjdk.org/browse/JDK-8375294): (fs) Files.copy can fail with EOPNOTSUPP when copy_file_range not supported (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2801/head:pull/2801` \
`$ git checkout pull/2801`

Update a local copy of the PR: \
`$ git checkout pull/2801` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2801`

View PR using the GUI difftool: \
`$ git pr show -t 2801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2801.diff">https://git.openjdk.org/jdk21u-dev/pull/2801.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2801#issuecomment-4170997932)
</details>
