### PR TITLE
8383630: Fix iteration in tests doing class redefinition

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/DefineClass.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/DefineClass.java
@@ -193,7 +193,7 @@ public class DefineClass {
 
     private static int getStringIndex(String needle, byte[] buf, int offset) {
         outer:
-        for (int i = offset; i < buf.length - offset - needle.length(); i++) {
+        for (int i = offset; i <= buf.length - needle.length(); i++) {
             for (int j = 0; j < needle.length(); j++) {
                 if (buf[i + j] != (byte)needle.charAt(j)) continue outer;
             }

--- a/test/hotspot/jtreg/runtime/vthread/RedefineClass.java
+++ b/test/hotspot/jtreg/runtime/vthread/RedefineClass.java
@@ -120,7 +120,7 @@ public class RedefineClass {
 
     private static int getStringIndex(String needle, byte[] buf, int offset) {
         outer:
-        for (int i = offset; i < buf.length - offset - needle.length(); i++) {
+        for (int i = offset; i <= buf.length - needle.length(); i++) {
             for (int j = 0; j < needle.length(); j++) {
                 if (buf[i + j] != (byte)needle.charAt(j)) continue outer;
             }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/ClassVersionAfterRedefine.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/ClassVersionAfterRedefine.java
@@ -54,7 +54,7 @@ public class ClassVersionAfterRedefine extends ClassLoader {
 
     private static int getStringIndex(String needle, byte[] buf, int offset) {
         outer:
-        for (int i = offset; i < buf.length - offset - needle.length(); i++) {
+        for (int i = offset; i < buf.length - needle.length(); i++) {
             for (int j = 0; j < needle.length(); j++) {
                 if (buf[i + j] != (byte)needle.charAt(j)) continue outer;
             }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/ClassVersionAfterRedefine.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/ClassVersionAfterRedefine.java
@@ -54,7 +54,7 @@ public class ClassVersionAfterRedefine extends ClassLoader {
 
     private static int getStringIndex(String needle, byte[] buf, int offset) {
         outer:
-        for (int i = offset; i < buf.length - offset - needle.length(); i++) {
+        for (int i = offset; i <= buf.length - needle.length(); i++) {
             for (int j = 0; j < needle.length(); j++) {
                 if (buf[i + j] != (byte)needle.charAt(j)) continue outer;
             }


### PR DESCRIPTION
The iteration in the test does not walk to the end of the buf.  The upper bound wrongly subtracts the offset, which is already considered in the initialization of the iteration variable.

[add on]
After Matthias' comment I turned the JBS issue into a change for head, and this into a backport.
The backport fixes the two tests that bear the error in head, and adds the third that only has the issue in 21.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8383630](https://bugs.openjdk.org/browse/JDK-8383630) needs maintainer approval

### Issue
 * [JDK-8383630](https://bugs.openjdk.org/browse/JDK-8383630): Fix iteration in tests doing class redefinition (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2884/head:pull/2884` \
`$ git checkout pull/2884`

Update a local copy of the PR: \
`$ git checkout pull/2884` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2884`

View PR using the GUI difftool: \
`$ git pr show -t 2884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2884.diff">https://git.openjdk.org/jdk21u-dev/pull/2884.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2884#issuecomment-4350210082)
</details>
