### PR TITLE
8388431: [21u] Backport of JDK-8352565 misses previous vm symbol to be deleted

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -441,7 +441,6 @@
   template(cs_name,                                   "cs")                                       \
   template(refStack_name,                             "refStack")                                 \
   template(refSP_name,                                "refSP")                                    \
-  template(get_name,                                  "get")                                      \
   template(get0_name,                                 "get0")                                     \
   template(refersTo0_name,                            "refersTo0")                                \
   template(put_name,                                  "put")                                      \


### PR DESCRIPTION
The backport of https://bugs.openjdk.org/browse/JDK-8352565 misses previous vm symbol "get_name" to be deleted that used to be renamed to "get_name0".

Test:
- test/hotspot/jtreg/gc/TestNativeReferenceGet.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8388431](https://bugs.openjdk.org/browse/JDK-8388431) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388431](https://bugs.openjdk.org/browse/JDK-8388431): [21u] Backport of JDK-8352565 misses previous vm symbol to be deleted (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2963/head:pull/2963` \
`$ git checkout pull/2963`

Update a local copy of the PR: \
`$ git checkout pull/2963` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2963`

View PR using the GUI difftool: \
`$ git pr show -t 2963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2963.diff">https://git.openjdk.org/jdk21u-dev/pull/2963.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2963#issuecomment-5003094865)
</details>
