### PR TITLE
8340336: Open some checkbox awt tests

### DIFF
--- a/test/jdk/java/awt/Checkbox/AppearanceIfLargeFont.java
+++ b/test/jdk/java/awt/Checkbox/AppearanceIfLargeFont.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.CheckboxMenuItem;
+import java.awt.Frame;
+import java.awt.PopupMenu;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 6401956
+ * @summary The right mark of the CheckboxMenu item is broken
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AppearanceIfLargeFont
+ */
+
+public class AppearanceIfLargeFont extends Frame {
+    private static final String INSTRUCTIONS = """
+            1) Make sure that font-size is large.
+               You could change this using 'Appearance' dialog.
+            2) Press button 'Press'
+               You will see a menu item with check-mark.
+            3) If check-mark is correctly painted then the test passed.
+               Otherwise, test failed.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("AppearanceIfLargeFont")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(AppearanceIfLargeFont::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public AppearanceIfLargeFont() {
+        createComponents();
+
+        setSize(200, 200);
+        validate();
+    }
+
+    void createComponents() {
+        final Button press = new Button("Press");
+        final PopupMenu popup = new PopupMenu();
+        press.add(popup);
+        add(press);
+
+        CheckboxMenuItem item = new CheckboxMenuItem("CheckboxMenuItem", true);
+        popup.add(item);
+
+        press.addActionListener(
+                new ActionListener() {
+                    public void actionPerformed(ActionEvent ae) {
+                        popup.show(press, press.getSize().width, 0);
+                    }
+                }
+        );
+    }
+}

--- a/test/jdk/java/awt/Checkbox/CheckboxMenuItemEventsTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxMenuItemEventsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.CheckboxMenuItem;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.PopupMenu;
+import java.awt.TextArea;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+/*
+ * @test
+ * @bug 4814163 5005195
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests events fired by CheckboxMenuItem
+ * @run main/manual CheckboxMenuItemEventsTest
+*/
+
+public class CheckboxMenuItemEventsTest extends Frame implements ActionListener {
+    Button trigger;
+    PopupMenu popup;
+    TextArea ta;
+
+    class Listener implements ItemListener, ActionListener {
+        public void itemStateChanged(ItemEvent e) {
+            ta.append("CORRECT: ItemEvent fired\n");
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            ta.append("ERROR: ActionEvent fired\n");
+        }
+    }
+
+    Listener listener = new Listener();
+
+    private static final String INSTRUCTIONS = """
+            Press button to invoke popup menu
+            When you press checkbox menu item
+            Item state should toggle (on/off).
+            ItemEvent should be displayed in log below.
+            And ActionEvent should not be displayed
+            Press PASS if ItemEvents are generated
+            and ActionEvents are not, FAIL Otherwise.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("CheckboxMenuItemEventsTest")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(CheckboxMenuItemEventsTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public CheckboxMenuItemEventsTest() {
+        CheckboxMenuItem i1 = new CheckboxMenuItem("CheckBoxMenuItem 1");
+        CheckboxMenuItem i2 = new CheckboxMenuItem("CheckBoxMenuItem 2");
+        Panel p1 = new Panel();
+        Panel p2 = new Panel();
+
+        setLayout(new BorderLayout());
+        ta = new TextArea();
+        p2.add(ta);
+
+        trigger = new Button("menu");
+        trigger.addActionListener(this);
+
+        popup = new PopupMenu();
+
+        i1.addItemListener(listener);
+        i1.addActionListener(listener);
+        popup.add(i1);
+        i2.addItemListener(listener);
+        i2.addActionListener(listener);
+        popup.add(i2);
+
+        trigger.add(popup);
+
+        p1.add(trigger);
+
+        add(p1, BorderLayout.NORTH);
+        add(p2, BorderLayout.SOUTH);
+
+        pack();
+        validate();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (e.getSource() == (Object) trigger) {
+            popup.show(trigger, trigger.getSize().width, 0);
+        }
+    }
+}

--- a/test/jdk/java/awt/Container/ValidateTest.java
+++ b/test/jdk/java/awt/Container/ValidateTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+
+/*
+ * @test
+ * @bug 4136190
+ * @requires (os.family == "windows")
+ * @summary Recursive validation calls would cause major USER resource leakage
+ * @key headful
+ * @run main/timeout=30 ValidateTest
+ */
+
+public class ValidateTest {
+    static Frame frame;
+
+    public static void main(String args[]) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                createGUI();
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public static void createGUI() {
+        frame = new Frame("Test for 4136190 : JVM and win95 resource leakage issues");
+        frame.setLayout(new GridLayout(1, 1));
+        MyPanel panel = new MyPanel();
+        frame.add(panel);
+        frame.invalidate();
+        frame.validate();
+        frame.setSize(500, 400);
+        frame.setVisible(true);
+    }
+
+    static class MyPanel extends Panel {
+        int recurseCounter = 0;
+
+        public void validate() {
+            recurseCounter++;
+            if (recurseCounter >= 100) {
+                return;
+            }
+            getParent().validate();
+            super.validate();
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8340336: Open some checkbox awt tests.

This PR introduces new AWT checkbox related tests.

For parity with Oracle JDK.

Ran related tests on macos-aarch64:

```~/github/jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/Checkbox/AppearanceIfLargeFont.java```

Screenshot:

<img width="865" height="265" alt="Screenshot 2026-04-13 at 9 49 22 AM" src="https://github.com/user-attachments/assets/9db715dd-0449-425e-9b4b-3f84cf8fc8c5" />

Results:

```test result: Passed. Execution successful```

[AppearanceIfLargeFont.jtr.txt](https://github.com/user-attachments/files/26681835/AppearanceIfLargeFont.jtr.txt)

```~/github/jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/Checkbox/CheckboxMenuItemEventsTest.java```

Screenshot:

<img width="1036" height="326" alt="Screenshot 2026-04-13 at 9 52 35 AM" src="https://github.com/user-attachments/assets/562a4d55-b917-4b1d-b421-8ba2d5ed041a" />

Results:

```test result: Passed. Execution successful```

[CheckboxMenuItemEventsTest.jtr.txt](https://github.com/user-attachments/files/26681909/CheckboxMenuItemEventsTest.jtr.txt)

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Container/ValidateTest.java (Requires Windows)

[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/26684037/windows-x64-specific-3-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/26684034/linux-aarch64-specific-3-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/26684035/linux-x64-specific-3-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/26684036/macos-aarch64-specific-3-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340336](https://bugs.openjdk.org/browse/JDK-8340336) needs maintainer approval

### Issue
 * [JDK-8340336](https://bugs.openjdk.org/browse/JDK-8340336): Open some checkbox awt tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2840/head:pull/2840` \
`$ git checkout pull/2840`

Update a local copy of the PR: \
`$ git checkout pull/2840` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2840`

View PR using the GUI difftool: \
`$ git pr show -t 2840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2840.diff">https://git.openjdk.org/jdk21u-dev/pull/2840.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2840#issuecomment-4238200524)
</details>
