### PR TITLE
8381270: TestGCPhaseConcurrent.java#Z intermittent fails OOME

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
@@ -47,7 +47,7 @@ import jdk.test.lib.jfr.Events;
  */
 
 /**
- * @test TestGCPhaseConcurrent
+ * @test id=Shenandoah
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
  * @requires vm.hasJFR & vm.gc.Shenandoah

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import jdk.test.lib.jfr.Events;
  * @key jfr
  * @library /test/lib /test/jdk /test/hotspot/jtreg
  * @requires vm.hasJFR & vm.gc.ZGenerational
- * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M jdk.jfr.event.gc.detailed.TestGCPhaseConcurrent Z
+ * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx64M jdk.jfr.event.gc.detailed.TestGCPhaseConcurrent Z
  */
 
 /**


### PR DESCRIPTION
Hi all,

This backport will fix the test bug which cause test intermittent OOME fails, jdk21u-dev lack JDK-8318098(Update jfr tests to replace keyword jfr with vm.flagless) cause this backport not cleanly. And I think we do not have good reason to backport JDK-8318098 first.

Change has been verified locally by run the test manually on linux-x64. Test-fix only, no risk.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] [JDK-8381270](https://bugs.openjdk.org/browse/JDK-8381270) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8381270](https://bugs.openjdk.org/browse/JDK-8381270): TestGCPhaseConcurrent.java#Z intermittent fails OOME (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2915/head:pull/2915` \
`$ git checkout pull/2915`

Update a local copy of the PR: \
`$ git checkout pull/2915` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2915`

View PR using the GUI difftool: \
`$ git pr show -t 2915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2915.diff">https://git.openjdk.org/jdk21u-dev/pull/2915.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2915#issuecomment-4560278330)
</details>
