### PR TITLE
8387625: Add "dt_socket" to `CheckedFeatures.notImplemented` for Windows/ARM64

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -604,6 +604,9 @@ class CheckedFeatures {
 
         {"windows-x64",     "com.sun.jdi.CommandLineLaunch", "dt_socket"},
         {"windows-x64",     "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
+
+        {"windows-aarch64", "com.sun.jdi.CommandLineLaunch", "dt_socket"},
+        {"windows-aarch64", "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
 
         {"macosx-amd64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
         {"macosx-amd64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},


### PR DESCRIPTION
Backport of commit [41a6eee8](https://github.com/openjdk/jdk/commit/41a6eee8756ccd2ae8c511f1aacf7454aa5731db) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository; reviewed by Chris Plummer and Aleksey Shipilev.

The only merge conflict was in the year of the copyright header, otherwise the original patch to JDK tip applied cleanly.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8387625](https://bugs.openjdk.org/browse/JDK-8387625) needs maintainer approval

### Issue
 * [JDK-8387625](https://bugs.openjdk.org/browse/JDK-8387625): Add "dt_socket" to `CheckedFeatures.notImplemented` for Windows/ARM64 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2967/head:pull/2967` \
`$ git checkout pull/2967`

Update a local copy of the PR: \
`$ git checkout pull/2967` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2967`

View PR using the GUI difftool: \
`$ git pr show -t 2967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2967.diff">https://git.openjdk.org/jdk21u-dev/pull/2967.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2967#issuecomment-5044272674)
</details>
