### PR TITLE
8340494: Open some dialog awt tests 4

### DIFF
--- a/test/jdk/java/awt/Container/ActivateOnFocusTest.java
+++ b/test/jdk/java/awt/Container/ActivateOnFocusTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+
+/*
+ * @test
+ * @bug 4111098
+ * @key headful
+ * @summary Test for no window activation on control requestFocus()
+ * @run main/timeout=30 ActivateOnFocusTest
+ */
+
+public class ActivateOnFocusTest {
+    static MyFrame mf1;
+    static Point p;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                mf1 = new MyFrame();
+                mf1.setBounds(100, 100, 300, 300);
+                mf1.mc1.requestFocusInWindow();
+            });
+
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                p = mf1.mb.getLocationOnScreen();
+            });
+
+            robot.waitForIdle();
+
+            robot.mouseMove(p.x + 5, p.y + 5);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(250);
+
+        } finally {
+            if (mf1 != null) {
+                EventQueue.invokeAndWait(mf1::dispose);
+            }
+        }
+    }
+}
+
+class MyFrame extends Frame implements ActionListener {
+    public Button mb;
+    public MyComponent mc1;
+    public MyComponent mc2;
+
+    public MyFrame() {
+        super();
+        setTitle("ActivateOnFocusTest");
+        setLayout(new FlowLayout());
+        mb = new Button("Pull");
+        mb.addActionListener(this);
+        add(mb);
+        mc1 = new MyComponent(Color.red);
+        add(mc1);
+        mc2 = new MyComponent(Color.blue);
+        add(mc2);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowActivated(WindowEvent e) {
+                mc1.requestFocusInWindow();
+            }
+            @Override
+            public void windowDeactivated(WindowEvent e) {
+                mc2.requestFocusInWindow();
+            }
+        });
+        setVisible(true);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        MyFrame mf2 = new MyFrame();
+        mf2.setBounds(200, 200, 300, 300);
+        mf2.setVisible(true);
+        mf2.mc1.requestFocusInWindow();
+    }
+}
+
+class MyComponent extends Component {
+    public MyComponent(Color c) {
+        super();
+        setBackground(c);
+    }
+
+    public void paint(Graphics g) {
+        Dimension d = getSize();
+        g.setColor(getBackground());
+        g.fillRect(0, 0, d.width, d.height);
+    }
+
+    public boolean isFocusTraversable() {
+        return true;
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(50, 50);
+    }
+}

