### PR TITLE
8341436: containers/docker/TestJcmdWithSideCar.java takes needlessly long to run

### DIFF
--- a/test/hotspot/jtreg/containers/docker/EventGeneratorLoop.java
+++ b/test/hotspot/jtreg/containers/docker/EventGeneratorLoop.java
@@ -24,6 +24,8 @@ import jdk.jfr.Event;
 import jdk.jfr.Description;
 import jdk.jfr.Label;
 
+import java.util.concurrent.TimeUnit;
+
 
 // This class generates simple event in a loop for a specified time.
 public class EventGeneratorLoop {
@@ -44,16 +46,21 @@ public class EventGeneratorLoop {
             throw new IllegalArgumentException("Expecting one argument: time to run (seconds)");
         }
         int howLong = Integer.parseInt(args[0]);
+        long endTime = System.nanoTime() + TimeUnit.SECONDS.toNanos(howLong);
 
         System.out.println(MAIN_METHOD_STARTED + ", argument is " + howLong);
 
-        for (int i=0; i < howLong; i++) {
+        int count = 0;
+        while (System.nanoTime() < endTime) {
             SimpleEvent ev = new SimpleEvent();
             ev.msg = "Hello";
-            ev.count = i;
+            ev.count = count++;
             ev.commit();
 
-            try { Thread.sleep(1000); } catch (InterruptedException e) {}
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ignore) {
+            }
             System.out.print(".");
         }
 

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -49,10 +49,10 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import jdk.test.lib.Container;
 import jdk.test.lib.Platform;
@@ -68,7 +68,6 @@ public class TestJcmdWithSideCar {
     private static final String IMAGE_NAME = Common.imageName("jfr-jcmd");
     private static final int TIME_TO_RUN_MAIN_PROCESS = (int) (30 * Utils.TIMEOUT_FACTOR); // seconds
     private static final long TIME_TO_WAIT_FOR_MAIN_METHOD_START = 50 * 1000; // milliseconds
-    private static final String MAIN_CONTAINER_NAME = "test-container-main";
 
     private static final String UID = "uid";
     private static final String GID = "gid";
@@ -116,19 +115,19 @@ public class TestJcmdWithSideCar {
                         // Elevated attach via proc/root not yet supported.
                         continue;
                     }
-                    long mainProcPid = testCase01(attachStrategy, elevated);
+                    long mainProcPid = testCase01(mainContainer, attachStrategy, elevated);
 
                     // Excluding the test case below until JDK-8228850 is fixed
                     // JDK-8228850: jhsdb jinfo fails with ClassCastException:
                     // s.j.h.oops.TypeArray cannot be cast to s.j.h.oops.Instance
                     // mainContainer.assertIsAlive();
-                    // testCase02(mainProcPid, attachStrategy, elevated);
+                    // testCase02(mainContainer, mainProcPid, attachStrategy, elevated);
 
                     mainContainer.assertIsAlive();
-                    testCase03(mainProcPid, attachStrategy, elevated);
+                    testCase03(mainContainer, mainProcPid, attachStrategy, elevated);
                 }
 
-                mainContainer.waitForAndCheck(TIME_TO_RUN_MAIN_PROCESS * 1000);
+                mainContainer.stop();
             }
         } finally {
             DockerTestUtils.removeDockerImage(IMAGE_NAME);
@@ -137,8 +136,8 @@ public class TestJcmdWithSideCar {
 
 
     // Run "jcmd -l" in a sidecar container, find a target process.
-    private static long testCase01(AttachStrategy attachStrategy, boolean elevated) throws Exception {
-        OutputAnalyzer out = runSideCar(MAIN_CONTAINER_NAME, attachStrategy, elevated, "/jdk/bin/jcmd", "-l")
+    private static long testCase01(MainContainer mainContainer, AttachStrategy attachStrategy, boolean elevated) throws Exception {
+        OutputAnalyzer out = runSideCar(mainContainer, attachStrategy, elevated, "/jdk/bin/jcmd", "-l")
             .shouldHaveExitValue(0)
             .shouldContain("sun.tools.jcmd.JCmd");
         long pid = findProcess(out, "EventGeneratorLoop");
@@ -150,8 +149,8 @@ public class TestJcmdWithSideCar {
     }
 
     // run jhsdb jinfo <PID> (jhsdb uses PTRACE)
-    private static void testCase02(long pid, AttachStrategy attachStrategy, boolean elevated) throws Exception {
-        runSideCar(MAIN_CONTAINER_NAME, attachStrategy, elevated, "/jdk/bin/jhsdb", "jinfo", "--pid", "" + pid)
+    private static void testCase02(MainContainer mainContainer, long pid, AttachStrategy attachStrategy, boolean elevated) throws Exception {
+        runSideCar(mainContainer, attachStrategy, elevated, "/jdk/bin/jhsdb", "jinfo", "--pid", "" + pid)
             .shouldHaveExitValue(0)
             .shouldContain("Java System Properties")
             .shouldContain("VM Flags");
@@ -159,11 +158,11 @@ public class TestJcmdWithSideCar {
 
     // test jcmd with some commands (help, start JFR recording)
     // JCMD will use signal mechanism and Unix Socket
-    private static void testCase03(long pid, AttachStrategy attachStrategy, boolean elevated) throws Exception {
-        runSideCar(MAIN_CONTAINER_NAME, attachStrategy, elevated, "/jdk/bin/jcmd", "" + pid, "help")
+    private static void testCase03(MainContainer mainContainer, long pid, AttachStrategy attachStrategy, boolean elevated) throws Exception {
+        runSideCar(mainContainer, attachStrategy, elevated, "/jdk/bin/jcmd", "" + pid, "help")
             .shouldHaveExitValue(0)
             .shouldContain("VM.version");
-        runSideCar(MAIN_CONTAINER_NAME, attachStrategy, elevated, "/jdk/bin/jcmd", "" + pid, "JFR.start")
+        runSideCar(mainContainer, attachStrategy, elevated, "/jdk/bin/jcmd", "" + pid, "JFR.start")
             .shouldHaveExitValue(0)
             .shouldContain("Started recording");
     }
@@ -175,18 +174,18 @@ public class TestJcmdWithSideCar {
     // we have two options:
     // 1. mount /tmp from the main container using --volumes-from.
     // 2. access /tmp from the main container via /proc/<pid>/root/tmp.
-    private static OutputAnalyzer runSideCar(String mainContainerName, AttachStrategy attachStrategy, boolean elevated,  String whatToRun, String... args) throws Exception {
+    private static OutputAnalyzer runSideCar(MainContainer mainContainer, AttachStrategy attachStrategy, boolean elevated,  String whatToRun, String... args) throws Exception {
         System.out.println("Attach strategy " + attachStrategy);
 
         List<String> initialCommands = List.of(
             Container.ENGINE_COMMAND, "run",
             "--tty=true", "--rm",
             "--cap-add=SYS_PTRACE", "--sig-proxy=true",
-            "--pid=container:" + mainContainerName
+            "--pid=container:" + mainContainer.name()
         );
 
         List<String> attachStrategyCommands = switch (attachStrategy) {
-            case TMP_MOUNTED_INTO_SIDECAR -> List.of("--volumes-from", mainContainerName);
+            case TMP_MOUNTED_INTO_SIDECAR -> List.of("--volumes-from", mainContainer.name());
             case ACCESS_TMP_VIA_PROC_ROOT -> List.of();
         };
 
@@ -210,11 +209,11 @@ public class TestJcmdWithSideCar {
         List<String> l = out.asLines()
             .stream()
             .filter(s -> s.contains(name))
-            .collect(Collectors.toList());
+            .toList();
         if (l.isEmpty()) {
             return -1;
         }
-        String psInfo = l.get(0);
+        String psInfo = l.getFirst();
         System.out.println("findProcess(): psInfo: " + psInfo);
         String pid = psInfo.substring(0, psInfo.indexOf(' '));
         System.out.println("findProcess(): pid: " + pid);
@@ -237,6 +236,10 @@ public class TestJcmdWithSideCar {
 
 
     static class MainContainer {
+        private static final String MAIN_CONTAINER_NAME_PREFIX = "test-container-main";
+        private static final Random RANDOM = Utils.getRandomInstance();
+
+        String name;
         boolean mainMethodStarted;
         Process p;
 
@@ -256,8 +259,11 @@ public class TestJcmdWithSideCar {
                 opts.addDockerOpts(NET_BIND_SERVICE);
             }
 
+            name = MAIN_CONTAINER_NAME_PREFIX + "-elevated-" + elevated + "-" + RANDOM.nextInt();
+
             opts.addDockerOpts("--cap-add=SYS_PTRACE")
-                .addDockerOpts("--name", MAIN_CONTAINER_NAME)
+                .addDockerOpts("--init")
+                .addDockerOpts("--name", name)
                 .addDockerOpts("--volume", "/tmp")
                 .addDockerOpts("--volume", Paths.get(".").toAbsolutePath() + ":/workdir/")
                 .addJavaOpts("-XX:+UsePerfData")
@@ -297,25 +303,18 @@ public class TestJcmdWithSideCar {
             p.waitFor(timeout, TimeUnit.MILLISECONDS);
         }
 
-        public void waitForAndCheck(long timeout) throws Exception {
-            int exitValue = -1;
-            int retryCount = 3;
-
-            do {
-                waitFor(timeout);
-                try {
-                    exitValue = p.exitValue();
-                } catch(IllegalThreadStateException ex) {
-                    System.out.println("IllegalThreadStateException occurred when calling exitValue()");
-                    retryCount--;
-                }
-            } while (exitValue == -1 && retryCount > 0);
-
-            if (exitValue != 0) {
-                throw new RuntimeException("DockerThread stopped unexpectedly, non-zero exit value is " + exitValue);
+        public void stop() throws Exception {
+            OutputAnalyzer out = DockerTestUtils.execute(Container.ENGINE_COMMAND, "ps")
+                    .shouldHaveExitValue(0);
+            if (out.contains(name)) {
+                DockerTestUtils.execute(Container.ENGINE_COMMAND, "stop", name)
+                        .shouldHaveExitValue(0);
             }
         }
 
+        public String name() {
+            return name;
+        }
     }
 
     private enum AttachStrategy {

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -322,7 +322,7 @@ public class DockerTestUtils {
         System.out.println("[ELAPSED: " + (System.currentTimeMillis() - started) + " ms]");
         System.out.println("[STDERR]\n" + output.getStderr());
         System.out.println("[STDOUT]\n" + stdoutLimited);
-        if (stdout != stdoutLimited) {
+        if (!stdout.equals(stdoutLimited)) {
             System.out.printf("Child process STDOUT is limited to %d lines\n",
                               max);
         }


### PR DESCRIPTION
This PR reduces the TestJcmdWithSideCar execution time by stopping the container after each iteration, and randomizing container names to avoid conflicts.

For parity with Oracle JDK.

Ran related tests on linux-x64:

```sudo ../jtreg/build/images/jtreg/bin/jtreg -jdk:build/linux-x86_64-server-release/images/jdk -Drequires.container.support=true test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java```

Results:

```test result: Passed. Execution successful```

[TestJcmdWithSideCar.jtr.txt](https://github.com/user-attachments/files/27485616/TestJcmdWithSideCar.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341436](https://bugs.openjdk.org/browse/JDK-8341436) needs maintainer approval

### Issue
 * [JDK-8341436](https://bugs.openjdk.org/browse/JDK-8341436): containers/docker/TestJcmdWithSideCar.java takes needlessly long to run (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2895/head:pull/2895` \
`$ git checkout pull/2895`

Update a local copy of the PR: \
`$ git checkout pull/2895` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2895`

View PR using the GUI difftool: \
`$ git pr show -t 2895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2895.diff">https://git.openjdk.org/jdk21u-dev/pull/2895.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2895#issuecomment-4398210548)
</details>
