### PR TITLE
8383185: [21u] Backport of JDK-8382925 causes test failure in SetDefaultProvider

### DIFF
--- a/test/jdk/java/nio/file/spi/fs.policy
+++ b/test/jdk/java/nio/file/spi/fs.policy
@@ -1,3 +1,3 @@
 grant codeBase "file:${test.classes}${/}-" {
-    permission java.io.FilePermission "${java.io.tmpdir}${/}-", "write";
+    permission java.io.FilePermission "${user.dir}${/}-", "write";
 };


### PR DESCRIPTION
The backport of [JDK-8382018](https://bugs.openjdk.org/browse/JDK-8382018) to JDK21 (done with [JDK-8382925](https://bugs.openjdk.org/browse/JDK-8382925)) causes a testfailure. 
The fs.policy has to be adjusted to the newly used temp directory because JDK21 still has a SecurityManager.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8383185](https://bugs.openjdk.org/browse/JDK-8383185) needs maintainer approval

### Issue
 * [JDK-8383185](https://bugs.openjdk.org/browse/JDK-8383185): [21u] Backport of JDK-8382925 causes test failure in SetDefaultProvider (**Bug** - P4 - Approved)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2876/head:pull/2876` \
`$ git checkout pull/2876`

Update a local copy of the PR: \
`$ git checkout pull/2876` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2876`

View PR using the GUI difftool: \
`$ git pr show -t 2876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2876.diff">https://git.openjdk.org/jdk21u-dev/pull/2876.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2876#issuecomment-4313625746)
</details>
