### PR TITLE
8323792: ThreadSnapshot::initialize can cause assert in Thread::check_for_dangling_thread_pointer (possibility of dangling Thread pointer)

### DIFF
--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -727,7 +727,8 @@ JavaThread* ThreadsList::find_JavaThread_from_java_tid(jlong java_tid) const {
         }
       }
     }
-  } else if (!thread->is_exiting()) {
+  } else if (includes(thread) && !thread->is_exiting()) {
+    // The thread is protected by this list and has not yet exited
     return thread;
   }
   return nullptr;
@@ -866,7 +867,7 @@ void ThreadsSMRSupport::add_thread(JavaThread *thread){
 
   ThreadsList *old_list = xchg_java_thread_list(new_list);
   free_list(old_list);
-  if (ThreadIdTable::is_initialized()) {
+  if (ThreadIdTable::is_initialized_acquire()) {
     jlong tid = SharedRuntime::get_java_tid(thread);
     ThreadIdTable::add_thread(tid, thread);
   }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1044,7 +1044,7 @@ void Threads::remove(JavaThread* p, bool is_daemon) {
     MutexLocker throttle_ml(UseThreadsLockThrottleLock ? ThreadsLockThrottle_lock : nullptr);
     MonitorLocker ml(Threads_lock);
 
-    if (ThreadIdTable::is_initialized()) {
+    if (ThreadIdTable::is_initialized_acquire()) {
       // This cleanup must be done before the current thread's GC barrier
       // is detached since we need to touch the threadObj oop.
       jlong tid = SharedRuntime::get_java_tid(p);

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1130,6 +1130,7 @@ JVM_ENTRY(jint, jmm_GetThreadInfo(JNIEnv *env, jlongArray ids, jint maxDepth, jo
         // create dummy snapshot
         dump_result.add_thread_snapshot();
       } else {
+        assert(dump_result.t_list()->includes(jt), "Must be protected");
         dump_result.add_thread_snapshot(jt);
       }
     }

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -1,6 +1,6 @@
 
 /*
-* Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 #include "precompiled.hpp"
 #include "classfile/javaClasses.inline.hpp"
-#include "runtime/atomic.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaThread.inline.hpp"
 #include "runtime/threadSMR.hpp"
@@ -83,24 +82,25 @@ class ThreadIdTableConfig : public AllStatic {
 // Lazily creates the table and populates it with the given
 // thread list
 void ThreadIdTable::lazy_initialize(const ThreadsList *threads) {
-  if (!_is_initialized) {
+  if (!Atomic::load_acquire(&_is_initialized)) {
     {
       // There is no obvious benefit in allowing the thread table
       // to be concurrently populated during initialization.
       MutexLocker ml(ThreadIdTableCreate_lock);
-      if (_is_initialized) {
+      if (Atomic::load(&_is_initialized)) {
         return;
       }
       create_table(threads->length());
-      _is_initialized = true;
+      Atomic::release_store(&_is_initialized, true);
     }
+
     for (uint i = 0; i < threads->length(); i++) {
       JavaThread* thread = threads->thread_at(i);
       oop tobj = thread->threadObj();
       if (tobj != nullptr) {
-        jlong java_tid = java_lang_Thread::thread_id(tobj);
         MutexLocker ml(Threads_lock);
         if (!thread->is_exiting()) {
+          jlong java_tid = java_lang_Thread::thread_id(tobj);
           // Must be inside the lock to ensure that we don't add a thread to the table
           // that has just passed the removal point in Threads::remove().
           add_thread(java_tid, thread);
@@ -213,7 +213,7 @@ public:
 };
 
 void ThreadIdTable::do_concurrent_work(JavaThread* jt) {
-  assert(_is_initialized, "Thread table is not initialized");
+  assert(Atomic::load(&_is_initialized), "Thread table is not initialized");
   _has_work = false;
   double load_factor = get_load_factor();
   log_debug(thread, table)("Concurrent work, load factor: %g", load_factor);
@@ -223,7 +223,8 @@ void ThreadIdTable::do_concurrent_work(JavaThread* jt) {
 }
 
 JavaThread* ThreadIdTable::add_thread(jlong tid, JavaThread* java_thread) {
-  assert(_is_initialized, "Thread table is not initialized");
+  assert(Threads_lock->owned_by_self(), "Must hold Threads_lock");
+  assert(Atomic::load(&_is_initialized), "Thread table is not initialized");
   Thread* thread = Thread::current();
   ThreadIdTableLookup lookup(tid);
   ThreadGet tg;
@@ -242,7 +243,7 @@ JavaThread* ThreadIdTable::add_thread(jlong tid, JavaThread* java_thread) {
 }
 
 JavaThread* ThreadIdTable::find_thread_by_tid(jlong tid) {
-  assert(_is_initialized, "Thread table is not initialized");
+  assert(Atomic::load(&_is_initialized), "Thread table is not initialized");
   Thread* thread = Thread::current();
   ThreadIdTableLookup lookup(tid);
   ThreadGet tg;
@@ -251,7 +252,8 @@ JavaThread* ThreadIdTable::find_thread_by_tid(jlong tid) {
 }
 
 bool ThreadIdTable::remove_thread(jlong tid) {
-  assert(_is_initialized, "Thread table is not initialized");
+  assert(Threads_lock->owned_by_self(), "Must hold Threads_lock");
+  assert(Atomic::load(&_is_initialized), "Thread table is not initialized");
   Thread* thread = Thread::current();
   ThreadIdTableLookup lookup(tid);
   return _local_table->remove(thread, lookup);

--- a/src/hotspot/share/services/threadIdTable.hpp
+++ b/src/hotspot/share/services/threadIdTable.hpp
@@ -1,6 +1,6 @@
 
 /*
-* Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 #define SHARE_SERVICES_THREADIDTABLE_HPP
 
 #include "memory/allStatic.hpp"
+#include "runtime/atomic.hpp"
 
 class JavaThread;
 class ThreadsList;
@@ -41,7 +42,9 @@ class ThreadIdTable : public AllStatic {
 public:
   // Initialization
   static void lazy_initialize(const ThreadsList* threads);
-  static bool is_initialized() { return _is_initialized; }
+  static bool is_initialized_acquire() {
+    return Atomic::load_acquire(&_is_initialized);
+  }
 
   // Lookup and list management
   static JavaThread* find_thread_by_tid(jlong tid);

--- a/test/hotspot/jtreg/serviceability/threads/ThreadInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/threads/ThreadInfoTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Utils;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * @test
+ * @bug 8323792
+ * @summary Make sure that jmm_GetThreadInfo() call does not crash JVM
+ * @library /test/lib
+ * @modules java.management
+ * @run main/othervm ThreadInfoTest
+ *
+ * @comment Exercise getThreadInfo(ids, 0).  Depth parameter of zero means
+ * no VM operation, which could crash with Threads starting and ending.
+ */
+
+public class ThreadInfoTest {
+    private static com.sun.management.ThreadMXBean mbean =
+        (com.sun.management.ThreadMXBean)ManagementFactory.getThreadMXBean();
+
+    private static final int NUM_THREADS = 2;
+    static long[] ids = new long[NUM_THREADS];
+    static ThreadInfo[] infos = new ThreadInfo[NUM_THREADS];
+    static volatile int count = 0;
+    static int ITERATIONS = 4;
+
+    public static void main(String[] argv) throws Exception {
+        boolean replacing = false;
+
+        startThreads(ids, NUM_THREADS);
+        new MyGetThreadInfoThread(ids).start();
+        new MyReplacerThread(ids).start();
+        for (int i = 0; i < ITERATIONS; i++) {
+            do {
+                count = countInfo(infos);
+                System.out.println("Iteration " + i + ": ThreadInfos found (Threads alive): " + count);
+                goSleep(100);
+            } while (count > 0);
+        }
+    }
+
+    private static Thread newThread(int i) {
+        Thread thread = new MyThread(i);
+        thread.setDaemon(true);
+        return thread;
+    }
+
+   private static void startThreads(long[] ids, int count) {
+        System.out.println("Starting " + count + " Threads...");
+        Thread[] threads = new Thread[count];
+        for (int i = 0; i < count; i++) {
+            threads[i] = newThread(i);
+            threads[i].start();
+            ids[i] = threads[i].getId();
+        }
+        System.out.println(ids);
+    }
+
+    // Count ThreadInfo from array, return how many are non-null.
+    private static int countInfo(ThreadInfo[] info) {
+        int count = 0;
+        if (info != null) {
+            int i = 0;
+            for (ThreadInfo ti: info) {
+                if (ti != null) {
+                    count++;
+                }
+                i++;
+            }
+        }
+        return count;
+    }
+
+    private static int replaceThreads(long[] ids, ThreadInfo[] info) {
+        int replaced = 0;
+        if (info != null) {
+            for (int i = 0; i < info.length; i++) {
+                ThreadInfo ti = info[i];
+                if (ti == null) {
+                    Thread thread = newThread(i);
+                    thread.start();
+                    ids[i] = thread.getId();
+                    replaced++;
+                }
+            }
+        }
+        return replaced;
+    }
+
+    private static void goSleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            System.out.println("Unexpected exception is thrown: " + e);
+        }
+    }
+
+    // A Thread which replaces Threads in the shared array of threads.
+    static class MyReplacerThread extends Thread {
+        long[] ids;
+
+        public MyReplacerThread(long[] ids) {
+            this.ids = ids;
+            this.setDaemon(true);
+        }
+
+        public void run() {
+            boolean replacing = false;
+            while (true) {
+                if (replacing) {
+                    replaceThreads(ids, infos);
+                }
+                if (count < 10) {
+                    replacing = true;
+                }
+                if (count > 20) {
+                    replacing = false;
+                }
+                goSleep(1);
+            }
+        }
+    }
+
+    // A Thread which lives for a short while.
+    static class MyThread extends Thread {
+        long endTimeMs;
+
+        public MyThread(long n) {
+            super("MyThread-" + n);
+            endTimeMs = (n * n * 10) + System.currentTimeMillis();
+        }
+
+        public void run() {
+            try {
+                long sleep = Math.max(1, endTimeMs - System.currentTimeMillis());
+                goSleep(sleep);
+            } catch (Exception e) {
+                System.out.println(Thread.currentThread().getName() + ": " + e);
+            }
+        }
+    }
+
+    // A Thread to continually call getThreadInfo on a shared array of thread ids.
+    static class MyGetThreadInfoThread extends Thread {
+        long[] ids;
+
+        public MyGetThreadInfoThread(long[] ids) {
+            this.ids = ids;
+            this.setDaemon(true);
+        }
+
+        public void run() {
+            while (true) {
+                infos = mbean.getThreadInfo(ids, 0);
+                goSleep(10);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.12-oracle based on the change in 25.

src/hotspot/share/runtime/threadSMR.cpp
src/hotspot/share/services/management.cpp
src/hotspot/share/services/threadIdTable.cpp
Resolved Copyright, probably clean anyways.

[x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323792](https://bugs.openjdk.org/browse/JDK-8323792) needs maintainer approval

### Issue
 * [JDK-8323792](https://bugs.openjdk.org/browse/JDK-8323792): ThreadSnapshot::initialize can cause assert in Thread::check_for_dangling_thread_pointer (possibility of dangling Thread pointer) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2821/head:pull/2821` \
`$ git checkout pull/2821`

Update a local copy of the PR: \
`$ git checkout pull/2821` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2821`

View PR using the GUI difftool: \
`$ git pr show -t 2821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2821.diff">https://git.openjdk.org/jdk21u-dev/pull/2821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2821#issuecomment-4213148176)
</details>
