### PR TITLE
8377347: jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java intermittent OOME

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,8 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR & vm.gc.ZSinglegen
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
+ * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xmx32M
+ *                   jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
  */
 
 /**
@@ -44,7 +45,8 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR & vm.gc.ZGenerational
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
- * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M
+ *                   jdk.jfr.event.gc.detailed.TestZAllocationStallEvent
  */
 
 public class TestZAllocationStallEvent {
@@ -55,7 +57,7 @@ public class TestZAllocationStallEvent {
             recording.start();
 
             // Allocate many large objects quickly, to outrun the GC
-            for (int i = 0; i < 100; i++) {
+            for (int i = 0; i < 1000; i++) {
                 blackHole(new byte[16 * 1024 * 1024]);
             }
 


### PR DESCRIPTION
Needed full but trivial resolve.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8377347](https://bugs.openjdk.org/browse/JDK-8377347) needs maintainer approval

### Issue
 * [JDK-8377347](https://bugs.openjdk.org/browse/JDK-8377347): jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java intermittent OOME (**Bug** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2886/head:pull/2886` \
`$ git checkout pull/2886`

Update a local copy of the PR: \
`$ git checkout pull/2886` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2886`

View PR using the GUI difftool: \
`$ git pr show -t 2886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2886.diff">https://git.openjdk.org/jdk21u-dev/pull/2886.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2886#issuecomment-4351690072)
</details>
