### PR TITLE
8384540: [25u, 21u, 17u] Update GHA JDKs after Apr/26 updates

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,17 +29,17 @@ GTEST_VERSION=1.14.0
 JTREG_VERSION=7.5.2+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.6_7.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=a2650fba422283fbed20d936ce5d2a52906a5414ec17b2f7676dddb87201dbae
+LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_linux_hotspot_21.0.11_10.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=4b2220e232a97997b436ca6ab15cbf70171ecff52958a46159dfa5a8c44ca4de
 
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
-MACOS_AARCH64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.6_7.tar.gz
-MACOS_AARCH64_BOOT_JDK_SHA256=4ef4083919126a3d93e603284b405c7493905497485a92b375f5d6c3e8f7e8f2
+MACOS_AARCH64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.tar.gz
+MACOS_AARCH64_BOOT_JDK_SHA256=6ebcf221c9b41507b14c098e93c6ead6440b8d9bd154f8ec666c4c73abbdb201
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_mac_hotspot_21.0.6_7.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=7aacfc400078ad65b7c7de3ec75ff74bf5c2077d6740b350f85ae10be4f71e76
+MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_mac_hotspot_21.0.11_10.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=34180eb03e6d207c388cce3da668f6cc7cd7508c185c24782fadac2c9c0e66f9
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_windows_hotspot_21.0.6_7.zip
-WINDOWS_X64_BOOT_JDK_SHA256=897c8eebb0f85a99ccecbd482ebae9a45d88c19d6077054f6529ebab49b6d259
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.11_10.zip
+WINDOWS_X64_BOOT_JDK_SHA256=d3625e7cadf23787ea540229544b6e2ab494b3b54da1801879e583e1dfee0a64


### PR DESCRIPTION
This pull request is formally a backport of commit [4c7fde58](https://github.com/openjdk/jdk25u-dev/commit/4c7fde58285d3b0aaf0baa5b39093443589f1d22) from the [openjdk/jdk25u-dev](https://git.openjdk.org/jdk25u-dev) repository.

Technically, however, the change is completely different as it updates the boot JDK binaries to the JDK 21 equivalents appropriate for jdk21u-dev, bumping from Temurin 21.0.6+7 to Temurin 21.0.11+10 for all platforms (Linux x64, macOS aarch64, macOS x64, Windows x64).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8384540](https://bugs.openjdk.org/browse/JDK-8384540) needs maintainer approval

### Issue
 * [JDK-8384540](https://bugs.openjdk.org/browse/JDK-8384540): [25u, 21u, 17u] Update GHA JDKs after Apr/26 updates (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2901/head:pull/2901` \
`$ git checkout pull/2901`

Update a local copy of the PR: \
`$ git checkout pull/2901` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2901`

View PR using the GUI difftool: \
`$ git pr show -t 2901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2901.diff">https://git.openjdk.org/jdk21u-dev/pull/2901.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2901#issuecomment-4454170721)
</details>
