### PR TITLE
8342836: Automatically determine that a test in the docs test root is requested

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1293,9 +1293,13 @@ test-hotspot-jtreg-native: test-hotspot_native_sanity
 test-hotspot-gtest: exploded-test-gtest
 test-jdk-jtreg-native: test-jdk_native_sanity
 
+# Set dependencies for doc tests
+$(eval $(call AddTestDependency, docs_all, docs-jdk))
+test-docs: test-docs_all
+
 ALL_TARGETS += $(RUN_TEST_TARGETS) run-test exploded-run-test check \
     test-hotspot-jtreg test-hotspot-jtreg-native test-hotspot-gtest \
-    test-jdk-jtreg-native
+    test-jdk-jtreg-native test-docs
 
 ################################################################################
 ################################################################################

--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -132,6 +132,15 @@ define CleanModule
   $(call Clean-include, $1)
 endef
 
+define AddTestDependency
+  test-$(strip $1): $2
+
+  exploded-test-$(strip $1): $2
+
+  ifneq ($(filter $(TEST), $1), )
+    TEST_DEPS += $2
+  endif
+endef
 
 ################################################################################
 


### PR DESCRIPTION
I backport this to improve testing in 21.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8342836](https://bugs.openjdk.org/browse/JDK-8342836) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342836](https://bugs.openjdk.org/browse/JDK-8342836): Automatically determine that a test in the docs test root is requested (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2881/head:pull/2881` \
`$ git checkout pull/2881`

Update a local copy of the PR: \
`$ git checkout pull/2881` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2881`

View PR using the GUI difftool: \
`$ git pr show -t 2881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2881.diff">https://git.openjdk.org/jdk21u-dev/pull/2881.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2881#issuecomment-4333950384)
</details>
