### PR TITLE
8367096: jdk/open/test/jdk/sun/security/pkcs11/ rsa, ec, config, secmod and sslecc tests are skipping but showing as pass

### DIFF
--- a/test/jdk/sun/security/pkcs11/Config/ReadConfInUTF16Env.java
+++ b/test/jdk/sun/security/pkcs11/Config/ReadConfInUTF16Env.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
  */
 
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 import org.testng.annotations.Test;
 
 import java.security.Provider;
@@ -47,8 +48,7 @@ public class ReadConfInUTF16Env {
         public static void main(String[] args) throws Exception {
             Provider p = Security.getProvider("SunPKCS11");
             if (p == null) {
-                System.out.println("Skipping test - no PKCS11 provider available");
-                return;
+                throw new SkippedException("No PKCS11 provider available");
             }
             System.out.println(p.getName());
         }

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -796,7 +796,7 @@ public abstract class PKCS11Test {
 
     private void premain(Provider p) throws Exception {
         if (skipTest(p)) {
-            return;
+            throw new SkippedException("See logs for details");
         }
 
         // set a security manager and policy before a test case runs,

--- a/test/jdk/sun/security/pkcs11/Secmod/AddPrivateKey.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/AddPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,9 +68,7 @@ public class AddPrivateKey extends SecmodTest {
                     BASE + File.separator + args[1]);
         }
 
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nss.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/AddTrustedCert.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/AddTrustedCert.java
@@ -53,9 +53,7 @@ public class AddTrustedCert extends SecmodTest {
                     BASE + File.separator + args[1]);
         }
 
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         X509Certificate cert;
         try (InputStream in = new FileInputStream(BASE + SEP + "anchor.cer")) {

--- a/test/jdk/sun/security/pkcs11/Secmod/Crypto.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/Crypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,9 +41,7 @@ import java.security.Signature;
 public class Crypto extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nsscrypto.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/GetPrivateKey.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/GetPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,9 +52,7 @@ public class GetPrivateKey extends SecmodTest {
                     BASE + File.separator + args[1]);
         }
 
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nss.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/JksSetPrivateKey.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/JksSetPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,7 @@ public class JksSetPrivateKey extends SecmodTest {
                     BASE + File.separator + args[1]);
         }
 
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nss.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/LoadKeystore.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/LoadKeystore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,9 +48,7 @@ public class LoadKeystore extends SecmodTest {
                     BASE + File.separator + args[1]);
         }
 
-        if (!initSecmod()) {
-            return;
-        }
+        initSecmod();
 
         String configName = BASE + SEP + "nss.cfg";
         Provider p = getSunPKCS11(configName);

--- a/test/jdk/sun/security/pkcs11/Secmod/TestNssDbSqlite.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/TestNssDbSqlite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. and/or its affiliates.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -46,6 +46,7 @@ import java.security.KeyStore;
 import java.security.Provider;
 import java.security.Signature;
 
+import jtreg.SkippedException;
 import sun.security.rsa.SunRsaSign;
 import sun.security.jca.ProviderList;
 import sun.security.jca.Providers;
@@ -66,9 +67,7 @@ public final class TestNssDbSqlite extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
 
