### PR TITLE
8346463: Add test coverage for deploying the default provider as a module

### DIFF
--- a/test/jdk/java/net/UnixDomainSocketAddress/AddressTest.java
+++ b/test/jdk/java/net/UnixDomainSocketAddress/AddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8231358
- * @compile ../../nio/file/spi/TestProvider.java AddressTest.java
+ * @compile ../../nio/file/spi/testfsp/testfsp/TestProvider.java AddressTest.java
  * @run testng/othervm AddressTest
  */
 
@@ -51,8 +51,8 @@ public class AddressTest {
 
     @Test
     public static void runTest() throws Exception {
-        TestProvider prov = new TestProvider(FileSystems.getDefault().provider());
-        Path path = prov.getPath(URI.create("file:/"));
+        var fsp = new testfsp.TestProvider(FileSystems.getDefault().provider());
+        Path path = fsp.getPath(URI.create("file:/"));
         assertThrows(IAE, () -> UnixDomainSocketAddress.of(path));
     }
 }

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,13 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 4313887 7006126 8142968 8178380 8183320 8210112 8266345 8263940
- * @modules jdk.jartool
+ * @modules jdk.jartool jdk.jlink
  * @library /test/lib
- * @build SetDefaultProvider TestProvider m/* jdk.test.lib.process.ProcessTools
- * @run testng/othervm SetDefaultProvider
+ * @build testfsp/* testapp/*
+ * @run junit SetDefaultProvider
  * @summary Runs tests with -Djava.nio.file.spi.DefaultFileSystemProvider set on
  *          the command line to override the default file system provider
  */
@@ -37,189 +37,224 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.spi.ToolProvider;
 import java.util.stream.Stream;
 
 import jdk.test.lib.process.ProcessTools;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeAll;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
