### PR TITLE
7067310: 3 tests from closed/javax/sound/sampled caused BSOD on win 7 x86

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -649,17 +649,8 @@ sun/security/tools/keytool/GenKeyPairSigner.java                8342002 generic-
 ############################################################################
 
 # jdk_sound
-javax/sound/sampled/DirectAudio/bug6372428.java                      8055097 generic-all
-javax/sound/sampled/Clip/bug5070081.java                             8055097 generic-all
-javax/sound/sampled/DataLine/LongFramePosition.java                  8055097 generic-all
 
 javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
-
-javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
-
-javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,macosx-aarch64
-javax/sound/midi/Sequencer/Looping.java 8136897 generic-all
-javax/sound/sampled/Clip/ClipIsRunningAfterStop.java 8307574 linux-x64
 
 ############################################################################
 


### PR DESCRIPTION
Backporting JDK-7067310, JDK-8307574, and JDK-8308395: tests from closed/javax/sound/sampled caused BSOD on win 7 x86, ClipIsRunningAfterStop.java failed with "../nptl/pthread_mutex_lock.c:81: __pthread_mutex_lock: Assertion `mutex->__data.__owner == 0' failed.", and javax/sound/sampled/Clip/ClipFlushCrash.java timed out

This PR removes several sound tests from the problem list.

For parity with Oracle JDK. Already backported to 25.

This PR is not clean because "javax/sound/sampled/Clip/ClipFlushCrash.java" wasn't initially on the problem list.

Ran related tests on linux-x64, linux-aarch64, and macos-aarch64:

make test TEST="test/jdk/javax/sound/sampled/DirectAudio/bug6372428.java test/jdk/javax/sound/sampled/Clip/bug5070081.java test/jdk/javax/sound/sampled/DataLine/LongFramePosition.java test/jdk/javax/sound/sampled/Mixers/DisabledAssertionCrash.java test/jdk/javax/sound/midi/Sequencer/Recording.java test/jdk/javax/sound/midi/Sequencer/Looping.java test/jdk/javax/sound/sampled/Clip/ClipIsRunningAfterStop.java test/jdk/javax/sound/sampled/Clip/ClipFlushCrash.java"

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/30315935/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/30315936/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/30315938/linux-aarch64-specific-test.log)

Ran related tests on windows-x64:

make test TEST=test/jdk/javax/sound/sampled/DirectAudio/bug6372428.java
make test TEST=test/jdk/javax/sound/sampled/Clip/bug5070081.java
make test TEST=test/jdk/javax/sound/sampled/DataLine/LongFramePosition.java
make test TEST=test/jdk/javax/sound/sampled/Mixers/DisabledAssertionCrash.java
make test TEST=test/jdk/javax/sound/midi/Sequencer/Recording.java
make test TEST=test/jdk/javax/sound/midi/Sequencer/Looping.java
make test TEST=test/jdk/javax/sound/sampled/Clip/ClipIsRunningAfterStop.java
make test TEST=test/jdk/javax/sound/sampled/Clip/ClipFlushCrash.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/30315941/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/30315943/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/30315944/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/30315945/windows-x64-specific-4-test.log)
[windows-x64-specific-5-test.log](https://github.com/user-attachments/files/30315946/windows-x64-specific-5-test.log)
[windows-x64-specific-6-test.log](https://github.com/user-attachments/files/30315947/windows-x64-specific-6-test.log)
[windows-x64-specific-7-test.log](https://github.com/user-attachments/files/30315948/windows-x64-specific-7-test.log)
[windows-x64-specific-8-test.log](https://github.com/user-attachments/files/30315950/windows-x64-specific-8-test.log)

Please note that I also ran "../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk test/jdk/javax/sound/midi/Sequencer/Looping.java" on windows-x64 and it passed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8307574](https://bugs.openjdk.org/browse/JDK-8307574) needs maintainer approval
- \[x\] [JDK-8308395](https://bugs.openjdk.org/browse/JDK-8308395) needs maintainer approval
- \[x\] [JDK-7067310](https://bugs.openjdk.org/browse/JDK-7067310) needs maintainer approval

### Issues
 * [JDK-7067310](https://bugs.openjdk.org/browse/JDK-7067310): 3 tests from closed/javax/sound/sampled caused BSOD on win 7 x86 (**Bug** - P3 - Approved)
 * [JDK-8307574](https://bugs.openjdk.org/browse/JDK-8307574): ClipIsRunningAfterStop.java failed with "../nptl/pthread_mutex_lock.c:81: __pthread_mutex_lock: Assertion `mutex-&gt;__data.__owner == 0' failed." (**Bug** - P4 - Approved)
 * [JDK-8308395](https://bugs.openjdk.org/browse/JDK-8308395): javax/sound/sampled/Clip/ClipFlushCrash.java timed out (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2969/head:pull/2969` \
`$ git checkout pull/2969`

Update a local copy of the PR: \
`$ git checkout pull/2969` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2969`

View PR using the GUI difftool: \
`$ git pr show -t 2969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2969.diff">https://git.openjdk.org/jdk21u-dev/pull/2969.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2969#issuecomment-5060500061)
</details>