--- a/test/jdk/java/awt/Container/MouseEnteredTest.java
+++ b/test/jdk/java/awt/Container/MouseEnteredTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import javax.swing.ButtonGroup;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JRadioButtonMenuItem;
+import javax.swing.JTextArea;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+/*
+ * @test
+ * @bug 4159745
+ * @key headful
+ * @summary Mediumweight popup dragging broken
+ * @run main MouseEnteredTest
+ */
+
+public class MouseEnteredTest extends JFrame implements ActionListener {
+    static volatile MouseEnteredTest test;
+    static volatile Point p;
+    static volatile Point p2;
+
+    static String strMotif = "Motif";
+    static String motifClassName = "com.sun.java.swing.plaf.motif.MotifLookAndFeel";
+    static char cMotif = 'o';
+
+    static String strWindows = "Windows";
+    static String windowsClassName = "com.sun.java.swing.plaf.windows.WindowsLookAndFeel";
+    static char cWindows = 'W';
+
+    static String strMetal = "Metal";
+    static String metalClassName = "javax.swing.plaf.metal.MetalLookAndFeel";
+    static char cMetal = 'M';
+
+    static JMenu m;
+    static JMenu menu;
+
+    static MouseListener ml = new MouseEnteredTest.MouseEventListener();
+
+    public MouseEnteredTest() {
+        setTitle("MouseEnteredTest");
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        setJMenuBar(getMyMenuBar());
+        getContentPane().add("Center", new JTextArea());
+        setSize(400, 500);
+        setLocationRelativeTo(null);
+        setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                test = new MouseEnteredTest();
+            });
+
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                p = m.getLocationOnScreen();
+                p2 = menu.getLocationOnScreen();
+            });
+            robot.waitForIdle();
+            robot.delay(250);
+            robot.mouseMove(p.x + 5, p.y + 10);
+            robot.waitForIdle();
+
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (int i = p.x; i < p2.x + 10; i = i + 2) {
+                robot.mouseMove(i, p2.y + 10);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(2000);
+
+            if (m.isPopupMenuVisible()) {
+                throw new RuntimeException("First menu is showing. Test Failed.");
+            }
+        } finally {
+            if (test != null) {
+                EventQueue.invokeAndWait(test::dispose);
+            }
+        }
+    }
+
+    public JMenuBar getMyMenuBar() {
+        JMenuBar menubar;
+        JMenuItem menuItem;
+
+        menubar = GetLNFMenuBar();
+
+        menu = menubar.add(new JMenu("Test"));
+        menu.setName("Test");
+        menu.addMouseListener(ml);
+        menu.setMnemonic('T');
+        menuItem = menu.add(new JMenuItem("Menu Item"));
+        menuItem.addActionListener(this);
+        menuItem.setMnemonic('M');
+        menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, ActionEvent.ALT_MASK));
+
+        JRadioButtonMenuItem mi = new JRadioButtonMenuItem("Radio Button");
+        mi.addActionListener(this);
+        mi.setMnemonic('R');
+        mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, ActionEvent.ALT_MASK));
+        menu.add(mi);
+
+        JCheckBoxMenuItem mi1 = new JCheckBoxMenuItem("Check Box");
+        mi1.addActionListener(this);
+        mi1.setMnemonic('C');
+        mi1.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, ActionEvent.ALT_MASK));
+        menu.add(mi1);
+        return menubar;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        String str = e.getActionCommand();
+        if (str.equals(metalClassName) || str.equals(windowsClassName) || str.equals(motifClassName)) {
+            changeLNF(str);
+        } else {
+            System.out.println("ActionEvent: " + str);
+        }
+    }
+
+    public void changeLNF(String str) {
+        System.out.println("Changing LNF to " + str);
+        try {
+            UIManager.setLookAndFeel(str);
+            SwingUtilities.updateComponentTreeUI(this);
+            pack();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public JMenuBar GetLNFMenuBar() {
+        JMenuBar mbar = new JMenuBar();
+        m = new JMenu("Look and Feel");
+        m.setName("Look and Feel");
+        m.addMouseListener(ml);
+        m.setMnemonic('L');
+        ButtonGroup bg = new ButtonGroup();
+
+        JRadioButtonMenuItem mi;
+
+        mi = new JRadioButtonMenuItem(strMetal);
+        mi.addActionListener(this);
+        mi.setActionCommand(metalClassName);
+        mi.setMnemonic(cMetal);
+        mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_1, ActionEvent.ALT_MASK));
+        mi.setSelected(true);
+        bg.add(mi);
+        m.add(mi);
+
+        mi = new JRadioButtonMenuItem(strWindows);
+        mi.addActionListener(this);
+        mi.setActionCommand(windowsClassName);
+        mi.setMnemonic(cWindows);
+        mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_2, ActionEvent.ALT_MASK));
+        bg.add(mi);
+        m.add(mi);
+
+        mi = new JRadioButtonMenuItem(strMotif);
+        mi.addActionListener(this);
+        mi.setActionCommand(motifClassName);
+        mi.setMnemonic(cMotif);
+        mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_3, ActionEvent.ALT_MASK));
+        bg.add(mi);
+        m.add(mi);
+
+        mbar.add(m);
+        return mbar;
+    }
+
+    static class MouseEventListener implements MouseListener, MouseMotionListener {
+        public void mouseClicked(MouseEvent e) {
+            System.out.println("In mouseClicked for " + e.getComponent().getName());
+        }
+
+        public void mousePressed(MouseEvent e) {
+            Component c = e.getComponent();
+            System.out.println("In mousePressed for " + c.getName());
+        }
+
+        public void mouseReleased(MouseEvent e) {
+            System.out.println("In mouseReleased for " + e.getComponent().getName());
+        }
+
+        public void mouseEntered(MouseEvent e) {
+            System.out.println("In mouseEntered for " + e.getComponent().getName());
+            System.out.println("MouseEvent:" + e.getComponent());
+        }
+
+        public void mouseExited(MouseEvent e) {
+            System.out.println("In mouseExited for " + e.getComponent().getName());
+        }
+
+        public void mouseDragged(MouseEvent e) {
+            System.out.println("In mouseDragged for " + e.getComponent().getName());
+        }
+
+        public void mouseMoved(MouseEvent e) {
+            System.out.println("In mouseMoved for " + e.getComponent().getName());
+        }
+    }
+}

