### PR TITLE
8129418: JShell: better highlighting of errors in imports on demand

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4295,7 +4295,7 @@ public class Check {
                 TypeSymbol tsym = imp.qualid.selected.type.tsym;
                 if (tsym.kind == PCK && tsym.members().isEmpty() &&
                     !(Feature.IMPORT_ON_DEMAND_OBSERVABLE_PACKAGES.allowedInSource(source) && tsym.exists())) {
-                    log.error(DiagnosticFlag.RESOLVE_ERROR, imp.pos, Errors.DoesntExist(tsym));
+                    log.error(DiagnosticFlag.RESOLVE_ERROR, imp.qualid.selected.pos(), Errors.DoesntExist(tsym));
                 }
             }
         }

--- a/test/langtools/jdk/jshell/ImportTest.java
+++ b/test/langtools/jdk/jshell/ImportTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8141415
+ * @bug 8141415 8129418
  * @summary Test imports
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -76,12 +76,11 @@ public class ImportTest extends KullaTesting {
         assertEval("abs(cos(PI / 2)) < 0.00001;", "true");
     }
 
-    @Test(enabled = false) // TODO 8129418
     public void testUnknownPackage() {
         assertDeclareFail("import unknown.qqq;",
                 new ExpectedDiagnostic("compiler.err.doesnt.exist", 7, 18, 14, -1, -1, Diagnostic.Kind.ERROR));
         assertDeclareFail("import unknown.*;",
-                new ExpectedDiagnostic("compiler.err.doesnt.exist", 7, 15, 7, -1, -1, Diagnostic.Kind.ERROR));
+                new ExpectedDiagnostic("compiler.err.doesnt.exist", 7, 14, 7, -1, -1, Diagnostic.Kind.ERROR));
     }
 
     public void testBogusImportIgnoredInFuture() {

--- a/test/langtools/tools/javac/7129225/NegTest.out
+++ b/test/langtools/tools/javac/7129225/NegTest.out
@@ -1,2 +1,2 @@
-TestImportStar.java:16:1: compiler.err.doesnt.exist: xxx
+TestImportStar.java:16:8: compiler.err.doesnt.exist: xxx
 1 error

--- a/test/langtools/tools/javac/7129225/TestImportStar.out
+++ b/test/langtools/tools/javac/7129225/TestImportStar.out
@@ -1,4 +1,4 @@
 - compiler.note.proc.messager: RUNNING - lastRound = false
-TestImportStar.java:16:1: compiler.err.doesnt.exist: xxx
+TestImportStar.java:16:8: compiler.err.doesnt.exist: xxx
 - compiler.note.proc.messager: RUNNING - lastRound = true
 1 error

--- a/test/langtools/tools/javac/importChecks/ImportIsFullyQualified.out
+++ b/test/langtools/tools/javac/importChecks/ImportIsFullyQualified.out
@@ -1,2 +1,2 @@
-ImportIsFullyQualified.java:11:1: compiler.err.doesnt.exist: JobAttributes
+ImportIsFullyQualified.java:11:8: compiler.err.doesnt.exist: JobAttributes
 1 error

--- a/test/langtools/tools/javac/importChecks/ImportsObservable.out
+++ b/test/langtools/tools/javac/importChecks/ImportsObservable.out
@@ -1,2 +1,2 @@
-ImportsObservable.java:9:1: compiler.err.doesnt.exist: javax
+ImportsObservable.java:9:8: compiler.err.doesnt.exist: javax
 1 error

--- a/test/langtools/tools/javac/modules/ConvenientAccessErrorsTest.java
+++ b/test/langtools/tools/javac/modules/ConvenientAccessErrorsTest.java
@@ -799,7 +799,7 @@ public class ConvenientAccessErrorsTest extends ModuleTestBase {
                 .getOutputLines(Task.OutputKind.DIRECT);
 
         List<String> expected = Arrays.asList(
-                "Test.java:1:31: compiler.err.doesnt.exist: ma",
+                "Test.java:1:38: compiler.err.doesnt.exist: ma",
                 "1 error");
 
         if (!expected.equals(log))
@@ -827,7 +827,7 @@ public class ConvenientAccessErrorsTest extends ModuleTestBase {
                 .getOutputLines(Task.OutputKind.DIRECT);
 
         List<String> expected = Arrays.asList(
-                "Test.java:1:15: compiler.err.doesnt.exist: ma",
+                "Test.java:1:22: compiler.err.doesnt.exist: ma",
                 "1 error");
 
         if (!expected.equals(log))
@@ -861,7 +861,7 @@ public class ConvenientAccessErrorsTest extends ModuleTestBase {
                 .getOutputLines(Task.OutputKind.DIRECT);
 
         List<String> expected = Arrays.asList(
-                "Test.java:1:15: compiler.err.doesnt.exist: ma",
+                "Test.java:1:22: compiler.err.doesnt.exist: ma",
                 "1 error");
 
         if (!expected.equals(log))


### PR DESCRIPTION
I backport this to improve error messages.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8129418](https://bugs.openjdk.org/browse/JDK-8129418) needs maintainer approval

### Issue
 * [JDK-8129418](https://bugs.openjdk.org/browse/JDK-8129418): JShell: better highlighting of errors in imports on demand (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2825/head:pull/2825` \
`$ git checkout pull/2825`

Update a local copy of the PR: \
`$ git checkout pull/2825` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2825`

View PR using the GUI difftool: \
`$ git pr show -t 2825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2825.diff">https://git.openjdk.org/jdk21u-dev/pull/2825.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2825#issuecomment-4214477189)
</details>
