### PR TITLE
8321620: Optimize JImage decompressors

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package jdk.internal.jimage.decompressor;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.zip.Inflater;
 
 /**
@@ -44,21 +45,25 @@ final class ZipDecompressor implements ResourceDecompressor {
         return ZipDecompressorFactory.NAME;
     }
 
-    static byte[] decompress(byte[] bytesIn, int offset) throws Exception {
+    static byte[] decompress(byte[] bytesIn, int offset, long originalSize) throws Exception {
+        if (originalSize > Integer.MAX_VALUE) {
+            throw new OutOfMemoryError("Required array size too large");
+        }
+        byte[] bytesOut = new byte[(int) originalSize];
+
         Inflater inflater = new Inflater();
         inflater.setInput(bytesIn, offset, bytesIn.length - offset);
-        ByteArrayOutputStream stream = new ByteArrayOutputStream(bytesIn.length - offset);
-        byte[] buffer = new byte[1024];
 
-        while (!inflater.finished()) {
-            int count = inflater.inflate(buffer);
-            stream.write(buffer, 0, count);
+        int count = 0;
+        while (!inflater.finished() && count < originalSize) {
+            count += inflater.inflate(bytesOut, count, bytesOut.length - count);
         }
 
-        stream.close();
-
-        byte[] bytesOut = stream.toByteArray();
         inflater.end();
+
+        if (count != originalSize) {
+            throw new IOException("Resource content size mismatch");
+        }
 
         return bytesOut;
     }
@@ -66,7 +71,7 @@ final class ZipDecompressor implements ResourceDecompressor {
     @Override
     public byte[] decompress(StringsProvider reader, byte[] content, int offset,
             long originalSize) throws Exception {
-        byte[] decompressed = decompress(content, offset);
+        byte[] decompressed = decompress(content, offset, originalSize);
         return decompressed;
     }
 }


### PR DESCRIPTION
This backport speeds up decompressing resources in Jimage. The backport is clean and passes GHA. The speedup is confirmed in 21 using the JMH benchmark from https://github.com/openjdk/jdk/pull/17405. There is an approximately 21% improvement.

Benchmark results on `jlink --compress 2 --add-modules java.se,jdk.unsupported,jdk.management` image with the change:
```
# JMH version: 1.37
# VM version: JDK 21.0.12-internal, OpenJDK 64-Bit Server VM, 21.0.12-internal-adhoc.costmuch.jdk21u-dev
# VM invoker: /local/home/costmuch/openjdk/tmp-21/bin/java
# VM options: -XX:+UseG1GC -Xms8g -Xmx8g --add-exports=java.base/jdk.internal.jimage=ALL-UNNAMED
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 10 iterations, 2 s each
# Measurement: 5 iterations, 3 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.sample.Decompress.test

# Run progress: 0.00% complete, ETA 00:00:35
# Fork: 1 of 1
# Warmup Iteration   1: 116933.648 ns/op
# Warmup Iteration   2: 130391.755 ns/op
# Warmup Iteration   3: 130170.647 ns/op
# Warmup Iteration   4: 130018.576 ns/op
# Warmup Iteration   5: 128857.627 ns/op
# Warmup Iteration   6: 108888.215 ns/op
# Warmup Iteration   7: 105861.984 ns/op
# Warmup Iteration   8: 105864.905 ns/op
# Warmup Iteration   9: 106019.903 ns/op
# Warmup Iteration  10: 105798.792 ns/op
Iteration   1: 105872.699 ns/op
Iteration   2: 106284.048 ns/op
Iteration   3: 106047.265 ns/op
Iteration   4: 105964.228 ns/op
Iteration   5: 106149.110 ns/op


Result "org.sample.Decompress.test":
  106063.470 ±(99.9%) 616.386 ns/op [Average]
  (min, avg, max) = (105872.699, 106063.470, 106284.048), stdev = 160.074
  CI (99.9%): [105447.084, 106679.856] (assumes normal distribution)


# Run complete. Total time: 00:00:35

Benchmark        Mode  Cnt       Score     Error  Units
Decompress.test  avgt    5  106063.470 ± 616.386  ns/op
```

Without the change:
```
# JMH version: 1.37
# VM version: JDK 21.0.12-internal, OpenJDK 64-Bit Server VM, 21.0.12-internal-adhoc.costmuch.jdk21u-dev
# VM invoker: /local/home/costmuch/openjdk/tmp-21-old/bin/java
# VM options: -XX:+UseG1GC -Xms8g -Xmx8g --add-exports=java.base/jdk.internal.jimage=ALL-UNNAMED
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 10 iterations, 2 s each
# Measurement: 5 iterations, 3 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.sample.Decompress.test

# Run progress: 0.00% complete, ETA 00:00:35
# Fork: 1 of 1
# Warmup Iteration   1: 196769.284 ns/op
# Warmup Iteration   2: 223800.815 ns/op
# Warmup Iteration   3: 177901.888 ns/op
# Warmup Iteration   4: 134710.921 ns/op
# Warmup Iteration   5: 133574.398 ns/op
# Warmup Iteration   6: 134214.697 ns/op
# Warmup Iteration   7: 137277.920 ns/op
# Warmup Iteration   8: 135750.559 ns/op
# Warmup Iteration   9: 136598.964 ns/op
# Warmup Iteration  10: 135417.511 ns/op
Iteration   1: 134626.058 ns/op
Iteration   2: 136550.141 ns/op
Iteration   3: 136133.909 ns/op
Iteration   4: 134677.199 ns/op
Iteration   5: 133592.739 ns/op


Result "org.sample.Decompress.test":
  135116.009 ±(99.9%) 4655.066 ns/op [Average]
  (min, avg, max) = (133592.739, 135116.009, 136550.141), stdev = 1208.906
  CI (99.9%): [130460.944, 139771.075] (assumes normal distribution)

Benchmark        Mode  Cnt       Score      Error  Units
Decompress.test  avgt    5  135116.009 ± 4655.066  ns/op
```

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8321620](https://bugs.openjdk.org/browse/JDK-8321620) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321620](https://bugs.openjdk.org/browse/JDK-8321620): Optimize JImage decompressors (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2842/head:pull/2842` \
`$ git checkout pull/2842`

Update a local copy of the PR: \
`$ git checkout pull/2842` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2842`

View PR using the GUI difftool: \
`$ git pr show -t 2842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2842.diff">https://git.openjdk.org/jdk21u-dev/pull/2842.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2842#issuecomment-4374634282)
</details>
