### PR TITLE
8373623: Refactor Serialization tests for Records to JUnit

### DIFF
--- a/test/jdk/java/io/Serializable/records/AbsentStreamValuesTest.java
+++ b/test/jdk/java/io/Serializable/records/AbsentStreamValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8246774
  * @summary Checks that the appropriate default value is given to the canonical ctr
- * @run testng AbsentStreamValuesTest
- * @run testng/othervm/java.security.policy=empty_security.policy AbsentStreamValuesTest
+ * @run junit AbsentStreamValuesTest
+ * @run junit/othervm/java.security.policy=empty_security.policy AbsentStreamValuesTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -35,16 +35,20 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.io.ObjectStreamConstants.*;
 import static java.lang.System.out;
-import static org.testng.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Basic test to check that default primitive / reference values are presented
  * to the record's canonical constructor, for fields not in the stream.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AbsentStreamValuesTest {
 
     record R01(boolean  x) implements Serializable { }
@@ -62,7 +66,6 @@ public class AbsentStreamValuesTest {
     record R13(R12      x) implements Serializable { }
     record R14(R13[]    x) implements Serializable { }
 
-    @DataProvider(name = "recordTypeAndExpectedValue")
     public Object[][] recordTypeAndExpectedValue() {
         return new Object[][] {
                 new Object[] { R01.class, false    },
@@ -82,7 +85,8 @@ public class AbsentStreamValuesTest {
         };
     }
 
-    @Test(dataProvider = "recordTypeAndExpectedValue")
+    @ParameterizedTest
+    @MethodSource("recordTypeAndExpectedValue")
     public void testWithDifferentTypes(Class<?> clazz, Object expectedXValue)
         throws Exception
     {
@@ -93,7 +97,7 @@ public class AbsentStreamValuesTest {
         Object obj = deserialize(bytes);
         out.println("deserialized: " + obj);
         Object actualXValue = clazz.getDeclaredMethod("x").invoke(obj);
-        assertEquals(actualXValue, expectedXValue);
+        assertEquals(expectedXValue, actualXValue);
     }
 
     // --- all together
@@ -108,18 +112,18 @@ public class AbsentStreamValuesTest {
 
         R15 obj = (R15)deserialize(bytes);
         out.println("deserialized: " + obj);
-        assertEquals(obj.a, false);
-        assertEquals(obj.b, 0);
-        assertEquals(obj.c, 0);
-        assertEquals(obj.d, '\u0000');
-        assertEquals(obj.e, 0);
-        assertEquals(obj.f, 0l);
-        assertEquals(obj.g, 0f);
-        assertEquals(obj.h, 0d);
-        assertEquals(obj.i, null);
-        assertEquals(obj.j, null);
-        assertEquals(obj.k, null);
-        assertEquals(obj.l, null);
+        assertEquals(false, obj.a);
+        assertEquals(0, obj.b);
+        assertEquals(0, obj.c);
+        assertEquals('\u0000', obj.d);
+        assertEquals(0, obj.e);
+        assertEquals(0l, obj.f);
+        assertEquals(0f, obj.g);
+        assertEquals(0d, obj.h);
+        assertEquals(null, obj.i);
+        assertEquals(null, obj.j);
+        assertEquals(null, obj.k);
+        assertEquals(null, obj.l);
     }
 
     // --- generic type
@@ -133,8 +137,8 @@ public class AbsentStreamValuesTest {
 
         R16 obj = (R16)deserialize(bytes);
         out.println("deserialized: " + obj);
-        assertEquals(obj.t, null);
-        assertEquals(obj.u, null);
+        assertEquals(null, obj.t);
+        assertEquals(null, obj.u);
     }
 
     // --- infra

--- a/test/jdk/java/io/Serializable/records/BadCanonicalCtrTest.java
+++ b/test/jdk/java/io/Serializable/records/BadCanonicalCtrTest.java
@@ -28,7 +28,7 @@
  *          cannot be found during deserialization.
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
- * @run testng BadCanonicalCtrTest
+ * @run junit BadCanonicalCtrTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -44,20 +44,23 @@ import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.MethodVisitor;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 import jdk.test.lib.ByteCodeLoader;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
 import static jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
+
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Checks that an InvalidClassException is thrown when the canonical
  * constructor cannot be found during deserialization.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BadCanonicalCtrTest {
 
     // ClassLoader for creating instances of the records to test with.
@@ -74,7 +77,7 @@ public class BadCanonicalCtrTest {
      * the initial bytecode for the record classes using javac, then removes or
      * modifies the generated canonical constructor.
      */
-    @BeforeTest
+    @BeforeAll
     public void setup() {
         {
             byte[] byteCode = InMemoryJavaCompiler.compile("R1",
@@ -131,7 +134,6 @@ public class BadCanonicalCtrTest {
         return c.getConstructor(long.class).newInstance(l);
     }
 
-    @DataProvider(name = "recordInstances")
     public Object[][] recordInstances() throws Exception {
         return new Object[][] {
                 new Object[] { newR1()        },
@@ -146,13 +148,14 @@ public class BadCanonicalCtrTest {
      * Tests that InvalidClassException is thrown when no constructor is
      * present.
      */
-    @Test(dataProvider = "recordInstances")
+    @ParameterizedTest
+    @MethodSource("recordInstances")
     public void missingConstructorTest(Object objToSerialize) throws Exception {
         out.println("\n---");
         out.println("serializing : " + objToSerialize);
         byte[] bytes = serialize(objToSerialize);
         out.println("deserializing");
-        InvalidClassException ice = expectThrows(ICE, () -> deserialize(bytes, missingCtrClassLoader));
+        InvalidClassException ice = Assertions.assertThrows(ICE, () -> deserialize(bytes, missingCtrClassLoader));
         out.println("caught expected ICE: " + ice);
         assertTrue(ice.getMessage().contains("record canonical constructor not found"));
     }
@@ -162,13 +165,14 @@ public class BadCanonicalCtrTest {
      * constructor is not present. ( a non-canonical constructor is
      * present ).
      */
-    @Test(dataProvider = "recordInstances")
+    @ParameterizedTest
+    @MethodSource("recordInstances")
     public void nonCanonicalConstructorTest(Object objToSerialize) throws Exception {
         out.println("\n---");
         out.println("serializing : " + objToSerialize);
         byte[] bytes = serialize(objToSerialize);
         out.println("deserializing");
-        InvalidClassException ice = expectThrows(ICE, () -> deserialize(bytes, nonCanonicalCtrClassLoader));
+        InvalidClassException ice = Assertions.assertThrows(ICE, () -> deserialize(bytes, nonCanonicalCtrClassLoader));
         out.println("caught expected ICE: " + ice);
         assertTrue(ice.getMessage().contains("record canonical constructor not found"));
     }

--- a/test/jdk/java/io/Serializable/records/BadValues.java
+++ b/test/jdk/java/io/Serializable/records/BadValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Basic test for ClassNotFoundException
- * @run testng BadValues
+ * @run junit BadValues
  */
 
 import java.io.ByteArrayInputStream;
@@ -32,10 +32,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import org.testng.annotations.Test;
 import static java.io.ObjectStreamConstants.*;
 import static java.lang.System.out;
-import static org.testng.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Not directly related to records but provokes surrounding code, and ensures
@@ -73,7 +74,7 @@ public class BadValues {
     public void testNotFoundSer() throws Exception {
         out.println("\n---");
         byte[] bytes = byteStreamFor("XxYyZz", 0L, (byte)SC_SERIALIZABLE);
-        Throwable t = expectThrows(CNFE, () -> deserialize(bytes));
+        Throwable t = assertThrows(CNFE, () -> deserialize(bytes));
         out.println("caught expected CNFE: " + t);
     }
 
@@ -81,7 +82,7 @@ public class BadValues {
     public void testNotFoundSerWr() throws Exception {
         out.println("\n---");
         byte[] bytes = byteStreamFor("XxYyZz", 0L, (byte)(SC_SERIALIZABLE | SC_WRITE_METHOD));
-        Throwable t = expectThrows(CNFE, () -> deserialize(bytes));
+        Throwable t = assertThrows(CNFE, () -> deserialize(bytes));
         out.println("caught expected CNFE: " + t);
     }
 
@@ -89,7 +90,7 @@ public class BadValues {
     public void testNotFoundExt() throws Exception {
         out.println("\n---");
         byte[] bytes = byteStreamFor("AaBbCc", 0L, (byte)SC_EXTERNALIZABLE);
-        Throwable t = expectThrows(CNFE, () -> deserialize(bytes));
+        Throwable t = assertThrows(CNFE, () -> deserialize(bytes));
         out.println("caught expected CNFE: " + t);
     }
 
@@ -97,7 +98,7 @@ public class BadValues {
     public void testNotFoundExtWr() throws Exception {
         out.println("\n---");
         byte[] bytes = byteStreamFor("AaBbCc", 0L, (byte)(SC_SERIALIZABLE | SC_WRITE_METHOD));
-        Throwable t = expectThrows(CNFE, () -> deserialize(bytes));
+        Throwable t = assertThrows(CNFE, () -> deserialize(bytes));
         out.println("caught expected CNFE: " + t);
     }
 

--- a/test/jdk/java/io/Serializable/records/BasicRecordSer.java
+++ b/test/jdk/java/io/Serializable/records/BasicRecordSer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8246774
  * @summary Basic test that serializes and deserializes a number of records
- * @run testng BasicRecordSer
- * @run testng/othervm/java.security.policy=empty_security.policy BasicRecordSer
+ * @run junit BasicRecordSer
+ * @run junit/othervm/java.security.policy=empty_security.policy BasicRecordSer
  */
 
 import java.io.ByteArrayInputStream;
@@ -40,19 +40,24 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.String.format;
 import static java.lang.System.out;
 import static java.net.InetAddress.getLoopbackAddress;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
-import static org.testng.Assert.fail;
+
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Basic test that serializes and deserializes a number of simple records.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BasicRecordSer {
 
     // a mix of a few record and non-record classes
@@ -102,7 +107,6 @@ public class BasicRecordSer {
 
     record Wubble (Wobble wobble, Wibble wibble, String s) implements ThrowingExternalizable { }
 
-    @DataProvider(name = "serializable")
     public Object[][] serializable() {
         Foo foo = new Foo(23);
         return new Object[][] {
@@ -122,14 +126,20 @@ public class BasicRecordSer {
     }
 
     /** Tests serializing and deserializing a number of records. */
-    @Test(dataProvider = "serializable")
+    @ParameterizedTest
+    @MethodSource("serializable")
     public void testSerializable(Object objToSerialize) throws Exception {
         out.println("\n---");
         out.println("serializing : " + objToSerialize);
         var objDeserialized = serializeDeserialize(objToSerialize);
         out.println("deserialized: " + objDeserialized);
-        assertEquals(objToSerialize, objDeserialized);
-        assertEquals(objDeserialized, objToSerialize);
+        if (objToSerialize.getClass().isArray()) {
+            assertArrayEquals((Object[]) objDeserialized, (Object[]) objToSerialize);
+            assertArrayEquals((Object[]) objToSerialize, (Object[]) objDeserialized);
+        } else {
+            assertEquals(objDeserialized, objToSerialize);
+            assertEquals(objToSerialize, objDeserialized);
+        }
     }
 
     /** Tests serializing and deserializing of local records. */
@@ -155,8 +165,8 @@ public class BasicRecordSer {
         out.println("serializing : " + objToSerialize);
         Foo[] objDeserialized = (Foo[])serializeDeserialize(objToSerialize);
         out.println("deserialized: " + objDeserialized);
-        assertEquals(objToSerialize, objDeserialized);
-        assertEquals(objDeserialized, objToSerialize);
+        Assertions.assertArrayEquals(objDeserialized, objToSerialize);
+        Assertions.assertArrayEquals(objToSerialize, objDeserialized);
 
         for (Foo f : objDeserialized)
             assertTrue(objDeserialized[0] == f);
@@ -172,8 +182,8 @@ public class BasicRecordSer {
         out.println("serializing : " + objToSerialize);
         Wobble[] objDeserialized = (Wobble[])serializeDeserialize(objToSerialize);
         out.println("deserialized: " + objDeserialized);
-        assertEquals(objToSerialize, objDeserialized);
-        assertEquals(objDeserialized, objToSerialize);
+        Assertions.assertArrayEquals(objDeserialized, objToSerialize);
+        Assertions.assertArrayEquals(objToSerialize, objDeserialized);
 
         for (Wobble w : objDeserialized) {
             assertTrue(objDeserialized[0] == w);
@@ -193,7 +203,6 @@ public class BasicRecordSer {
         final NotSer notSer = new NotSer(7);
     }
 
-    @DataProvider(name = "notSerializable")
     public Object[][] notSerializable() {
         return new Object[][] {
             new Object[] { new NotSerEmpty()                       },
@@ -210,11 +219,12 @@ public class BasicRecordSer {
     static final Class<NotSerializableException> NSE = NotSerializableException.class;
 
     /** Tests that non-Serializable record objects throw NotSerializableException. */
-    @Test(dataProvider = "notSerializable")
+    @ParameterizedTest
+    @MethodSource("notSerializable")
     public void testNotSerializable(Object objToSerialize) throws Exception {
         out.println("\n---");
         out.println("serializing : " + objToSerialize);
-        NotSerializableException expected = expectThrows(NSE, () -> serialize(objToSerialize));
+        NotSerializableException expected = Assertions.assertThrows(NSE, () -> serialize(objToSerialize));
         out.println("caught expected NSE:" + expected);
 
     }
@@ -236,9 +246,9 @@ public class BasicRecordSer {
         out.println("serializing : " + objToSerialize);
         var objDeserialized = serializeDeserialize(objToSerialize);
         out.println("deserialized: " + objDeserialized);
-        assertEquals(objToSerialize, objDeserialized);
         assertEquals(objDeserialized, objToSerialize);
-        assertEquals(e_ctrInvocationCount, 1);
+        assertEquals(objToSerialize, objDeserialized);
+        assertEquals(1, e_ctrInvocationCount);
     }
 
     // ---
@@ -259,9 +269,9 @@ public class BasicRecordSer {
         var objToSerialize = new G();
         g_ctrInvocationCount = 0;  // reset
         out.println("serializing : " + objToSerialize);
-        NotSerializableException expected = expectThrows(NSE, () -> serialize(objToSerialize));
+        NotSerializableException expected = Assertions.assertThrows(NSE, () -> serialize(objToSerialize));
         out.println("caught expected NSE:" + expected);
-        assertEquals(g_ctrInvocationCount, 0);
+        assertEquals(0, g_ctrInvocationCount);
     }
 
     // --- infra

--- a/test/jdk/java/io/Serializable/records/ConstructorAccessTest.java
+++ b/test/jdk/java/io/Serializable/records/ConstructorAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8246774
  * @summary Ensures that the serialization implementation can *always* access
  *          the record constructor
- * @run testng ConstructorAccessTest
- * @run testng/othervm/java.security.policy=empty_security.policy ConstructorAccessTest
+ * @run junit ConstructorAccessTest
+ * @run junit/othervm/java.security.policy=empty_security.policy ConstructorAccessTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -39,16 +39,19 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Externalizable;
 import java.io.Serializable;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /*implicit*/ record Aux1 (int x) implements Serializable { }
 
 /*implicit*/ record Aux2 (int x) implements Serializable { }
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ConstructorAccessTest {
 
     public record A (int x) implements Serializable { }
@@ -76,7 +79,6 @@ public class ConstructorAccessTest {
 
     private record H (double d) implements ThrowingExternalizable { }
 
-    @DataProvider(name = "recordInstances")
     public Object[][] recordInstances() {
         return new Object[][] {
             new Object[] { new A(34)        },
@@ -92,7 +94,8 @@ public class ConstructorAccessTest {
         };
     }
 
-    @Test(dataProvider = "recordInstances")
+    @ParameterizedTest
+    @MethodSource("recordInstances")
     public void roundTrip(Object objToSerialize) throws Exception {
         out.println("\n---");
         out.println("serializing : " + objToSerialize);

--- a/test/jdk/java/io/Serializable/records/CycleTest.java
+++ b/test/jdk/java/io/Serializable/records/CycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8246774
  * @summary Ensures basic behavior of cycles from record components
- * @run testng CycleTest
- * @run testng/othervm/java.security.policy=empty_security.policy CycleTest
+ * @run junit CycleTest
+ * @run junit/othervm/java.security.policy=empty_security.policy CycleTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -35,10 +35,11 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class CycleTest {
 
@@ -62,10 +63,10 @@ public class CycleTest {
         out.println("serializing : " + r);
         R deserializedObj = serializeDeserialize(r);
         out.println("deserialized: " + deserializedObj);
-        assertEquals(deserializedObj.x(), 1);           // sanity
-        assertEquals(deserializedObj.y(), 2);           // sanity
+        assertEquals(1, deserializedObj.x());           // sanity
+        assertEquals(2, deserializedObj.y());           // sanity
         assertTrue(deserializedObj.c() instanceof C);   // sanity
-        assertEquals(deserializedObj.c().obj, null);    // cycle, expect null
+        assertEquals(null, deserializedObj.c().obj);    // cycle, expect null
     }
 
     /**
@@ -85,8 +86,8 @@ public class CycleTest {
         out.println("deserialized: " + deserializedObj);
         assertTrue(deserializedObj instanceof C);         // sanity
         assertTrue(deserializedObj.obj != null);          // expect non-null, r
-        assertEquals(((R)deserializedObj.obj).x(), 3);    // sanity
-        assertEquals(((R)deserializedObj.obj).y(), 4);    // sanity
+        assertEquals(3, ((R)deserializedObj.obj).x());    // sanity
+        assertEquals(4, ((R)deserializedObj.obj).y());    // sanity
     }
 
     record R2 (int x, int y, C c1, C c2) implements Serializable { }
@@ -106,8 +107,8 @@ public class CycleTest {
         out.println("serializing : " + r);
         R2 deserializedObj = serializeDeserialize(r);
         out.println("deserialized: " + deserializedObj);
-        assertEquals(deserializedObj.x(), 5);         // sanity
-        assertEquals(deserializedObj.y(), 6);         // sanity
+        assertEquals(5, deserializedObj.x());         // sanity
+        assertEquals(6, deserializedObj.y());         // sanity
 
         c1 = deserializedObj.c1();
         c2 = deserializedObj.c2();
@@ -133,11 +134,11 @@ public class CycleTest {
         R3 deserializedObj = serializeDeserialize(r3);
         out.println("deserialized: " + deserializedObj);
         assertTrue(deserializedObj.r() != null);
-        assertEquals(deserializedObj.l(), 9);              // sanity
-        assertEquals(deserializedObj.r().x(), 7);          // sanity
-        assertEquals(deserializedObj.r().y(), 8);          // sanity
+        assertEquals(9, deserializedObj.l());              // sanity
+        assertEquals(7, deserializedObj.r().x());          // sanity
+        assertEquals(8, deserializedObj.r().y());          // sanity
         assertTrue(deserializedObj.r().c() instanceof C);  // sanity
-        assertEquals(deserializedObj.r().c().obj, null);   // cycle, expect null
+        assertEquals(null, deserializedObj.r().c().obj);   // cycle, expect null
     }
 
     // --- infra

--- a/test/jdk/java/io/Serializable/records/DifferentStreamFieldsTest.java
+++ b/test/jdk/java/io/Serializable/records/DifferentStreamFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8246774
  * @summary Checks that the appropriate value is given to the canonical ctr
  * @library /test/lib
- * @run testng DifferentStreamFieldsTest
- * @run testng/othervm/java.security.policy=empty_security.policy DifferentStreamFieldsTest
+ * @run junit DifferentStreamFieldsTest
+ * @run junit/othervm/java.security.policy=empty_security.policy DifferentStreamFieldsTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -39,14 +39,19 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import jdk.test.lib.serial.SerialObjectBuilder;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
+
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Checks that the appropriate value is given to the canonical ctr.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DifferentStreamFieldsTest {
 
     record R01(boolean x) implements Serializable {}
@@ -77,7 +82,6 @@ public class DifferentStreamFieldsTest {
 
     record R14(R13[]x) implements Serializable {}
 
-    @DataProvider(name = "recordTypeAndExpectedValue")
     public Object[][] recordTypeAndExpectedValue() {
         return new Object[][]{
             new Object[]{R01.class, false},
@@ -97,7 +101,8 @@ public class DifferentStreamFieldsTest {
         };
     }
 
-    @Test(dataProvider = "recordTypeAndExpectedValue")
+    @ParameterizedTest
+    @MethodSource("recordTypeAndExpectedValue")
     public void testWithDifferentTypes(Class<?> clazz, Object expectedXValue)
     throws Exception {
         out.println("\n---");
@@ -109,7 +114,7 @@ public class DifferentStreamFieldsTest {
         Object obj = deserialize(bytes);
         out.println("deserialized: " + obj);
         Object actualXValue = clazz.getDeclaredMethod("x").invoke(obj);
-        assertEquals(actualXValue, expectedXValue);
+        assertEquals(expectedXValue, actualXValue);
 
         bytes = SerialObjectBuilder
             .newBuilder(clazz.getName())
@@ -119,7 +124,7 @@ public class DifferentStreamFieldsTest {
         obj = deserialize(bytes);
         out.println("deserialized: " + obj);
         actualXValue = clazz.getDeclaredMethod("x").invoke(obj);
-        assertEquals(actualXValue, expectedXValue);
+        assertEquals(expectedXValue, actualXValue);
     }
 
     // --- all together
@@ -138,18 +143,18 @@ public class DifferentStreamFieldsTest {
 
         R15 obj = deserialize(bytes);
         out.println("deserialized: " + obj);
-        assertEquals(obj.a, false);
-        assertEquals(obj.b, 0);
-        assertEquals(obj.c, 0);
-        assertEquals(obj.d, '\u0000');
-        assertEquals(obj.e, 0);
-        assertEquals(obj.f, 0l);
-        assertEquals(obj.g, 0f);
-        assertEquals(obj.h, 0d);
-        assertEquals(obj.i, null);
-        assertEquals(obj.j, null);
-        assertEquals(obj.k, null);
-        assertEquals(obj.l, null);
+        assertEquals(false, obj.a);
+        assertEquals(0, obj.b);
+        assertEquals(0, obj.c);
+        assertEquals('\u0000', obj.d);
+        assertEquals(0, obj.e);
+        assertEquals(0l, obj.f);
+        assertEquals(0f, obj.g);
+        assertEquals(0d, obj.h);
+        assertEquals(null, obj.i);
+        assertEquals(null, obj.j);
+        assertEquals(null, obj.k);
+        assertEquals(null, obj.l);
     }
 
     @Test
@@ -167,9 +172,9 @@ public class DifferentStreamFieldsTest {
                 .build();
 
             var deser1 = deserialize(OOSBytes);
-            assertEquals(deser1, r);
+            assertEquals(r, deser1);
             var deser2 = deserialize(builderBytes);
-            assertEquals(deser2, deser1);
+            assertEquals(deser1, deser2);
         }
         {
             record R(int x, int y) implements Serializable {}
@@ -177,7 +182,7 @@ public class DifferentStreamFieldsTest {
             var r = new R(7, 8);
             byte[] OOSBytes = serialize(r);
             var deser1 = deserialize(OOSBytes);
-            assertEquals(deser1, r);
+            assertEquals(r, deser1);
 
             byte[] builderBytes = SerialObjectBuilder
                 .newBuilder(R.class.getName())
@@ -186,7 +191,7 @@ public class DifferentStreamFieldsTest {
                 .build();
 
             var deser2 = deserialize(builderBytes);
-            assertEquals(deser2, deser1);
+            assertEquals(deser1, deser2);
 
             builderBytes = SerialObjectBuilder
                 .newBuilder(R.class.getName())
@@ -194,7 +199,7 @@ public class DifferentStreamFieldsTest {
                 .addPrimitiveField("x", int.class, 7)
                 .build();
             deser2 = deserialize(builderBytes);
-            assertEquals(deser2, deser1);
+            assertEquals(deser1, deser2);
 
             builderBytes = SerialObjectBuilder
                 .newBuilder(R.class.getName())
@@ -204,12 +209,12 @@ public class DifferentStreamFieldsTest {
                 .addPrimitiveField("z", int.class, 9) // additional fields
                 .build();
             deser2 = deserialize(builderBytes);
-            assertEquals(deser2, deser1);
+            assertEquals(deser1, deser2);
 
             r = new R(0, 0);
             OOSBytes = serialize(r);
             deser1 = deserialize(OOSBytes);
-            assertEquals(deser1, r);
+            assertEquals(r, deser1);
 
             builderBytes = SerialObjectBuilder
                 .newBuilder(R.class.getName())
@@ -217,13 +222,13 @@ public class DifferentStreamFieldsTest {
                 .addPrimitiveField("x", int.class, 0)
                 .build();
             deser2 = deserialize(builderBytes);
-            assertEquals(deser2, deser1);
+            assertEquals(deser1, deser2);
 
             builderBytes = SerialObjectBuilder
                 .newBuilder(R.class.getName())  // no field values
                 .build();
             deser2 = deserialize(builderBytes);
-            assertEquals(deser2, deser1);
+            assertEquals(deser1, deser2);
         }
     }
 
@@ -235,7 +240,7 @@ public class DifferentStreamFieldsTest {
 
         var r = new Str("Hello", "World!");
         var deser1 = deserialize(serialize(r));
-        assertEquals(deser1, r);
+        assertEquals(r, deser1);
 
         byte[] builderBytes = SerialObjectBuilder
             .newBuilder(Str.class.getName())
@@ -244,7 +249,7 @@ public class DifferentStreamFieldsTest {
             .build();
 
         var deser2 = deserialize(builderBytes);
-        assertEquals(deser2, deser1);
+        assertEquals(deser1, deser2);
 
         builderBytes = SerialObjectBuilder
             .newBuilder(Str.class.getName())
@@ -255,7 +260,7 @@ public class DifferentStreamFieldsTest {
             .build();
 
         var deser3 = deserialize(builderBytes);
-        assertEquals(deser3, deser1);
+        assertEquals(deser1, deser3);
     }
 
     @Test
@@ -265,8 +270,8 @@ public class DifferentStreamFieldsTest {
             record IntArray(int[]ints, long[]longs) implements Serializable {}
             IntArray r = new IntArray(new int[]{5, 4, 3, 2, 1}, new long[]{9L});
             IntArray deser1 = deserialize(serialize(r));
-            assertEquals(deser1.ints(), r.ints());
-            assertEquals(deser1.longs(), r.longs());
+            Assertions.assertArrayEquals(r.ints(), deser1.ints());
+            Assertions.assertArrayEquals(r.longs(), deser1.longs());
 
             byte[] builderBytes = SerialObjectBuilder
                 .newBuilder(IntArray.class.getName())
@@ -275,14 +280,14 @@ public class DifferentStreamFieldsTest {
                 .build();
 
             IntArray deser2 = deserialize(builderBytes);
-            assertEquals(deser2.ints(), deser1.ints());
-            assertEquals(deser2.longs(), deser1.longs());
+            Assertions.assertArrayEquals(deser1.ints(), deser2.ints());
+            Assertions.assertArrayEquals(deser1.longs(), deser2.longs());
         }
         {
             record StrArray(String[]stringArray) implements Serializable {}
             StrArray r = new StrArray(new String[]{"foo", "bar"});
             StrArray deser1 = deserialize(serialize(r));
-            assertEquals(deser1.stringArray(), r.stringArray());
+            Assertions.assertArrayEquals(r.stringArray(), deser1.stringArray());
 
             byte[] builderBytes = SerialObjectBuilder
                 .newBuilder(StrArray.class.getName())
@@ -290,7 +295,7 @@ public class DifferentStreamFieldsTest {
                 .build();
 
             StrArray deser2 = deserialize(builderBytes);
-            assertEquals(deser2.stringArray(), deser1.stringArray());
+            Assertions.assertArrayEquals(deser1.stringArray(), deser2.stringArray());
         }
     }
 
@@ -303,7 +308,7 @@ public class DifferentStreamFieldsTest {
 
             var r = new NumberHolder(123);
             var deser1 = deserialize(serialize(r));
-            assertEquals(deser1, r);
+            assertEquals(r, deser1);
 
             byte[] builderBytes = SerialObjectBuilder
                 .newBuilder(NumberHolder.class.getName())
@@ -311,7 +316,7 @@ public class DifferentStreamFieldsTest {
                 .build();
 
             var deser2 = deserialize(builderBytes);
-            assertEquals(deser2, deser1);
+            assertEquals(deser1, deser2);
         }
 
         {
@@ -319,7 +324,7 @@ public class DifferentStreamFieldsTest {
 
             var r = new IntegerHolder(123);
             var deser1 = deserialize(serialize(r));
-            assertEquals(deser1, r);
+            assertEquals(r, deser1);
 
             byte[] builderBytes = SerialObjectBuilder
                 .newBuilder(IntegerHolder.class.getName())
@@ -327,7 +332,7 @@ public class DifferentStreamFieldsTest {
                 .build();
 
             var deser2 = deserialize(builderBytes);
-            assertEquals(deser2, deser1);
+            assertEquals(deser1, deser2);
         }
     }
 
@@ -339,7 +344,7 @@ public class DifferentStreamFieldsTest {
 
         var r = new StringHolder("123");
         var deser1 = deserialize(serialize(r));
-        assertEquals(deser1, r);
+        assertEquals(r, deser1);
 
         byte[] builderBytes = SerialObjectBuilder
             .newBuilder(StringHolder.class.getName())
@@ -363,7 +368,7 @@ public class DifferentStreamFieldsTest {
 
         var r = new IntHolder(123);
         var deser1 = deserialize(serialize(r));
-        assertEquals(deser1, r);
+        assertEquals(r, deser1);
 
         byte[] builderBytes = SerialObjectBuilder
             .newBuilder(IntHolder.class.getName())

--- a/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
+++ b/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Basic tests for prohibited magic serialization methods
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
- * @run testng ProhibitedMethods
+ * @run junit ProhibitedMethods
  */
 
 import java.io.ByteArrayInputStream;
@@ -51,23 +51,27 @@ import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.MethodVisitor;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 import jdk.test.lib.ByteCodeLoader;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
 import static jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
-import static org.testng.Assert.fail;
+
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Checks that the various prohibited Serialization magic methods, and
  * Externalizable methods, are not invoked ( effectively ignored ) for
  * record objects.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ProhibitedMethods {
 
     public interface ThrowingExternalizable extends Externalizable {
@@ -101,7 +105,7 @@ public class ProhibitedMethods {
      *           fail("readObjectNoData should not be invoked");          }
      *   }
      */
-    @BeforeTest
+    @BeforeAll
     public void setup() {
         {
             byte[] byteCode = InMemoryJavaCompiler.compile("Foo",
@@ -166,7 +170,6 @@ public class ProhibitedMethods {
         }
     }
 
-    @DataProvider(name = "recordInstances")
     public Object[][] recordInstances() {
         return new Object[][] {
             new Object[] { newFoo()                                           },
@@ -178,7 +181,8 @@ public class ProhibitedMethods {
         };
     }
 
-    @Test(dataProvider = "recordInstances")
+    @ParameterizedTest
+    @MethodSource("recordInstances")
     public void roundTrip(Object objToSerialize) throws Exception {
         out.println("\n---");
         out.println("serializing : " + objToSerialize);
@@ -271,7 +275,8 @@ public class ProhibitedMethods {
             MethodVisitor mv = cv.visitMethod(ACC_PRIVATE, WRITE_OBJECT_NAME, WRITE_OBJECT_DESC, null, null);
             mv.visitCode();
             mv.visitLdcInsn(WRITE_OBJECT_NAME + " should not be invoked");
-            mv.visitMethodInsn(INVOKESTATIC, "org/testng/Assert", "fail", "(Ljava/lang/String;)V", false);
+            mv.visitMethodInsn(INVOKESTATIC, "org/junit/jupiter/api/Assertions", "fail",
+                               "(Ljava/lang/String;)Ljava/lang/Object;", false);
             mv.visitInsn(RETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
@@ -332,37 +337,37 @@ public class ProhibitedMethods {
                 Method m = obj.getClass().getDeclaredMethod("writeObject", ObjectOutputStream.class);
                 assertTrue((m.getModifiers() & Modifier.PRIVATE) != 0);
                 m.setAccessible(true);
-                ReflectiveOperationException t = expectThrows(ROE, () ->
+                ReflectiveOperationException t = Assertions.assertThrows(ROE, () ->
                         m.invoke(obj, new ObjectOutputStream(OutputStream.nullOutputStream())));
                 Throwable assertionError = t.getCause();
                 out.println("caught expected AssertionError: " + assertionError);
                 assertTrue(assertionError instanceof AssertionError,
                            "Expected AssertionError, got:" + assertionError);
-                assertEquals(assertionError.getMessage(), "writeObject should not be invoked");
+                assertEquals("writeObject should not be invoked", assertionError.getMessage());
             }
             {   // readObject
                 Method m = obj.getClass().getDeclaredMethod("readObject", ObjectInputStream.class);
                 assertTrue((m.getModifiers() & Modifier.PRIVATE) != 0);
                 m.setAccessible(true);
-                ReflectiveOperationException t = expectThrows(ROE, () ->
+                ReflectiveOperationException t = Assertions.assertThrows(ROE, () ->
                         m.invoke(obj, new ObjectInputStream() {
                         }));
                 Throwable assertionError = t.getCause();
                 out.println("caught expected AssertionError: " + assertionError);
                 assertTrue(assertionError instanceof AssertionError,
                            "Expected AssertionError, got:" + assertionError);
-                assertEquals(assertionError.getMessage(), "readObject should not be invoked");
+                assertEquals("readObject should not be invoked", assertionError.getMessage());
             }
             {   // readObjectNoData
                 Method m = obj.getClass().getDeclaredMethod("readObjectNoData");
                 assertTrue((m.getModifiers() & Modifier.PRIVATE) != 0);
                 m.setAccessible(true);
-                ReflectiveOperationException t = expectThrows(ROE, () -> m.invoke(obj));
+                ReflectiveOperationException t = Assertions.assertThrows(ROE, () -> m.invoke(obj));
                 Throwable assertionError = t.getCause();
                 out.println("caught expected AssertionError: " + assertionError);
                 assertTrue(assertionError instanceof AssertionError,
                            "Expected AssertionError, got:" + assertionError);
-                assertEquals(assertionError.getMessage(), "readObjectNoData should not be invoked");
+                assertEquals("readObjectNoData should not be invoked", assertionError.getMessage());
             }
         }
     }

--- a/test/jdk/java/io/Serializable/records/ReadResolveTest.java
+++ b/test/jdk/java/io/Serializable/records/ReadResolveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8246774
  * @summary Basic tests for readResolve
- * @run testng ReadResolveTest
- * @run testng/othervm/java.security.policy=empty_security.policy ReadResolveTest
+ * @run junit ReadResolveTest
+ * @run junit/othervm/java.security.policy=empty_security.policy ReadResolveTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -36,15 +36,19 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.String.format;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests records being used as a serial proxy.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ReadResolveTest {
 
     static class C1 implements Serializable {
@@ -95,7 +99,6 @@ public class ReadResolveTest {
         }
     }
 
-    @DataProvider(name = "objectsToSerialize")
     public Object[][] objectsToSerialize() {
         return new Object[][] {
                 new Object[] { new C1(3,4)        },
@@ -104,13 +107,14 @@ public class ReadResolveTest {
         };
     }
 
-    @Test(dataProvider = "objectsToSerialize")
+    @ParameterizedTest
+    @MethodSource("objectsToSerialize")
     public void testSerialize(Object objectToSerialize) throws Exception {
         out.println("\n---");
         out.println("serializing : " + objectToSerialize);
         Object deserializedObj = serializeDeserialize(objectToSerialize);
         out.println("deserialized: " + deserializedObj);
-        assertEquals(deserializedObj, objectToSerialize);
+        assertEquals(objectToSerialize, deserializedObj);
     }
 
     // -- null replacement
@@ -129,7 +133,7 @@ public class ReadResolveTest {
         out.println("serializing : " + objectToSerialize);
         Object deserializedObj = serializeDeserialize(objectToSerialize);
         out.println("deserialized: " + deserializedObj);
-        assertEquals(deserializedObj, null);
+        assertEquals(null, deserializedObj);
     }
 
     // --- infra

--- a/test/jdk/java/io/Serializable/records/RecordClassTest.java
+++ b/test/jdk/java/io/Serializable/records/RecordClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8246774
  * @summary Basic tests for serializing and deserializing record classes
- * @run testng RecordClassTest
- * @run testng/othervm/java.security.policy=empty_security.policy RecordClassTest
+ * @run junit RecordClassTest
+ * @run junit/othervm/java.security.policy=empty_security.policy RecordClassTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -39,15 +39,18 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.Serializable;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Serializes and deserializes record classes. Ensures that the SUID is 0.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RecordClassTest {
 
     record Foo () implements Serializable { }
@@ -75,7 +78,6 @@ public class RecordClassTest {
 
     record Wubble (Wobble wobble, Wibble wibble, String s) implements ThrowingExternalizable { }
 
-    @DataProvider(name = "recordClasses")
     public Object[][] recordClasses() {
         return new Object[][] {
             new Object[] { Foo.class    , 0L         },
@@ -88,7 +90,8 @@ public class RecordClassTest {
     }
 
     /** Tests that the serialized and deserialized instances are equal. */
-    @Test(dataProvider = "recordClasses")
+    @ParameterizedTest
+    @MethodSource("recordClasses")
     public void testClassSerialization(Class<?> recordClass, long unused)
         throws Exception
     {
@@ -96,21 +99,22 @@ public class RecordClassTest {
         out.println("serializing : " + recordClass);
         var deserializedClass = serializeDeserialize(recordClass);
         out.println("deserialized: " + deserializedClass);
-        assertEquals(recordClass, deserializedClass);
         assertEquals(deserializedClass, recordClass);
+        assertEquals(recordClass, deserializedClass);
     }
 
     /** Tests that the SUID is always 0 unless explicitly declared. */
-    @Test(dataProvider = "recordClasses")
+    @ParameterizedTest
+    @MethodSource("recordClasses")
     public void testSerialVersionUID(Class<?> recordClass, long expectedUID) {
         out.println("\n---");
         ObjectStreamClass osc = ObjectStreamClass.lookup(recordClass);
         out.println("ObjectStreamClass::lookup  : " + osc);
-        assertEquals(osc.getSerialVersionUID(), expectedUID);
+        assertEquals(expectedUID, osc.getSerialVersionUID());
 
         osc = ObjectStreamClass.lookupAny(recordClass);
         out.println("ObjectStreamClass::lookupAny: " + osc);
-        assertEquals(osc.getSerialVersionUID(), expectedUID);
+        assertEquals(expectedUID, osc.getSerialVersionUID());
     }
 
     // --- not Serializable
@@ -121,7 +125,6 @@ public class RecordClassTest {
 
     record NotSerializable3<T>(T t) { }
 
-    @DataProvider(name = "notSerRecordClasses")
     public Object[][] notSerRecordClasses() {
         return new Object[][] {
             new Object[] { NotSerializable1.class },
@@ -131,16 +134,17 @@ public class RecordClassTest {
     }
 
     /** Tests that the generated SUID is always 0 for all non-Serializable record classes. */
-    @Test(dataProvider = "notSerRecordClasses")
+    @ParameterizedTest
+    @MethodSource("notSerRecordClasses")
     public void testSerialVersionUIDNonSer(Class<?> recordClass) {
         out.println("\n---");
         ObjectStreamClass osc = ObjectStreamClass.lookup(recordClass);
         out.println("ObjectStreamClass::lookup  : " + osc);
-        assertEquals(osc, null);
+        assertEquals(null, osc);
 
         osc = ObjectStreamClass.lookupAny(recordClass);
         out.println("ObjectStreamClass::lookupAny: " + osc);
-        assertEquals(osc.getSerialVersionUID(), 0L);
+        assertEquals(0L, osc.getSerialVersionUID());
     }
 
     // --- infra

--- a/test/jdk/java/io/Serializable/records/SerialPersistentFieldsTest.java
+++ b/test/jdk/java/io/Serializable/records/SerialPersistentFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Basic tests for prohibited magic serialPersistentFields
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
- * @run testng SerialPersistentFieldsTest
+ * @run junit SerialPersistentFieldsTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -49,18 +49,21 @@ import jdk.internal.org.objectweb.asm.MethodVisitor;
 import jdk.internal.org.objectweb.asm.Type;
 import jdk.test.lib.ByteCodeLoader;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
 import static jdk.internal.org.objectweb.asm.ClassWriter.*;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Checks that the serialPersistentFields declaration is effectively ignored.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SerialPersistentFieldsTest {
 
     ClassLoader serializableRecordLoader;
@@ -78,7 +81,7 @@ public class SerialPersistentFieldsTest {
      *       };
      *   }
      */
-    @BeforeTest
+    @BeforeAll
     public void setup() {
         {  // R1
             byte[] byteCode = InMemoryJavaCompiler.compile("R1",
@@ -164,7 +167,6 @@ public class SerialPersistentFieldsTest {
         return newRecord("R5", new Class[]{int.class}, new Object[]{x});
     }
 
-    @DataProvider(name = "recordInstances")
     public Object[][] recordInstances() {
         return new Object[][] {
             new Object[] { newR1()                                },
@@ -175,14 +177,15 @@ public class SerialPersistentFieldsTest {
         };
     }
 
-    @Test(dataProvider = "recordInstances")
+    @ParameterizedTest
+    @MethodSource("recordInstances")
     public void roundTrip(Object objToSerialize) throws Exception {
         out.println("\n---");
         out.println("serializing : " + objToSerialize);
         var objDeserialized = serializeDeserialize(objToSerialize);
         out.println("deserialized: " + objDeserialized);
-        assertEquals(objToSerialize, objDeserialized);
         assertEquals(objDeserialized, objToSerialize);
+        assertEquals(objToSerialize, objDeserialized);
     }
 
     <T> byte[] serialize(T obj) throws IOException {
@@ -323,7 +326,8 @@ public class SerialPersistentFieldsTest {
     // -- infra sanity --
 
     /** Checks to ensure correct operation of the test's generation logic. */
-    @Test(dataProvider = "recordInstances")
+    @ParameterizedTest
+    @MethodSource("recordInstances")
     public void wellFormedGeneratedClasses(Object obj) throws Exception {
         out.println("\n---");
         out.println(obj);

--- a/test/jdk/java/io/Serializable/records/SerialVersionUIDTest.java
+++ b/test/jdk/java/io/Serializable/records/SerialVersionUIDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8246774
  * @summary Basic tests for SUID in the serial stream
- * @run testng SerialVersionUIDTest
- * @run testng/othervm/java.security.policy=empty_security.policy SerialVersionUIDTest
+ * @run junit SerialVersionUIDTest
+ * @run junit/othervm/java.security.policy=empty_security.policy SerialVersionUIDTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -40,13 +40,16 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.LongStream;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.io.ObjectStreamConstants.*;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SerialVersionUIDTest {
 
     record R1 () implements Serializable {
@@ -65,7 +68,6 @@ public class SerialVersionUIDTest {
         private static final long serialVersionUID = 5678L;
     }
 
-    @DataProvider(name = "recordObjects")
     public Object[][] recordObjects() {
         return new Object[][] {
             new Object[] { new R1(),        1L    },
@@ -79,7 +81,8 @@ public class SerialVersionUIDTest {
     /**
      * Tests that a declared SUID for a record class is inserted into the stream.
      */
-    @Test(dataProvider = "recordObjects")
+    @ParameterizedTest
+    @MethodSource("recordObjects")
     public void testSerialize(Object objectToSerialize, long expectedUID)
         throws Exception
     {
@@ -91,17 +94,16 @@ public class SerialVersionUIDTest {
         DataInputStream dis = new DataInputStream(bais);
 
         // sanity
-        assertEquals(dis.readShort(), STREAM_MAGIC);
-        assertEquals(dis.readShort(), STREAM_VERSION);
-        assertEquals(dis.readByte(), TC_OBJECT);
-        assertEquals(dis.readByte(), TC_CLASSDESC);
-        assertEquals(dis.readUTF(), objectToSerialize.getClass().getName());
+        assertEquals(STREAM_MAGIC, dis.readShort());
+        assertEquals(STREAM_VERSION, dis.readShort());
+        assertEquals(TC_OBJECT, dis.readByte());
+        assertEquals(TC_CLASSDESC, dis.readByte());
+        assertEquals(objectToSerialize.getClass().getName(), dis.readUTF());
 
         // verify that the UID is as expected
-        assertEquals(dis.readLong(), expectedUID);
+        assertEquals(expectedUID, dis.readLong());
     }
 
-    @DataProvider(name = "recordClasses")
     public Object[][] recordClasses() {
         List<Object[]> list = new ArrayList<>();
         List<Class<?>> recordClasses = List.of(R1.class, R2.class, R3.class, R4.class, R5.class);
@@ -116,14 +118,15 @@ public class SerialVersionUIDTest {
      * Tests that matching of the serialVersionUID values ( stream value
      * and runtime class value ) is waived for record classes.
      */
-    @Test(dataProvider = "recordClasses")
+    @ParameterizedTest
+    @MethodSource("recordClasses")
     public void testSerializeFromClass(Class<? extends Record> cl, long suid)
         throws Exception
     {
         out.println("\n---");
         byte[] bytes = byteStreamFor(cl.getName(), suid);
         Object obj = deserialize(bytes);
-        assertEquals(obj.getClass(), cl);
+        assertEquals(cl, obj.getClass());
         assertTrue(obj.getClass().isRecord());
     }
 

--- a/test/jdk/java/io/Serializable/records/StreamRefTest.java
+++ b/test/jdk/java/io/Serializable/records/StreamRefTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8246774
  * @summary Tests for stream references
- * @run testng StreamRefTest
+ * @run junit StreamRefTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -36,11 +36,12 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
+
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for stream references.
@@ -123,14 +124,14 @@ public class StreamRefTest {
         updateIntValue(3, -3, bytes, 40);
         var byteStream = new ObjectInputStream(new ByteArrayInputStream(bytes));
 
-        InvalidObjectException ioe = expectThrows(IOE, () -> deserializeOne(byteStream));
+        InvalidObjectException ioe = Assertions.assertThrows(IOE, () -> deserializeOne(byteStream));
         out.println("caught expected IOE: " + ioe);
         Throwable t = ioe.getCause();
         assertTrue(t instanceof IllegalArgumentException, "Expected IAE, got:" + t);
         out.println("expected cause IAE: " + t);
 
         B b1 = (B)deserializeOne(byteStream);
-        assertEquals(b1.a, null);
+        assertEquals(null, b1.a);
     }
 
     @Test
@@ -144,14 +145,14 @@ public class StreamRefTest {
         updateIntValue(3, -3, bytes, 96);
         var byteStream = new ObjectInputStream(new ByteArrayInputStream(bytes));
 
-        InvalidObjectException ioe = expectThrows(IOE, () -> deserializeOne(byteStream));
+        InvalidObjectException ioe = Assertions.assertThrows(IOE, () -> deserializeOne(byteStream));
         out.println("caught expected IOE: " + ioe);
         Throwable t = ioe.getCause();
         assertTrue(t instanceof IllegalArgumentException, "Expected IAE, got:" + t);
         out.println("expected cause IAE: " + t);
 
         A a1 = (A)deserializeOne(byteStream);
-        assertEquals(a1, null);
+        assertEquals(null, a1);
     }
 
     // ---
@@ -211,7 +212,7 @@ public class StreamRefTest {
         throws IOException {
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes, offset, 4);
         DataInputStream dis = new DataInputStream(bais);
-        assertEquals(dis.readInt(), expectedValue);
+        assertEquals(expectedValue, dis.readInt());
     }
 
     static void updateIntValue(int expectedValue, int newValue, byte[] bytes, int offset)

--- a/test/jdk/java/io/Serializable/records/ThrowingConstructorTest.java
+++ b/test/jdk/java/io/Serializable/records/ThrowingConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8246774
  * @summary Tests constructor invocation exceptions are handled appropriately
- * @run testng ThrowingConstructorTest
- * @run testng/othervm/java.security.policy=empty_security.policy ThrowingConstructorTest
+ * @run junit ThrowingConstructorTest
+ * @run junit/othervm/java.security.policy=empty_security.policy ThrowingConstructorTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -36,17 +36,20 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
+
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * If the constructor invocation throws an exception, an
  * `InvalidObjectException` is thrown with that exception as its cause.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ThrowingConstructorTest {
 
     /** "big switch" that can be used to allow/disallow record construction
@@ -85,7 +88,6 @@ public class ThrowingConstructorTest {
 
     static final Class<InvalidObjectException> IOE = InvalidObjectException.class;
 
-    @DataProvider(name = "exceptionInstances")
     public Object[][] exceptionInstances() {
         Object[][] objs =  new Object[][] {
             new Object[] { new R1(),            NullPointerException.class,     "thrown from R1" },
@@ -99,7 +101,8 @@ public class ThrowingConstructorTest {
         return  objs;
     }
 
-    @Test(dataProvider = "exceptionInstances")
+    @ParameterizedTest
+    @MethodSource("exceptionInstances")
     public void testExceptions(Object objectToSerialize,
                                Class<? extends Throwable> expectedExType,
                                String expectedExMessage)
@@ -108,13 +111,13 @@ public class ThrowingConstructorTest {
         out.println("\n---");
         out.println("serializing: " + objectToSerialize);
         byte[] bytes = serialize(objectToSerialize);
-        InvalidObjectException ioe = expectThrows(IOE, () -> deserialize(bytes));
+        InvalidObjectException ioe = Assertions.assertThrows(IOE, () -> deserialize(bytes));
         out.println("caught expected IOE: " + ioe);
         Throwable t = ioe.getCause();
         assertTrue(t.getClass().equals(expectedExType),
                    "Expected:" + expectedExType + ", got:" + t);
         out.println("expected cause " + expectedExType +" : " + t);
-        assertEquals(t.getMessage(), expectedExMessage);
+        assertEquals(expectedExMessage, t.getMessage());
     }
 
     //  -- errors ( pass through unwrapped )
@@ -144,7 +147,6 @@ public class ThrowingConstructorTest {
         }
     }
 
-    @DataProvider(name = "errorInstances")
     public Object[][] errorInstances() {
         Object[][] objs =  new Object[][] {
             new Object[] { new R4(),              OutOfMemoryError.class,   "thrown from R4" },
@@ -158,7 +160,8 @@ public class ThrowingConstructorTest {
         return objs;
     }
 
-    @Test(dataProvider = "errorInstances")
+    @ParameterizedTest
+    @MethodSource("errorInstances")
     public void testErrors(Object objectToSerialize,
                            Class<? extends Throwable> expectedExType,
                            String expectedExMessage)
@@ -167,11 +170,11 @@ public class ThrowingConstructorTest {
         out.println("\n---");
         out.println("serializing: " + objectToSerialize);
         byte[] bytes = serialize(objectToSerialize);
-        Throwable t = expectThrows(expectedExType, () -> deserialize(bytes));
+        Throwable t = Assertions.assertThrows(expectedExType, () -> deserialize(bytes));
         assertTrue(t.getClass().equals(expectedExType),
                    "Expected:" + expectedExType + ", got:" + t);
         out.println("caught expected " + expectedExType +" : " + t);
-        assertEquals(t.getMessage(), expectedExMessage);
+        assertEquals(expectedExMessage, t.getMessage());
     }
 
     // --- infra

--- a/test/jdk/java/io/Serializable/records/UnsharedTest.java
+++ b/test/jdk/java/io/Serializable/records/UnsharedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8238763 8246774
  * @summary ObjectInputStream readUnshared method handling of Records
- * @run testng UnsharedTest
+ * @run junit UnsharedTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -35,10 +35,11 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
+import org.junit.jupiter.api.Assertions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests OOS::writeUnshared and OIS::readUnshared to verify that records
@@ -56,16 +57,16 @@ public class UnsharedTest {
         {  // shared - sanity to ensure the second foo is a ref
             var byteStream = serialize(foo, foo);
             var foo1 = (Foo) deserializeOne(byteStream);
-            assertEquals(foo1.x, foo.x);
+            assertEquals(foo.x, foo1.x);
             var foo2 = (Foo) deserializeOne(byteStream);
-            assertEquals(foo2.x, foo.x);
+            assertEquals(foo.x, foo2.x);
             assertTrue(foo2 == foo1);
         }
         {  // unshared
             var byteStream = serialize(foo, foo);
             var foo1 = (Foo) deserializeOneUnshared(byteStream);
-            assertEquals(foo1.x, foo.x);
-            var expected = expectThrows(IOE, () -> deserializeOne(byteStream));
+            assertEquals(foo.x, foo1.x);
+            var expected = Assertions.assertThrows(IOE, () -> deserializeOne(byteStream));
             assertTrue(expected.getMessage().contains("cannot read back reference to unshared object"));
         }
     }
@@ -76,17 +77,17 @@ public class UnsharedTest {
         {  // shared - sanity to ensure the second foo is NOT a ref
             var byteStream = serializeUnshared(foo, foo);
             var foo1 = (Foo) deserializeOne(byteStream);
-            assertEquals(foo1.x, foo.x);
+            assertEquals(foo.x, foo1.x);
             var foo2 = (Foo) deserializeOne(byteStream);
-            assertEquals(foo2.x, foo.x);
+            assertEquals(foo.x, foo2.x);
             assertTrue(foo2 != foo1);
         }
         {  // unshared
             var byteStream = serializeUnshared(foo, foo);
             var foo1 = (Foo) deserializeOneUnshared(byteStream);
-            assertEquals(foo1.x, foo.x);
+            assertEquals(foo.x, foo1.x);
             var foo2 = (Foo) deserializeOneUnshared(byteStream);
-            assertEquals(foo2.x, foo.x);
+            assertEquals(foo.x, foo2.x);
             assertTrue(foo2 != foo1);
         }
     }

--- a/test/jdk/java/io/Serializable/records/WriteReplaceTest.java
+++ b/test/jdk/java/io/Serializable/records/WriteReplaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8246774
  * @summary Basic tests for writeReplace
- * @run testng WriteReplaceTest
- * @run testng/othervm/java.security.policy=empty_security.policy WriteReplaceTest
+ * @run junit WriteReplaceTest
+ * @run junit/othervm/java.security.policy=empty_security.policy WriteReplaceTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -35,11 +35,15 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class WriteReplaceTest {
 
     record R1 () implements Serializable {
@@ -72,7 +76,6 @@ public class WriteReplaceTest {
         }
     }
 
-    @DataProvider(name = "recordObjects")
     public Object[][] recordObjects() {
         return new Object[][] {
             new Object[] { new R1(),                       R1.class             },
@@ -82,7 +85,8 @@ public class WriteReplaceTest {
         };
     }
 
-    @Test(dataProvider = "recordObjects")
+    @ParameterizedTest
+    @MethodSource("recordObjects")
     public void testSerialize(Object objectToSerialize, Class<?> expectedType)
         throws Exception
     {
@@ -91,9 +95,9 @@ public class WriteReplaceTest {
         Object deserializedObj = serializeDeserialize(objectToSerialize);
         out.println("deserialized: " + deserializedObj);
         if (objectToSerialize.getClass().equals(expectedType))
-            assertEquals(deserializedObj, objectToSerialize);
+            assertEquals(objectToSerialize, deserializedObj);
         else
-            assertEquals(deserializedObj.getClass(), expectedType);
+            assertEquals(expectedType, deserializedObj.getClass());
     }
 
     // -- null replacement
@@ -109,7 +113,7 @@ public class WriteReplaceTest {
         out.println("serializing : " + objectToSerialize);
         Object deserializedObj = serializeDeserialize(objectToSerialize);
         out.println("deserialized: " + deserializedObj);
-        assertEquals(deserializedObj, null);
+        assertEquals(null, deserializedObj);
     }
 
     // --- infra

--- a/test/jdk/java/io/Serializable/records/migration/AbstractTest.java
+++ b/test/jdk/java/io/Serializable/records/migration/AbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,9 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import jdk.test.lib.compiler.CompilerUtils;
-import org.testng.annotations.BeforeTest;
-import static org.testng.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * An abstract superclass for tests that require to serialize and deserialize
@@ -54,7 +55,7 @@ public class AbstractTest {
     static final Path RECORD_SRC_DIR = Path.of(TEST_SRC, "record");
     static final Path RECORD_DEST_DIR = Path.of("record");
 
-    @BeforeTest
+    @BeforeAll
     public void setup() throws IOException {
         assertTrue(CompilerUtils.compile(PLAIN_SRC_DIR, PLAIN_DEST_DIR,
                    "--class-path", TEST_CLASSES_DIR.toString()));

--- a/test/jdk/java/io/Serializable/records/migration/AssignableFromTest.java
+++ b/test/jdk/java/io/Serializable/records/migration/AssignableFromTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,24 +29,26 @@
  * @modules jdk.compiler
  * @compile AssignableFrom.java Point.java
  *          DefaultValues.java SuperStreamFields.java
- * @run testng AssignableFromTest
+ * @run junit AssignableFromTest
  */
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Basic test to check that stream field values that are not the exact
  * declared param/field type, but assignable to a declared supertype,
  * are bound/assigned correctly.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AssignableFromTest extends AbstractTest {
 
-    @DataProvider(name = "plainInstances")
     public Object[][] plainInstances() {
         return new Object[][] {
             new Object[] { newPlainAssignableFrom(Byte.valueOf((byte)11))   },
@@ -59,7 +61,8 @@ public class AssignableFromTest extends AbstractTest {
     }
 
     /** Serialize non-record (plain) instances, deserialize as a record. */
-    @Test(dataProvider = "plainInstances")
+    @ParameterizedTest
+    @MethodSource("plainInstances")
     public void testPlainToRecord(AssignableFrom objToSerialize) throws Exception {
         assert !objToSerialize.getClass().isRecord();
         out.println("serialize   : " + objToSerialize);
@@ -68,13 +71,12 @@ public class AssignableFromTest extends AbstractTest {
         assert objDeserialized.getClass().isRecord();
         out.println("deserialized: " + objDeserialized);
 
-        assertEquals(objToSerialize.number(), objDeserialized.number());
         assertEquals(objDeserialized.number(), objToSerialize.number());
+        assertEquals(objToSerialize.number(), objDeserialized.number());
         assertEquals(objDeserialized.number().getClass(), objDeserialized.number().getClass());
 
     }
 
-    @DataProvider(name = "recordInstances")
     public Object[][] recordInstances() {
         return new Object[][] {
             new Object[] { newRecordAssignableFrom(Byte.valueOf((byte)21))   },
@@ -87,7 +89,8 @@ public class AssignableFromTest extends AbstractTest {
     }
 
     /** Serialize record instances, deserialize as non-record (plain). */
-    @Test(dataProvider = "recordInstances")
+    @ParameterizedTest
+    @MethodSource("recordInstances")
     public void testRecordToPlain(AssignableFrom objToSerialize) throws Exception {
         assert objToSerialize.getClass().isRecord();
         out.println("serialize   : " + objToSerialize);
@@ -96,8 +99,8 @@ public class AssignableFromTest extends AbstractTest {
         assert !objDeserialized.getClass().isRecord();
         out.println("deserialized: " + objDeserialized);
 
-        assertEquals(objToSerialize.number(), objDeserialized.number());
         assertEquals(objDeserialized.number(), objToSerialize.number());
+        assertEquals(objToSerialize.number(), objDeserialized.number());
         assertEquals(objDeserialized.number().getClass(), objDeserialized.number().getClass());
     }
 

--- a/test/jdk/java/io/Serializable/records/migration/DefaultValuesTest.java
+++ b/test/jdk/java/io/Serializable/records/migration/DefaultValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,21 +28,24 @@
  * @library /test/lib
  * @modules jdk.compiler
  * @compile AssignableFrom.java Point.java DefaultValues.java SuperStreamFields.java
- * @run testng DefaultValuesTest
+ * @run junit DefaultValuesTest
  */
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
-import org.testng.annotations.Test;
 import static java.io.ObjectStreamConstants.*;
 import static java.lang.System.out;
-import static org.testng.Assert.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 /**
  * Basic test to check that default primitive / reference values are
  * presented to the record's canonical constructor, for fields not in
  * the stream.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DefaultValuesTest extends AbstractTest {
 
     /**
@@ -77,13 +80,13 @@ public class DefaultValuesTest extends AbstractTest {
 
         Point point = deserializeAsPlain(bytes);
         out.println("deserialized: " + point);
-        assertEquals(point.x(), 0);
-        assertEquals(point.y(), 0);
+        assertEquals(0, point.x());
+        assertEquals(0, point.y());
 
         point = deserializeAsRecord(bytes);
         out.println("deserialized: " + point);
-        assertEquals(point.x(), 0);
-        assertEquals(point.y(), 0);
+        assertEquals(0, point.x());
+        assertEquals(0, point.y());
     }
 
     // ---
@@ -115,8 +118,8 @@ public class DefaultValuesTest extends AbstractTest {
         DefaultValues o1 = deserializeAsRecord(bytes);
         out.println("deserialized: " + o1);
 
-        assertEquals(o1.point().x(), point.x());   // sanity
-        assertEquals(o1.point().y(), point.y());   // sanity
+        assertEquals(point.x(), o1.point().x());   // sanity
+        assertEquals(point.y(), o1.point().y());   // sanity
         assertTrue(o1.bool() == Defaults.bool);
         assertTrue(o1.by() == Defaults.by);
         assertTrue(o1.ch() == Defaults.ch);

--- a/test/jdk/java/io/Serializable/records/migration/SuperStreamFieldsTest.java
+++ b/test/jdk/java/io/Serializable/records/migration/SuperStreamFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,20 +28,23 @@
  * @library /test/lib
  * @modules jdk.compiler
  * @compile AssignableFrom.java Point.java DefaultValues.java SuperStreamFields.java
- * @run testng SuperStreamFieldsTest
+ * @run junit SuperStreamFieldsTest
  */
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import static java.lang.System.out;
-import static org.testng.Assert.assertEquals;
+
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  *  Tests that superclass fields in the stream are discarded.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SuperStreamFieldsTest extends AbstractTest {
 
-    @DataProvider(name = "plainInstances")
     public Object[][] plainInstances() {
         return new Object[][] {
             new Object[] { newPlainSuperStreamFields("cat", new int[] { 1 },    1)   },
@@ -51,7 +54,8 @@ public class SuperStreamFieldsTest extends AbstractTest {
     }
 
     /** Serializes non-record (plain) instance, deserializes as a record. */
-    @Test(dataProvider = "plainInstances")
+    @ParameterizedTest
+    @MethodSource("plainInstances")
     public void testPlainToRecord(SuperStreamFields objToSerialize) throws Exception {
         assert !objToSerialize.getClass().isRecord();
         out.println("serialize   : " + objToSerialize);
@@ -60,12 +64,11 @@ public class SuperStreamFieldsTest extends AbstractTest {
         assert objDeserialized.getClass().isRecord();
         out.println("deserialized: " + objDeserialized);
 
-        assertEquals(objToSerialize.str(), objDeserialized.str());
-        assertEquals(objToSerialize.x(),   objDeserialized.x());
-        assertEquals(objToSerialize.y(),   objDeserialized.y());
+        assertEquals(objDeserialized.str(), objToSerialize.str());
+        Assertions.assertArrayEquals(objDeserialized.x(), objToSerialize.x());
+        assertEquals(objDeserialized.y(), objToSerialize.y());
     }
 
-    @DataProvider(name = "recordInstances")
     public Object[][] recordInstances() {
         return new Object[][] {
             new Object[] { newRecordSuperStreamFields("goat",   new int[] { 56 },     66)   },
@@ -75,7 +78,8 @@ public class SuperStreamFieldsTest extends AbstractTest {
     }
 
     /** Serializes record instance, deserializes as non-record (plain). */
-    @Test(dataProvider = "recordInstances")
+    @ParameterizedTest
+    @MethodSource("recordInstances")
     public void testRecordToPlain(SuperStreamFields objToSerialize) throws Exception {
         assert objToSerialize.getClass().isRecord();
         out.println("serialize   : " + objToSerialize);
@@ -84,9 +88,9 @@ public class SuperStreamFieldsTest extends AbstractTest {
         assert !objDeserialized.getClass().isRecord();
         out.println("deserialized: " + objDeserialized);
 
-        assertEquals(objToSerialize.str(), objDeserialized.str());
-        assertEquals(objToSerialize.x(),   objDeserialized.x());
-        assertEquals(objToSerialize.y(),   objDeserialized.y());
+        assertEquals(objDeserialized.str(), objToSerialize.str());
+        Assertions.assertArrayEquals(objDeserialized.x(), objToSerialize.x());
+        assertEquals(objDeserialized.y(), objToSerialize.y());
 
     }
 


### PR DESCRIPTION
Backporting JDK-8373623: Refactor Serialization tests for Records to JUnit.

This PR converts serialization tests for Records from TestNG to JUnit as part of the broader test framework migration initiative (JDK-8307843).

This PR is not clean because it skips JDK-8338411, which implements JEP 486, and JDK-8294977 (+ other related commits), which use JEP 457. These are not part of Java 21. The PR was refactored to work around the missing commits.

For parity with Oracle JDK. Already backported to 25.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/io/Serializable/records

Results attached:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/26518185/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/26518186/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/26518187/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/26518188/linux-aarch64-specific-test.log)

---------

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8373623](https://bugs.openjdk.org/browse/JDK-8373623) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373623](https://bugs.openjdk.org/browse/JDK-8373623): Refactor Serialization tests for Records to JUnit (**Sub-task** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2815/head:pull/2815` \
`$ git checkout pull/2815`

Update a local copy of the PR: \
`$ git checkout pull/2815` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2815`

View PR using the GUI difftool: \
`$ git pr show -t 2815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2815.diff">https://git.openjdk.org/jdk21u-dev/pull/2815.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2815#issuecomment-4193866278)
</details>
