### PR TITLE
8370489: Some compiler tests miss the @key randomness

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMinMaxSubword.java
@@ -31,6 +31,7 @@ import java.util.Random;
 /*
  * @test
  * @bug 8294816
+ * @key randomness
  * @summary Test Math.min/max vectorization miscompilation for integer subwords
  * @library /test/lib /
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestMulNodeIdealization.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestMulNodeIdealization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8291336
+ * @key randomness
  * @summary Test that transformation of multiply-by-2 is appropriately turned into additions.
  * @library /test/lib /
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 /*
  * @test
  * @bug 8277850 8278949 8285793
+ * @key randomness
  * @summary C2: optimize mask checks in counted loops
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestShiftAndMask

--- a/test/hotspot/jtreg/compiler/loopopts/superword/MinMaxRed_Int.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/MinMaxRed_Int.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8302673
+ * @key randomness
  * @summary [SuperWord] MaxReduction and MinReduction should vectorize for int
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.MinMaxRed_Int

--- a/test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8074981 8302652
+ * @key randomness
  * @summary Test SuperWord Reduction Perf.
  * @library /test/lib /
  * @run main/othervm -Xbatch

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -158,6 +158,7 @@
 /*
  * @test id=sse4-v004-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -168,8 +169,8 @@
 
 /*
  * @test id=sse4-v004-U
- * @key randomness
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -204,8 +205,8 @@
 
 /*
  * @test id=avx1-v032-A
- * @key randomness
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -158,7 +158,6 @@
 /*
  * @test id=sse4-v004-A
  * @bug 8298935 8310308 8312570
- * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
@@ -92,6 +92,7 @@
 /*
  * @test id=vanilla-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestDependencyOffsets vanilla-A
@@ -100,6 +101,7 @@
 /*
  * @test id=vanilla-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestDependencyOffsets vanilla-U
@@ -108,6 +110,7 @@
 /*
  * @test id=sse4-v016-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -119,6 +122,7 @@
 /*
  * @test id=sse4-v016-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -130,6 +134,7 @@
 /*
  * @test id=sse4-v008-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -141,6 +146,7 @@
 /*
  * @test id=sse4-v008-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -162,6 +168,7 @@
 
 /*
  * @test id=sse4-v004-U
+ * @key randomness
  * @bug 8298935 8310308 8312570
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
@@ -174,6 +181,7 @@
 /*
  * @test id=sse4-v002-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -185,6 +193,7 @@
 /*
  * @test id=sse4-v002-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -195,6 +204,7 @@
 
 /*
  * @test id=avx1-v032-A
+ * @key randomness
  * @bug 8298935 8310308 8312570
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
@@ -207,6 +217,7 @@
 /*
  * @test id=avx1-v032-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -218,6 +229,7 @@
 /*
  * @test id=avx1-v016-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -229,6 +241,7 @@
 /*
  * @test id=avx1-v016-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -240,6 +253,7 @@
 /*
  * @test id=avx2-v032-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -251,6 +265,7 @@
 /*
  * @test id=avx2-v032-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -262,6 +277,7 @@
 /*
  * @test id=avx2-v016-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -273,6 +289,7 @@
 /*
  * @test id=avx2-v016-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -284,6 +301,7 @@
 /*
  * @test id=avx512-v064-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -295,6 +313,7 @@
 /*
  * @test id=avx512-v064-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -306,6 +325,7 @@
 /*
  * @test id=avx512-v032-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -317,6 +337,7 @@
 /*
  * @test id=avx512-v032-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -328,6 +349,7 @@
 /*
  * @test id=avx512bw-v064-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -339,6 +361,7 @@
 /*
  * @test id=avx512bw-v064-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -350,6 +373,7 @@
 /*
  * @test id=avx512bw-v032-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -361,6 +385,7 @@
 /*
  * @test id=avx512bw-v032-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64")
@@ -372,6 +397,7 @@
 /*
  * @test id=vec-v064-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -382,6 +408,7 @@
 /*
  * @test id=vec-v064-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -392,6 +419,7 @@
 /*
  * @test id=vec-v032-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -402,6 +430,7 @@
 /*
  * @test id=vec-v032-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -412,6 +441,7 @@
 /*
  * @test id=vec-v016-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -422,6 +452,7 @@
 /*
  * @test id=vec-v016-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -432,6 +463,7 @@
 /*
  * @test id=vec-v008-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -442,6 +474,7 @@
 /*
  * @test id=vec-v008-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -452,6 +485,7 @@
 /*
  * @test id=vec-v004-A
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")
@@ -462,6 +496,7 @@
 /*
  * @test id=vec-v004-U
  * @bug 8298935 8310308 8312570
+ * @key randomness
  * @summary Test SuperWord: vector size, offsets, dependencies, alignment.
  * @requires vm.compiler2.enabled
  * @requires (os.arch!="x86" & os.arch!="i386" & os.arch!="amd64" & os.arch!="x86_64")

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegment.java
@@ -34,6 +34,7 @@ import java.lang.foreign.*;
 /*
  * @test id=byte-array
  * @bug 8329273
+ * @key randomness
  * @summary Test vectorization of loops over MemorySegment
  * @library /test/lib /
  * @compile --enable-preview -source ${jdk.version} TestMemorySegment.java

--- a/test/hotspot/jtreg/compiler/vectorapi/Test8278948.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/Test8278948.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8278948
+ * @key randomness
  * @summary Intermediate integer promotion vector length encoding is calculated incorrectly on x86
  * @modules jdk.incubator.vector
  * @library /test/lib

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorCompressExpandBits.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorCompressExpandBits.java
@@ -38,6 +38,7 @@ import jdk.test.lib.Utils;
 /**
  * @test
  * @bug 8301012
+ * @key randomness
  * @library /test/lib /
  * @requires os.arch == "aarch64" & vm.cpu.features ~= ".*sve2.*" & vm.cpu.features ~= ".*svebitperm.*"
  * @summary [vectorapi]: Intrinsify CompressBitsV/ExpandBitsV and add the AArch64 SVE backend implementation

--- a/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestAutoVecIntMinMax.java
@@ -30,6 +30,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8288107
+ * @key randomness
  * @summary Auto-vectorization enhancement for integer Math.max/Math.min operations
  * @library /test/lib /
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/vectorization/TestEor3AArch64.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestEor3AArch64.java
@@ -33,6 +33,7 @@ import jdk.test.lib.Utils;
 /*
  * @test
  * @bug 8293488
+ * @key randomness
  * @summary Test EOR3 Neon/SVE2 instruction for aarch64 SHA3 extension
  * @library /test/lib /
  * @requires os.arch == "aarch64"

--- a/test/hotspot/jtreg/compiler/vectorization/TestMacroLogicVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestMacroLogicVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8241040
+ * @key randomness
  * @library /test/lib
  *
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorZeroCount.java
@@ -21,19 +21,19 @@
  * questions.
  */
 
