### PR TITLE
8315588: JShell does not accept underscore from JEP 443 even with --enable-preview

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
@@ -190,7 +190,7 @@ class CompletenessAnalyzer {
         EOF(TokenKind.EOF, 0),  //
         ERROR(TokenKind.ERROR, XERRO),  //
         IDENTIFIER(TokenKind.IDENTIFIER, XEXPR1|XDECL1|XTERM),  //
-        UNDERSCORE(TokenKind.UNDERSCORE, XERRO),  //  _
+        UNDERSCORE(TokenKind.UNDERSCORE, XDECL1),  //  _
         CLASS(TokenKind.CLASS, XEXPR|XDECL1|XBRACESNEEDED),  //  class decl (MAPPED: DOTCLASS)
         MONKEYS_AT(TokenKind.MONKEYS_AT, XEXPR|XDECL1),  //  @
         IMPORT(TokenKind.IMPORT, XDECL1|XSTART),  //  import -- consider declaration


### PR DESCRIPTION
A small fix for jshell

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8315588](https://bugs.openjdk.org/browse/JDK-8315588) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315588](https://bugs.openjdk.org/browse/JDK-8315588): JShell does not accept underscore from JEP 443 even with --enable-preview (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2834/head:pull/2834` \
`$ git checkout pull/2834`

Update a local copy of the PR: \
`$ git checkout pull/2834` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2834`

View PR using the GUI difftool: \
`$ git pr show -t 2834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2834.diff">https://git.openjdk.org/jdk21u-dev/pull/2834.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2834#issuecomment-4235602217)
</details>
