### PR TITLE
8343698: Linux x86_64 lto build gives a lot of warnings and fails lto-wrapper: fatal error: make returned 2 exit status

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -37,6 +37,10 @@ ifeq ($(TOOLCHAIN_TYPE), gcc)
     # Need extra inlining to collapse shared marking code into the hot marking loop
     BUILD_LIBJVM_shenandoahMark.cpp_CXXFLAGS := --param inline-unit-growth=1000
   endif
+  # disable lto in g1ParScanThreadState because of special inlining/flattening used there
+  ifeq ($(call check-jvm-feature, link-time-opt), true)
+    BUILD_LIBJVM_g1ParScanThreadState.cpp_CXXFLAGS := -fno-lto
+  endif
 endif
 
 LIBJVM_FDLIBM_COPY_OPT_FLAG := $(CXX_O_FLAG_NONE)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9576546b](https://github.com/openjdk/jdk/commit/9576546b9c0f22b0784c4f845f2694050cae2f16) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 25 Nov 2024 and was reviewed by Magnus Ihse Bursie and Julian Waters.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8343698](https://bugs.openjdk.org/browse/JDK-8343698) needs maintainer approval

### Issue
 * [JDK-8343698](https://bugs.openjdk.org/browse/JDK-8343698): Linux x86_64 lto build gives a lot of warnings and fails lto-wrapper: fatal error: make returned 2 exit status (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2907/head:pull/2907` \
`$ git checkout pull/2907`

Update a local copy of the PR: \
`$ git checkout pull/2907` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2907`

View PR using the GUI difftool: \
`$ git pr show -t 2907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2907.diff">https://git.openjdk.org/jdk21u-dev/pull/2907.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2907#issuecomment-4570785017)
</details>
