### PR TITLE
8333729: C2 SuperWord: remove some @requires usages in test/hotspot/jtreg/compiler/loopopts/superword

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/CoLocatePackMemoryState.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/CoLocatePackMemoryState.java
@@ -24,12 +24,11 @@
 
 /**
  * @test
- * @requires vm.compiler2.enabled
  * @bug 8238438
  * @summary Tests to select the memory state of the last load in a load pack in SuperWord::co_locate_pack.
  *
  * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.loopopts.superword.CoLocatePackMemoryState::test
- *      -XX:LoopMaxUnroll=16 compiler.loopopts.superword.CoLocatePackMemoryState
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:LoopMaxUnroll=16 compiler.loopopts.superword.CoLocatePackMemoryState
  */
 
 package compiler.loopopts.superword;

--- a/test/hotspot/jtreg/compiler/loopopts/superword/RedTest_long.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/RedTest_long.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8240248
  * @summary Add C2 x86 Superword support for scalar logical reduction optimizations : long test
- * @requires vm.bits == "64"
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.RedTest_long
  */
@@ -137,6 +136,7 @@ public class RedTest_long {
         failOn = {IRNode.ADD_REDUCTION_VL})
     @IR(applyIfCPUFeature = {"avx2", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long sumReductionImplement(
             long[] a,
@@ -154,6 +154,7 @@ public class RedTest_long {
         failOn = {IRNode.OR_REDUCTION_V})
     @IR(applyIfCPUFeature = {"avx2", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.OR_REDUCTION_V, ">= 1", IRNode.OR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long orReductionImplement(
             long[] a,
@@ -171,6 +172,7 @@ public class RedTest_long {
         failOn = {IRNode.AND_REDUCTION_V})
     @IR(applyIfCPUFeature = {"avx2", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.AND_REDUCTION_V, ">= 1", IRNode.AND_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long andReductionImplement(
             long[] a,
@@ -188,6 +190,7 @@ public class RedTest_long {
         failOn = {IRNode.XOR_REDUCTION_V})
     @IR(applyIfCPUFeature = {"avx2", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.XOR_REDUCTION_V, ">= 1", IRNode.XOR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long xorReductionImplement(
             long[] a,
@@ -205,6 +208,7 @@ public class RedTest_long {
         failOn = {IRNode.MUL_REDUCTION_VL})
     @IR(applyIfCPUFeature = {"avx512dq", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.MUL_REDUCTION_VL, ">= 1", IRNode.MUL_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long mulReductionImplement(
             long[] a,

--- a/test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
@@ -25,11 +25,10 @@
  * @test
  * @bug 8074981 8302652
  * @summary Test SuperWord Reduction Perf.
- * @requires vm.compiler2.enabled
- * @requires vm.simpleArch == "x86" | vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @library /test/lib /
- * @run main/othervm -Xbatch -XX:LoopUnrollLimit=250
+ * @run main/othervm -Xbatch
  *                   -XX:CompileCommand=exclude,compiler.loopopts.superword.ReductionPerf::main
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:LoopUnrollLimit=250
  *                   compiler.loopopts.superword.ReductionPerf
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestCyclicDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestCyclicDependency.java
@@ -27,7 +27,6 @@
  * @bug 8298935
  * @summary Writing forward on array creates cyclic dependency
  *          which leads to wrong result, when ignored.
- * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver TestCyclicDependency
  */

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -28,7 +28,7 @@
  *   Note: CompileCommand Option Vectorize is enabled.
  *
  * Note: this test is auto-generated. Please modify / generate with script:
- *       https://bugs.openjdk.org/browse/JDK-8312570
+ *       https://bugs.openjdk.org/browse/JDK-8333729
  *
  * Types: int, long, short, char, byte, float, double
  * Offsets: 0, -1, 1, -2, 2, -3, 3, -4, 4, -7, 7, -8, 8, -14, 14, -16, 16, -18, 18, -20, 20, -31, 31, -32, 32, -63, 63, -64, 64, -65, 65, -128, 128, -129, 129, -192, 192
@@ -93,7 +93,6 @@
  * @test id=vanilla-A
  * @bug 8298935 8310308 8312570
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
- * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestDependencyOffsets vanilla-A
  */
@@ -102,7 +101,6 @@
  * @test id=vanilla-U
  * @bug 8298935 8310308 8312570
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
- * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestDependencyOffsets vanilla-U
  */
@@ -1266,7 +1264,7 @@ public class TestDependencyOffsets {
                            "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestDependencyOffsets::init",
                            "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestDependencyOffsets::test*",
                            "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestDependencyOffsets::verify",
-                           "-XX:LoopUnrollLimit=250");
+                           "-XX:+IgnoreUnrecognizedVMOptions", "-XX:LoopUnrollLimit=250");
 
         if (args.length != 1) {
             throw new RuntimeException("Test requires exactly one argument!");

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
@@ -27,7 +27,6 @@
  * @summary Test reduction vectorizations that are enabled by performing SLP
  *          reduction analysis on unrolled loops.
  * @library /test/lib /
- * @requires vm.bits == 64
  * @run driver compiler.loopopts.superword.TestGeneralizedReductions
  */
 
@@ -42,7 +41,7 @@ public class TestGeneralizedReductions {
 
     public static void main(String[] args) throws Exception {
         // Fix maximum number of unrolls for test stability.
-        TestFramework.runWithFlags("-XX:LoopMaxUnroll=16");
+        TestFramework.runWithFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:LoopMaxUnroll=16");
     }
 
     @Run(test = {"testReductionOnGlobalAccumulator",
@@ -82,7 +81,9 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"}, applyIf = {"SuperWordReductions", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        applyIf = {"SuperWordReductions", "true"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnGlobalAccumulator(long[] array) {
         acc = 0;
@@ -93,7 +94,9 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"}, applyIf = {"SuperWordReductions", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        applyIf = {"SuperWordReductions", "true"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnPartiallyUnrolledLoop(long[] array) {
         int sum = 0;
@@ -105,7 +108,9 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"}, applyIf = {"SuperWordReductions", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        applyIf = {"SuperWordReductions", "true"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnLargePartiallyUnrolledLoop(long[] array) {
         int sum = 0;
@@ -128,7 +133,9 @@ public class TestGeneralizedReductions {
     // If this limitation is overcome in the future, the test case should be
     // turned into a positive one.
     @Test
-    @IR(applyIfCPUFeature = {"avx2", "true"}, applyIf = {"SuperWordReductions", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        applyIf = {"SuperWordReductions", "true"},
+        applyIfPlatform = {"64-bit", "true"},
         failOn = {IRNode.ADD_REDUCTION_VI})
     private static long testReductionOnPartiallyUnrolledLoopWithSwappedInputs(long[] array) {
         int sum = 0;
@@ -142,6 +149,7 @@ public class TestGeneralizedReductions {
     @Test
     @IR(applyIfCPUFeature = {"avx2", "true"},
         applyIfAnd = {"SuperWordReductions", "true","UsePopCountInstruction", "true"},
+        applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1",
                   IRNode.POPCOUNT_VL, ">= 1"})
     private static long testMapReductionOnGlobalAccumulator(long[] array) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java
@@ -27,8 +27,6 @@
  * @bug 8304042
  * @summary Test some examples with independent packs with cyclic dependency
  *          between the packs.
- * @requires vm.bits == 64
- * @requires vm.compiler2.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestIndependentPacksWithCyclicDependency
@@ -78,7 +76,7 @@ public class TestIndependentPacksWithCyclicDependency {
                                    "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestIndependentPacksWithCyclicDependency::test*",
                                    "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestIndependentPacksWithCyclicDependency::verify",
                                    "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestIndependentPacksWithCyclicDependency::init",
-                                   "-XX:LoopUnrollLimit=1000");
+                                   "-XX:+IgnoreUnrecognizedVMOptions", "-XX:LoopUnrollLimit=1000");
     }
 
     TestIndependentPacksWithCyclicDependency() {
@@ -120,6 +118,7 @@ public class TestIndependentPacksWithCyclicDependency {
 
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VF, "> 0"},
+        applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test0(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {
@@ -144,6 +143,7 @@ public class TestIndependentPacksWithCyclicDependency {
 
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VF, "> 0", IRNode.VECTOR_CAST_F2I, "> 0", IRNode.VECTOR_CAST_I2F, "> 0"},
+        applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"avx2", "true", "asimd", "true"})
     static void test1(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {
@@ -167,6 +167,7 @@ public class TestIndependentPacksWithCyclicDependency {
 
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VI, "> 0"},
+        applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test2(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {
@@ -191,6 +192,7 @@ public class TestIndependentPacksWithCyclicDependency {
 
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VF, "> 0"},
+        applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test3(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb) {
         for (int i = 0; i < RANGE; i+=2) {
@@ -267,6 +269,7 @@ public class TestIndependentPacksWithCyclicDependency {
 
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0", IRNode.MUL_VI, "> 0", IRNode.ADD_VF, "> 0"},
+        applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     static void test6(int[] dataIa, int[] dataIb, float[] dataFa, float[] dataFb,
                       long[] dataLa, long[] dataLb) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency2.java
@@ -28,11 +28,10 @@
  * @summary Test some examples with independent packs with cyclic dependency
  *          between the packs.
  *          Before fix, this hit: "assert(!is_visited) failed: visit only once"
- * @requires vm.compiler2.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @run main/othervm -XX:LoopUnrollLimit=250
- *                   -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestIndependentPacksWithCyclicDependency2::test
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestIndependentPacksWithCyclicDependency2::test
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:LoopUnrollLimit=250
  *                   compiler.loopopts.superword.TestIndependentPacksWithCyclicDependency2
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestLargeScaleAndStride.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestLargeScaleAndStride.java
@@ -35,8 +35,7 @@
  * @bug 8328938
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
- * @requires vm.compiler2.enabled
- * @run main/othervm -XX:+AlignVector compiler.loopopts.superword.TestLargeScaleAndStride
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+AlignVector compiler.loopopts.superword.TestLargeScaleAndStride
  */
 
 package compiler.loopopts.superword;

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMovingLoadBeforeStore.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMovingLoadBeforeStore.java
@@ -24,7 +24,6 @@
 
 /**
  * @test
- * @requires vm.compiler2.enabled
  * @requires vm.cpu.features ~= ".*avx2.*"
  * @bug 8316679 8316594
  * @summary In SuperWord::output, LoadVector can be moved before StoreVector, but only if it is proven to be safe.
@@ -32,9 +31,10 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestMovingLoadBeforeStore::test*
- *                   -Xbatch -XX:LoopUnrollLimit=100
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM
  *                   --add-modules java.base --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+ *                   -Xbatch
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:LoopUnrollLimit=100
  *                   compiler.loopopts.superword.TestMovingLoadBeforeStore
  */
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestPeeledReductionNode.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestPeeledReductionNode.java
@@ -29,8 +29,9 @@
  * @library /test/lib
  * @comment The test is run with -XX:LoopUnrollLimit=32 to prevent unrolling
  *          from fully replacing vectorization.
- * @run main/othervm -Xbatch -XX:LoopUnrollLimit=32
- *      compiler.loopopts.superword.TestPeeledReductionNode
+ * @run main/othervm -Xbatch
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:LoopUnrollLimit=32
+ *                   compiler.loopopts.superword.TestPeeledReductionNode
  */
 package compiler.loopopts.superword;
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestPickFirstMemoryState.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestPickFirstMemoryState.java
@@ -24,7 +24,6 @@
 
 /**
  * @test
- * @requires vm.compiler2.enabled
  * @bug 8240281
  * @summary Test which needs to select the memory state of the first load in a load pack in SuperWord::co_locate_pack.
  *

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestPickLastMemoryState.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestPickLastMemoryState.java
@@ -24,7 +24,6 @@
 
 /**
  * @test
- * @requires vm.compiler2.enabled
  * @bug 8290910 8293216
  * @summary Test which needs to select the memory state of the last load in a load pack in SuperWord::co_locate_pack.
  *

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestScheduleReordersScalarMemops.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestScheduleReordersScalarMemops.java
@@ -28,7 +28,6 @@
  * @bug 8304720
  * @summary Test some examples where non-vectorized memops also need to
  *          be reordered during SuperWord::schedule.
- * @requires vm.compiler2.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestScheduleReordersScalarMemops
@@ -55,8 +54,8 @@ public class TestScheduleReordersScalarMemops {
                                    "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestScheduleReordersScalarMemops::test*",
                                    "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestScheduleReordersScalarMemops::verify",
                                    "-XX:CompileCommand=compileonly,compiler.loopopts.superword.TestScheduleReordersScalarMemops::init",
-                                   "-XX:LoopUnrollLimit=1000",
-                                   "-XX:-TieredCompilation", "-Xbatch");
+                                   "-XX:-TieredCompilation", "-Xbatch",
+                                   "-XX:+IgnoreUnrecognizedVMOptions", "-XX:LoopUnrollLimit=1000");
     }
 
     TestScheduleReordersScalarMemops() {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
@@ -25,7 +25,6 @@
  * @test id=Vanilla-Unaligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
- * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReduction Vanilla-Unaligned
  */
@@ -34,7 +33,6 @@
  * @test id=Vanilla-Aligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
- * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReduction Vanilla-Aligned
  */
@@ -43,7 +41,6 @@
  * @test id=MaxVectorSize16-Unaligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
- * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReduction MaxVectorSize16-Unaligned
  */
@@ -52,7 +49,6 @@
  * @test id=MaxVectorSize32-Aligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
- * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReduction MaxVectorSize32-Aligned
  */
@@ -75,10 +71,10 @@ public class TestUnorderedReduction {
         }
 
         switch (args[0]) {
-            case "Vanilla-Unaligned"         -> { framework.addFlags("-XX:-AlignVector"); }
-            case "Vanilla-Aligned"           -> { framework.addFlags("-XX:+AlignVector"); }
-            case "MaxVectorSize16-Unaligned" -> { framework.addFlags("-XX:-AlignVector", "-XX:MaxVectorSize=16"); }
-            case "MaxVectorSize32-Aligned"   -> { framework.addFlags("-XX:+AlignVector", "-XX:MaxVectorSize=32"); }
+            case "Vanilla-Unaligned"         -> { framework.addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-AlignVector"); }
+            case "Vanilla-Aligned"           -> { framework.addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+AlignVector"); }
+            case "MaxVectorSize16-Unaligned" -> { framework.addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:-AlignVector", "-XX:MaxVectorSize=16"); }
+            case "MaxVectorSize32-Aligned"   -> { framework.addFlags("-XX:+IgnoreUnrecognizedVMOptions", "-XX:+AlignVector", "-XX:MaxVectorSize=32"); }
             default -> { throw new RuntimeException("Test argument not recognized: " + args[0]); }
         }
         framework.start();

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -26,7 +26,6 @@
  * @bug JDK-8310130
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
  *          Here a case with partial vectorization of the reduction.
- * @requires vm.bits == "64"
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReductionPartialVectorization
  */
@@ -62,6 +61,7 @@ public class TestUnorderedReductionPartialVectorization {
     @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                   IRNode.OR_REDUCTION_V,                                                 "> 0",},
+        applyIfPlatform = {"64-bit", "true"},
         applyIfCPUFeatureOr = {"avx2", "true"})
     static long test1(int[] data, long sum) {
         for (int i = 0; i < data.length; i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/Vec_MulAddS2I.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/Vec_MulAddS2I.java
@@ -27,47 +27,62 @@
  * @bug 8214751
  * @summary Test operations in C2 MulAddS2I and MulAddVS2VI nodes.
  * @library /test/lib
- * @requires vm.compiler2.enabled
  *
- * @run main/othervm -XX:LoopUnrollLimit=250
+ * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1
  *      -XX:+UseSuperWord
  *      -XX:LoopMaxUnroll=2
  *      compiler.loopopts.superword.Vec_MulAddS2I
- * @run main/othervm -XX:LoopUnrollLimit=250
+ * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1
  *      -XX:-UseSuperWord
  *      -XX:LoopMaxUnroll=2
  *      compiler.loopopts.superword.Vec_MulAddS2I
  *
- * @run main/othervm -XX:LoopUnrollLimit=250
+ * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1
  *      -XX:+UseSuperWord
  *      -XX:LoopMaxUnroll=4
  *      compiler.loopopts.superword.Vec_MulAddS2I
- * @run main/othervm -XX:LoopUnrollLimit=250
+ * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1
  *      -XX:-UseSuperWord
  *      -XX:LoopMaxUnroll=4
  *      compiler.loopopts.superword.Vec_MulAddS2I
  *
- * @run main/othervm -XX:LoopUnrollLimit=250
+ * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1
  *      -XX:+UseSuperWord
  *      -XX:LoopMaxUnroll=8
  *      compiler.loopopts.superword.Vec_MulAddS2I
- * @run main/othervm -XX:LoopUnrollLimit=250
+ * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1
  *      -XX:-UseSuperWord
  *      -XX:LoopMaxUnroll=8
  *      compiler.loopopts.superword.Vec_MulAddS2I
  *
- * @run main/othervm -XX:LoopUnrollLimit=250
+ * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1
  *      -XX:+UseSuperWord
  *      -XX:LoopMaxUnroll=16
  *      compiler.loopopts.superword.Vec_MulAddS2I
- * @run main/othervm -XX:LoopUnrollLimit=250
+ * @run main/othervm
+ *      -XX:+IgnoreUnrecognizedVMOptions
+ *      -XX:LoopUnrollLimit=250
  *      -XX:CompileThresholdScaling=0.1
  *      -XX:-UseSuperWord
  *      -XX:LoopMaxUnroll=16


### PR DESCRIPTION
I backport this to keep the tests up to date.

 

Five tests are not in 21, two had to be resolved.
I checked for the chages missing in 21, but none should be backported as prereq I think.

5 tests not in 21::

test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVector.java
test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
  https://bugs.openjdk.org/browse/JDK-8310190: C2 SuperWord: AlignVector is broken, generates misaligned packs
  Too big to backport as prereq.
test/hotspot/jtreg/compiler/loopopts/superword/TestLargeCompilation.java
  https://bugs.openjdk.org/browse/JDK-8327978: C2 SuperWord: Fix compilation time regression in dependency graph traversal after JDK-8325651
  Don't backport, problem does not exist in 21.
test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
  https://bugs.openjdk.org/browse/JDK-8310886: C2 SuperWord: Two nodes should be isomorphic if they are loop invariant but pinned at different nodes outside the loop
test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
  https://bugs.openjdk.org/browse/JDK-8326139: C2 SuperWord: split packs (match use/def packs, implemented, mutual independence)

And two needed trivial resolves:

test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
test/hotspot/jtreg/compiler/loopopts/superword/TestMovingLoadBeforeStore.java
  https://bugs.openjdk.org/browse/JDK-8310190: C2 SuperWord: AlignVector is broken, generates misaligned packs

None of the dependencies should be backported I think.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333729](https://bugs.openjdk.org/browse/JDK-8333729) needs maintainer approval

### Issue
 * [JDK-8333729](https://bugs.openjdk.org/browse/JDK-8333729): C2 SuperWord: remove some @<!---->requires usages in test/hotspot/jtreg/compiler/loopopts/superword (**Sub-task** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2831/head:pull/2831` \
`$ git checkout pull/2831`

Update a local copy of the PR: \
`$ git checkout pull/2831` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2831`

View PR using the GUI difftool: \
`$ git pr show -t 2831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2831.diff">https://git.openjdk.org/jdk21u-dev/pull/2831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2831#issuecomment-4234349273)
</details>
