### PR TITLE
8372615: Many container tests fail when running rootless on cgroup v1

### DIFF
--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
  * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build HelloDocker
@@ -45,10 +46,7 @@ public class DockerBasicTest {
     private static final String imageNameAndTag = Common.imageName("basic");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         DockerTestUtils.buildJdkContainerImage(imageNameAndTag);
 
         try {

--- a/test/hotspot/jtreg/containers/docker/ShareTmpDir.java
+++ b/test/hotspot/jtreg/containers/docker/ShareTmpDir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  * @requires container.support
  * @requires !vm.asan
  * @library /test/lib
+ * @modules java.base/jdk.internal.platform
  * @build WaitForFlagFile
  * @run driver ShareTmpDir
  */
@@ -50,10 +51,7 @@ public class ShareTmpDir {
     private static final String imageName = Common.imageName("sharetmpdir");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,9 +48,8 @@ public class TestCPUAwareness {
     private static final int availableCPUs = Runtime.getRuntime().availableProcessors();
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
 
         System.out.println("Test Environment: detected availableCPUs = " + availableCPUs);
         DockerTestUtils.buildJdkContainerImage(imageName);

--- a/test/hotspot/jtreg/containers/docker/TestCPUSets.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @requires (os.arch != "s390x")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build AttemptOOM jdk.test.whitebox.WhiteBox PrintContainerInfo
@@ -52,11 +53,8 @@ public class TestCPUSets {
     private static final String imageName = Common.imageName("cpusets");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
-
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
         Common.prepareWhiteBox();
         DockerTestUtils.buildJdkContainerImage(imageName);
 

--- a/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
+++ b/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,6 +31,7 @@
  * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build CheckContainerized jdk.test.whitebox.WhiteBox PrintContainerInfo
@@ -49,10 +50,7 @@ public class TestContainerInfo {
     private static final String imageName = Common.imageName("container-info");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         Common.prepareWhiteBox();
         DockerTestUtils.buildJdkContainerImage(imageName);
 

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -33,6 +33,7 @@
  * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build JfrReporter
@@ -56,9 +57,7 @@ public class TestJFREvents {
 
     public static void main(String[] args) throws Exception {
         System.out.println("Test Environment: detected availableCPUs = " + availableCPUs);
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
+        DockerTestUtils.checkCanTestDocker();
 
         DockerTestUtils.buildJdkContainerImage(imageName);
 

--- a/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build JfrNetwork
@@ -48,10 +49,7 @@ public class TestJFRNetworkEvents {
 
     public static void main(String[] args) throws Exception {
         System.out.println("Test Environment: detected availableCPUs = " + availableCPUs);
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {

--- a/test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
  * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build EventProducer
@@ -73,9 +74,7 @@ public class TestJFRWithJMX {
     static final AtomicReference<String> ipAddr = new AtomicReference();
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            throw new SkippedException("Docker is not supported on this host");
-        }
+        DockerTestUtils.checkCanTestDocker();
 
         if (DockerTestUtils.isPodman() & !Platform.isRoot()) {
             throw new SkippedException("test cannot be run under rootless podman configuration");

--- a/test/hotspot/jtreg/containers/docker/TestJcmd.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmd.java
@@ -29,6 +29,7 @@
  * @requires container.support
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @library /test/lib
@@ -62,7 +63,7 @@ public class TestJcmd {
 
 
     public static void main(String[] args) throws Exception {
-        DockerTestUtils.canTestDocker();
+        DockerTestUtils.checkCanTestDocker();
 
         // podman versions below 3.3.1 hava a bug where cross-container testing with correct
         // permissions fails. See JDK-8273216

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@
  * @requires vm.flagless
  * @requires !vm.asan
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @library /test/lib
@@ -95,10 +96,7 @@ public class TestJcmdWithSideCar {
     private static final String NET_BIND_SERVICE = "--cap-add=NET_BIND_SERVICE";
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         DockerTestUtils.buildJdkContainerImage(IMAGE_NAME);
 
         try {

--- a/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
+++ b/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,6 +32,7 @@
  * @requires container.support
  * @requires !vm.asan
  * @library /test/lib
+ * @modules java.base/jdk.internal.platform
  * @build jdk.test.whitebox.WhiteBox LimitUpdateChecker
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
  * @run driver TestLimitsUpdating
@@ -54,10 +55,8 @@ public class TestLimitsUpdating {
     private static final String imageName = Common.imageName("limitsUpdating");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
         Common.prepareWhiteBox();
         DockerTestUtils.buildJdkContainerImage(imageName);
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -59,10 +59,7 @@ public class TestMemoryAwareness {
     }
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         Common.prepareWhiteBox();
         DockerTestUtils.buildJdkContainerImage(imageName);
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryInvisibleParent.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryInvisibleParent.java
@@ -54,10 +54,7 @@ public class TestMemoryInvisibleParent {
             System.out.println("Cgroup not configured.");
             return;
         }
-        if (!DockerTestUtils.canTestDocker()) {
-            System.out.println("Unable to run docker tests.");
-            return;
-        }
+        DockerTestUtils.checkCanTestDocker();
 
         ContainerRuntimeVersionTestUtils.checkContainerVersionSupported();
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022, Tencent. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,10 +52,8 @@ public class TestMemoryWithCgroupV1 {
             return;
         }
         if ("cgroupv1".equals(metrics.getProvider())) {
-            if (!DockerTestUtils.canTestDocker()) {
-                return;
-            }
-
+            DockerTestUtils.checkCanTestDocker();
+            DockerTestUtils.checkCanUseResourceLimits();
             Common.prepareWhiteBox();
             DockerTestUtils.buildJdkContainerImage(imageName);
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -51,10 +51,7 @@ public class TestMemoryWithSubgroups {
             System.out.println("Cgroup not configured.");
             return;
         }
-        if (!DockerTestUtils.canTestDocker()) {
-            System.out.println("Unable to run docker tests.");
-            return;
-        }
+        DockerTestUtils.checkCanTestDocker();
 
         ContainerRuntimeVersionTestUtils.checkContainerVersionSupported();
 

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -46,14 +46,10 @@ import jtreg.SkippedException;
 
 
 public class TestMisc {
-    private static final Metrics metrics = Metrics.systemMetrics();
     private static final String imageName = Common.imageName("misc");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         Common.prepareWhiteBox();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
@@ -102,14 +98,8 @@ public class TestMisc {
     // Test the mapping function on cgroups v2. Should also pass on cgroups v1 as it's
     // a direct mapping there.
     private static void testPrintContainerInfoCPUShares() throws Exception {
-        // Test won't work on cgv1 rootless podman since resource limits don't
-        // work there.
-        if ("cgroupv1".equals(metrics.getProvider()) &&
-            DockerTestUtils.isPodman() &&
-            DockerTestUtils.isRootless()) {
-            throw new SkippedException("Resource limits required for testPrintContainerInfoCPUShares(). " +
-                                       "This is cgv1 with podman in rootless mode. Test skipped.");
-        }
+        // Test won't work on cgv1 rootless since resource limits don't work there.
+        DockerTestUtils.checkCanUseResourceLimits();
         // Anything less than 1024 should return the back-mapped cpu-shares value without
         // rounding to next multiple of 1024 (on cg v2). Only ensure that we get
         // 'cpu_shares: <back-mapped-value>' over 'cpu_shares: no shares'.

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -31,6 +31,7 @@
  * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  * @build jdk.test.whitebox.WhiteBox PrintContainerInfo
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
@@ -54,10 +55,8 @@ public class TestPids {
     static final String warning_kernel_no_pids_support = "WARNING: Your kernel does not support pids limit capabilities";
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
         Common.prepareWhiteBox();
         DockerTestUtils.buildJdkContainerImage(imageName);
 

--- a/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Red Hat, Inc.
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  * @requires container.support
  * @requires !vm.asan
  * @library /test/lib
+ * @modules java.base/jdk.internal.platform
  * @run main/timeout=360 TestDockerBasic
  */
 
@@ -42,10 +43,8 @@ public class TestDockerBasic {
     private static final String imageName = Common.imageName("javaDockerBasic");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {

--- a/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,8 @@ public class TestDockerCpuMetrics {
     private static final String imageName = Common.imageName("metrics-cpu");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
 
         // These tests create a docker image and run this image with
         // varying docker cpu options.  The arguments passed to the docker

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -45,9 +45,8 @@ public class TestDockerMemoryMetrics {
     private static final String imageName = Common.imageName("metrics-memory");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
 
         // These tests create a docker image and run this image with
         // varying docker memory options.  The arguments passed to the docker

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
@@ -57,10 +57,7 @@ public class TestDockerMemoryMetricsSubgroup {
             System.out.println("Cgroup not configured.");
             return;
         }
-        if (!DockerTestUtils.canTestDocker()) {
-            System.out.println("Unable to run docker tests.");
-            return;
-        }
+        DockerTestUtils.checkCanTestDocker();
 
         ContainerRuntimeVersionTestUtils.checkContainerVersionSupported();
 

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -29,9 +29,11 @@
  * @requires container.support
  * @requires !vm.asan
  * @library /test/lib
+ * @modules java.base/jdk.internal.platform
  * @build GetFreeSwapSpaceSize
  * @run driver TestGetFreeSwapSpaceSize
  */
+
 import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
@@ -41,10 +43,8 @@ public class TestGetFreeSwapSpaceSize {
     private static final String imageName = Common.imageName("osbeanSwapSpace");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {

--- a/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
+++ b/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
@@ -55,10 +55,8 @@ public class TestLimitsUpdating {
     private static final String imageName = Common.imageName("limitsUpdatingJDK");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {

--- a/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
+++ b/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
@@ -30,6 +30,7 @@
  * @requires container.support
  * @requires !vm.asan
  * @library /test/lib
+ * @modules java.base/jdk.internal.platform
  * @build TestPidsLimit
  * @run driver TestPidsLimit
  */
@@ -49,10 +50,8 @@ public class TestPidsLimit {
     private static final int UNLIMITED_PIDS_DOCKER = -1;
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
+        DockerTestUtils.checkCanUseResourceLimits();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {

--- a/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
@@ -42,10 +42,7 @@ public class TestSystemMetrics {
     private static final String imageName = Common.imageName("metrics");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {

--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -42,10 +42,7 @@ public class TestUseContainerSupport {
     private static final String imageName = Common.imageName("useContainerSupport");
 
     public static void main(String[] args) throws Exception {
-        if (!DockerTestUtils.canTestDocker()) {
-            return;
-        }
-
+        DockerTestUtils.checkCanTestDocker();
         DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import jdk.internal.platform.Metrics;
 import jdk.test.lib.Container;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -47,6 +48,7 @@ import jtreg.SkippedException;
 public class DockerTestUtils {
     private static boolean isDockerEngineAvailable = false;
     private static boolean wasDockerEngineChecked = false;
+    private static final Metrics metrics = Metrics.systemMetrics();
 
     // Specifies how many lines to copy from child STDOUT to main test output.
     // Having too many lines in the main test output will result
@@ -93,16 +95,12 @@ public class DockerTestUtils {
     }
 
     /**
-     * Convenience method, will check if docker engine is available and usable;
-     * will print the appropriate message when not available.
+     * Checks if the docker engine is available and usable, throws an exception if not.
      *
-     * @return true if docker engine is available
      * @throws Exception
      */
-    public static boolean canTestDocker() throws Exception {
-        if (isDockerEngineAvailable()) {
-            return true;
-        } else {
+    public static void checkCanTestDocker() throws Exception {
+        if (!isDockerEngineAvailable()) {
             throw new SkippedException("Docker engine is not available on this system");
         }
     }
@@ -131,6 +129,17 @@ public class DockerTestUtils {
 
     private static String getEngineInfo(String format) throws Exception {
         return execute(Container.ENGINE_COMMAND, "info", "-f", format).getStdout();
+    }
+
+    /**
+     * Checks if the engine can use resource limits, throws an exception if not.
+     *
+     * @throws Exception
+     */
+    public static void checkCanUseResourceLimits() throws Exception {
+        if (isRootless() && "cgroupv1".equals(metrics.getProvider())) {
+            throw new SkippedException("Resource limits are not available on this system");
+        }
     }
 
     /**


### PR DESCRIPTION
Backport of the change in 25.  

Resolved Copyright in DockerTestUtils.java, probably clean anyways.

Will make this depend on the push in 25 for skara once available.

--> made it depend on the original push, probably clean, too.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8372615](https://bugs.openjdk.org/browse/JDK-8372615) needs maintainer approval

### Issue
 * [JDK-8372615](https://bugs.openjdk.org/browse/JDK-8372615): Many container tests fail when running rootless on cgroup v1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2948/head:pull/2948` \
`$ git checkout pull/2948`

Update a local copy of the PR: \
`$ git checkout pull/2948` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2948`

View PR using the GUI difftool: \
`$ git pr show -t 2948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2948.diff">https://git.openjdk.org/jdk21u-dev/pull/2948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2948#issuecomment-4808782952)
</details>
