### PR TITLE
8380222: Refactor test/jdk/java/lang/Character TestNG tests to JUnit

### DIFF
--- a/test/jdk/java/lang/Character/Latin1CaseConversion.java
+++ b/test/jdk/java/lang/Character/Latin1CaseConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +21,16 @@
  * questions.
  */
 
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @test
  * @bug 8302877
  * @summary Provides exhaustive verification of Character.toUpperCase and Character.toLowerCase
  * for all code points in the latin1 range 0-255.
- * @run testng Latin1CaseConversion
+ * @run junit Latin1CaseConversion
  */
 public class Latin1CaseConversion {
 
@@ -44,41 +43,41 @@ public class Latin1CaseConversion {
             if (c < 0x41) { // Before A
                 assertUnchanged(upper, lower, c);
             } else if (c <= 0x5A) { // A-Z
-                assertEquals(upper, c);
-                assertEquals(lower, c + 32);
+                assertEquals(c, upper);
+                assertEquals(c + 32, lower);
             } else if (c < 0x61) { // Between Z and a
                 assertUnchanged(upper, lower, c);
             } else if (c <= 0x7A) { // a-z
-                assertEquals(upper, c - 32);
-                assertEquals(lower, c);
+                assertEquals(c - 32, upper);
+                assertEquals(c, lower);
             } else if (c < 0xB5) { // Between z and Micro Sign
                 assertUnchanged(upper, lower, c);
             } else if (c == 0xB5) { // Special case for Micro Sign
-                assertEquals(upper, 0x39C);
-                assertEquals(lower, c);
+                assertEquals(0x39C, upper);
+                assertEquals(c, lower);
             } else if (c < 0xC0) { // Between my and A-grave
                 assertUnchanged(upper, lower, c);
             } else if (c < 0xD7) { // A-grave - O with Diaeresis
-                assertEquals(upper, c);
-                assertEquals(lower, c + 32);
+                assertEquals(c, upper);
+                assertEquals(c + 32, lower);
             } else if (c == 0xD7) { // Multiplication
                 assertUnchanged(upper, lower, c);
             } else if (c <= 0xDE) { // O with slash - Thorn
-                assertEquals(upper, c);
-                assertEquals(lower, c + 32);
+                assertEquals(c, upper);
+                assertEquals(c + 32, lower);
             } else if (c == 0xDF) { // Sharp s
                 assertUnchanged(upper, lower, c);
             } else if (c < 0xF7) { // a-grave - divsion
-                assertEquals(upper, c - 32);
-                assertEquals(lower, c);
+                assertEquals(c - 32, upper);
+                assertEquals(c, lower);
             } else if (c == 0xF7) { // Division
                 assertUnchanged(upper, lower, c);
             } else if (c < 0xFF) { // o with slash - thorn
-                assertEquals(upper, c - 32);
-                assertEquals(lower, c);
+                assertEquals(c - 32, upper);
+                assertEquals(c, lower);
             } else if (c == 0XFF) { // Special case for y with Diaeresis
-                assertEquals(upper, 0x178);
-                assertEquals(lower, c);
+                assertEquals(0x178, upper);
+                assertEquals(c, lower);
             } else {
                 fail("Uncovered code point: " + Integer.toHexString(c));
             }
@@ -86,7 +85,7 @@ public class Latin1CaseConversion {
     }
 
     private static void assertUnchanged(int upper, int lower, int c) {
-        assertEquals(upper, c);
-        assertEquals(lower, c);
+        assertEquals(c, upper);
+        assertEquals(c, lower);
     }
 }

--- a/test/jdk/java/lang/Character/UnicodeBlock/NumberEntities.java
+++ b/test/jdk/java/lang/Character/UnicodeBlock/NumberEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,17 @@
  *      of Character.UnicodeBlock constants. Also checks the size of
  *      Character.UnicodeScript's "aliases" map.
  * @modules java.base/java.lang:open
- * @run testng NumberEntities
+ * @run junit NumberEntities
  */
-
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
 import java.util.Map;
 
-@Test
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class NumberEntities {
+    @Test
     public void test_UnicodeBlock_NumberEntities() throws Throwable {
         // The number of entries in Character.UnicodeBlock.map.
         // See src/java.base/share/classes/java/lang/Character.java
@@ -46,13 +46,14 @@ public class NumberEntities {
         Field m = Character.UnicodeBlock.class.getDeclaredField("map");
         n.setAccessible(true);
         m.setAccessible(true);
-        assertEquals(((Map)m.get(null)).size(), n.getInt(null));
+        assertEquals(n.getInt(null), ((Map)m.get(null)).size());
     }
+    @Test
     public void test_UnicodeScript_aliases() throws Throwable {
         // The number of entries in Character.UnicodeScript.aliases.
         // See src/java.base/share/classes/java/lang/Character.java
         Field aliases = Character.UnicodeScript.class.getDeclaredField("aliases");
         aliases.setAccessible(true);
-        assertEquals(((Map)aliases.get(null)).size(), Character.UnicodeScript.UNKNOWN.ordinal() + 1);
+        assertEquals(Character.UnicodeScript.UNKNOWN.ordinal() + 1, ((Map)aliases.get(null)).size());
     }
 }


### PR DESCRIPTION
Backporting JDK-8380222: Refactor test/jdk/java/lang/Character TestNG tests to JUnit.

This PR converts Character tests from TestNG to JUnit 5.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/lang/Character/Latin1CaseConversion.java
make test TEST=test/jdk/java/lang/Character/UnicodeBlock/NumberEntities.java

Results attached:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27054464/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27054465/windows-x64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27054466/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27054467/macos-aarch64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27054468/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27054469/linux-x64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27054470/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27054471/linux-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8380222](https://bugs.openjdk.org/browse/JDK-8380222) needs maintainer approval

### Issue
 * [JDK-8380222](https://bugs.openjdk.org/browse/JDK-8380222): Refactor test/jdk/java/lang/Character TestNG tests to JUnit (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2875/head:pull/2875` \
`$ git checkout pull/2875`

Update a local copy of the PR: \
`$ git checkout pull/2875` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2875`

View PR using the GUI difftool: \
`$ git pr show -t 2875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2875.diff">https://git.openjdk.org/jdk21u-dev/pull/2875.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2875#issuecomment-4306472137)
</details>
