### PR TITLE
8373928: 4 Dangling pointer defect groups in java.c

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1512,6 +1512,7 @@ InitializeJVM(JavaVM **pvm, JNIEnv **penv, InvocationFunctions *ifn)
 
     r = ifn->CreateJavaVM(pvm, (void **)penv, &args);
     JLI_MemFree(options);
+    options = NULL;
     return r == JNI_OK;
 }
 
@@ -2199,6 +2200,7 @@ FreeKnownVMs()
         knownVMs[i].name = NULL;
     }
     JLI_MemFree(knownVMs);
+    knownVMs = NULL;
 }
 
 /*
@@ -2272,8 +2274,9 @@ ShowSplashScreen()
     (void)UnsetEnv(SPLASH_JAR_ENV_ENTRY);
 
     JLI_MemFree(splash_jar_entry);
+    splash_jar_entry = NULL;
     JLI_MemFree(splash_file_entry);
-
+    splash_file_entry = NULL;
 }
 
 static const char* GetFullVersion()


### PR DESCRIPTION
I backport this for parity with 21.0.12-oracle.

Resolved Copyright, probably clean anyways.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8373928](https://bugs.openjdk.org/browse/JDK-8373928) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373928](https://bugs.openjdk.org/browse/JDK-8373928): 4 Dangling pointer defect groups in java.c (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2850/head:pull/2850` \
`$ git checkout pull/2850`

Update a local copy of the PR: \
`$ git checkout pull/2850` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2850`

View PR using the GUI difftool: \
`$ git pr show -t 2850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2850.diff">https://git.openjdk.org/jdk21u-dev/pull/2850.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2850#issuecomment-4250490052)
</details>
