### PR TITLE
8347836: Disabled PopupMenu shows shortcuts on Mac

### DIFF
--- a/test/jdk/java/awt/PopupMenu/PopupMenuVisuals.java
+++ b/test/jdk/java/awt/PopupMenu/PopupMenuVisuals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,12 +20,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 6180413 6184485 6267144
  * @summary test for popup menu visual bugs in XAWT
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jdk.test.lib.Platform
  * @run main/manual PopupMenuVisuals
 */
 
@@ -40,16 +41,20 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 
+import jdk.test.lib.Platform;
+
 public class PopupMenuVisuals {
     private static final String INSTRUCTIONS = """
          This test should show a button 'Popup'.
          Click on the button. A popup menu should be shown.
          If following conditions are met:
-          - Menu is disabled
-          - Menu has caption 'Popup menu' (only applicable for linux)
-          - Menu items don't show shortcuts
+          - Menu is disabled %s%s
 
-         Click Pass else click Fail.""";
+         Click Pass else click Fail."""
+            .formatted(
+                    Platform.isLinux() ? "\n - Menu has caption 'Popup menu'" : "",
+                    !Platform.isOSX() ? "\n - Menu items don't show shortcuts" : ""
+            );
 
     static PopupMenu pm;
     static Frame frame;
@@ -58,7 +63,6 @@ public class PopupMenuVisuals {
         PassFailJFrame.builder()
                 .title("PopupMenu Instructions")
                 .instructions(INSTRUCTIONS)
-                .rows((int) INSTRUCTIONS.lines().count() + 2)
                 .columns(35)
                 .testUI(PopupMenuVisuals::createTestUI)
                 .build()
@@ -79,9 +83,9 @@ public class PopupMenuVisuals {
         CheckboxMenuItem mi3 = new CheckboxMenuItem("Item 3");
         Menu sm = new Menu("Submenu");
 
-        //Get things going.  Request focus, set size, et cetera
+        // Get things going.  Request focus, set size, et cetera
         frame = new Frame("PopupMenuVisuals");
-        frame.setSize (200,200);
+        frame.setSize(200, 200);
         frame.validate();
 
         frame.add(b);


### PR DESCRIPTION
Backporting JDK-8347836: Disabled PopupMenu shows shortcuts on Mac.

This PR fixes a false manual test failure on macOS by updating the verification steps. macOS natively shows shortcuts on disabled popup menu items.

For parity with Oracle JDK.

Ran related test on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/java/awt/PopupMenu/PopupMenuVisuals.java```

Screenshot:

<img width="732" height="290" alt="Screenshot 2026-04-17 at 7 25 50 AM" src="https://github.com/user-attachments/assets/ce0fc8a4-64b1-4744-a7fa-e9bb1e19bb73" />

Results:

```test result: Passed. Execution successful```

[PopupMenuVisuals.jtr.txt](https://github.com/user-attachments/files/26829432/PopupMenuVisuals.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8347836](https://bugs.openjdk.org/browse/JDK-8347836) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347836](https://bugs.openjdk.org/browse/JDK-8347836): Disabled PopupMenu shows shortcuts on Mac (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2868/head:pull/2868` \
`$ git checkout pull/2868`

Update a local copy of the PR: \
`$ git checkout pull/2868` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2868`

View PR using the GUI difftool: \
`$ git pr show -t 2868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2868.diff">https://git.openjdk.org/jdk21u-dev/pull/2868.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2868#issuecomment-4268990657)
</details>
