### PR TITLE
8384163: (so) SocketChannel.connect and finishConnect() exception messages could be improved

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -910,13 +910,13 @@ Java_sun_nio_ch_Net_pollConnect(JNIEnv *env, jobject this, jobject fdo, jlong ti
         errno = 0;
         result = getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &n);
         if (result < 0) {
-            handleSocketError(env, errno);
+            handleSocketErrorWithMessage(env, errno, "getsockopt failed");
             return JNI_FALSE;
         } else if (error) {
-            handleSocketError(env, error);
+            handleSocketErrorWithMessage(env, error, "connect failed");
             return JNI_FALSE;
         } else if ((poller.revents & POLLHUP) != 0) {
-            handleSocketError(env, ENOTCONN);
+            handleSocketErrorWithMessage(env, ENOTCONN, "peer closed connection after accepting");
             return JNI_FALSE;
         }
         // connected


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8384163](https://bugs.openjdk.org/browse/JDK-8384163) needs maintainer approval

### Issue
 * [JDK-8384163](https://bugs.openjdk.org/browse/JDK-8384163): (so) SocketChannel.connect and finishConnect() exception messages could be improved (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2929/head:pull/2929` \
`$ git checkout pull/2929`

Update a local copy of the PR: \
`$ git checkout pull/2929` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2929`

View PR using the GUI difftool: \
`$ git pr show -t 2929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2929.diff">https://git.openjdk.org/jdk21u-dev/pull/2929.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2929#issuecomment-4682455456)
</details>
