### PR TITLE
8384158: GHA: Downgrade Windows GHA runners to windows-2022 temporarily

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,6 +31,9 @@ on:
       platform:
         required: true
         type: string
+      runs-on:
+        required: true
+        type: string
       extra-conf-options:
         required: false
         type: string
@@ -63,7 +66,7 @@ env:
 jobs:
   build-windows:
     name: build
-    runs-on: windows-2025
+    runs-on: ${{ inputs.runs-on }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,6 +261,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
+      runs-on: windows-2022
       msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
@@ -273,6 +274,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
+      runs-on: windows-2022
       msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
@@ -330,4 +332,4 @@ jobs:
     with:
       platform: windows-x64
       bootjdk-platform: windows-x64
-      runs-on: windows-2025
+      runs-on: windows-2022


### PR DESCRIPTION
Windows builds are currently failing because of the `windows-2025` target being [switched to VS2026 prematurely](https://github.com/actions/runner-images/issues/14004)

This patch just reverts each target to `windows-2022`.  Backport from 25u is almost clean but the context at the end of `main.yml` is slightly different due to [JDK-8343546](https://bugs.openjdk.org/browse/JDK-8343546) and [JDK-8355452](https://bugs.openjdk.org/browse/JDK-8355452) in 25u.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8384158](https://bugs.openjdk.org/browse/JDK-8384158) needs maintainer approval

### Issue
 * [JDK-8384158](https://bugs.openjdk.org/browse/JDK-8384158): GHA: Downgrade Windows GHA runners to windows-2022 temporarily (**Bug** - P2 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2899/head:pull/2899` \
`$ git checkout pull/2899`

Update a local copy of the PR: \
`$ git checkout pull/2899` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2899`

View PR using the GUI difftool: \
`$ git pr show -t 2899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2899.diff">https://git.openjdk.org/jdk21u-dev/pull/2899.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2899#issuecomment-4433632499)
</details>
