### PR TITLE
8369020: Test compiler/intrinsics/TestLongUnsignedDivMod.java completed and timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
@@ -110,7 +110,6 @@ public class TestLongUnsignedDivMod {
     }
 
     @Test // needs to be run in (fast) debug mode
-    @Warmup(10000)
     @IR(counts = {IRNode.UDIV_L, ">= 1"}) // At least one UDivL node is generated if intrinsic is used
     public void testDivideUnsigned() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
@@ -124,7 +123,6 @@ public class TestLongUnsignedDivMod {
     }
 
     @Test // needs to be run in (fast) debug mode
-    @Warmup(10000)
     @IR(counts = {IRNode.UMOD_L, ">= 1"}) // At least one UModL node is generated if intrinsic is used
     public void testRemainderUnsigned() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
@@ -139,7 +137,6 @@ public class TestLongUnsignedDivMod {
 
 
     @Test // needs to be run in (fast) debug mode
-    @Warmup(10000)
     @IR(applyIfPlatform = {"x64", "true"},
         counts = {IRNode.UDIV_MOD_L, ">= 1"}) // At least one UDivModL node is generated if intrinsic is used
     public void testDivModUnsigned() {


### PR DESCRIPTION
Backporting JDK-8369020: Test compiler/intrinsics/TestLongUnsignedDivMod.java completed and timed out.

This PR fixes the test timeout issue in TestLongUnsignedDivMod.java.

For parity with Oracle JDK. Already backported to 25.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/30317036/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/30317037/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/30317038/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/30317039/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8369020](https://bugs.openjdk.org/browse/JDK-8369020) needs maintainer approval

### Issue
 * [JDK-8369020](https://bugs.openjdk.org/browse/JDK-8369020): Test compiler/intrinsics/TestLongUnsignedDivMod.java completed and timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2970/head:pull/2970` \
`$ git checkout pull/2970`

Update a local copy of the PR: \
`$ git checkout pull/2970` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2970`

View PR using the GUI difftool: \
`$ git pr show -t 2970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2970.diff">https://git.openjdk.org/jdk21u-dev/pull/2970.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2970#issuecomment-5060490609)
</details>
