### PR TITLE
8355371: NegativeArraySizeException in print methods in IO or System.console() in JShell

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
@@ -329,7 +329,9 @@ public class ConsoleImpl {
                 buffer = Arrays.copyOf(buffer, 2 * buffer.length);
             }
 
-            buffer[bp++] = b;
+            // Can be negative because widening from byte in write(byte[], int, int).
+            // java.io.OutputStream.write(int b) stipulates "The 24 high-order bits of b are ignored."
+            buffer[bp++] = b & 0xff;
 
             switch (Task.values()[buffer[0]]) {
                 case WRITE_CHARS -> {
@@ -346,7 +348,7 @@ public class ConsoleImpl {
                 }
                 case READ_CHARS -> {
                     if (bp >= 5) {
-                        int len = readInt(b);
+                        int len = readInt(1);
                         int c = console.reader().read();
                         //XXX: EOF handling!
                         sendChars(sinkOutput, new char[] {(char) c}, 0, 1);

--- a/test/langtools/jdk/jshell/ConsoleTest.java
+++ b/test/langtools/jdk/jshell/ConsoleTest.java
@@ -148,6 +148,31 @@ public class ConsoleTest extends KullaTesting {
     }
 
     @Test
+    public void testConsoleUnicodeWritingTest() {
+        StringBuilder sb = new StringBuilder();
+        console = new ThrowingJShellConsole() {
+            @Override
+            public PrintWriter writer() {
+                return new PrintWriter(new Writer() {
+                    @Override
+                    public void write(char[] cbuf, int off, int len) throws IOException {
+                        sb.append(cbuf, off, len);
+                    }
+                    @Override
+                    public void flush() throws IOException {}
+                    @Override
+                    public void close() throws IOException {}
+                });
+            }
+        };
+        int count = 384; // 128-255, 384-511, 640-767, ... (JDK-8355371)
+        String testStr = "\u30A2"; // Japanese katakana (A2 >= 80) (JDK-8354910)
+        assertEval("System.console().writer().write(\"" + testStr + "\".repeat(" + count + "))");
+        String expected = testStr.repeat(count);
+        assertEquals(sb.toString(), expected);
+    }
+
+    @Test
     public void testConsoleMultiThreading() {
         StringBuilder sb = new StringBuilder();
         console = new ThrowingJShellConsole() {


### PR DESCRIPTION
I'd like to fix this in 21. Clean.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354910](https://bugs.openjdk.org/browse/JDK-8354910) needs maintainer approval
- [x] [JDK-8355371](https://bugs.openjdk.org/browse/JDK-8355371) needs maintainer approval

### Issues
 * [JDK-8355371](https://bugs.openjdk.org/browse/JDK-8355371): NegativeArraySizeException in print methods in IO or System.console() in JShell (**Bug** - P4 - Approved)
 * [JDK-8354910](https://bugs.openjdk.org/browse/JDK-8354910): Output by java.io.IO or System.console() corrupted for some non-ASCII characters (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2823/head:pull/2823` \
`$ git checkout pull/2823`

Update a local copy of the PR: \
`$ git checkout pull/2823` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2823`

View PR using the GUI difftool: \
`$ git pr show -t 2823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2823.diff">https://git.openjdk.org/jdk21u-dev/pull/2823.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2823#issuecomment-4214201067)
</details>
