### PR TITLE
8359364: java/net/URL/EarlyOrDelayedParsing test fails intermittently

### DIFF
--- a/test/jdk/java/net/URL/EarlyOrDelayedParsing.java
+++ b/test/jdk/java/net/URL/EarlyOrDelayedParsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,10 @@
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -57,6 +61,19 @@ public class EarlyOrDelayedParsing {
     {
         String value = System.getProperty("jdk.net.url.delayParsing", "false");
         EARLY_PARSING = !value.isEmpty() && !Boolean.parseBoolean(value);
+        if (!EARLY_PARSING) {
+            // we will open the connection in that case.
+            // make sure no proxy is selected
+            ProxySelector.setDefault(new ProxySelector() {
+                @Override
+                public List<Proxy> select(URI uri) {
+                    return List.of(Proxy.NO_PROXY);
+                }
+                @Override
+                public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+                }
+            });
+        }
     }
 
     // Some characters that when included at the wrong place


### PR DESCRIPTION
I backport this for parity with 21.0.12-oracle,

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8359364](https://bugs.openjdk.org/browse/JDK-8359364) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359364](https://bugs.openjdk.org/browse/JDK-8359364): java/net/URL/EarlyOrDelayedParsing test fails intermittently (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2838/head:pull/2838` \
`$ git checkout pull/2838`

Update a local copy of the PR: \
`$ git checkout pull/2838` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2838`

View PR using the GUI difftool: \
`$ git pr show -t 2838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2838.diff">https://git.openjdk.org/jdk21u-dev/pull/2838.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2838#issuecomment-4241952908)
</details>