+package compiler.vectorization;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
 /* @test
  * @bug 8349637
+ * @key randomness
  * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @summary Ensure that vectorization of numberOfLeadingZeros and numberOfTrailingZeros outputs correct values
  * @library /test/lib /
  * @run main/othervm compiler.vectorization.TestVectorZeroCount
  */
-
-package compiler.vectorization;
-
-import java.util.Random;
-
-import jdk.test.lib.Utils;
 
 public class TestVectorZeroCount {
     private static final int SIZE = 1024;


### PR DESCRIPTION
I backport this for parity with 21.0.12-oracle based on the change in 25.

Many tests are not in 21:

test/hotspot/jtreg/compiler/c2/TestMergeStores.java
  https://bugs.openjdk.org/browse/JDK-8318446: C2: optimize stores into primitive arrays by combining values into larger store
test/hotspot/jtreg/compiler/c2/TestMergeStoresMemorySegment.java
  https://bugs.openjdk.org/browse/JDK-8335392: C2 MergeStores: enhanced pointer parsing
test/hotspot/jtreg/compiler/c2/irTests/ModDNodeTests.java
test/hotspot/jtreg/compiler/c2/irTests/ModFNodeTests.java
  Both https://bugs.openjdk.org/browse/JDK-8345766: C2 should emit macro nodes for ModF/ModD instead of calls during parsing
test/hotspot/jtreg/compiler/c2/irTests/ModINodeIdealizationTests.java
test/hotspot/jtreg/compiler/c2/irTests/ModLNodeIdealizationTests.java
test/hotspot/jtreg/compiler/c2/irTests/UDivINodeIdealizationTests.java
test/hotspot/jtreg/compiler/c2/irTests/UDivLNodeIdealizationTests.java
test/hotspot/jtreg/compiler/c2/irTests/UModINodeIdealizationTests.java
test/hotspot/jtreg/compiler/c2/irTests/UModLNodeIdealizationTests.java
  All six: https://bugs.openjdk.org/browse/JDK-8332268: C2: Add missing optimizations for UDivI/L and UModI/L and unify the shared logic with the signed nodes
test/hotspot/jtreg/compiler/controldependency/TestDivDependentOnMainLoopGuard.java
  https://bugs.openjdk.org/browse/JDK-8349139: C2: Div looses dependency on condition that guarantees divisor not zero in counted loop
test/hotspot/jtreg/compiler/igvn/ExpressionFuzzer.java
  https://bugs.openjdk.org/browse/JDK-8359412: Template-Framework Library: Operations and Expressions
test/hotspot/jtreg/compiler/intrinsics/float16/TestFloat16MaxMinSpecialValues.java
  https://bugs.openjdk.org/browse/JDK-8352585: Add special case handling for Float16.max/min x86 backend
test/hotspot/jtreg/compiler/loopopts/InvariantCodeMotionReassociateAddSub.java
test/hotspot/jtreg/compiler/loopopts/InvariantCodeMotionReassociateCmp.java
  Both https://bugs.openjdk.org/browse/JDK-8323220: Reassociate loop invariants involved in Cmps and Add/Subs
test/hotspot/jtreg/compiler/loopopts/parallel_iv/TestParallelIvInIntCountedLoop.java
  https://bugs.openjdk.org/browse/JDK-8328528: C2 should optimize long-typed parallel iv in an int counted loop
test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVector.java
  https://bugs.openjdk.org/browse/JDK-8310190: C2 SuperWord: AlignVector is broken, generates misaligned packs
  Sounds like a bugfix that could make sense to backport as prereq, but it is large and requires quite some rework, so the risk is too big.
test/hotspot/jtreg/compiler/loopopts/superword/TestCompatibleUseDefTypeSize.java
  https://bugs.openjdk.org/browse/JDK-8325155: C2 SuperWord: remove alignment boundaries
test/hotspot/jtreg/compiler/loopopts/superword/TestEquivalentInvariants.java
  https://bugs.openjdk.org/browse/JDK-8343685: C2 SuperWord: refactor VPointer with MemPointer
test/hotspot/jtreg/compiler/loopopts/superword/TestMemorySegmentUnalignedAddress.java
  https://bugs.openjdk.org/browse/JDK-8323582: C2 SuperWord AlignVector: misaligned vector memory access with unaligned native memory
test/hotspot/jtreg/compiler/loopopts/superword/TestSplitPacks.java
  https://bugs.openjdk.org/browse/JDK-8326139: C2 SuperWord: split packs (match use/def packs, implemented, mutual independence)
test/hotspot/jtreg/compiler/vectorapi/TestVectorAddMulReduction.java
  https://bugs.openjdk.org/browse/JDK-8320725: AArch64: C2: Add "requires_strict_order" flag for floating-point add and mul reduction
test/hotspot/jtreg/compiler/vectorapi/VectorMultiplyOpt.java
  https://bugs.openjdk.org/browse/JDK-8341137: Optimize long vector multiplication using x86 VPMUL[U]DQ instruction
test/hotspot/jtreg/compiler/vectorapi/VectorSaturatedOperationsTest.java
  https://bugs.openjdk.org/browse/JDK-8342677: Add IR validation tests for newly added saturated vector add / sub operations
  Test only, but backport pointless as tested feature not in 21.

In addition, I had to resolve three tests:

test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
Trivial resolve due to Context as https://bugs.openjdk.org/browse/JDK-8346664: "C2: Optimize mask check with constant offset" is not in 21.

test/hotspot/jtreg/compiler/loopopts/superword/ReductionPerf.java
Copyright.

test/hotspot/jtreg/compiler/loopopts/superword/TestDependencyOffsets.java
Trivial & tedious resolve.  21 has two extra tests, I added the key there, too. 21 is several changes behind 25 here.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8370489](https://bugs.openjdk.org/browse/JDK-8370489) needs maintainer approval

### Issue
 * [JDK-8370489](https://bugs.openjdk.org/browse/JDK-8370489): Some compiler tests miss the @<!---->key randomness (**Bug** - P5 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2855/head:pull/2855` \
`$ git checkout pull/2855`

Update a local copy of the PR: \
`$ git checkout pull/2855` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2855`

View PR using the GUI difftool: \
`$ git pr show -t 2855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2855.diff">https://git.openjdk.org/jdk21u-dev/pull/2855.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2855#issuecomment-4259452030)
</details>
