### PR TITLE
8371967: Add Visual Studio 2026 to build toolchain for Windows

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -598,7 +598,7 @@ update.</p>
 (Note that this version is often presented as "MSVC 14.28", and reported
 by cl.exe as 19.28.) Older versions will not be accepted by
 <code>configure</code> and will not work. The maximum accepted version
-of Visual Studio is 2022.</p>
+of Visual Studio is 2026.</p>
 <p>If you have multiple versions of Visual Studio installed,
 <code>configure</code> will by default pick the latest. You can request
 a specific version to be used by setting

--- a/doc/building.md
+++ b/doc/building.md
@@ -386,10 +386,10 @@ available for this update.
 
 ### Microsoft Visual Studio
 
-The minimum accepted version is Visual Studio 2019 version 16.8. (Note that this
-version is often presented as "MSVC 14.28", and reported by cl.exe as 19.28.)
-Older versions will not be accepted by `configure` and will not work. The
-maximum accepted version of Visual Studio is 2022.
+The minimum accepted version is Visual Studio 2019 version 16.8. (Note that
+this version is often presented as "MSVC 14.28", and reported by cl.exe as
+19.28.) Older versions will not be accepted by `configure` and will not work.
+The maximum accepted version of Visual Studio is 2026.
 
 If you have multiple versions of Visual Studio installed, `configure` will by
 default pick the latest. You can request a specific version to be used by

--- a/doc/building.md
+++ b/doc/building.md
@@ -386,10 +386,10 @@ available for this update.
 
 ### Microsoft Visual Studio
 
-The minimum accepted version is Visual Studio 2019 version 16.8. (Note that
-this version is often presented as "MSVC 14.28", and reported by cl.exe as
-19.28.) Older versions will not be accepted by `configure` and will not work.
-The maximum accepted version of Visual Studio is 2026.
+The minimum accepted version is Visual Studio 2019 version 16.8. (Note that this
+version is often presented as "MSVC 14.28", and reported by cl.exe as 19.28.)
+Older versions will not be accepted by `configure` and will not work. The
+maximum accepted version of Visual Studio is 2026.
 
 If you have multiple versions of Visual Studio installed, `configure` will by
 default pick the latest. You can request a specific version to be used by

--- a/make/autoconf/toolchain_microsoft.m4
+++ b/make/autoconf/toolchain_microsoft.m4
@@ -25,7 +25,7 @@
 
 ################################################################################
 # The order of these defines the priority by which we try to find them.
-VALID_VS_VERSIONS="2022 2019"
+VALID_VS_VERSIONS="2022 2019 2026"
 
 VS_DESCRIPTION_2019="Microsoft Visual Studio 2019"
 VS_VERSION_INTERNAL_2019=142
@@ -56,6 +56,21 @@ VS_VS_PLATFORM_NAME_2022="v143"
 VS_SDK_PLATFORM_NAME_2022=
 VS_SUPPORTED_2022=true
 VS_TOOLSET_SUPPORTED_2022=true
+
+VS_DESCRIPTION_2026="Microsoft Visual Studio 2026"
+VS_VERSION_INTERNAL_2026=145
+VS_MSVCR_2026=vcruntime140.dll
+VS_VCRUNTIME_1_2026=vcruntime140_1.dll
+VS_MSVCP_2026=msvcp140.dll
+VS_ENVVAR_2026="VS180COMNTOOLS"
+VS_USE_UCRT_2026="true"
+VS_VS_INSTALLDIR_2026="Microsoft Visual Studio/18"
+VS_EDITIONS_2026="BuildTools Community Professional Enterprise"
+VS_SDK_INSTALLDIR_2026=
+VS_VS_PLATFORM_NAME_2026="v145"
+VS_SDK_PLATFORM_NAME_2026=
+VS_SUPPORTED_2026=true
+VS_TOOLSET_SUPPORTED_2026=true
 
 ################################################################################
 

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -262,6 +262,8 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 17.13 (VS2022)"
       #elif _MSC_VER == 1944
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 17.14 (VS2022)"
+      #elif _MSC_VER == 1950
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 18.0 (VS2026)"
       #else
         #define HOTSPOT_BUILD_COMPILER "unknown MS VC++:" XSTR(_MSC_VER)
       #endif


### PR DESCRIPTION
Clean backport. Only the VS 2026 references in `doc/building.md` were changed manually because of a different text format.

Problem this solves:
The build system currently rejects newer Visual Studio versions that we increasingly need to use:
1. Microsoft has stopped offering VS 2022 as the default download. New developer machines and build agents provisioned today install VS 2026 by default. Forcing developers/build infra to manually procure VS 2022 installers creates friction.
2. Compiler and toolchain fixes increasingly land in VS 2026 first. VS 2022 backports are delayed or skipped. As JDK 21 is an LTS release, it with current tooling becomes more important over time.

Risk assessment:
Low risk. The change is additive: it appends VS 2026 to the VALID_VS_VERSIONS list, so existing VS 2019/2022 builds are unaffected. I have validated the backport locally by configuring and building JDK 21 on Windows x64 with VS 2026 and running tier-1 tests (no regression).


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8371967](https://bugs.openjdk.org/browse/JDK-8371967) needs maintainer approval
- [x] [JDK-8373593](https://bugs.openjdk.org/browse/JDK-8373593) needs maintainer approval

### Issues
 * [JDK-8371967](https://bugs.openjdk.org/browse/JDK-8371967): Add Visual Studio 2026 to build toolchain for Windows (**Bug** - P4 - Approved)
 * [JDK-8373593](https://bugs.openjdk.org/browse/JDK-8373593): Support latest  VS2026 MSC_VER in abstract_vm_version.cpp (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2892/head:pull/2892` \
`$ git checkout pull/2892`

Update a local copy of the PR: \
`$ git checkout pull/2892` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2892`

View PR using the GUI difftool: \
`$ git pr show -t 2892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2892.diff">https://git.openjdk.org/jdk21u-dev/pull/2892.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2892#issuecomment-4387219138)
</details>
