### PR TITLE
8310331: JitTester: Exclude java.lang.Math.random

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/conf/exclude.methods.lst
+++ b/test/hotspot/jtreg/testlibrary/jittester/conf/exclude.methods.lst
@@ -1,4 +1,5 @@
 java/lang/EnumConstantNotPresentException::EnumConstantNotPresentException(Ljava/lang/Class;Ljava/lang/String;)
+java/lang/Math::random()
 java/lang/Object::notify()
 java/lang/Object::notifyAll()
 java/lang/Object::toString()


### PR DESCRIPTION
Backporting JDK-8310331: JitTester: Exclude java.lang.Math.random.

This PR updates the JIT Tester exclude methods list.

For parity with Oracle JDK.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8310331](https://bugs.openjdk.org/browse/JDK-8310331) needs maintainer approval

### Issue
 * [JDK-8310331](https://bugs.openjdk.org/browse/JDK-8310331): JitTester: Exclude java.lang.Math.random (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2939/head:pull/2939` \
`$ git checkout pull/2939`

Update a local copy of the PR: \
`$ git checkout pull/2939` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2939`

View PR using the GUI difftool: \
`$ git pr show -t 2939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2939.diff">https://git.openjdk.org/jdk21u-dev/pull/2939.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2939#issuecomment-4751891340)
</details>
