### PR TITLE
8341833: incomplete snippet from loaded files from command line is ignored

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -1290,6 +1290,9 @@ public class JShellTool implements MessageHandler {
                 continue;
             }
             if (line == null) {
+                if (!src.isEmpty()) {
+                    errormsg("jshell.err.incomplete.input", src);
+                }
                 //EOF
                 if (input.interactiveOutput()) {
                     // End after user ctrl-D

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -169,6 +169,7 @@ jshell.err.exception.thrown = Exception {0}
 jshell.err.exception.thrown.message = Exception {0}: {1}
 jshell.err.exception.cause = Caused by: {0}
 jshell.err.exception.cause.message = Caused by: {0}: {1}
+jshell.err.incomplete.input = Incomplete input: {0}
 
 jshell.console.see.synopsis = <press tab again to see synopsis>
 jshell.console.see.full.documentation = <press tab again to see full documentation>

--- a/test/langtools/jdk/jshell/StartOptionTest.java
+++ b/test/langtools/jdk/jshell/StartOptionTest.java
@@ -22,12 +22,13 @@
  */
 
  /*
- * @test 8151754 8080883 8160089 8170162 8166581 8172102 8171343 8178023 8186708 8179856 8185840 8190383
+ * @test 8151754 8080883 8160089 8170162 8166581 8172102 8171343 8178023 8186708 8179856 8185840 8190383 8341833
  * @summary Testing startExCe-up options.
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.jdeps/com.sun.tools.javap
  *          jdk.jshell/jdk.internal.jshell.tool
+ *          jdk.jshell/jdk.internal.jshell.tool.resources:+open
  * @library /tools/lib
  * @build Compiler toolbox.ToolBox
  * @run testng StartOptionTest
@@ -38,13 +39,16 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.ResourceBundle;
 import java.util.function.Consumer;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import jdk.jshell.JShell;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -123,6 +127,14 @@ public class StartOptionTest {
         check(cmderr, checkError, "cmderr");
         check(console, checkConsole, "console");
         check(userout, checkUserOutput, "userout");
+        check(usererr, null, "usererr");
+    }
+
+    protected void startCheckError(Consumer<String> checkError,
+            String... args) {
+        runShell(args);
+        check(cmderr, checkError, "userout");
+        check(userout, null, "userout");
         check(usererr, null, "usererr");
     }
 
@@ -357,6 +369,25 @@ public class StartOptionTest {
                 s -> assertTrue(s.trim().startsWith("jshell>"), "Expected prompt, got: " + s),
                 "--show-version");
     }
+
+    public void testErroneousFile() {
+        String code = """
+                      var v = (
+                      System.console().readLine("prompt: ");
+                      /exit
+                      """;
+        String readLinePrompt = writeToFile(code);
+        String expectedErrorFormat =
+                ResourceBundle.getBundle("jdk.internal.jshell.tool.resources.l10n",
+                                         Locale.getDefault(),
+                                         JShell.class.getModule())
+                              .getString("jshell.err.incomplete.input");
+        String expectedError =
+                new MessageFormat(expectedErrorFormat).format(new Object[] {code});
+        startCheckError(s -> assertEquals(s, expectedError),
+                        readLinePrompt);
+    }
+
 
     @AfterMethod
     public void tearDown() {

--- a/test/langtools/jdk/jshell/ToolProviderTest.java
+++ b/test/langtools/jdk/jshell/ToolProviderTest.java
@@ -34,6 +34,7 @@ import static org.testng.Assert.assertTrue;
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.jdeps/com.sun.tools.javap
  *          jdk.jshell/jdk.internal.jshell.tool
+ *          jdk.jshell/jdk.internal.jshell.tool.resources:+open
  * @library /tools/lib
  * @build Compiler toolbox.ToolBox
  * @run testng ToolProviderTest


### PR DESCRIPTION
I would like to backport this small fix to im prove error handling o fjshell.

Resolved the two test files, trivial.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341833](https://bugs.openjdk.org/browse/JDK-8341833) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8341833: incomplete snippet from loaded files from command line is ignored`

### Issue
 * [JDK-8341833](https://bugs.openjdk.org/browse/JDK-8341833): incomplete snippet from loaded files from command line is ignored (**Bug** - P3 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2833/head:pull/2833` \
`$ git checkout pull/2833`

Update a local copy of the PR: \
`$ git checkout pull/2833` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2833`

View PR using the GUI difftool: \
`$ git pr show -t 2833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2833.diff">https://git.openjdk.org/jdk21u-dev/pull/2833.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2833#issuecomment-4235604271)
</details>