-        if (!initialize()) {
-            return;
-        }
+        initializeProvider();
 
         if (enableDebug) {
             System.out.println("SunPKCS11 provider: " +
@@ -110,16 +109,9 @@ public final class TestNssDbSqlite extends SecmodTest {
         }
     }
 
-    private static boolean initialize() throws Exception {
-        return initializeProvider();
-    }
-
-    private static boolean initializeProvider() throws Exception {
+    private static void initializeProvider() throws Exception {
         useSqlite(true);
-        if (!initSecmod()) {
-            System.out.println("Cannot init security module database, skipping");
-            return false;
-        }
+        initSecmod();
 
         sunPKCS11NSSProvider = getSunPKCS11(BASE + SEP + "nss-sqlite.cfg");
         sunJCEProvider = new com.sun.crypto.provider.SunJCE();
@@ -135,7 +127,5 @@ public final class TestNssDbSqlite extends SecmodTest {
         gen.generate(2048);
         privateKey = gen.getPrivateKey();
         certificate = gen.getSelfCertificate(new X500Name("CN=Me"), 365);
-
-        return true;
     }
 }

--- a/test/jdk/sun/security/pkcs11/Secmod/TrustAnchors.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/TrustAnchors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,9 +44,7 @@ import java.util.TreeSet;
 public class TrustAnchors extends SecmodTest {
 
     public static void main(String[] args) throws Exception {
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
 
         // our secmod.db file says nssckbi.*so*, so NSS does not find the
         // *DLL* on Windows nor the *DYLIB* on Mac OSX.

--- a/test/jdk/sun/security/pkcs11/SecmodTest.java
+++ b/test/jdk/sun/security/pkcs11/SecmodTest.java
@@ -42,7 +42,7 @@ public class SecmodTest extends PKCS11Test {
         useSqlite = b;
     }
 
-    static boolean initSecmod() throws Exception {
+    static void initSecmod() throws Exception {
         useNSS();
         LIBPATH = getNSSLibDir();
         // load all the libraries except libnss3 into memory
@@ -60,7 +60,7 @@ public class SecmodTest extends PKCS11Test {
             System.setProperty("pkcs11test.nss.db", DBDIR);
         }
         File dbdirFile = new File(DBDIR);
-        if (dbdirFile.exists() == false) {
+        if (!dbdirFile.exists()) {
             dbdirFile.mkdir();
         }
 
@@ -73,7 +73,6 @@ public class SecmodTest extends PKCS11Test {
             copyFile("key3.db", BASE, DBDIR);
             copyFile("cert8.db", BASE, DBDIR);
         }
-        return true;
     }
 
     private static void copyFile(String name, String srcDir, String dstDir) throws IOException {

--- a/test/jdk/sun/security/pkcs11/ec/ReadCertificates.java
+++ b/test/jdk/sun/security/pkcs11/ec/ReadCertificates.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import javax.security.auth.x500.X500Principal;
 import jdk.test.lib.security.Providers;
+import jtreg.SkippedException;
 
 public class ReadCertificates extends PKCS11Test {
 
@@ -79,8 +80,7 @@ public class ReadCertificates extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("Signature", "SHA1withECDSA") == null) {
-            System.out.println("Provider does not support ECDSA, skipping...");
-            return;
+            throw new SkippedException("Provider does not support ECDSA");
         }
 
         /*

--- a/test/jdk/sun/security/pkcs11/ec/ReadPKCS12.java
+++ b/test/jdk/sun/security/pkcs11/ec/ReadPKCS12.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import jdk.test.lib.security.Providers;
+import jtreg.SkippedException;
 
 public class ReadPKCS12 extends PKCS11Test {
 
@@ -67,8 +68,7 @@ public class ReadPKCS12 extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("Signature", "SHA1withECDSA") == null) {
-            System.out.println("Provider does not support ECDSA, skipping...");
-            return;
+            throw new SkippedException("Provider does not support ECDSA");
         }
 
         /*

--- a/test/jdk/sun/security/pkcs11/ec/TestKeyFactory.java
+++ b/test/jdk/sun/security/pkcs11/ec/TestKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
  * @run main/othervm TestKeyFactory
  * @run main/othervm -Djava.security.manager=allow TestKeyFactory sm
  */
+
+import jtreg.SkippedException;
 
 import java.security.Key;
 import java.security.KeyFactory;
@@ -127,8 +129,7 @@ public class TestKeyFactory extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("KeyFactory", "EC") == null) {
-            System.out.println("Provider does not support EC, skipping");
-            return;
+            throw new SkippedException("Provider does not support EC, skipping");
         }
         int[] keyLengths = {256, 521};
         KeyFactory kf = KeyFactory.getInstance("EC", p);

--- a/test/jdk/sun/security/pkcs11/rsa/KeyWrap.java
+++ b/test/jdk/sun/security/pkcs11/rsa/KeyWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@
  * @run main/othervm -Djava.security.manager=allow KeyWrap sm
  */
 
+import jtreg.SkippedException;
+
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -55,8 +57,7 @@ public class KeyWrap extends PKCS11Test {
         try {
             Cipher.getInstance("RSA/ECB/PKCS1Padding", p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
         KeyPair kp;
         try {
@@ -75,8 +76,7 @@ public class KeyWrap extends PKCS11Test {
                 kp = new KeyPair(pub, priv);
             } catch (NoSuchAlgorithmException | InvalidKeyException ee) {
                 ee.printStackTrace();
-                System.out.println("Provider does not support RSA, skipping");
-                return;
+                throw new SkippedException("Provider does not support RSA, skipping");
             }
         }
         System.out.println(kp);

--- a/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
+++ b/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
@@ -42,6 +42,7 @@
 import java.security.Provider;
 import java.security.Security;
 import jdk.test.lib.security.Providers;
+import jtreg.SkippedException;
 
 public class ClientJSSEServerJSSE extends PKCS11Test {
 
@@ -60,8 +61,7 @@ public class ClientJSSEServerJSSE extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("KeyFactory", "EC") == null) {
-            System.out.println("Provider does not support EC, skipping");
-            return;
+            throw new SkippedException("Provider does not support EC, skipping");
         }
         Providers.setAt(p, 1);
         CipherTest.main(new JSSEFactory(), cmdArgs);

--- a/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
+++ b/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
@@ -454,9 +454,7 @@ public final class FipsModeTLS12 extends SecmodTest {
         disabledAlgorithms += "RSASSA-PSS";
         Security.setProperty("jdk.tls.disabledAlgorithms", disabledAlgorithms);
 
-        if (initSecmod() == false) {
-            return;
-        }
+        initSecmod();
         String configName = BASE + SEP + "nss.cfg";
         sunPKCS11NSSProvider = getSunPKCS11(configName);
         System.out.println("SunPKCS11 provider: " + sunPKCS11NSSProvider);


### PR DESCRIPTION
Several trivial resolves needed.  Also, this change removes import of java.io.File, but that 
is still needed in 21 for File.seperator.

patching file test/jdk/sun/security/pkcs11/Config/ReadConfInUTF16Env.java
Copyright.
patching file test/jdk/sun/security/pkcs11/Secmod/AddPrivateKey.java
patching file test/jdk/sun/security/pkcs11/Secmod/AddTrustedCert.java
Trivial resolve.
patching file test/jdk/sun/security/pkcs11/Secmod/Crypto.java
Copyright.

patching file test/jdk/sun/security/pkcs11/Secmod/GetPrivateKey.java
patching file test/jdk/sun/security/pkcs11/Secmod/JksSetPrivateKey.java
patching file test/jdk/sun/security/pkcs11/Secmod/LoadKeystore.java
Same trivial resolve as above.
patching file test/jdk/sun/security/pkcs11/Secmod/TrustAnchors.java
patching file test/jdk/sun/security/pkcs11/ec/TestKeyFactory.java
patching file test/jdk/sun/security/pkcs11/rsa/KeyWrap.java
Copyright.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367096](https://bugs.openjdk.org/browse/JDK-8367096) needs maintainer approval

### Issue
 * [JDK-8367096](https://bugs.openjdk.org/browse/JDK-8367096): jdk/open/test/jdk/sun/security/pkcs11/ rsa, ec, config, secmod and sslecc tests are skipping but showing as pass (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2827/head:pull/2827` \
`$ git checkout pull/2827`

Update a local copy of the PR: \
`$ git checkout pull/2827` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2827`

View PR using the GUI difftool: \
`$ git pr show -t 2827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2827.diff">https://git.openjdk.org/jdk21u-dev/pull/2827.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2827#issuecomment-4215050416)
</details>
