### PR TITLE
8340987: Open some TextArea awt tests 1

### DIFF
--- a/test/jdk/java/awt/TextArea/TextAreaAppendScrollTest2.java
+++ b/test/jdk/java/awt/TextArea/TextAreaAppendScrollTest2.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 6192116
+ * @summary Auto-scrolling does not work properly for TextArea when appending some text, on XToolkit
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaAppendScrollTest2
+ */
+
+public class TextAreaAppendScrollTest2 extends Frame {
+    TextArea area;
+    private static final String INSTRUCTIONS = """
+            Press pass if you see exclamation marks in the bottom of textarea.
+            Press fail if you don't.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaAppendScrollTest2")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(TextAreaAppendScrollTest2::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public TextAreaAppendScrollTest2() {
+        setLayout(new BorderLayout());
+        area = new TextArea("AWT is cool ", 3, 3, TextArea.SCROLLBARS_NONE);
+        add("Center", area);
+        setSize(200, 200);
+        StringBuilder coolStr = new StringBuilder("");
+        // I count 15 lines with 12 cools per line
+        for (int i = 0; i < 12 * 15; i++) {
+            coolStr.append("cool ");
+        }
+        coolStr.append("!!!!!!!");
+        area.append(coolStr.toString());
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaAppendTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaAppendTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 4118915
+ * @summary Test appending to a TextArea after the peer is created
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaAppendTest
+ */
+
+public class TextAreaAppendTest {
+    private static final String INSTRUCTIONS = """
+            If all four lines are visible in TextArea, the test passed.
+            If the last two lines have only one character visible, the test failed.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaAppendTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(TextAreaAppendTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame f = new Frame("TextAreaAppendTest");
+        TextArea ta = new TextArea();
+        f.add(ta);
+        ta.append("line 1 (added before drawing)\n");
+        ta.append("line 2 (added before drawing)\n");
+
+        f.pack();
+        f.show();
+
+        ta.append("line 3 (added after drawing)\n");
+        ta.append("line 4 (added after drawing)\n");
+
+        return f;
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaCRLFAutoDetectManualTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaCRLFAutoDetectManualTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4800187
+ * @summary REGRESSION:show the wrong selection when there are \r characters in the text
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaCRLFAutoDetectManualTest
+ */
+
+public class TextAreaCRLFAutoDetectManualTest {
+    static int flag = 1;
+
+    private static final String INSTRUCTIONS = """
+                Please click the button several times.
+                If you see the text '679' selected on the left TextArea
+                and the same text on the right TextArea
+                each time you press the button,
+                the test passed, else failed.
+                """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaCRLFAutoDetectManualTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(TextAreaCRLFAutoDetectManualTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame f = new Frame("TextAreaCRLFAutoDetectManualTest");
+
+        TextArea ta1 = new TextArea(5, 20);
+        TextArea ta2 = new TextArea(5, 20);
+
+        TextField tf1 = new TextField("123", 20);
+        TextField tf2 = new TextField("567", 20);
+        TextField tf3 = new TextField("90", 20);
+
+        Button b = new Button("Click Me Several Times");
+
+        b.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                ta1.setText("");
+                ta2.setText("");
+                flag++;
+                String eoln = ((flag % 2) != 0) ? "\r\n" : "\n";
+                ta1.setText(eoln + tf1.getText() + eoln + tf2.getText() + eoln + tf3.getText() + eoln);
+                ta1.select(6, 10);
+                ta2.setText(ta1.getSelectedText());
+                ta1.requestFocus();
+            }
+        });
+
+        f.setLayout(new FlowLayout());
+
+        Panel tfpanel = new Panel();
+        tfpanel.setLayout(new GridLayout(3, 1));
+        tfpanel.add(tf1);
+        tfpanel.add(tf2);
+        tfpanel.add(tf3);
+        f.add(tfpanel);
+
+        f.add(ta1);
+        f.add(ta2);
+        f.add(b);
+
+        f.pack();
+        return f;
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaLimit.java
+++ b/test/jdk/java/awt/TextArea/TextAreaLimit.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 4341196
+ * @summary Tests that TextArea can handle more than 64K of text
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaLimit
+ */
+
+public class TextAreaLimit extends Frame {
+    static TextArea text;
+    private static final String INSTRUCTIONS = """
+            You will see a text area with 40000 lines of text
+            each with its own line number. If you see the caret after line 39999
+            then test passes. Otherwise it fails.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaLimit")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(TextAreaLimit::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public TextAreaLimit() {
+        setLayout(new BorderLayout());
+
+        text = new TextArea();
+        add(text);
+        StringBuffer buf = new StringBuffer();
+        for (int i = 0; i < 40000; i++) {
+            buf.append(i + "\n");
+        }
+        text.setText(buf.toString());
+        text.setCaretPosition(buf.length());
+        text.requestFocus();
+        setSize(200, 200);
+    }
+}


### PR DESCRIPTION
Backporting JDK-8340987: Open some TextArea awt tests 1.

This PR introduces new AWT TextArea related tests.

For parity with Oracle JDK.

Ran related tests on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaAppendScrollTest2.java```

Screenshot:

<img width="780" height="438" alt="Screenshot 2026-04-16 at 9 58 35 AM" src="https://github.com/user-attachments/assets/18b9225f-0b41-45b4-8780-0539aae96d70" />

Results:

```test result: Passed. Execution successful```

[TextAreaAppendScrollTest2.jtr.txt](https://github.com/user-attachments/files/26794168/TextAreaAppendScrollTest2.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaAppendTest.java```

Screenshot:

<img width="1103" height="322" alt="Screenshot 2026-04-16 at 10 00 53 AM" src="https://github.com/user-attachments/assets/af512f14-4fef-493b-9ee5-f1356863b10a" />

Results:

```test result: Passed. Execution successful```

[TextAreaAppendTest.jtr.txt](https://github.com/user-attachments/files/26794284/TextAreaAppendTest.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaCRLFAutoDetectManualTest.java```

Screenshot:

<img width="786" height="458" alt="Screenshot 2026-04-16 at 10 06 22 AM" src="https://github.com/user-attachments/assets/4e3837b3-5f5d-41fd-985a-7f38f08067e6" />

Results:

```test result: Passed. Execution successful```

[TextAreaCRLFAutoDetectManualTest.jtr.txt](https://github.com/user-attachments/files/26794392/TextAreaCRLFAutoDetectManualTest.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaLimit.java```

Screenshot:

<img width="755" height="261" alt="Screenshot 2026-04-16 at 10 08 34 AM" src="https://github.com/user-attachments/assets/471be104-e158-43e0-9068-823ecacc7f83" />

Results:

```test result: Passed. Execution successful```

[TextAreaLimit.jtr.txt](https://github.com/user-attachments/files/26794422/TextAreaLimit.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340987](https://bugs.openjdk.org/browse/JDK-8340987) needs maintainer approval

### Issue
 * [JDK-8340987](https://bugs.openjdk.org/browse/JDK-8340987): Open some TextArea awt tests 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2860/head:pull/2860` \
`$ git checkout pull/2860`

Update a local copy of the PR: \
`$ git checkout pull/2860` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2860`

View PR using the GUI difftool: \
`$ git pr show -t 2860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2860.diff">https://git.openjdk.org/jdk21u-dev/pull/2860.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2860#issuecomment-4262052220)
</details>
