### PR TITLE
8322532: JShell : Unnamed variable issue

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
@@ -190,7 +190,7 @@ class CompletenessAnalyzer {
         EOF(TokenKind.EOF, 0),  //
         ERROR(TokenKind.ERROR, XERRO),  //
         IDENTIFIER(TokenKind.IDENTIFIER, XEXPR1|XDECL1|XTERM),  //
-        UNDERSCORE(TokenKind.UNDERSCORE, XERRO),  //  _
+        UNDERSCORE(TokenKind.UNDERSCORE, XDECL1),  //  _
         CLASS(TokenKind.CLASS, XEXPR|XDECL1|XBRACESNEEDED),  //  class decl (MAPPED: DOTCLASS)
         MONKEYS_AT(TokenKind.MONKEYS_AT, XEXPR|XDECL1),  //  @
         IMPORT(TokenKind.IMPORT, XDECL1|XSTART),  //  import -- consider declaration

--- a/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
@@ -190,7 +190,7 @@ class CompletenessAnalyzer {
         EOF(TokenKind.EOF, 0),  //
         ERROR(TokenKind.ERROR, XERRO),  //
         IDENTIFIER(TokenKind.IDENTIFIER, XEXPR1|XDECL1|XTERM),  //
-        UNDERSCORE(TokenKind.UNDERSCORE, XDECL1),  //  _
+        UNDERSCORE(TokenKind.UNDERSCORE, XDECL1|XEXPR),  //  _
         CLASS(TokenKind.CLASS, XEXPR|XDECL1|XBRACESNEEDED),  //  class decl (MAPPED: DOTCLASS)
         MONKEYS_AT(TokenKind.MONKEYS_AT, XEXPR|XDECL1),  //  @
         IMPORT(TokenKind.IMPORT, XDECL1|XSTART),  //  import -- consider declaration

--- a/test/langtools/jdk/jshell/VariablesTest.java
+++ b/test/langtools/jdk/jshell/VariablesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236 8252409 8294431
+ * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236 8252409 8294431 8322532
  * @summary Tests for EvaluationState.variables
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -619,6 +619,12 @@ public class VariablesTest extends KullaTesting {
 
     public void varAnonymousClassAndStaticField() { //JDK-8294431
         assertEval("var obj = new Object() { public static final String msg = \"hello\"; };");
+    }
+
+    public void underscoreAsLambdaParameter() { //JDK-8322532
+        assertAnalyze("Func f = _ -> 0; int i;",
+                      "Func f = _ -> 0;",
+                      " int i;", true);
     }
 
 }


### PR DESCRIPTION
A small fix for jshell

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322532](https://bugs.openjdk.org/browse/JDK-8322532) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322532](https://bugs.openjdk.org/browse/JDK-8322532): JShell : Unnamed variable issue (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2835/head:pull/2835` \
`$ git checkout pull/2835`

Update a local copy of the PR: \
`$ git checkout pull/2835` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2835`

View PR using the GUI difftool: \
`$ git pr show -t 2835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2835.diff">https://git.openjdk.org/jdk21u-dev/pull/2835.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2835#issuecomment-4235745144)
</details>
