### PR TITLE
8385584: CAInterop.java#buypassclass3ca fails with Intermediate Root CA not found in the chain

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -607,8 +607,8 @@ public class CAInterop {
                     new CATestURLs("https://valid.business.ca22.ssl.buypass.no",
                     "https://revoked.business.ca22.ssl.buypass.no");
             case "buypassclass3ca" ->
-                    new CATestURLs("https://valid.qcevident.ca23.ssl.buypass.no",
-                    "https://revoked.qcevident.ca23.ssl.buypass.no");
+                    new CATestURLs("https://valid.evident.ca23.ssl.buypass.no",
+                    "https://revoked.evident.ca23.ssl.buypass.no");
 
             case "comodorsaca" ->
                     new CATestURLs("https://comodorsacertificationauthority-ev.comodoca.com",


### PR DESCRIPTION
Backporting JDK-8385584: CAInterop.java#buypassclass3ca fails with Intermediate Root CA not found in the chain.

This PR updates CAInterop.java#buypassclass3ca to use Buypass CA's current Class 3 SSL test endpoints.

For parity with Oracle JDK. Already backported to 25.

Ran related test on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#buypassclass3ca```

Results:

```test result: Passed. Execution successful```

[CAInterop_buypassclass3ca.jtr.txt](https://github.com/user-attachments/files/28758509/CAInterop_buypassclass3ca.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8385584](https://bugs.openjdk.org/browse/JDK-8385584) needs maintainer approval

### Issue
 * [JDK-8385584](https://bugs.openjdk.org/browse/JDK-8385584): CAInterop.java#buypassclass3ca fails with Intermediate Root CA not found in the chain (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2924/head:pull/2924` \
`$ git checkout pull/2924`

Update a local copy of the PR: \
`$ git checkout pull/2924` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2924`

View PR using the GUI difftool: \
`$ git pr show -t 2924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2924.diff">https://git.openjdk.org/jdk21u-dev/pull/2924.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2924#issuecomment-4660642484)
</details>
