### PR TITLE
8384804: JMX remote bootstrap tests fail on Windows

### DIFF
--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -45,9 +45,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.UserPrincipal;
 import java.nio.channels.SocketChannel;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.MessageDigest;
@@ -56,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.Map;
@@ -1033,25 +1036,18 @@ public final class Utils {
         } else if (attr.contains("acl")) {
             AclFileAttributeView view =
                     Files.getFileAttributeView(file, AclFileAttributeView.class);
+            UserPrincipal everyone = file.getFileSystem()
+                    .getUserPrincipalLookupService()
+                    .lookupPrincipalByName("Everyone");
+            UserPrincipal principal = userOnly ? view.getOwner() : everyone;
+            EnumSet<AclEntryPermission> allPermissions = EnumSet.allOf(AclEntryPermission.class);
+
             List<AclEntry> acl = new ArrayList<>();
-            for (AclEntry thisEntry : view.getAcl()) {
-                if (userOnly) {
-                    if (thisEntry.principal().getName()
-                            .equals(view.getOwner().getName())) {
-                        acl.add(allowAccess(thisEntry));
-                    } else if (thisEntry.type() == AclEntryType.ALLOW) {
-                        acl.add(revokeAccess(thisEntry));
-                    } else {
-                        acl.add(thisEntry);
-                    }
-                } else {
-                    if (thisEntry.type() != AclEntryType.ALLOW) {
-                        acl.add(allowAccess(thisEntry));
-                    } else {
-                        acl.add(thisEntry);
-                    }
-                }
-            }
+            acl.add(AclEntry.newBuilder()
+                    .setType(AclEntryType.ALLOW)
+                    .setPrincipal(principal)
+                    .setPermissions(allPermissions)
+                    .build());
             view.setAcl(acl);
         } else {
             throw new RuntimeException("Unsupported file attributes: " + attr);


### PR DESCRIPTION
Patch applies cleanly.  Also fixes JMX remote bootstrap tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8384804](https://bugs.openjdk.org/browse/JDK-8384804) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384804](https://bugs.openjdk.org/browse/JDK-8384804): JMX remote bootstrap tests fail on Windows (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2954/head:pull/2954` \
`$ git checkout pull/2954`

Update a local copy of the PR: \
`$ git checkout pull/2954` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2954`

View PR using the GUI difftool: \
`$ git pr show -t 2954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2954.diff">https://git.openjdk.org/jdk21u-dev/pull/2954.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2954#issuecomment-4857046589)
</details>
