### PR TITLE
8323672: Suppress unwanted autoconf added flags in CC and CXX

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -380,7 +380,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_POST_DETECTION],
 [
   # Restore old path, except for the microsoft toolchain, which requires the
   # toolchain path to remain in place. Otherwise the compiler will not work in
-  # some siutations in later configure checks.
+  # some situations in later configure checks.
   if test "x$TOOLCHAIN_TYPE" != "xmicrosoft"; then
     PATH="$OLD_PATH"
   fi
@@ -389,10 +389,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_POST_DETECTION],
   # This is necessary since AC_PROG_CC defaults CFLAGS to "-g -O2"
   CFLAGS="$ORG_CFLAGS"
   CXXFLAGS="$ORG_CXXFLAGS"
-
-  # filter out some unwanted additions autoconf may add to CXX; we saw this on macOS with autoconf 2.72
-  UTIL_GET_NON_MATCHING_VALUES(cxx_filtered, $CXX, -std=c++11 -std=gnu++11)
-  CXX="$cxx_filtered"
 ])
 
 # Check if a compiler is of the toolchain type we expect, and save the version

--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -26,6 +26,70 @@
 m4_include([util_paths.m4])
 
 ###############################################################################
+# Overwrite the existing version of AC_PROG_CC with our own custom variant.
+# Unlike the regular AC_PROG_CC, the compiler list must always be passed.
+AC_DEFUN([AC_PROG_CC],
+[
+  AC_LANG_PUSH(C)
+  AC_ARG_VAR([CC], [C compiler command])
+  AC_ARG_VAR([CFLAGS], [C compiler flags])
+
+  _AC_ARG_VAR_LDFLAGS()
+  _AC_ARG_VAR_LIBS()
+  _AC_ARG_VAR_CPPFLAGS()
+
+  AC_CHECK_TOOLS(CC, [$1])
+
+  test -z "$CC" && AC_MSG_FAILURE([no acceptable C compiler found in \$PATH])
+
+  # Provide some information about the compiler.
+  _AS_ECHO_LOG([checking for _AC_LANG compiler version])
+  set X $ac_compile
+  ac_compiler=$[2]
+  for ac_option in --version -v -V -qversion -version; do
+    _AC_DO_LIMIT([$ac_compiler $ac_option >&AS_MESSAGE_LOG_FD])
+  done
+
+  m4_expand_once([_AC_COMPILER_EXEEXT])
+  m4_expand_once([_AC_COMPILER_OBJEXT])
+
+  _AC_PROG_CC_G
+
+  AC_LANG_POP(C)
+])
+
+###############################################################################
+# Overwrite the existing version of AC_PROG_CXX with our own custom variant.
+# Unlike the regular AC_PROG_CXX, the compiler list must always be passed.
+AC_DEFUN([AC_PROG_CXX],
+[
+  AC_LANG_PUSH(C++)
+  AC_ARG_VAR([CXX], [C++ compiler command])
+  AC_ARG_VAR([CXXFLAGS], [C++ compiler flags])
+
+  _AC_ARG_VAR_LDFLAGS()
+  _AC_ARG_VAR_LIBS()
+  _AC_ARG_VAR_CPPFLAGS()
+
+  AC_CHECK_TOOLS(CXX, [$1])
+
+  # Provide some information about the compiler.
+  _AS_ECHO_LOG([checking for _AC_LANG compiler version])
+  set X $ac_compile
+  ac_compiler=$[2]
+  for ac_option in --version -v -V -qversion; do
+    _AC_DO_LIMIT([$ac_compiler $ac_option >&AS_MESSAGE_LOG_FD])
+  done
+
+  m4_expand_once([_AC_COMPILER_EXEEXT])
+  m4_expand_once([_AC_COMPILER_OBJEXT])
+
+  _AC_PROG_CXX_G
+
+  AC_LANG_POP(C++)
+])
+
+################################################################################
 # Create a function/macro that takes a series of named arguments. The call is
 # similar to AC_DEFUN, but the setup of the function looks like this:
 # UTIL_DEFUN_NAMED([MYFUNC], [FOO *BAR], [$@], [


### PR DESCRIPTION
Recent versions of `autoconf` have taken it upon themselves to set the C or C++ standard as part of detecting the compiler path.  We are currently seeing this on MacOS and 11u:

~~~
checking for /usr/bin/clang option to enable C23 features... -std=gnu23
...
* C Compiler:     Version 17.0.0 (at /usr/bin/clang -std=gnu23)
* C++ Compiler:   Version 17.0.0 (at /usr/bin/clang++)
~~~

which later causes the build to fail, I believe because the C compiler is used with C++ headers in pre-compiled header generation:

~~~
Generating precompiled header
error: invalid argument '-std=gnu23' not allowed with 'C++'
~~~

I'd like to backport this fix from OpenJDK 24 which takes C and C++ compiler detection under the control of the OpenJDK Makefiles.  This is a more general fix for the hack we already have in `toolchain.m4` (removed in this patch) to filter out certain `-std` flags from the C++ compiler only.  That route means having to update the filter every time autoconf tries something new.

I believe this is relatively low risk and it would be easier to fix issues with the new macros than try to second guess every possible future autoconf change to their versions of these macros.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323672](https://bugs.openjdk.org/browse/JDK-8323672) needs maintainer approval

### Issue
 * [JDK-8323672](https://bugs.openjdk.org/browse/JDK-8323672): Suppress unwanted autoconf added flags in CC and CXX (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2812/head:pull/2812` \
`$ git checkout pull/2812`

Update a local copy of the PR: \
`$ git checkout pull/2812` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2812`

View PR using the GUI difftool: \
`$ git pr show -t 2812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2812.diff">https://git.openjdk.org/jdk21u-dev/pull/2812.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2812#issuecomment-4185587820)
</details>
