### PR TITLE
Add required paralelgc to sun/tools/jstat shell tests to avoid failure

### DIFF
--- a/test/jdk/sun/tools/jstat/jstatGcCapacityOutput1.sh
+++ b/test/jdk/sun/tools/jstat/jstatGcCapacityOutput1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatGcCapacityOutput1.sh
 # @summary Test that output of 'jstat -gccapacity 0' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatGcMetaCapacityOutput1.sh
+++ b/test/jdk/sun/tools/jstat/jstatGcMetaCapacityOutput1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatGcMetaCapacityOutput1.sh
 # @summary Test that output of 'jstat -gcmetacapacity 0' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatGcNewCapacityOutput1.sh
+++ b/test/jdk/sun/tools/jstat/jstatGcNewCapacityOutput1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatGcNewCapacityOutput1.sh
 # @summary Test that output of 'jstat -gcnewcapacity 0' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatGcNewOutput1.sh
+++ b/test/jdk/sun/tools/jstat/jstatGcNewOutput1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatGcNewOutput1.sh
 # @summary Test that output of 'jstat -gcnew 0' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatGcOldCapacityOutput1.sh
+++ b/test/jdk/sun/tools/jstat/jstatGcOldCapacityOutput1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatGcOldCapacityOutput1.sh
 # @summary Test that output of 'jstat -gcoldcapcaity 0' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatGcOldOutput1.sh
+++ b/test/jdk/sun/tools/jstat/jstatGcOldOutput1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatGcOldOutput1.sh
 # @summary Test that output of 'jstat -gcold 0' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatGcOutput1.sh
+++ b/test/jdk/sun/tools/jstat/jstatGcOutput1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatGcOutput1.sh
 # @summary Test that output of 'jstat -gc 0' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatLineCounts1.sh
+++ b/test/jdk/sun/tools/jstat/jstatLineCounts1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatLineCounts1.sh
 # @summary Test that output of 'jstat -gcutil 0 250 5' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatLineCounts2.sh
+++ b/test/jdk/sun/tools/jstat/jstatLineCounts2.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatLineCounts2.sh
 # @summary Test that output of 'jstat -gcutil 0' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatLineCounts3.sh
+++ b/test/jdk/sun/tools/jstat/jstatLineCounts3.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatLineCounts3.sh
 # @summary Test that output of 'jstat -gcutil -h 10 250 10' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatLineCounts4.sh
+++ b/test/jdk/sun/tools/jstat/jstatLineCounts4.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatLineCounts4.sh
 # @summary Test that output of 'jstat -gcutil -h 10 250 11' has expected line counts
 

--- a/test/jdk/sun/tools/jstat/jstatTimeStamp1.sh
+++ b/test/jdk/sun/tools/jstat/jstatTimeStamp1.sh
@@ -23,6 +23,7 @@
 
 # @test
 # @bug 4990825
+# @requires vm.gc.Parallel
 # @run shell jstatTimeStamp1.sh
 # @summary Test that output of 'jstat -gcutil -t 0' has expected format
 


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8387985

The affected tests invoke jstat with -J-XX:+UseParallelGC, which causes the JVM running jstat to fail during initialization with:

```
Error occurred during initialization of VM
Option -XX:+UseParallelGC not supported 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2960/head:pull/2960` \
`$ git checkout pull/2960`

Update a local copy of the PR: \
`$ git checkout pull/2960` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2960`

View PR using the GUI difftool: \
`$ git pr show -t 2960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2960.diff">https://git.openjdk.org/jdk21u-dev/pull/2960.diff</a>

</details>
