### PR TITLE
8383601: RISC-V: ShenandoahBarrierSetAssembler::load_reference_barrier calls "weak" on "phantom" path

### DIFF
--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -298,7 +298,7 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   } else {
     assert(is_phantom, "only remaining strength");
     assert(!is_narrow, "phantom access cannot be narrow");
-    target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak);
+    target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom);
   }
   __ call(target);
   __ mv(t0, x10);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [631d0e92](https://github.com/openjdk/jdk/commit/631d0e92f045b302ce24dbe54eb6a94767b09d14) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Aleksey Shipilev on 30 Apr 2026 and was reviewed by Fei Yang and Dingli Zhang.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8383601](https://bugs.openjdk.org/browse/JDK-8383601) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383601](https://bugs.openjdk.org/browse/JDK-8383601): RISC-V: ShenandoahBarrierSetAssembler::load_reference_barrier calls "weak" on "phantom" path (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2891/head:pull/2891` \
`$ git checkout pull/2891`

Update a local copy of the PR: \
`$ git checkout pull/2891` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2891`

View PR using the GUI difftool: \
`$ git pr show -t 2891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2891.diff">https://git.openjdk.org/jdk21u-dev/pull/2891.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2891#issuecomment-4377373507)
</details>
