### PR TITLE
8364106: Include java.runtime.version in thread dump output

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1306,10 +1306,24 @@ void Threads::print_on(outputStream* st, bool print_stacks,
   char buf[32];
   st->print_raw_cr(os::local_time_string(buf, sizeof(buf)));
 
-  st->print_cr("Full thread dump %s (%s %s):",
+  st->print_cr("Full thread dump %s (%s %s)",
                VM_Version::vm_name(),
                VM_Version::vm_release(),
                VM_Version::vm_info_string());
+  JDK_Version::current().to_string(buf, sizeof(buf));
+  const char* runtime_name = JDK_Version::runtime_name() != nullptr ?
+                             JDK_Version::runtime_name() : "";
+  const char* runtime_version = JDK_Version::runtime_version() != nullptr ?
+                                JDK_Version::runtime_version() : "";
+  const char* vendor_version = JDK_Version::runtime_vendor_version() != nullptr ?
+                               JDK_Version::runtime_vendor_version() : "";
+  const char* jdk_debug_level = VM_Version::printable_jdk_debug_level() != nullptr ?
+                                VM_Version::printable_jdk_debug_level() : "";
+
+  st->print_cr("                 JDK version: %s%s%s (%s) (%sbuild %s)", runtime_name,
+                (*vendor_version != '\0') ? " " : "", vendor_version,
+                buf, jdk_debug_level, runtime_version);
+
   st->cr();
 
 #if INCLUDE_SERVICES

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,6 +168,9 @@ public class PrintTest {
             output.shouldNotMatch(jucLockPattern1);
             output.shouldNotMatch(jucLockPattern2);
         }
+
+        /* Check for presence of version string */
+        output.shouldContain("JDK version:");
     }
 
     @Test


### PR DESCRIPTION
Backporting JDK-8364106: Include java.runtime.version in thread dump output.

This PR adds additional metadata to the thread dump.

For parity with Oracle JDK. Already backported to 25.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
make test TEST=test/hotspot/jtreg/serviceability/dcmd

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28640220/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/28640221/windows-x64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28640222/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28640224/macos-aarch64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28640225/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/28640227/linux-x64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28640228/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28640230/linux-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8364106](https://bugs.openjdk.org/browse/JDK-8364106) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8364106](https://bugs.openjdk.org/browse/JDK-8364106): Include java.runtime.version in thread dump output (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2920/head:pull/2920` \
`$ git checkout pull/2920`

Update a local copy of the PR: \
`$ git checkout pull/2920` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2920`

View PR using the GUI difftool: \
`$ git pr show -t 2920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2920.diff">https://git.openjdk.org/jdk21u-dev/pull/2920.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2920#issuecomment-4623604148)
</details>
