### PR TITLE
8341055: Open some TextArea awt tests 2

### DIFF
--- a/test/jdk/java/awt/TextArea/TextAreaHScrollbarTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaHScrollbarTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 4648702
+ * @summary TextArea horizontal scrollbar behavior is incorrect
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaHScrollbarTest
+ */
+
+public class TextAreaHScrollbarTest {
+    private static final String INSTRUCTIONS = """
+                Please look at the frame.
+                If the vertical and horizontal scrollbars are visible
+                the test passed else failed.
+                """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaHScrollbarTest")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(TextAreaHScrollbarTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame test = new Frame();
+        test.add(new TextArea("TextAreaHScrollbarTest", 5, 60,
+                TextArea.SCROLLBARS_BOTH));
+        test.setSize(200, 100);
+        return test;
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaLineScrollWrapTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaLineScrollWrapTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 4776535
+ * @summary Regression: line should not wrap around into multi lines in TextArea.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaLineScrollWrapTest
+ */
+
+public class TextAreaLineScrollWrapTest {
+    private static final String INSTRUCTIONS = """
+            You should see a frame "TextAreaLineScrollWrapTest" with
+            a TextArea that contains a very long line.
+            If the line is wrapped the test is failed.
+
+            Insert a lot of text lines and move a caret to the last one.
+            If a caret hides and a content of the TextArea
+            does not scroll the test is failed
+            else the test is passed.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaLineScrollWrapTest")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(TextAreaLineScrollWrapTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame f = new Frame("TextAreaLineScrollWrapTest");
+        f.add(new TextArea("long long long long long long long line...........",
+                3, 4));
+        f.setSize(100, 100);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaScrollbarTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaScrollbarTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 4158997
+ * @key headful
+ * @summary Make sure that the TextArea has both horizontal and
+ * vertical scrollbars when bad scrollbar arguments are passed
+ * into the constructor.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextAreaScrollbarTest
+ */
+
+public class TextAreaScrollbarTest {
+    private static final String INSTRUCTIONS = """
+            Check to see that each TextArea has the specified
+            number and placement of scrollbars, i.e., both scrollbars,
+            horizontal only, vertical only, or no scrollbars at all.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextAreaScrollbarTest")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(TestFrame::new)
+                .build()
+                .awaitAndCheck();
+    }
+}
+
+class TestFrame extends Frame {
+    private String both = "Both Scrollbars  Both Scrollbars  Both Scrollbars\n";
+    private String horiz = "Horizontal Scrollbar Only  Horizontal Scrollbar Only\n";
+    private String vert = "Vertical Scrollbar Only  Vertical Scrollbar Only\n";
+    private String none = "No Scrollbars  No Scrollbars  No Scrollbars  No Scrollbars\n";
+
+    public TestFrame() {
+        super("Test frame");
+
+        // sets a GridLayout w/ 2 columns and an unspecified # of rows
+        setLayout(new GridLayout(0, 2, 15, 5));
+
+        TextArea t1 = new TextArea(both + both + both + both + both + both, 3, 8, 0);
+        add(new Label("TA should have both scrollbars: arg = 0"));
+        add(t1);
+
+        TextArea t2 = new TextArea(both + both + both + both + both + both, 3, 8, -1);
+        add(new Label("TA should have both scrollbars: arg = -1"));
+        add(t2);
+
+        TextArea t3 = new TextArea(both + both + both + both + both + both, 3, 8, 4);
+        add(new Label("TA should have both scrollbars: arg = 4"));
+        add(t3);
+
+        TextArea t4 = new TextArea(horiz + horiz + horiz + horiz + horiz + horiz, 3, 8, 2);
+        add(new Label("TA should have horizontal scrollbar: arg = 2"));
+        add(t4);
+
+        TextArea t5 = new TextArea(vert + vert + vert + vert + vert + vert, 3, 8, 1);
+        add(new Label("TA should have vertical scrollbar: arg = 1"));
+        add(t5);
+
+        TextArea t6 = new TextArea(none + none + none + none + none + none, 3, 8, 3);
+        add(new Label("TA should have no scrollbars: arg = 3"));
+        add(t6);
+
+        TextArea t7 = new TextArea();
+        t7.setText(both + both + both + both + both + both);
+        add(new Label("Both scrollbars: TextArea()"));
+        add(t7);
+
+        TextArea t8 = new TextArea(both + both + both + both + both + both);
+        add(new Label("Both scrollbars: TextArea(String text)"));
+        add(t8);
+
+        TextArea t9 = new TextArea(3, 8);
+        t9.setText(both + both + both + both + both + both);
+        add(new Label("Both scrollbars: TextArea(int rows, int columns)"));
+        add(t9);
+
+        TextArea t10 = new TextArea(both + both + both + both + both + both, 3, 8);
+        add(new Label("Both scrollbars: TextArea(text, rows, columns)"));
+        add(t10);
+
+        setSize(600, 600);
+    }
+}
+

