### PR TITLE
8373630: r18_tls should not be modified on Windows AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -301,7 +301,18 @@ static void restore_live_registers(StubAssembler* sasm, bool restore_fpu_registe
     __ add(sp, sp, 32 * wordSize);
   }
 
+#ifdef R18_RESERVED
+  /*
+  Do not modify r18_tls when restoring registers if it is a reserved register. On Windows,
+  for example, r18_tls is used to store the pointer to the current thread's TEB (where TLS
+  variables are stored). Therefore, modifying r18_tls would corrupt the TEB pointer.
+  */
+  __ pop(RegSet::range(r0, r17), sp);
+  __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r20, r29), sp);
+#else
   __ pop(RegSet::range(r0, r29), sp);
+#endif
 }
 
 static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_fpu_registers = true)  {
@@ -314,8 +325,20 @@ static void restore_live_registers_except_r0(StubAssembler* sasm, bool restore_f
     __ add(sp, sp, 32 * wordSize);
   }
 
+#ifdef R18_RESERVED
+  /*
+  Do not modify r18_tls when restoring registers if it is a reserved register. On Windows,
+  for example, r18_tls is used to store the pointer to the current thread's TEB (where TLS
+  variables are stored). Therefore, modifying r18_tls would corrupt the TEB pointer.
+  */
+  __ ldp(zr, r1, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r2, r17), sp);
+  __ ldp(zr, r19, Address(__ post(sp, 2 * wordSize)));
+  __ pop(RegSet::range(r20, r29), sp);
+#else
   __ ldp(zr, r1, Address(__ post(sp, 16)));
   __ pop(RegSet::range(r2, r29), sp);
+#endif
 }
 
 


### PR DESCRIPTION
Backport 84ee2e85d268dce4406ccad840baf28020753dbe from jdk25u with fix preventing r18 from being trashed.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8373630](https://bugs.openjdk.org/browse/JDK-8373630) needs maintainer approval

### Issue
 * [JDK-8373630](https://bugs.openjdk.org/browse/JDK-8373630): r18_tls should not be modified on Windows AArch64 (**Bug** - P1)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2877/head:pull/2877` \
`$ git checkout pull/2877`

Update a local copy of the PR: \
`$ git checkout pull/2877` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2877`

View PR using the GUI difftool: \
`$ git pr show -t 2877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2877.diff">https://git.openjdk.org/jdk21u-dev/pull/2877.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2877#issuecomment-4316256213)
</details>
