### PR TITLE
8319326: GC: Make TestParallelRefProc use createTestJavaProcessBuilder

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,13 +24,30 @@
 package gc.arguments;
 
 /*
- * @test TestParallelRefProc
- * @summary Test defaults processing for -XX:+ParallelRefProcEnabled.
+ * @test id=Serial
+ * @summary Test defaults processing for -XX:+ParallelRefProcEnabled with Serial GC.
  * @library /test/lib
  * @library /
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.arguments.TestParallelRefProc
+ * @requires vm.gc.Serial
+ * @run driver gc.arguments.TestParallelRefProc Serial
+ */
+
+/*
+ * @test id=Parallel
+ * @summary Test defaults processing for -XX:+ParallelRefProcEnabled with Parallel GC.
+ * @library /test/lib
+ * @library /
+ * @requires vm.gc.Parallel
+ * @run driver gc.arguments.TestParallelRefProc Parallel
+ */
+
+/*
+ * @test id=G1
+ * @summary Test defaults processing for -XX:+ParallelRefProcEnabled with G1 GC.
+ * @library /test/lib
+ * @library /
+ * @requires vm.gc.G1
+ * @run driver gc.arguments.TestParallelRefProc G1
  */
 
 import java.util.Arrays;
@@ -38,32 +55,44 @@ import java.util.ArrayList;
 
 import jdk.test.lib.process.OutputAnalyzer;
 
-import jtreg.SkippedException;
-import jdk.test.whitebox.gc.GC;
-
 public class TestParallelRefProc {
 
     public static void main(String args[]) throws Exception {
-        boolean noneGCSupported = true;
-        if (GC.Serial.isSupported()) {
-            noneGCSupported = false;
-            testFlag(new String[] { "-XX:+UseSerialGC" }, false);
+        if (args.length == 0) {
+            throw new IllegalArgumentException("Test type must be specified as argument");
         }
-        if (GC.Parallel.isSupported()) {
-            noneGCSupported = false;
-            testFlag(new String[] { "-XX:+UseParallelGC", "-XX:ParallelGCThreads=1" }, false);
-            testFlag(new String[] { "-XX:+UseParallelGC", "-XX:ParallelGCThreads=2" }, true);
-            testFlag(new String[] { "-XX:+UseParallelGC", "-XX:-ParallelRefProcEnabled", "-XX:ParallelGCThreads=2" }, false);
+
+        String testType = args[0];
+
+        switch (testType) {
+            case "Serial":
+                testSerial();
+                break;
+            case "Parallel":
+                testParallel();
+                break;
+            case "G1":
+                testG1();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown test type \"" + testType + "\"");
         }
-        if (GC.G1.isSupported()) {
-            noneGCSupported = false;
-            testFlag(new String[] { "-XX:+UseG1GC", "-XX:ParallelGCThreads=1" }, false);
-            testFlag(new String[] { "-XX:+UseG1GC", "-XX:ParallelGCThreads=2" }, true);
-            testFlag(new String[] { "-XX:+UseG1GC", "-XX:-ParallelRefProcEnabled", "-XX:ParallelGCThreads=2" }, false);
-        }
-        if (noneGCSupported) {
-            throw new SkippedException("Skipping test because none of Serial/Parallel/G1 is supported.");
-        }
+    }
+
+    private static void testSerial() throws Exception {
+        testFlag(new String[] { "-XX:+UseSerialGC" }, false);
+    }
+
+    private static void testParallel() throws Exception {
+        testFlag(new String[] { "-XX:+UseParallelGC", "-XX:ParallelGCThreads=1" }, false);
+        testFlag(new String[] { "-XX:+UseParallelGC", "-XX:ParallelGCThreads=2" }, true);
+        testFlag(new String[] { "-XX:+UseParallelGC", "-XX:-ParallelRefProcEnabled", "-XX:ParallelGCThreads=2" }, false);
+    }
+
+    private static void testG1() throws Exception {
+        testFlag(new String[] { "-XX:+UseG1GC", "-XX:ParallelGCThreads=1" }, false);
+        testFlag(new String[] { "-XX:+UseG1GC", "-XX:ParallelGCThreads=2" }, true);
+        testFlag(new String[] { "-XX:+UseG1GC", "-XX:-ParallelRefProcEnabled", "-XX:ParallelGCThreads=2" }, false);
     }
 
     private static final String parallelRefProcEnabledPattern =
@@ -77,7 +106,7 @@ public class TestParallelRefProc {
         result.addAll(Arrays.asList(args));
         result.add("-XX:+PrintFlagsFinal");
         result.add("-version");
-        OutputAnalyzer output = GCArguments.executeLimitedTestJava(result);
+        OutputAnalyzer output = GCArguments.executeTestJava(result);
 
         output.shouldHaveExitValue(0);
 


### PR DESCRIPTION
Backporting JDK-8319326: GC: Make TestParallelRefProc use createTestJavaProcessBuilder.

This PR splits the monolithic TestParallelRefProc test into three separate jtreg test cases (Serial, Parallel, G1), each with its own @requires vm.gc.* precondition, replacing the previous runtime WhiteBox-based GC detection and single-test-for-all-GCs approach.

For parity with Oracle JDK. Already backported to 25.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java

Results attached:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/26438765/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/26438767/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/26438768/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/26438769/linux-aarch64-specific-test.log)

---------

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319326](https://bugs.openjdk.org/browse/JDK-8319326) needs maintainer approval

### Issue
 * [JDK-8319326](https://bugs.openjdk.org/browse/JDK-8319326): GC: Make TestParallelRefProc use createTestJavaProcessBuilder (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2807/head:pull/2807` \
`$ git checkout pull/2807`

Update a local copy of the PR: \
`$ git checkout pull/2807` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2807`

View PR using the GUI difftool: \
`$ git pr show -t 2807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2807.diff">https://git.openjdk.org/jdk21u-dev/pull/2807.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2807#issuecomment-4172906567)
</details>