--- a/test/jdk/java/awt/TextArea/TextScrollTest.java
+++ b/test/jdk/java/awt/TextArea/TextScrollTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 4127272
+ * @summary TextArea displays head of text when scrolling horizontal bar.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TextScrollTest
+ */
+
+public class TextScrollTest extends Frame {
+    private static final String INSTRUCTIONS = """
+            1. A TextArea whose content starts with the text ",
+               'Scroll till the' will appear on the applet ",
+            2. Use the Horizontal thumb button of the TextArea to view the entire",
+               content of the TextArea",
+            3. While scrolling, if the text 'Scroll till the' appears repeatedly, Click Fail  ",
+               else Click Pass"
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("TextScrollTest")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(TextScrollTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public TextScrollTest() {
+        this.setLayout(new BorderLayout());
+
+        Panel p = new Panel();
+        TextArea ta = new TextArea("Scroll till the right end of the " +
+                "TextArea is reached. Action Done?\n", 10, 20);
+
+        p.add(ta);
+        add("Center", p);
+        setSize(200, 200);
+    }
+}


### PR DESCRIPTION
Backporting JDK-8341055: Open some TextArea awt tests 2.

This PR introduces new AWT TextArea related tests.

For parity with Oracle JDK.

Ran related tests on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaHScrollbarTest.java```

Screenshot:

<img width="757" height="242" alt="Screenshot 2026-04-16 at 9 28 53 AM" src="https://github.com/user-attachments/assets/fe060e84-0f01-4785-aefd-04632a7a6a86" />

Results:

```test result: Passed. Execution successful```

[TextAreaHScrollbarTest.jtr.txt](https://github.com/user-attachments/files/26793102/TextAreaHScrollbarTest.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaLineScrollWrapTest.java```

Screenshot:

<img width="663" height="306" alt="Screenshot 2026-04-16 at 9 32 22 AM" src="https://github.com/user-attachments/assets/8c1fa023-767e-43c9-bff4-6717d095ec2f" />

Results:

```test result: Passed. Execution successful```

[TextAreaLineScrollWrapTest.jtr.txt](https://github.com/user-attachments/files/26793177/TextAreaLineScrollWrapTest.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextAreaScrollbarTest.java```

Screenshot:

<img width="1110" height="670" alt="Screenshot 2026-04-16 at 9 35 17 AM" src="https://github.com/user-attachments/assets/c6ae00fb-904c-4a95-bc01-3d82e1ef3fff" />

Results:

```test result: Passed. Execution successful```

[TextAreaScrollbarTest.jtr.txt](https://github.com/user-attachments/files/26793310/TextAreaScrollbarTest.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/TextScrollTest.java```

Screenshot:

<img width="780" height="279" alt="Screenshot 2026-04-16 at 9 38 08 AM" src="https://github.com/user-attachments/assets/bed17c57-7039-4e30-b0fc-81eccce3d92e" />

Results:

```test result: Passed. Execution successful```

[TextScrollTest.jtr.txt](https://github.com/user-attachments/files/26793389/TextScrollTest.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8341055](https://bugs.openjdk.org/browse/JDK-8341055) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341055](https://bugs.openjdk.org/browse/JDK-8341055): Open some TextArea awt tests 2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2861/head:pull/2861` \
`$ git checkout pull/2861`

Update a local copy of the PR: \
`$ git checkout pull/2861` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2861`

View PR using the GUI difftool: \
`$ git pr show -t 2861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2861.diff">https://git.openjdk.org/jdk21u-dev/pull/2861.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2861#issuecomment-4261859512)
</details>
