### PR TITLE
8340851: Open some TextArea awt tests

### DIFF
--- a/test/jdk/java/awt/TextArea/TextAreaAppendScrollTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaAppendScrollTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.TextArea;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 5003402
+ * @summary TextArea must scroll automatically when calling append and select, even when not in focus
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaAppendScrollTest
+ */
+
+public class TextAreaAppendScrollTest extends Frame implements ActionListener {
+    int phase;
+    int pos1, pos2;
+    TextArea area;
+    private static final String INSTRUCTIONS = """
+                Press "Click Here" button.
+                The word "First" should be visible in the TextArea.
+
+                Press "Click Here" button again.
+                The word "Next" should be visible in the TextArea.
+
+                Press "Click Here" button again.
+                The word "Last" should be visible in the TextArea.
+                If you have seen all three words, press Pass, else press Fail.
+                """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaAppendScrollTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(TextAreaAppendScrollTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public TextAreaAppendScrollTest() {
+        area = new TextArea();
+        add("Center", area);
+        Button bt1 = new Button("Click Here");
+        add("South", bt1);
+        String filler = "";
+        for (int i = 0; i < 100; i++) {
+            filler = filler + i + "\n";
+        }
+        String text = filler;
+        pos1 = text.length();
+        text = text + "First\n" + filler;
+        pos2 = text.length();
+        text = text + "Next\n" + filler;
+        area.setText(text);
+        phase = 0;
+        bt1.addActionListener(this);
+        pack();
+    }
+
+    public void actionPerformed(ActionEvent ev) {
+        if (phase == 0) {
+            area.select(pos1, pos1);
+            phase = 1;
+        } else if (phase == 1) {
+            area.select(pos2, pos2);
+            phase = 2;
+        } else {
+            area.append("Last\n");
+            phase = 0;
+        }
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaCursorTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaCursorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.TextArea;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4060320
+ * @summary Test TextArea cursor shape on its scrollbars
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaCursorTest
+ */
+
+public class TextAreaCursorTest {
+    private static final String INSTRUCTIONS = """
+            Move the cursor into textarea and on scrollbar. Verify that the shape of
+            cursor on scrollbar should not be I-beam. Also, when the cursor in textarea
+            is set to some other shape, it does not affect the cursor shape on the
+            scrollbars.
+            """;
+
+    public static void main(String args[]) throws Exception {
+            PassFailJFrame.builder()
+                    .title("TextAreaCursorTest")
+                    .instructions(INSTRUCTIONS)
+                    .rows((int) INSTRUCTIONS.lines().count() + 2)
+                    .columns(40)
+                    .testUI(TextAreaCursorTest::createGUI)
+                    .build()
+                    .awaitAndCheck();
+    }
+
+    public static Frame createGUI () {
+        Frame f = new Frame("TextAreaCursorTest");
+        BorderLayout layout = new BorderLayout();
+        f.setLayout(layout);
+
+        TextArea ta = new TextArea("A test to make sure that cursor \n" +
+                "on scrollbars has the correct shape\n\n" +
+                "Press button to change the textarea\n" +
+                "cursor to Hand_Cursor\n" +
+                "Make sure that the cursor on scrollbars\n" +
+                "remains the same", 10, 30);
+
+        Button bu = new Button("Change Cursor");
+
+        f.add(ta, BorderLayout.NORTH);
+        f.add(bu, BorderLayout.SOUTH);
+        bu.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                Cursor curs1 = new Cursor(Cursor.HAND_CURSOR);
+                ta.setCursor(curs1);
+            }
+        });
+        f.pack();
+        return f;
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaKeypadTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaKeypadTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 6240876
+ * @summary Number pad up & down arrows don't work in XToolkit TextArea
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaKeypadTest
+ */
+
+public class TextAreaKeypadTest {
+    private static final String INSTRUCTIONS = """
+            Press pass if you can move the caret in the textarea with _number pad_ UP/DOWN keys.
+            Press fail if you don't.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaKeypadTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(TextAreaKeypadTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame frame = new Frame("TextAreaKeypadTest");
+        frame.setLayout(new BorderLayout());
+        TextArea area = new TextArea("One\nTwo\nThree", 3, 3, TextArea.SCROLLBARS_NONE);
+        frame.add("Center", area);
+        frame.pack();
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaSelectionTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaSelectionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.TextArea;
+import java.awt.TextField;
+
+/*
+ * @test
+ * @bug 4095946
+ * @summary 592677:TEXTFIELD TAB SELECTION CONFUSING; REMOVE ES_NOHIDESEL STYLE IN
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaSelectionTest
+ */
+
+public class TextAreaSelectionTest {
+    private static final String INSTRUCTIONS = """
+                Please look at the 'TextAreaSelectionTest' frame.
+
+                If you see that the all TextFields and TextAreas have
+                the highlighted selections, the test FAILED. Else, if
+                you see that the text of the focused component is
+                highlighted, it is ok.
+
+                Try to traverse the focus through all components by
+                pressing CTRL+TAB. If the focused component highlights
+                its selection, the test is passed for a while.
+
+                Please select the entire/part of the text of some component
+                by mouse and choose some menu item. If the highlighted
+                selection is hidden, the test FAILED.
+
+                Please select the entire/part of the text of some component
+                by mouse and click right mouse button. A context menu
+                should appear. Please check its items.
+                Press ESC to hide the context menu. If the selection
+                of the text component is not visible, the test FAILED.
+
+                Please double click on the word 'DoubleClickMe' in the
+                first text area. If there are several words selected, the
+                test FAILED, if the word 'DoubleClickMe' is selected only,
+                the test PASSED!
+                """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaSelectionTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(TextAreaSelectionTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame f = new Frame("TextAreaSelectionTest");
+        f.setLayout(new FlowLayout());
+
+        MenuBar mb = new MenuBar();
+        String name = "Submenu";
+        Menu m = new Menu(name, false);
+        m.add(new MenuItem(name + " item 1"));
+        m.add(new MenuItem(name + " item 2"));
+        m.add(new MenuItem(name + " item 3"));
+        mb.add(m);
+
+        TextField tf1, tf2;
+        TextArea ta1, ta2;
+        f.setMenuBar(mb);
+        f.add(tf1 = new TextField("some text"));
+        f.add(tf2 = new TextField("more text"));
+        String eoln = System.getProperty("line.separator", "\n");
+        f.add(ta1 = new TextArea("some text" + eoln + eoln + "DoubleClickMe"));
+        f.add(ta2 = new TextArea("more text"));
+
+        tf1.selectAll();
+        tf2.selectAll();
+        ta1.selectAll();
+        ta2.selectAll();
+
+        f.pack();
+        return f;
+    }
+
+}


### PR DESCRIPTION
Backporting JDK-8340851: Open some TextArea awt tests.

This PR introduces new AWT TextArea related tests.

For parity with Oracle JDK.

Ran related tests on macos-aarch64:

Results:

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaAppendScrollTest.java```

Screenshot:

<img width="1049" height="316" alt="Screenshot 2026-04-14 at 10 45 48 AM" src="https://github.com/user-attachments/assets/97c14040-95f1-4d8b-9398-3427232fc7ba" />

Results:

```test result: Passed. Execution successful```

[TextAreaAppendScrollTest.jtr.txt](https://github.com/user-attachments/files/26721354/TextAreaAppendScrollTest.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaCursorTest.java```

Screenshot:

<img width="832" height="321" alt="Screenshot 2026-04-14 at 10 48 27 AM" src="https://github.com/user-attachments/assets/61bbee70-6916-4aaa-9571-08f1cd763221" />

Results:

```test result: Passed. Execution successful```

[TextAreaCursorTest.jtr.txt](https://github.com/user-attachments/files/26721446/TextAreaCursorTest.jtr.txt)


```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaKeypadTest.java```

Screenshot:

<img width="652" height="210" alt="Screenshot 2026-04-14 at 10 51 37 AM" src="https://github.com/user-attachments/assets/8a8ba37f-34d2-4110-8467-44f1379981a4" />

Results:

```test result: Passed. Execution successful```

[TextAreaKeypadTest.jtr.txt](https://github.com/user-attachments/files/26721538/TextAreaKeypadTest.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaSelectionTest.java```

Screenshot:

<img width="1218" height="812" alt="Screenshot 2026-04-14 at 10 54 21 AM" src="https://github.com/user-attachments/assets/34e3ebb2-d4df-4eb1-8cdf-cd655d73cf32" />

Results:

```test result: Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Failure Reason: Context menu doesn't show up on right click.```

Please note that this is a manual test, so it wouldn't be a blocker to include. This may be a valid issue on the JDK.

[TextAreaSelectionTest.jtr.txt](https://github.com/user-attachments/files/26721740/TextAreaSelectionTest.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8340851](https://bugs.openjdk.org/browse/JDK-8340851) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340851](https://bugs.openjdk.org/browse/JDK-8340851): Open some TextArea awt tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2847/head:pull/2847` \
`$ git checkout pull/2847`

Update a local copy of the PR: \
`$ git checkout pull/2847` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2847`

View PR using the GUI difftool: \
`$ git pr show -t 2847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2847.diff">https://git.openjdk.org/jdk21u-dev/pull/2847.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2847#issuecomment-4246143351)
</details>
