### PR TITLE
8378878: Refactor java/nio/channels/AsynchronousSocketChannel test to use JUnit

### DIFF
--- a/test/jdk/java/nio/channels/AsynchronousSocketChannel/CompletionHandlerRelease.java
+++ b/test/jdk/java/nio/channels/AsynchronousSocketChannel/CompletionHandlerRelease.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /* @test
  * @bug 8202252
- * @run testng CompletionHandlerRelease
+ * @run junit CompletionHandlerRelease
  * @summary Verify that reference to CompletionHandler is cleared after use
  */
 
@@ -44,10 +44,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class CompletionHandlerRelease {
     @Test
@@ -132,16 +134,16 @@ public class CompletionHandlerRelease {
         }
     }
 
-    private AsynchronousChannelGroup GROUP;
+    private static AsynchronousChannelGroup GROUP;
 
-    @BeforeTest
-    void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         GROUP = AsynchronousChannelGroup.withFixedThreadPool(2,
             Executors.defaultThreadFactory());
     }
 
-    @AfterTest
-    void cleanup() throws IOException {
+    @AfterAll
+    static void cleanup() throws IOException {
         GROUP.shutdownNow();
     }
 
@@ -199,13 +201,13 @@ public class CompletionHandlerRelease {
         }
     }
 
-    private void waitForRefToClear(Reference ref, ReferenceQueue queue)
+    private static void waitForRefToClear(Reference ref, ReferenceQueue queue)
         throws InterruptedException {
         Reference r;
         while ((r = queue.remove(20)) == null) {
             System.gc();
         }
-        assertEquals(r, ref);
+        assertSame(ref, r);
         assertNull(r.get());
     }
 }


### PR DESCRIPTION
Backporting JDK-8378878: Refactor java/nio/channels/AsynchronousSocketChannel test to use JUnit.

This PR refactors CompletionHandlerRelease.java from TestNG to JUnit 5 as part of ongoing test framework migration.

For parity with Oracle JDK. Already backported to 25.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/nio/channels/AsynchronousSocketChannel/CompletionHandlerRelease.java

Results attached:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/26546824/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/26546825/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/26546826/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/26546827/linux-aarch64-specific-test.log)

---------

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8378878](https://bugs.openjdk.org/browse/JDK-8378878) needs maintainer approval

### Issue
 * [JDK-8378878](https://bugs.openjdk.org/browse/JDK-8378878): Refactor java/nio/channels/AsynchronousSocketChannel test to use JUnit (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2817/head:pull/2817` \
`$ git checkout pull/2817`

Update a local copy of the PR: \
`$ git checkout pull/2817` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2817`

View PR using the GUI difftool: \
`$ git pr show -t 2817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2817.diff">https://git.openjdk.org/jdk21u-dev/pull/2817.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2817#issuecomment-4200902181)
</details>
