### PR TITLE
8352431: java/net/httpclient/EmptyAuthenticate.java uses "localhost"

### DIFF
--- a/test/jdk/java/net/httpclient/EmptyAuthenticate.java
+++ b/test/jdk/java/net/httpclient/EmptyAuthenticate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,55 +24,120 @@
 /*
  * @test
  * @bug 8263899
- * @summary HttpClient throws NPE in AuthenticationFilter when parsing www-authenticate head
- *
- * @run main/othervm EmptyAuthenticate
+ * @summary Verifies that empty `WWW-Authenticate` header is correctly parsed
+ * @library /test/jdk/java/net/httpclient/lib
+ *          /test/lib
+ * @build jdk.httpclient.test.lib.common.HttpServerAdapters
+ *        jdk.test.lib.net.SimpleSSLContext
+ * @run junit EmptyAuthenticate
  */
-import com.sun.net.httpserver.HttpServer;
+
+import jdk.httpclient.test.lib.common.HttpServerAdapters;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestHandler;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestServer;
+import jdk.test.lib.net.SimpleSSLContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
 
-public class EmptyAuthenticate {
+import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-    public static void main(String[] args) throws IOException, URISyntaxException, InterruptedException {
-        int port = 0;
+class EmptyAuthenticate {
 
-        //start server:
-        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
-        port = server.getAddress().getPort();
-        server.createContext("/", exchange -> {
-            String response = "test body";
-            //this empty header will make the HttpClient throw NPE
-            exchange.getResponseHeaders().add("www-authenticate", "");
-            exchange.sendResponseHeaders(401, response.length());
-            OutputStream os = exchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
-        });
-        server.start();
+    private static final SSLContext SSL_CONTEXT = createSslContext();
 
-        HttpResponse<String> response = null;
-        //run client:
+    private static final String WWW_AUTH_HEADER_NAME = "WWW-Authenticate";
+
+    private static SSLContext createSslContext() {
         try {
-            HttpClient httpClient = HttpClient.newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder(new URI("http://localhost:" + port + "/")).GET().build();
-            //this line will throw NPE (wrapped by IOException) when parsing empty www-authenticate response header in AuthenticationFilter:
-            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            boolean ok = !response.headers().firstValue("WWW-Authenticate").isEmpty();
-            if (!ok) {
-                throw new RuntimeException("WWW-Authenicate missing");
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Test failed");
-        } finally {
-            server.stop(0);
+            return new SimpleSSLContext().get();
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
         }
     }
+
+    @ParameterizedTest
+    @MethodSource("args")
+    void test(Version version, boolean secure) throws Exception {
+        String handlerPath = "/%s/%s/".formatted(EmptyAuthenticate.class.getSimpleName(), version);
+        String uriPath = handlerPath + (secure ? 's' : 'c');
+        HttpTestServer server = createServer(version, secure, handlerPath);
+        try (HttpClient client = createClient(version, secure)) {
+            HttpRequest request = createRequest(server, secure, uriPath);
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            HttpHeaders responseHeaders = response.headers();
+            assertEquals(
+                    "",
+                    responseHeaders.firstValue(WWW_AUTH_HEADER_NAME).orElse(null),
+                    () -> "was expecting empty `%s` header in: %s".formatted(
+                            WWW_AUTH_HEADER_NAME, responseHeaders.map()));
+        } finally {
+            server.stop();
+        }
+    }
+
+    static Stream<Arguments> args() {
+        return Stream
+                .of(Version.HTTP_1_1, Version.HTTP_2)
+                .flatMap(version -> Stream
+                        .of(true, false)
+                        .map(secure -> Arguments.of(version, secure)));
+    }
+
+    private static HttpTestServer createServer(Version version, boolean secure, String uriPath)
+            throws IOException {
+        HttpTestServer server = secure
+                ? HttpTestServer.create(version, SSL_CONTEXT)
+                : HttpTestServer.create(version);
+        HttpTestHandler handler = new ServerHandlerRespondingWithEmptyWwwAuthHeader();
+        server.addHandler(handler, uriPath);
+        server.start();
+        return server;
+    }
+
+    private static final class ServerHandlerRespondingWithEmptyWwwAuthHeader implements HttpTestHandler {
+
+        private int responseIndex = 0;
+
+        @Override
+        public synchronized void handle(HttpServerAdapters.HttpTestExchange exchange) throws IOException {
+            try (exchange) {
+                exchange.getResponseHeaders().addHeader(WWW_AUTH_HEADER_NAME, "");
+                byte[] responseBodyBytes = "test body %d"
+                        .formatted(responseIndex)
+                        .getBytes(StandardCharsets.US_ASCII);
+                exchange.sendResponseHeaders(401, responseBodyBytes.length);
+                exchange.getResponseBody().write(responseBodyBytes);
+            } finally {
+                responseIndex++;
+            }
+        }
+
+    }
+
+    private static HttpClient createClient(Version version, boolean secure) {
+        HttpClient.Builder clientBuilder = HttpClient.newBuilder().version(version).proxy(NO_PROXY);
+        if (secure) {
+            clientBuilder.sslContext(SSL_CONTEXT);
+        }
+        return clientBuilder.build();
+    }
+
+    private static HttpRequest createRequest(HttpTestServer server, boolean secure, String uriPath) {
+        URI uri = URI.create("%s://%s%s".formatted(secure ? "https" : "http", server.serverAuthority(), uriPath));
+        return HttpRequest.newBuilder(uri).version(server.getVersion()).GET().build();
+    }
+
 }


### PR DESCRIPTION
Backporting JDK-8352431: java/net/httpclient/EmptyAuthenticate.java uses "localhost".

This PR re-implements the EmptyAuthenticate test to avoid host related issues and improve coverage.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/net/httpclient/EmptyAuthenticate.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27372120/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27372121/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27372122/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27372123/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352431](https://bugs.openjdk.org/browse/JDK-8352431) needs maintainer approval

### Issue
 * [JDK-8352431](https://bugs.openjdk.org/browse/JDK-8352431): java/net/httpclient/EmptyAuthenticate.java uses "localhost" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2889/head:pull/2889` \
`$ git checkout pull/2889`

Update a local copy of the PR: \
`$ git checkout pull/2889` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2889`

View PR using the GUI difftool: \
`$ git pr show -t 2889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2889.diff">https://git.openjdk.org/jdk21u-dev/pull/2889.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2889#issuecomment-4372825014)
</details>
