### PR TITLE
8370378: Some compiler tests inadvertently exclude particular platforms

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestBit.java
+++ b/test/hotspot/jtreg/compiler/c2/TestBit.java
@@ -33,7 +33,7 @@ import jdk.test.lib.process.ProcessTools;
  * @library /test/lib /
  *
  * @requires vm.flagless
- * @requires os.arch=="aarch64" | os.arch=="amd64" | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "riscv64"
+ * @requires os.arch == "aarch64" | os.arch == "amd64" | os.arch == "x86_64" | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "riscv64"
  * @requires vm.debug == true & vm.compiler2.enabled
  *
  * @run driver compiler.c2.TestBit

--- a/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeIntIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of RotateLeftNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.RotateLeftNodeIntIdealizationTests
- * @requires os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseZbb == true)
+ * @requires os.arch == "amd64" | os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseZbb == true)
  */
 public class RotateLeftNodeIntIdealizationTests {
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/RotateLeftNodeLongIdealizationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that Ideal transformations of RotateLeftNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.RotateLeftNodeLongIdealizationTests
- * @requires os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseZbb == true)
+ * @requires os.arch == "amd64" | os.arch == "x86_64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.opt.UseZbb == true)
  */
 public class RotateLeftNodeLongIdealizationTests {
 


### PR DESCRIPTION
I backport this for parity with 21.0.12-oracle.

Trivial resolve.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8370378](https://bugs.openjdk.org/browse/JDK-8370378) needs maintainer approval

### Issue
 * [JDK-8370378](https://bugs.openjdk.org/browse/JDK-8370378): Some compiler tests inadvertently exclude particular platforms (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2826/head:pull/2826` \
`$ git checkout pull/2826`

Update a local copy of the PR: \
`$ git checkout pull/2826` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2826`

View PR using the GUI difftool: \
`$ git pr show -t 2826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2826.diff">https://git.openjdk.org/jdk21u-dev/pull/2826.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2826#issuecomment-4214627194)
</details>