--- a/test/jdk/java/awt/Dialog/ModalExcludedTest.java
+++ b/test/jdk/java/awt/Dialog/ModalExcludedTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.JobAttributes;
+import java.awt.PageAttributes;
+import java.awt.Panel;
+import java.awt.PrintJob;
+import java.awt.TextArea;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+
+import sun.awt.SunToolkit;
+
+/*
+ * @test
+ * @bug 4813288 4866704
+ * @summary Test for "modal exclusion" functionality
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame
+ * @modules java.desktop/sun.awt
+ * @run main/manual ModalExcludedTest
+ */
+
+public class ModalExcludedTest {
+    private static final String INSTRUCTIONS = """
+            1. Press 'Modal dialog w/o modal excluded' button below
+                A window, a modeless dialog and a modal dialog will appear
+                Make sure the frame and the modeless dialog are inaccessible,
+                i.e. receive no mouse and keyboard events. MousePressed and
+                KeyPressed events are logged in the text area - use it
+                to watch events
+            Close all 3 windows
+
+            2. Press 'Modal dialog w/ modal excluded' button below
+                Again, 3 windows will appear (frame, dialog, modal dialog),
+                but the frame and the dialog would be modal excluded, i.e.
+                behave the same way as there is no modal dialog shown. Verify
+                this by pressing mouse buttons and typing any keys. The
+                RootFrame would be modal blocked - verify this too
+            Close all 3 windows
+
+            3. Repeat step 2 for file and print dialogs using appropriate
+                buttons below
+
+            Notes: if there is no printer installed in the system you may not
+                get any print dialogs
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ModalExcludedTest")
+                .instructions(INSTRUCTIONS)
+                .rows(10)
+                .columns(35)
+                .testUI(ModalExcludedTest::createGUIs)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUIs() {
+        final Frame f = new Frame("RootFrame");
+        f.setBounds(0, 0, 480, 500);
+        f.setLayout(new BorderLayout());
+
+        final TextArea messages = new TextArea();
+
+        final WindowListener wl = new WindowAdapter() {
+            public void windowClosing(WindowEvent ev) {
+                if (ev.getSource() instanceof Window) {
+                    ((Window) ev.getSource()).dispose();
+                }
+            }
+        };
+        final MouseListener ml = new MouseAdapter() {
+            public void mousePressed(MouseEvent ev) {
+                messages.append(ev + "\n");
+            }
+        };
+        final KeyListener kl = new KeyAdapter() {
+            public void keyPressed(KeyEvent ev) {
+                messages.append(ev + "\n");
+            }
+        };
+
+        if (!SunToolkit.isModalExcludedSupported()) {
+            throw new jtreg.SkippedException("Modal exclude is not supported on this platform.");
+        }
+
+        messages.addMouseListener(ml);
+        messages.addKeyListener(kl);
+        f.add(messages, BorderLayout.CENTER);
+
+        Panel buttons = new Panel();
+        buttons.setLayout(new GridLayout(6, 1));
+
+        Button b = new Button("Modal dialog w/o modal excluded");
+        b.addActionListener(ev -> {
+            Frame ff = new Frame("Non-modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            ff.setVisible(true);
+
+            Dialog dd = new Dialog(ff, "Non-modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
+
+            Dialog d = new Dialog(f, "Modal dialog", true);
+            d.setBounds(600, 200, 200, 100);
+            d.addWindowListener(wl);
+            d.addMouseListener(ml);
+            d.addKeyListener(kl);
+            d.setVisible(true);
+        });
+        buttons.add(b);
+
+        Button c = new Button("Modal dialog w/ modal excluded");
+        c.addActionListener(ev -> {
+            JFrame ff = new JFrame("Modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            JMenuBar mb = new JMenuBar();
+            JMenu m = new JMenu("Test menu");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            mb.add(m);
+            ff.setJMenuBar(mb);
+            // 1: set visible
+            ff.setVisible(true);
+
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
+
+            // 2: set modal excluded
+            SunToolkit.setModalExcluded(ff);
+
+            Dialog d = new Dialog(f, "Modal dialog", true);
+            d.setBounds(600, 200, 200, 100);
+            d.addWindowListener(wl);
+            d.addMouseListener(ml);
+            d.addKeyListener(kl);
+            d.setVisible(true);
+        });
+        buttons.add(c);
+
+        Button c1 = new Button("Modal dialog before modal excluded");
+        c1.addActionListener(ev -> {
+            // 1: create dialog
+            Dialog d = new Dialog(f, "Modal dialog", true);
+            d.setBounds(600, 200, 200, 100);
+            d.addWindowListener(wl);
+            d.addMouseListener(ml);
+            d.addKeyListener(kl);
+
+            // 2: create frame
+            Frame ff = new Frame("Modal-excluded frame");
+            // 3: set modal excluded
+            SunToolkit.setModalExcluded(ff);
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            // 4: show frame
+            ff.setVisible(true);
+
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
+
+            // 5: show dialog
+            d.setVisible(true);
+        });
+        buttons.add(c1);
+
+        Button d = new Button("File dialog w/ modal excluded");
+        d.addActionListener(ev -> {
+            Frame ff = new Frame("Modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            // 1: set modal excluded (peer is not created yet)
+            SunToolkit.setModalExcluded(ff);
+            // 2: set visible
+            ff.setVisible(true);
+
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
+            SunToolkit.setModalExcluded(dd);
+
+            Dialog d1 = new FileDialog(f, "File dialog");
+            d1.setVisible(true);
+        });
+        buttons.add(d);
+
+        Button e = new Button("Native print dialog w/ modal excluded");
+        e.addActionListener(ev -> {
+            Frame ff = new Frame("Modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            ff.setVisible(true);
+            SunToolkit.setModalExcluded(ff);
+
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
+
+            JobAttributes jobAttributes = new JobAttributes();
+            jobAttributes.setDialog(JobAttributes.DialogType.NATIVE);
+            PageAttributes pageAttributes = new PageAttributes();
+            PrintJob job = Toolkit.getDefaultToolkit().getPrintJob(f, "Test", jobAttributes, pageAttributes);
+        });
+        buttons.add(e);
+
+        Button g = new Button("Common print dialog w/ modal excluded");
+        g.addActionListener(ev -> {
+            Frame ff = new Frame("Modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            ff.setVisible(true);
+            SunToolkit.setModalExcluded(ff);
+            ff.dispose();
+            // modal excluded must still be alive
+            ff.setVisible(true);
+
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
+
+            JobAttributes jobAttributes = new JobAttributes();
+            jobAttributes.setDialog(JobAttributes.DialogType.COMMON);
+            PageAttributes pageAttributes = new PageAttributes();
+            PrintJob job = Toolkit.getDefaultToolkit().getPrintJob(f, "Test", jobAttributes, pageAttributes);
+        });
+        buttons.add(g);
+
+        f.add(buttons, BorderLayout.SOUTH);
+        return f;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8340494: Open some dialog awt tests 4.

This PR introduces new AWT dialog related tests.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Container/ActivateOnFocusTest.java
make test TEST=test/jdk/java/awt/Container/MouseEnteredTest.java

Results attached:

Please note that "test/jdk/java/awt/Container/MouseEnteredTest.java" failed on macos-aarch64. Created https://bugs.openjdk.org/browse/JDK-8382191 to report the issue and https://bugs.openjdk.org/browse/JDK-8382192 to problem list (PR to follow).

[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/26726383/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/26726384/linux-aarch64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/26726385/linux-x64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/26726386/linux-x64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/26726387/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/26726388/macos-aarch64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/26726389/windows-x64-specific-2-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/26726390/windows-x64-specific-test.log)

Ran related tests on macos-aarch64:

Results:

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/Dialog/ModalExcludedTest.java```

Screenshot:

<img width="1277" height="594" alt="Screenshot 2026-04-14 at 11 11 16 AM" src="https://github.com/user-attachments/assets/eba0b5cc-bdae-40e2-9218-88341d54b8a2" />

Results:

```test result: Passed. Execution successful```

[ModalExcludedTest.jtr.txt](https://github.com/user-attachments/files/26722039/ModalExcludedTest.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8340494](https://bugs.openjdk.org/browse/JDK-8340494) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340494](https://bugs.openjdk.org/browse/JDK-8340494): Open some dialog awt tests 4 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2846/head:pull/2846` \
`$ git checkout pull/2846`

Update a local copy of the PR: \
`$ git checkout pull/2846` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2846`

View PR using the GUI difftool: \
`$ git pr show -t 2846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2846.diff">https://git.openjdk.org/jdk21u-dev/pull/2846.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2846#issuecomment-4246178695)
</details>
