### PR TITLE
8339879: Open some dialog awt tests

### DIFF
--- a/test/jdk/java/awt/Dialog/DefaultIconTest.java
+++ b/test/jdk/java/awt/Dialog/DefaultIconTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dialog;
+import java.awt.Frame;
+
+/*
+ * @test
+ * @bug 4964237
+ * @requires (os.family == "windows")
+ * @summary Win: Changing theme changes java dialogs title icon
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DefaultIconTest
+ */
+
+public class DefaultIconTest {
+    static String instructions = """
+                    This test shows frame and two dialogs
+                    Change windows theme. Resizable dialog should retain default icon
+                    Non-resizable dialog should retain no icon
+                    Press PASS if icons look correct, FAIL otherwise
+                    """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ShownModalDialogSerializationTest Instructions")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(35)
+                .testUI(DefaultIconTest::createGUIs)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUIs() {
+        Frame f = new Frame("DefaultIconTest");
+        f.setSize(200, 100);
+        Dialog d1 = new Dialog(f, "Resizable Dialog, should show default icon");
+        d1.setSize(200, 100);
+        d1.setVisible(true);
+        d1.setLocation(0, 150);
+        Dialog d2 = new Dialog(f, "Non-resizable dialog, should have no icon");
+        d2.setSize(200, 100);
+        d2.setVisible(true);
+        d2.setResizable(false);
+        d2.setLocation(0, 300);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Dialog/DialogInitialResizability.java
+++ b/test/jdk/java/awt/Dialog/DialogInitialResizability.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+
+/*
+ * @test
+ * @bug 4912551
+ * @summary Checks that with resizable set to false before show()
+ *          dialog can not be resized.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DialogInitialResizability
+ */
+
+public class DialogInitialResizability {
+    static String instructions = """
+                    When this test is run a dialog will display (setResizable Test).
+                    This dialog should not be resizable.
+
+                    Additionally ensure that there are NO componentResized events in the log section.
+                    If the above conditions are true, then Press PASS else FAIL.
+                    """;
+
+    private static final Dimension INITIAL_SIZE = new Dimension(400, 150);
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("DialogInitialResizability")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 2)
+                .columns(40)
+                .testUI(DialogInitialResizability::createGUI)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static MyDialog createGUI() {
+        Frame f = new Frame("invisible dialog owner");
+
+        MyDialog ld = new MyDialog(f);
+        ld.setBounds(100, 100, INITIAL_SIZE.width, INITIAL_SIZE.height);
+        ld.setResizable(false);
+
+        PassFailJFrame.log("Dialog isResizable is set to: " + ld.isResizable());
+        PassFailJFrame.log("Dialog Initial Size " + ld.getSize());
+        return ld;
+    }
+
+    private static class MyDialog extends Dialog implements ComponentListener {
+        public MyDialog(Frame f) {
+            super(f, "setResizable test", false);
+            this.addComponentListener(this);
+        }
+
+        public void componentResized(ComponentEvent e) {
+            if (!e.getComponent().getSize().equals(INITIAL_SIZE)) {
+                PassFailJFrame.log("Component Resized. Test Failed!!");
+            }
+        }
+
+        public void componentMoved(ComponentEvent e) {
+        }
+
+        public void componentShown(ComponentEvent e) {
+        }
+
+        public void componentHidden(ComponentEvent e) {
+        }
+    }
+}

--- a/test/jdk/java/awt/Dialog/NestedDialogTest.java
+++ b/test/jdk/java/awt/Dialog/NestedDialogTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.Dialog;
+import java.awt.FileDialog;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.Vector;
+import java.util.Enumeration;
+
+/*
+ * @test
+ * @bug 4110094 4178930 4178390
+ * @summary Test: Rewrite of Win modal dialogs
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual NestedDialogTest
+ */
+
+public class NestedDialogTest {
+    private static Vector windows = new Vector();
+    static String instructions = """
+            To solve various race conditions, windows modal dialogs were rewritten. This
+            test exercises various modal dialog boundary conditions and checks that
+            previous fixes to modality are incorporated in the rewrite.
+
+            Check the following:
+            - No IllegalMonitorStateException is thrown when a dialog closes
+
+            - Open multiple nested dialogs and verify that all other windows
+            are disabled when modal dialog is active.
+
+            - Check that the proper window is activated when a modal dialog closes.
+
+            - Close nested dialogs out of order (e.g. close dialog1 before dialog2)
+            and verify that this works and no deadlock occurs.
+
+            - Check that all other windows are disabled when a FileDialog is open.
+
+            - Check that the proper window is activated when a FileDialog closes.
+
+            - Verify that the active window nevers switches to another application
+            when closing dialogs, even temporarily.
+
+            - Check that choosing Hide always sucessfully hides a dialog. You should
+            try this multiple times to catch any race conditions.
+
+            - Check that the scrollbar on the Choice component in the dialog works, as opposed
+              to just using drag-scrolling or the cursor keys
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("NestedDialogTest")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 2)
+                .columns(35)
+                .testUI(NestedDialogTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame frame1 = new NestedDialogTestFrame("frame0");
+        Frame frame2 = new NestedDialogTestFrame("frame1");
+        frame2.setLocation(100, 100);
+        return frame1;
+    }
+
+    public static void addWindow(Window window) {
+        // System.out.println("Pushing window " + window);
+        windows.removeElement(window);
+        windows.addElement(window);
+    }
+
+    public static void removeWindow(Window window) {
+        // System.out.println("Popping window " + window);
+        windows.removeElement(window);
+    }
+
+    public static Window getWindow(int index) {
+        return (Window) windows.elementAt(index);
+    }
+
+    public static Enumeration enumWindows() {
+        return windows.elements();
+    }
+
+    public static int getWindowIndex(Window win) {
+        return windows.indexOf(win);
+    }
+}
+
+class NestedDialogTestFrame extends Frame {
+    NestedDialogTestFrame(String name) {
+        super(name);
+        setSize(200, 200);
+        show();
+
+        setLayout(new FlowLayout());
+        Button btnDlg = new Button("Dialog...");
+        add(btnDlg);
+        Button btnFileDlg = new Button("FileDialog...");
+        add(btnFileDlg);
+
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent ev) {
+                System.exit(0);
+            }
+        });
+
+        btnDlg.addActionListener(
+                new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        Dialog d1 = new SimpleDialog(NestedDialogTestFrame.this, null, true);
+                        System.out.println("Returned from showing dialog: " + d1);
+                    }
+                }
+        );
+
+        btnFileDlg.addActionListener(
+                new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        FileDialog dlg = new FileDialog(NestedDialogTestFrame.this);
+                        dlg.show();
+                    }
+                }
+        );
+
+        validate();
+    }
+
+    public void show() {
+        if (!isVisible()) {
+            NestedDialogTest.addWindow(this);
+        }
+        super.show();
+    }
+
+    public void dispose() {
+        NestedDialogTest.removeWindow(this);
+        super.dispose();
+    }
+}
+
+class SimpleDialog extends Dialog {
+    Button btnNested;
+    Button btnFileDlg;
+    Button btnShow;
+    Button btnHide;
+    Button btnDispose;
+    Button btnExit;
+    List listWins;
+    Dialog dlgPrev;
+
+    public SimpleDialog(Frame frame, Dialog prev, boolean isModal) {
+        super(frame, "", isModal);
+
+        dlgPrev = prev;
+
+        addWindowListener(new WindowAdapter() {
+            public void windowActivated(WindowEvent ev) {
+                populateListWin();
+            }
+        });
+
+        setTitle(getName());
+
+        Panel panelNorth = new Panel();
+        panelNorth.setLayout(new GridLayout(1, 1));
+        listWins = new List();
+        panelNorth.add(listWins);
+
+        Panel panelSouth = new Panel();
+        panelSouth.setLayout(new FlowLayout());
+        btnNested = new Button("Dialog...");
+        panelSouth.add(btnNested);
+        btnFileDlg = new Button("FileDialog...");
+        panelSouth.add(btnFileDlg);
+        btnShow = new Button("Show");
+        panelSouth.add(btnShow);
+        btnHide = new Button("Hide");
+        panelSouth.add(btnHide);
+        btnDispose = new Button("Dispose");
+        panelSouth.add(btnDispose);
+
+        Choice cbox = new Choice();
+        cbox.add("Test1");
+        cbox.add("Test2");
+        cbox.add("Test3");
+        cbox.add("Test4");
+        cbox.add("Test5");
+        cbox.add("Test6");
+        cbox.add("Test7");
+        cbox.add("Test8");
+        cbox.add("Test9");
+        cbox.add("Test10");
+        cbox.add("Test11");
+        panelSouth.add(cbox);
+
+        validate();
+
+        add("Center", panelNorth);
+        add("South", panelSouth);
+
+        btnNested.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                Dialog dlg = new SimpleDialog((Frame) getParent(), SimpleDialog.this, true);
+                System.out.println("Returned from showing dialog: " + dlg);
+            }
+        });
+
+        btnFileDlg.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                FileDialog dlg = new FileDialog((Frame) getParent());
+                dlg.show();
+            }
+        });
+
+        btnHide.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                Window wnd = getSelectedWindow();
+                System.out.println(wnd);
+                wnd.hide();
+            }
+        });
+
+        btnShow.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                getSelectedWindow().show();
+            }
+        });
+
+        btnDispose.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                getSelectedWindow().dispose();
+                populateListWin();
+            }
+        });
+
+        pack();
+        setSize(getSize().width, getSize().height * 2);
+        if (dlgPrev != null) {
+            Point pt = dlgPrev.getLocation();
+            setLocation(pt.x + 30, pt.y + 50);
+        }
+        show();
+    }
+
+    private Window getSelectedWindow() {
+        Window window;
+        int index = listWins.getSelectedIndex();
+
+        window = NestedDialogTest.getWindow(index);
+        return window;
+    }
+
+    private void populateListWin() {
+        Enumeration enumWindows = NestedDialogTest.enumWindows();
+
+        listWins.removeAll();
+        while (enumWindows.hasMoreElements()) {
+            Window win = (Window) enumWindows.nextElement();
+            listWins.add(win.getName());
+        }
+        listWins.select(NestedDialogTest.getWindowIndex(this));
+    }
+
+    public void show() {
+        if (!isVisible()) {
+            NestedDialogTest.addWindow(this);
+        }
+        super.show();
+    }
+
+    public void dispose() {
+        NestedDialogTest.removeWindow(this);
+        super.dispose();
+    }
+}

--- a/test/jdk/java/awt/Dialog/ShownModalDialogSerializationTest.java
+++ b/test/jdk/java/awt/Dialog/ShownModalDialogSerializationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+
+import java.awt.TextArea;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
+
+/*
+ * @test
+ * @bug 4739757
+ * @summary REGRESSION: Modal Dialog is not serializable after showing
+ * @key headful
+ * @run main ShownModalDialogSerializationTest
+ */
+
+public class ShownModalDialogSerializationTest {
+    static volatile Frame frame;
+    static volatile Frame outputFrame;
+    static volatile Dialog dialog;
+
+    public static void main(String[] args) throws Exception {
+
+        EventQueue.invokeLater(ShownModalDialogSerializationTest::createTestUI);
+
+        while (dialog == null || !dialog.isShowing()) {
+            Thread.sleep(500);
+        }
+        File file = new File("dialog.ser");
+        FileOutputStream fos = new FileOutputStream(file);
+        ObjectOutputStream oos = new ObjectOutputStream(fos);
+        oos.writeObject(dialog);
+        oos.flush();
+        file.delete();
+
+        EventQueue.invokeAndWait(ShownModalDialogSerializationTest::deleteTestUI);
+    }
+
+    static void deleteTestUI() {
+        if (dialog != null) {
+            dialog.setVisible(false);
+            dialog.dispose();
+        }
+        if (frame != null) {
+            frame.setVisible(false);
+            frame.dispose();
+        }
+        if (outputFrame != null) {
+            outputFrame.setVisible(false);
+            outputFrame.dispose();
+        }
+    }
+
+    private static void createTestUI() {
+        outputFrame = new Frame("ShownModalDialogSerializationTest");
+        TextArea output = new TextArea(40, 50);
+        outputFrame.add(output);
+
+        frame = new Frame("invisible dialog owner");
+        dialog = new Dialog(frame, "Dialog for Close", true);
+        dialog.add(new Label("Close This Dialog"));
+        outputFrame.setSize(200, 200);
+        outputFrame.setVisible(true);
+        dialog.pack();
+        dialog.setVisible(true);
+    }
+}


### PR DESCRIPTION
Backporting JDK-8339879: Open some dialog awt tests.

This PR introduces new AWT checkbox related tests.

For parity with Oracle JDK.

Ran related tests on windows-x64:

```jtreg -nativepath:./build/windows-x86_64-server-fastdebug/images/test/jdk/jtreg/native -jdk build/windows-x86_64-server-fastdebug/images/jdk -m test/jdk/java/awt/Dialog/DefaultIconTest.java```

Screenshot:

<img width="669" height="359" alt="Screenshot 2026-04-13 at 12 45 18 PM" src="https://github.com/user-attachments/assets/2d8948b2-d7c4-4cee-b53c-7406c98b3b16" />

Results:

```test result: Passed. Execution successful```

[DefaultIconTest.jtr.log](https://github.com/user-attachments/files/26687067/DefaultIconTest.jtr.log)

Ran related tests on macos-aarch64:

```jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/Dialog/DialogInitialResizability.java```

Screenshot:

<img width="974" height="461" alt="Screenshot 2026-04-13 at 10 02 36 AM" src="https://github.com/user-attachments/assets/b360c7fd-7a5b-434f-997e-81daf4c48962" />

Results:

```test result: Passed. Execution successful```

[DialogInitialResizability.jtr.txt](https://github.com/user-attachments/files/26682076/DialogInitialResizability.jtr.txt)

```jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/Dialog/NestedDialogTest.java```

Screenshot:

<img width="1323" height="805" alt="Screenshot 2026-04-13 at 10 06 19 AM" src="https://github.com/user-attachments/assets/cd6fb6ff-3327-4b89-b630-3d3d459be0c8" />

Results:

```test result: Passed. Execution successful```

[NestedDialogTest.jtr.txt](https://github.com/user-attachments/files/26682159/NestedDialogTest.jtr.txt)

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Dialog/ShownModalDialogSerializationTest.java

[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/26687021/linux-aarch64-specific-4-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/26687023/linux-x64-specific-4-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/26687024/macos-aarch64-specific-4-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/26687025/windows-x64-specific-4-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339879](https://bugs.openjdk.org/browse/JDK-8339879) needs maintainer approval

### Issue
 * [JDK-8339879](https://bugs.openjdk.org/browse/JDK-8339879): Open some dialog awt tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2841/head:pull/2841` \
`$ git checkout pull/2841`

Update a local copy of the PR: \
`$ git checkout pull/2841` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2841`

View PR using the GUI difftool: \
`$ git pr show -t 2841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2841.diff">https://git.openjdk.org/jdk21u-dev/pull/2841.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2841#issuecomment-4238278446)
</details>
