### PR TITLE
8382018: test/jdk/java/nio/file/spi/SetDefaultProvider.java leaves a directory in /tmp

### DIFF
--- a/test/jdk/java/nio/file/spi/m/p/Main.java
+++ b/test/jdk/java/nio/file/spi/m/p/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class Main {
             throw new RuntimeException("FileSystemProvider not overridden");
 
         // exercise the file system
-        Path dir = Files.createTempDirectory("tmp");
+        Path dir = Files.createTempDirectory(Path.of(""), "tmp");
         if (dir.getFileSystem() != fs)
             throw new RuntimeException("'dir' not in default file system");
         System.out.println("created: " + dir);


### PR DESCRIPTION
Backport of small test improvement. Trivial resolve - copyright year and file name were different. the file was moved in another change from test/jdk/java/nio/file/spi/m/p/Main.java to test/jdk/java/nio/file/spi/testapp/testapp/Main.java


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8382018](https://bugs.openjdk.org/browse/JDK-8382018) needs maintainer approval

### Issue
 * [JDK-8382018](https://bugs.openjdk.org/browse/JDK-8382018): test/jdk/java/nio/file/spi/SetDefaultProvider.java leaves a directory in /tmp (**Enhancement** - P5 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2851/head:pull/2851` \
`$ git checkout pull/2851`

Update a local copy of the PR: \
`$ git checkout pull/2851` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2851`

View PR using the GUI difftool: \
`$ git pr show -t 2851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2851.diff">https://git.openjdk.org/jdk21u-dev/pull/2851.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2851#issuecomment-4251734326)
</details>
