### PR TITLE
8386345: Remove redundant @requires from TestGarbageCollectionEventWithZMinor

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMinor.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGarbageCollectionEventWithZMinor.java
@@ -41,7 +41,6 @@ import jdk.test.whitebox.WhiteBox;
  * @test
  * @key jfr
  * @requires vm.hasJFR & vm.gc.ZGenerational
- * @key jfr
  * @library /test/lib /test/jdk
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
In 21, it's a double @key.  This is what breaks jtreg 8.1.

[JDK-8318098](https://bugs.openjdk.org/browse/JDK-8318098): "Update jfr tests to replace keyword jfr with vm.flagless". converted the @key to @requires.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8386345](https://bugs.openjdk.org/browse/JDK-8386345) needs maintainer approval

### Issue
 * [JDK-8386345](https://bugs.openjdk.org/browse/JDK-8386345): Remove redundant @<!---->requires from TestGarbageCollectionEventWithZMinor (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2927/head:pull/2927` \
`$ git checkout pull/2927`

Update a local copy of the PR: \
`$ git checkout pull/2927` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2927`

View PR using the GUI difftool: \
`$ git pr show -t 2927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2927.diff">https://git.openjdk.org/jdk21u-dev/pull/2927.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2927#issuecomment-4679414824)
</details>
