### PR TITLE
8341376: Open some TextArea awt tests 4

### DIFF
--- a/test/jdk/java/awt/TextArea/ScrollBarArrowScrollTest.java
+++ b/test/jdk/java/awt/TextArea/ScrollBarArrowScrollTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 6175401
+ * @summary Keeping the left arrow pressedon horiz scrollbar
+ *          does not scroll the text in TextArea, XToolkit
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollBarArrowScrollTest
+*/
+
+
+public class ScrollBarArrowScrollTest extends Frame {
+    private static final String INSTRUCTIONS = """
+                1) Make sure, that the TextArea component has focus.
+                2) Press 'END' key in order to keep cursor at the end
+                   of the text of the TextArea component.
+                3) Click on the left arrow on the horizontal scrollbar
+                   of the TextArea component and keep it pressed.
+                4) If the text just scrolls once and stops, the test failed.
+                   Otherwise, the test passed.
+                """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ScrollBarArrowScrollTest")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(ScrollBarArrowScrollTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public ScrollBarArrowScrollTest() {
+        TextArea textarea = new TextArea("Very very very long string !!!! ", 10, 3);
+        add(textarea);
+        pack();
+
+    }
+}

--- a/test/jdk/java/awt/TextArea/WordWrappingTest.java
+++ b/test/jdk/java/awt/TextArea/WordWrappingTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.TextArea;
+
+/*
+ * @test
+ * @bug 4992455
+ * @summary REGRESSION: TextArea does not wrap text in JDK 1.5 as JDK 1.4.x
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual WordWrappingTest
+*/
+
+public class WordWrappingTest {
+    private static final String INSTRUCTIONS = """
+                Please look at the frame 'WordWrappingTest'
+                It contains two TextAreas that have text 'This text should be wrapped.'
+                One of them has a vertical scrollbar only. Another has no
+                scrollbars at all.
+                If their text is not wrapped at word boundaries and you partially see
+                mentioned text, the test failed.
+                """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("WordWrappingTest")
+                .instructions(INSTRUCTIONS)
+                .testUI(WordWrappingTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame f = new Frame("WordWrappingTest");
+        f.setLayout(new FlowLayout());
+        f.add(new TextArea("This text should be wrapped.", 5, 10,
+                TextArea.SCROLLBARS_VERTICAL_ONLY));
+        f.add(new TextArea("This text should be wrapped.", 5, 10,
+                TextArea.SCROLLBARS_NONE));
+        f.pack();
+        return f;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8341376: Open some TextArea awt tests 4.

This PR introduces new AWT TextArea related tests.

For parity with Oracle JDK.

Ran related test on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/ScrollBarArrowScrollTest.java```

Screenshot:

<img width="665" height="300" alt="Screenshot 2026-04-16 at 9 13 34 AM" src="https://github.com/user-attachments/assets/b66789eb-defc-46e3-883f-c4b83af77d90" />

Results:

```test result: Passed. Execution successful```

[ScrollBarArrowScrollTest.jtr.txt](https://github.com/user-attachments/files/26792620/ScrollBarArrowScrollTest.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/TextArea/WordWrappingTest.java```

Screenshot:

<img width="805" height="278" alt="Screenshot 2026-04-16 at 9 15 42 AM" src="https://github.com/user-attachments/assets/8c8f2f06-197d-475d-8b7f-fbf6f20fff0d" />

Results:

```test result: Passed. Execution successful```

[WordWrappingTest.jtr.txt](https://github.com/user-attachments/files/26792672/WordWrappingTest.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341376](https://bugs.openjdk.org/browse/JDK-8341376) needs maintainer approval

### Issue
 * [JDK-8341376](https://bugs.openjdk.org/browse/JDK-8341376): Open some TextArea awt tests 4 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2863/head:pull/2863` \
`$ git checkout pull/2863`

Update a local copy of the PR: \
`$ git checkout pull/2863` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2863`

View PR using the GUI difftool: \
`$ git pr show -t 2863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2863.diff">https://git.openjdk.org/jdk21u-dev/pull/2863.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2863#issuecomment-4261703423)
</details>
