### PR TITLE
8360702: runtime/Thread/AsyncExceptionTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionOnMonitorEnter.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionOnMonitorEnter.java
@@ -44,9 +44,13 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
     public static native int exitRawMonitor();
     public static native void destroyRawMonitor();
 
+    // Avoid using CountDownLatch or similar objects that require unparking the
+    // main thread. Otherwise, if the main thread is run as a virtual thread, the
+    // async exception could be sent while the target is still executing FJP logic.
+    public volatile boolean started = false;
+    public volatile boolean gotMonitor = false;
+
     private static Object o1 = new Object();
-    private static boolean firstWorker = true;
-    private static Semaphore sem = new Semaphore(0);
 
     @Override
     public void run() {
@@ -59,11 +63,9 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
 
     public void testWithJavaMonitor() {
         try {
+            started = true;
             synchronized (o1) {
-                if (firstWorker) {
-                    firstWorker = false;
-                    sem.release();
-                }
+                gotMonitor = true;
                 Thread.sleep(1000);
             }
         } catch (ThreadDeath td) {
@@ -74,20 +76,16 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
 
 
     public void testWithJVMTIRawMonitor() {
-        boolean savedFirst = false;
         try {
+            started = true;
             int retCode = enterRawMonitor();
-            if (retCode != 0 && firstWorker) {
+            if (retCode != 0) {
                 throw new RuntimeException("error in JVMTI RawMonitorEnter: retCode=" + retCode);
             }
-            if (firstWorker) {
-                firstWorker = false;
-                savedFirst = true;
-                sem.release();
-            }
-            Thread.sleep(1000);
+            gotMonitor = true;
+            Thread.sleep(500);
             retCode = exitRawMonitor();
-            if (retCode != 0 && savedFirst) {
+            if (retCode != 0) {
                 throw new RuntimeException("error in JVMTI RawMonitorExit: retCode=" + retCode);
             }
         } catch (ThreadDeath td) {
@@ -133,15 +131,18 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
             AsyncExceptionOnMonitorEnter worker2 = new AsyncExceptionOnMonitorEnter();
 
             try {
-                // Start firstWorker worker and wait until monitor is acquired
-                firstWorker = true;
+                // Start first worker and wait until monitor is acquired
                 worker1.start();
-                sem.acquire();
+                while (!worker1.gotMonitor) {
+                    Thread.sleep(1);
+                }
 
                 // Start second worker and allow some time for target to block on monitorenter
                 // before executing Thread.stop()
                 worker2.start();
-                Thread.sleep(300);
+                while (!worker2.started) {
+                    Thread.sleep(10);
+                }
 
                 while (true) {
                     JVMTIUtils.stopThread(worker2);
@@ -150,6 +151,8 @@ public class AsyncExceptionOnMonitorEnter extends Thread {
                         // not released worker2 will deadlock on enter
                         JVMTIUtils.stopThread(worker1);
                     }
+                    // Give time to throw exception
+                    Thread.sleep(10);
 
                     if (!worker1.isAlive() && !worker2.isAlive()) {
                         // Done with Thread.stop() calls since

--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
@@ -36,25 +36,25 @@
 
 import jvmti.JVMTIUtils;
 
-import java.util.concurrent.CountDownLatch;
-
 public class AsyncExceptionTest extends Thread {
     private final static int DEF_TIME_MAX = 30;  // default max # secs to test
     private final static String PROG_NAME = "AsyncExceptionTest";
 
-    public CountDownLatch exitSyncObj = new CountDownLatch(1);
-    public CountDownLatch startSyncObj = new CountDownLatch(1);
+    // Avoid using CountDownLatch or similar objects that require unparking the
+    // main thread. Otherwise, if the main thread is run as a virtual thread, the
+    // async exception could be sent while the target is still executing FJP logic.
+    public volatile boolean started = false;
 
-    private boolean firstEntry = true;
     private boolean receivedThreadDeathinInternal1 = false;
     private boolean receivedThreadDeathinInternal2 = false;
+    private volatile RuntimeException error = null;
 
     @Override
     public void run() {
         try {
             internalRun1();
         } catch (ThreadDeath td) {
-            throw new RuntimeException("Caught ThreadDeath in run() instead of internalRun2() or internalRun1().\n"
+            error = new RuntimeException("Caught ThreadDeath in run() instead of internalRun2() or internalRun1().\n"
                     + "receivedThreadDeathinInternal1=" + receivedThreadDeathinInternal1
                     + "; receivedThreadDeathinInternal2=" + receivedThreadDeathinInternal2);
         } catch (NoClassDefFoundError ncdfe) {
@@ -62,15 +62,15 @@ public class AsyncExceptionTest extends Thread {
         }
 
         if (receivedThreadDeathinInternal2 == false && receivedThreadDeathinInternal1 == false) {
-            throw new RuntimeException("Didn't catch ThreadDeath in internalRun2() nor in internalRun1().\n"
+            error = new RuntimeException("Didn't catch ThreadDeath in internalRun2() nor in internalRun1().\n"
                     + "receivedThreadDeathinInternal1=" + receivedThreadDeathinInternal1
                     + "; receivedThreadDeathinInternal2=" + receivedThreadDeathinInternal2);
         }
-        exitSyncObj.countDown();
     }
 
     public void internalRun1() {
         try {
+            started = true;
             while (!receivedThreadDeathinInternal2) {
               internalRun2();
             }
@@ -81,16 +81,10 @@ public class AsyncExceptionTest extends Thread {
 
     public void internalRun2() {
         try {
-            Integer myLocalCount = 1;
-            Integer myLocalCount2 = 1;
+            int myLocalCount = 1;
+            int myLocalCount2 = 1;
 
-            if (firstEntry) {
-                // Tell main thread we have started.
-                startSyncObj.countDown();
-                firstEntry = false;
-            }
-
-            while(myLocalCount > 0) {
+            while (myLocalCount > 0) {
                 myLocalCount2 = (myLocalCount % 3) / 2;
                 myLocalCount -= 1;
             }
@@ -122,19 +116,12 @@ public class AsyncExceptionTest extends Thread {
             thread.start();
             try {
                 // Wait for the worker thread to get going.
-                thread.startSyncObj.await();
-                while (true) {
-                    // Send async exception and wait until it is thrown
-                    JVMTIUtils.stopThread(thread);
-                    thread.exitSyncObj.await();
-                    Thread.sleep(100);
-
-                    if (!thread.isAlive()) {
-                        // Done with Thread.stop() calls since
-                        // thread is not alive.
-                        break;
-                    }
+                while (!thread.started) {
+                    Thread.sleep(1);
                 }
+                // Send async exception and wait until it is thrown
+                JVMTIUtils.stopThread(thread);
+                thread.join();
             } catch (InterruptedException e) {
                 throw new Error("Unexpected: " + e);
             } catch (NoClassDefFoundError ncdfe) {
@@ -143,11 +130,14 @@ public class AsyncExceptionTest extends Thread {
                 // in a worker thread can subsequently be seen in the
                 // main thread.
             }
-
-            try {
-                thread.join();
-            } catch (InterruptedException e) {
-                throw new Error("Unexpected: " + e);
+            if (thread.isAlive()) {
+                // Really shouldn't be possible after join() above...
+                throw new RuntimeException("Thread did not exit.\n"
+                    + "receivedThreadDeathinInternal1=" + thread.receivedThreadDeathinInternal1
+                    + "; receivedThreadDeathinInternal2=" + thread.receivedThreadDeathinInternal2);
+            }
+            if (thread.error != null) {
+                throw thread.error;
             }
         }
 


### PR DESCRIPTION
Backporting JDK-8360702: runtime/Thread/AsyncExceptionTest.java timed out.

This PR fixes the test timeouts by removing synchronization that allowed async exceptions to interrupt ForkJoinPool code when using virtual threads.

This PR is not clean because previous backports were modified to work within JDK 21 limitations. The current commit was refactored around those changes while preserving the original intent.

For parity with Oracle JDK. Already backported to 25.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/runtime/Thread/AsyncExceptionOnMonitorEnter.java
make test TEST=test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java

Results attached:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/26468767/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/26468768/windows-x64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/26468769/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/26468770/macos-aarch64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/26468771/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/26468772/linux-x64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/26468773/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/26468774/linux-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8360702](https://bugs.openjdk.org/browse/JDK-8360702) needs maintainer approval

### Issue
 * [JDK-8360702](https://bugs.openjdk.org/browse/JDK-8360702): runtime/Thread/AsyncExceptionTest.java timed out (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2809/head:pull/2809` \
`$ git checkout pull/2809`

Update a local copy of the PR: \
`$ git checkout pull/2809` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2809`

View PR using the GUI difftool: \
`$ git pr show -t 2809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2809.diff">https://git.openjdk.org/jdk21u-dev/pull/2809.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2809#issuecomment-4184100484)
</details>