-
-@Test
-public class SetDefaultProvider {
+class SetDefaultProvider {
 
     private static final String SET_DEFAULT_FSP =
-        "-Djava.nio.file.spi.DefaultFileSystemProvider=TestProvider";
+        "-Djava.nio.file.spi.DefaultFileSystemProvider=testfsp.TestProvider";
 
     private static final ToolProvider JAR_TOOL = ToolProvider.findFirst("jar")
         .orElseThrow(() ->
             new RuntimeException("jar tool not found")
         );
 
-    private static Path createTempDirectory(String prefix) throws IOException {
-        Path testDir = Paths.get(System.getProperty("test.dir", "."));
-        return Files.createTempDirectory(testDir, prefix);
+    private static final String TESTFSP = "testfsp";
+    private static final String TESTAPP = "testapp";
+    private static final String TESTAPP_MAIN = TESTAPP + ".Main";
+
+    // directory containing testfsp class files
+    private static String TESTFSP_CLASSES;
+
+    // directory containing testapp class files
+    private static String TESTAPP_CLASSES;
+
+    @BeforeAll
+    static void setup() {
+        TESTFSP_CLASSES = classes(TESTFSP);
+        TESTAPP_CLASSES = classes(TESTAPP);
     }
 
     /**
-     * Test override of default FileSystemProvider with the main application
-     * on the class path.
+     * Test file system provider exploded on the class path.
      */
-    public void testClassPath() throws Exception {
-        String moduleClasses = moduleClasses();
-        String testClasses = System.getProperty("test.classes");
-        String classpath = moduleClasses + File.pathSeparator + testClasses;
-        int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
-        assertEquals(exitValue, 0);
+    @Test
+    void testFspOnClassPath1() throws Exception {
+        exec(SET_DEFAULT_FSP,
+                "-cp", ofClasspath(TESTFSP_CLASSES, TESTAPP_CLASSES),
+                TESTAPP_MAIN);
     }
 
     /**
-     * Test override of default FileSystemProvider with a
-     * FileSystemProvider jar and the main application on the class path.
+     * Test file system provider in JAR file on the class path.
      */
-    public void testClassPathWithFileSystemProviderJar() throws Exception {
-        String testClasses = System.getProperty("test.classes");
-        Path jar = Path.of("testFileSystemProvider.jar");
-        Files.deleteIfExists(jar);
-        createFileSystemProviderJar(jar, Path.of(testClasses));
-        String classpath = jar + File.pathSeparator + testClasses
-                + File.separator + "modules" + File.separator + "m";
-        int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
-        assertEquals(exitValue, 0);
+    @Test
+    void testFspOnClassPath2() throws Exception {
+        String jarFile = createJar("fsp.jar", TESTFSP_CLASSES);
+        exec(SET_DEFAULT_FSP,
+                "-cp", ofClasspath(jarFile, TESTAPP_CLASSES),
+                TESTAPP_MAIN);
     }
 
     /**
-     * Creates a JAR containing the FileSystemProvider used to override the
-     * default FileSystemProvider
+     * Test file system provider in exploded module on the module path.
      */
-    private void createFileSystemProviderJar(Path jar, Path dir) throws IOException {
+    @Test
+    void testFspOnModulePath1() throws Exception {
+        exec(SET_DEFAULT_FSP,
+                "-p", TESTFSP_CLASSES,
+                "--add-modules", TESTFSP,
+                "-cp", TESTAPP_CLASSES,
+                TESTAPP_MAIN);
+    }
 
-        List<String>  args = new ArrayList<>();
+    /**
+     * Test file system provider in modular JAR on the module path.
+     */
+    @Test
+    void testFspOnModulePath2() throws Exception {
+        String jarFile = createJar("fsp.jar", TESTFSP_CLASSES);
+        exec(SET_DEFAULT_FSP,
+                "-p", jarFile,
+                "--add-modules", TESTFSP,
+                "-cp", TESTAPP_CLASSES,
+                TESTAPP_MAIN);
+    }
+
+    /**
+     * Test file system provider linked into run-time image.
+     */
+    @Disabled
+    @Test
+    void testFspInRuntimeImage() throws Exception {
+        String image = "image";
+
+        ToolProvider jlink = ToolProvider.findFirst("jlink").orElseThrow();
+        String[] jlinkCmd = {
+                "--module-path", TESTFSP_CLASSES,
+                "--add-modules", TESTFSP,
+                "--output", image
+        };
+        int exitCode = jlink.run(System.out, System.err, jlinkCmd);
+        assertEquals(0, exitCode);
+
+        String[] javaCmd = {
+                Path.of(image, "bin", "java").toString(),
+                SET_DEFAULT_FSP,
+                "--add-modules", TESTFSP,
+                "-cp", TESTAPP_CLASSES,
+                TESTAPP_MAIN
+        };
+        var pb = new ProcessBuilder(javaCmd);
+        ProcessTools.executeProcess(pb)
+                .outputTo(System.out)
+                .errorTo(System.err)
+                .shouldHaveExitValue(0);
+    }
+
+    /**
+     * Test file system provider on class path, application in exploded module on module path.
+     */
+    @Test
+    void testAppOnModulePath1() throws Exception {
+        exec(SET_DEFAULT_FSP,
+                "-p", TESTAPP_CLASSES,
+                "-cp", TESTFSP_CLASSES,
+                "-m", TESTAPP + "/" + TESTAPP_MAIN);
+    }
+
+    /**
+     * Test file system provider on class path, application in modular JAR on module path.
+     */
+    @Test
+    void testAppOnModulePath2() throws Exception {
+        String jarFile = createJar("testapp.jar", TESTAPP_CLASSES);
+        exec(SET_DEFAULT_FSP,
+                "-cp", TESTFSP_CLASSES,
+                "-p", jarFile,
+                "-m", TESTAPP + "/" + TESTAPP_MAIN);
+    }
+
+    /**
+     * Test file system provider on class path, application in modular JAR on module path
+     * that is patched with exploded patch.
+     */
+    @Test
+    void testPatchedAppOnModulePath1() throws Exception {
+        Path patchdir = createTempDirectory("patch");
+        Files.createFile(patchdir.resolve("aoo.properties"));
+        exec(SET_DEFAULT_FSP,
+                "--patch-module", TESTAPP + "=" + patchdir,
+                "-p", TESTAPP_CLASSES,
+                "-cp", TESTFSP_CLASSES,
+                "-m", TESTAPP + "/" + TESTAPP_MAIN);
+    }
+
+    /**
+     * Test file system provider on class path, application in modular JAR on module path
+     * that is patched with patch in JAR file.
+     */
+    @Test
+    void testPatchedAppOnModulePath2() throws Exception {
+        Path patchdir = createTempDirectory("patch");
+        Files.createFile(patchdir.resolve("app.properties"));
+        String jarFile = createJar("patch.jar", patchdir.toString());
+        exec(SET_DEFAULT_FSP,
+                "--patch-module", TESTAPP + "=" + jarFile,
+                "-p", TESTAPP_CLASSES,
+                "-cp", TESTFSP_CLASSES,
+                "-m", TESTAPP + "/" + TESTAPP_MAIN);
+    }
+
+    /**
+     * Returns the directory containing the classes for the given module.
+     */
+    private static String classes(String mn) {
+        String mp = System.getProperty("jdk.module.path");
+        return Arrays.stream(mp.split(File.pathSeparator))
+                .map(e -> Path.of(e, mn))
+                .filter(Files::isDirectory)
+                .findAny()
+                .map(Path::toString)
+                .orElseThrow();
+    }
+
+    /**
+     * Returns a class path from the given paths.
+     */
+    private String ofClasspath(String... paths) {
+        return String.join(File.pathSeparator, paths);
+    }
+
+    /**
+     * Creates a JAR file from the contains of the given directory.
+     */
+    private String createJar(String jar, String dir) throws IOException {
+        List<String> args = new ArrayList<>();
         args.add("--create");
         args.add("--file=" + jar);
-        try (Stream<Path> stream = Files.list(dir)) {
-            List<String> paths = stream
-                    .map(path -> path.getFileName().toString())
-                    .filter(f -> f.startsWith("TestProvider"))
-                    .toList();
-            for(var p : paths) {
-                args.add("-C");
-                args.add(dir.toString());
-                args.add(p);
-            }
-        }
-        int ret = JAR_TOOL.run(System.out, System.out, args.toArray(new String[0]));
-        assertEquals(ret, 0);
-    }
-
-    /**
-     * Test override of default FileSystemProvider with the main application
-     * on the class path and a SecurityManager enabled.
-     */
-    public void testClassPathWithSecurityManager() throws Exception {
-        String moduleClasses = moduleClasses();
-        String testClasses = System.getProperty("test.classes");
-        String classpath = moduleClasses + File.pathSeparator + testClasses;
-        String policyFile = System.getProperty("test.src", ".")
-            + File.separator + "fs.policy";
-        int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath,
-            "-Dtest.classes=" + testClasses, "-Djava.security.manager",
-            "-Djava.security.policy==" + policyFile, "p.Main");
-        assertEquals(exitValue, 0);
-    }
-
-    /**
-     * Test override of default FileSystemProvider with the main application
-     * on the module path as an exploded module.
-     */
-    public void testExplodedModule() throws Exception {
-        String modulePath = System.getProperty("jdk.module.path");
-        int exitValue = exec(SET_DEFAULT_FSP, "-p", modulePath, "-m", "m/p.Main");
-        assertEquals(exitValue, 0);
-    }
-
-    /**
-     * Test override of default FileSystemProvider with the main application
-     * on the module path as a modular JAR.
-     */
-    public void testModularJar() throws Exception {
-        String jarFile = createModularJar();
-        int exitValue = exec(SET_DEFAULT_FSP, "-p", jarFile, "-m", "m/p.Main");
-        assertEquals(exitValue, 0);
-    }
-
-    /**
-     * Test override of default FileSystemProvider where the main application
-     * is a module that is patched by an exploded patch.
-     */
-    public void testExplodedModuleWithExplodedPatch() throws Exception {
-        Path patchdir = createTempDirectory("patch");
-        String modulePath = System.getProperty("jdk.module.path");
-        int exitValue = exec(SET_DEFAULT_FSP,
-                             "--patch-module", "m=" + patchdir,
-                             "-p", modulePath,
-                             "-m", "m/p.Main");
-        assertEquals(exitValue, 0);
-    }
-
-    /**
-     * Test override of default FileSystemProvider where the main application
-     * is a module that is patched by an exploded patch.
-     */
-    public void testExplodedModuleWithJarPatch() throws Exception {
-        Path patchdir = createTempDirectory("patch");
-        Files.createDirectory(patchdir.resolve("m.properties"));
-        Path patch = createJarFile(patchdir);
-        String modulePath = System.getProperty("jdk.module.path");
-        int exitValue = exec(SET_DEFAULT_FSP,
-                             "--patch-module", "m=" + patch,
-                             "-p", modulePath,
-                             "-m", "m/p.Main");
-        assertEquals(exitValue, 0);
-    }
-
-    /**
-     * Returns the directory containing the classes for module "m".
-     */
-    private String moduleClasses() {
-        String mp = System.getProperty("jdk.module.path");
-        for (String dir : mp.split(File.pathSeparator)) {
-            Path m = Paths.get(dir, "m");
-            if (Files.exists(m)) return m.toString();
-        }
-        fail();
-        return null;
-    }
-
-    /**
-     * Creates a modular JAR containing module "m".
-     */
-    private String createModularJar() throws Exception {
-        Path dir = Paths.get(moduleClasses());
-        Path jar = createJarFile(dir);
-        return jar.toString();
-    }
-
-    /**
-     * Creates a JAR file containing the entries in the given file tree.
-     */
-    private Path createJarFile(Path dir) throws Exception {
-        Path jar = createTempDirectory("tmp").resolve("m.jar");
-        String[] args = { "--create", "--file=" + jar, "-C", dir.toString(), "." };
-        int ret = JAR_TOOL.run(System.out, System.out, args);
+        args.add("-C");
+        args.add(dir);
+        args.add(".");
+        int ret = JAR_TOOL.run(System.err, System.err, args.toArray(new String[0]));
         assertEquals(ret, 0);
         return jar;
     }
 
     /**
-     * Invokes the java launcher with the given arguments, returning the exit code.
+     * Create a temporary directory with the given prefix in the current directory.
      */
-    private int exec(String... args) throws Exception {
-       return ProcessTools.executeTestJava(args)
-                .outputTo(System.out)
-                .errorTo(System.out)
-                .getExitValue();
+    private static Path createTempDirectory(String prefix) throws IOException {
+        return Files.createTempDirectory(Path.of("."), prefix);
+    }
+
+    /**
+     * Invokes the java launcher with the given arguments, throws if the non-0 is returned.
+     */
+    private void exec(String... args) throws Exception {
+        ProcessTools.executeTestJava(args)
+                .outputTo(System.err)
+                .errorTo(System.err)
+                .shouldHaveExitValue(0);
     }
 }

--- a/test/jdk/java/nio/file/spi/TestDelegation.java
+++ b/test/jdk/java/nio/file/spi/TestDelegation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ import static org.testng.AssertJUnit.assertEquals;
  * @test
  * @summary Verifies that a FileSystemProvider's implementation of the exists
  * and readAttributesIfExists methods are invoked
- * @build TestDelegation TestProvider
- * @run testng/othervm  TestDelegation
+ * @compile testfsp/testfsp/TestProvider.java
+ * @run testng TestDelegation
  */
 public class TestDelegation {
 
@@ -54,7 +54,6 @@ public class TestDelegation {
     private Path fileThatExists;
     // The FileSystemProvider used by the test
     private MyProvider myProvider;
-
 
     /**
      * Create the FileSystemProvider, the FileSystem and
@@ -182,7 +181,7 @@ public class TestDelegation {
     /**
      * The FileSystemProvider implementation used by the test
      */
-    static class MyProvider extends TestProvider {
+    static class MyProvider extends testfsp.TestProvider {
         private final Map<String, List<Path>> calls = new HashMap<>();
 
         private MyProvider() {

--- a/test/jdk/java/nio/file/spi/testapp/module-info.java
+++ b/test/jdk/java/nio/file/spi/testapp/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,5 +20,5 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-module m {
+module testapp {
 }

--- a/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
+++ b/test/jdk/java/nio/file/spi/testapp/testapp/Main.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package p;
+package testapp;
 
 import java.io.File;
 import java.nio.file.FileSystem;

--- a/test/jdk/java/nio/file/spi/testfsp/module-info.java
+++ b/test/jdk/java/nio/file/spi/testfsp/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module testfsp {
+    exports testfsp to java.base;
+}

--- a/test/jdk/java/nio/file/spi/testfsp/testfsp/TestProvider.java
+++ b/test/jdk/java/nio/file/spi/testfsp/testfsp/TestProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package testfsp;
 
 import java.io.File;
 import java.nio.file.*;


### PR DESCRIPTION
Backporting JDK-8346463: Add test coverage for deploying the default provider as a module.

This PR refactors java.nio.file.spi tests to use a module structure and migrates SetDefaultProvider from TestNG to JUnit.

This PR isn't clean due to a conflict in the copyright header in Main.java, and the merge conflict in SetDefaultProvider.java needed to be manually resolved to resemble the Java 25 version because of skipped commits that don't apply to Java 21 (e.g., JEP 468).

For parity with Oracle JDK. Already backported to 25.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/net/UnixDomainSocketAddress/AddressTest.java
make test TEST=test/jdk/java/nio/file/spi/SetDefaultProvider.java
make test TEST=test/jdk/java/nio/file/spi/TestDelegation.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29298857/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/29298858/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/29298859/windows-x64-specific-3-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29298860/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/29298861/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/29298862/macos-aarch64-specific-3-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29298863/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/29298864/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/29298865/linux-x64-specific-3-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29298866/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/29298867/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/29298868/linux-aarch64-specific-3-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] [JDK-8346463](https://bugs.openjdk.org/browse/JDK-8346463) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8346463](https://bugs.openjdk.org/browse/JDK-8346463): Add test coverage for deploying the default provider as a module (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2942/head:pull/2942` \
`$ git checkout pull/2942`

Update a local copy of the PR: \
`$ git checkout pull/2942` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2942`

View PR using the GUI difftool: \
`$ git pr show -t 2942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2942.diff">https://git.openjdk.org/jdk21u-dev/pull/2942.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2942#issuecomment-4780915839)
</details>
