### PR TITLE
8388412: Update PKCS#11 Cryptographic Token Interface to v3.2

### DIFF
--- a/src/jdk.crypto.cryptoki/share/legal/pkcs11cryptotoken.md
+++ b/src/jdk.crypto.cryptoki/share/legal/pkcs11cryptotoken.md
@@ -1,76 +1,77 @@
-## OASIS PKCS #11 Cryptographic Token Interface v3.1
+## OASIS PKCS #11 Cryptographic Token Interface v3.2
 
 ### OASIS PKCS #11 Cryptographic Token Interface License
 <pre>
 
-Copyright © OASIS Open 2023. All Rights Reserved.
+Copyright © OASIS Open 2026. All Rights Reserved.
 
-All capitalized terms in the following text have the meanings
-assigned to them in the OASIS Intellectual Property Rights Policy (the
-"OASIS IPR Policy"). The full Policy may be found at the OASIS website:
-[https://www.oasis-open.org/policies-guidelines/ipr/].
+All capitalized terms in the following text have the meanings assigned to them
+in the OASIS Intellectual Property Rights Policy (the "OASIS IPR Policy"). The
+full Policy may be found at the OASIS website:
+<https://www.oasis-open.org/policies-guidelines/ipr/>.
 
-This document and translations of it may be copied and furnished to
-others, and derivative works that comment on or otherwise explain it or
-assist in its implementation may be prepared, copied, published, and
-distributed, in whole or in part, without restriction of any kind,
-provided that the above copyright notice and this section are included
-on all such copies and derivative works. However, this document itself
-may not be modified in any way, including by removing the copyright
-notice or references to OASIS, except as needed for the purpose of
-developing any document or deliverable produced by an OASIS Technical
-Committee (in which case the rules applicable to copyrights, as set
-forth in the OASIS IPR Policy, must be followed) or as required to
-translate it into languages other than English.
+This document and translations of it may be copied and furnished to others, and
+derivative works that comment on or otherwise explain it or assist in its
+implementation may be prepared, copied, published, and distributed, in whole or
+in part, without restriction of any kind, provided that the above copyright
+notice and this section are included on all such copies and derivative works.
+However, this document itself may not be modified in any way, including by
+removing the copyright notice or references to OASIS, except as needed for the
+purpose of developing any document or deliverable produced by an OASIS Technical
+Committee (in which case the rules applicable to copyrights, as set forth in the
+OASIS IPR Policy, must be followed) or as required to translate it into
+languages other than English.
 
-The limited permissions granted above are perpetual and will not be
-revoked by OASIS or its successors or assigns.
+The limited permissions granted above are perpetual and will not be revoked by
+OASIS or its successors or assigns.
 
-This document and the information contained herein is provided on an
-"AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED,
-INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
-INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED
-WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. OASIS
-AND ITS MEMBERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
-CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THIS DOCUMENT OR ANY
-PART THEREOF.
+This document and the information contained herein is provided on an "AS IS"
+basis and OASIS DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE
+ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR
+A PARTICULAR PURPOSE. OASIS AND ITS MEMBERS WILL NOT BE LIABLE FOR ANY DIRECT,
+INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THIS
+DOCUMENT OR ANY PART THEREOF.
 
-As stated in the OASIS IPR Policy, the following three paragraphs in
-brackets apply to OASIS Standards Final Deliverable documents (Committee
-Specifications, OASIS Standards, or Approved Errata).
+As stated in the OASIS IPR Policy, the following three paragraphs in brackets
+apply to OASIS Standards Final Deliverable documents (Committee Specifications,
+OASIS Standards, or Approved Errata).
 
-[OASIS requests that any OASIS Party or any other party that
-believes it has patent claims that would necessarily be infringed by
-implementations of this OASIS Standards Final Deliverable, to notify
-OASIS TC Administrator and provide an indication of its willingness to
-grant patent licenses to such patent claims in a manner consistent with
-the IPR Mode of the OASIS Technical Committee that produced this
-deliverable.]
+[OASIS requests that any OASIS Party or any other party that believes it has
+patent claims that would necessarily be infringed by implementations of this
+OASIS Standards Final Deliverable, to notify OASIS TC Administrator and provide
+an indication of its willingness to grant patent licenses to such patent claims
+in a manner consistent with the IPR Mode of the OASIS Technical Committee that
+produced this deliverable.]
 
-[OASIS invites any party to contact the OASIS TC Administrator if it
-is aware of a claim of ownership of any patent claims that would
-necessarily be infringed by implementations of this OASIS Standards
-Final Deliverable by a patent holder that is not willing to provide a
-license to such patent claims in a manner consistent with the IPR Mode
-of the OASIS Technical Committee that produced this OASIS Standards
-Final Deliverable. OASIS may include such claims on its website, but
-disclaims any obligation to do so.]
+[OASIS invites any party to contact the OASIS TC Administrator if it is aware of
+a claim of ownership of any patent claims that would necessarily be infringed by
+implementations of this OASIS Standards Final Deliverable by a patent holder
+that is not willing to provide a license to such patent claims in a manner
+consistent with the IPR Mode of the OASIS Technical Committee that produced this
+OASIS Standards Final Deliverable. OASIS may include such claims on its website,
+but disclaims any obligation to do so.]
 
-[OASIS takes no position regarding the validity or scope of any
-intellectual property or other rights that might be claimed to pertain
-to the implementation or use of the technology described in this OASIS
-Standards Final Deliverable or the extent to which any license under
-such rights might or might not be available; neither does it represent
-that it has made any effort to identify any such rights. Information on
-OASIS' procedures with respect to rights in any document or deliverable
-produced by an OASIS Technical Committee can be found on the OASIS
-website. Copies of claims of rights made available for publication and
-any assurances of licenses to be made available, or the result of an
-attempt made to obtain a general license or permission for the use of
-such proprietary rights by implementers or users of this OASIS Standards
-Final Deliverable, can be obtained from the OASIS TC Administrator.
-OASIS makes no representation that any information or list of
-intellectual property rights will at any time be complete, or that any
-claims in such list are, in fact, Essential Claims.]
+[OASIS takes no position regarding the validity or scope of any intellectual
+property or other rights that might be claimed to pertain to the implementation
+or use of the technology described in this OASIS Standards Final Deliverable or
+the extent to which any license under such rights might or might not be
+available; neither does it represent that it has made any effort to identify any
+such rights. Information on OASIS' procedures with respect to rights in any
+document or deliverable produced by an OASIS Technical Committee can be found on
+the OASIS website. Copies of claims of rights made available for publication and
+any assurances of licenses to be made available, or the result of an attempt
+made to obtain a general license or permission for the use of such proprietary
+rights by implementers or users of this OASIS Standards Final Deliverable, can
+be obtained from the OASIS TC Administrator. OASIS makes no representation that
+any information or list of intellectual property rights will at any time be
+complete, or that any claims in such list are, in fact, Essential Claims.]
+
+The name "OASIS" is a trademark of OASIS, the owner and developer of this
+document, and should be used only to refer to the organization and its official
+outputs. OASIS welcomes reference to, and implementation and use of, documents,
+while reserving the right to enforce its marks against misleading uses. Please
+see <https://www.oasis-open.org/policies-guidelines/trademark/> for above
+guidance.
 
 </pre>

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11.h
@@ -1,11 +1,12 @@
-/*
- * PKCS #11 Specification Version 3.1
- * OASIS Standard
- * 23 July 2023
- * Copyright (c) OASIS Open 2023. All Rights Reserved.
- * Source: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/include/pkcs11-v3.1/
- * Latest stage of narrative specification: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html
- * TC IPR Statement: https://www.oasis-open.org/committees/pkcs11/ipr.php
+/* Copyright (c) OASIS Open 2016,2019,2024. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-base/v3.2/pkcs11-base-v3.2.html
  */
 
 #ifndef _PKCS11_H_
@@ -204,6 +205,21 @@ extern "C" {
 #define CK_PKCS11_FUNCTION_INFO(name) \
   __PASTE(CK_,name) name;
 
+/* Create the 3.2 Function list */
+struct CK_FUNCTION_LIST_3_2 {
+
+  CK_VERSION    version;  /* Cryptoki version */
+
+/* Pile all the function pointers into the CK_FUNCTION_LIST. */
+/* pkcs11f.h has all the information about the Cryptoki
+ * function prototypes.
+ */
+#include "pkcs11f.h"
+
+};
+
+#define CK_PKCS11_3_0_ONLY 1   /* don't include the 3.2 and later functions */
+
 /* Create the 3.0 Function list */
 struct CK_FUNCTION_LIST_3_0 {
 
@@ -217,7 +233,9 @@ struct CK_FUNCTION_LIST_3_0 {
 
 };
 
-#define CK_PKCS11_2_0_ONLY 1
+#undef CK_PKCS11_3_0_ONLY
+
+#define CK_PKCS11_2_0_ONLY 1   /* don't include the 3.0 and later functions */
 
 /* Continue to define the old CK_FUNCTION_LIST */
 struct CK_FUNCTION_LIST {

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11f.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11f.h
@@ -1,11 +1,12 @@
-/*
- * PKCS #11 Specification Version 3.1
- * OASIS Standard
- * 23 July 2023
- * Copyright (c) OASIS Open 2023. All Rights Reserved.
- * Source: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/include/pkcs11-v3.1/
- * Latest stage of narrative specification: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html
- * TC IPR Statement: https://www.oasis-open.org/committees/pkcs11/ipr.php
+/* Copyright (c) OASIS Open 2016, 2019, 2024. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.2/pkcs11-spec-v3.2.html
  */
 
 /* This header file contains pretty much everything about all the
@@ -953,7 +954,7 @@ CK_PKCS11_FUNCTION_INFO(C_GetInterface)
   CK_UTF8CHAR_PTR       pInterfaceName, /* name of the interface */
   CK_VERSION_PTR        pVersion,       /* version of the interface */
   CK_INTERFACE_PTR_PTR  ppInterface,    /* returned interface */
-  CK_FLAGS              flags           /* flags controlling the semantics
+  CK_FLAGS      flags           /* flags controlling the semantics
                                          * of the interface */
 );
 #endif
@@ -1192,5 +1193,138 @@ CK_PKCS11_FUNCTION_INFO(C_MessageVerifyFinal)
 );
 #endif
 
-#endif /* CK_PKCS11_2_0_ONLY */
+#ifndef CK_PKCS11_3_0_ONLY
+CK_PKCS11_FUNCTION_INFO(C_EncapsulateKey)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR pMechanism,   /* the encapsulation mechanism */
+  CK_OBJECT_HANDLE hPublicKey,   /* the encapsulating key */
+  CK_ATTRIBUTE_PTR pTemplate,    /* new key template */
+  CK_ULONG ulAttributeCount,     /* template length */
+  CK_BYTE_PTR pCiphertext,       /* the wrapped key */
+  CK_ULONG_PTR pulCiphertextLen, /* the wrapped key size */
+  CK_OBJECT_HANDLE_PTR phKey     /* the encapsulated key */
+);
+#endif
 
+CK_PKCS11_FUNCTION_INFO(C_DecapsulateKey)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR pMechanism,   /* the decapsulation mechanism */
+  CK_OBJECT_HANDLE hPrivateKey,  /* the decapsulating key */
+  CK_ATTRIBUTE_PTR pTemplate,    /* new key template */
+  CK_ULONG ulAttributeCount,     /* template length */
+  CK_BYTE_PTR pCiphertext,       /* the wrapped key */
+  CK_ULONG ulCiphertextLen,      /* the wrapped key size */
+  CK_OBJECT_HANDLE_PTR phKey     /* the decapsulated key */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_VerifySignatureInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR pMechanism,   /* the verification mechanism */
+  CK_OBJECT_HANDLE hKey,         /* verification key */
+  CK_BYTE_PTR pSignature,        /* signature */
+  CK_ULONG ulSignatureLen        /* signature length */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_VerifySignature)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_BYTE_PTR pData,             /* signed data */
+  CK_ULONG ulDataLen             /* length of signed data */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_VerifySignatureUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_BYTE_PTR pPart,             /* signed data */
+  CK_ULONG ulPartLen             /* length of signed data */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_VerifySignatureFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+   CK_SESSION_HANDLE hSession    /* the session's handle */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_GetSessionValidationFlags)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,             /* the session's handle */
+  CK_SESSION_VALIDATION_FLAGS_TYPE type,  /* which state of flags */
+  CK_FLAGS_PTR pFlags                     /* validation flags */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_AsyncComplete)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,      /* the session's handle */
+  CK_UTF8CHAR_PTR pFunctionName,   /* pkcs11 function name */
+  CK_ASYNC_DATA_PTR pResult        /* operation result */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_AsyncGetID)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_UTF8CHAR_PTR pFunctionName, /* pkcs11 function name */
+  CK_ULONG_PTR pulID             /* persistent operation id */
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_AsyncJoin)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_UTF8CHAR_PTR pFunctionName, /* pkcs11 function name */
+  CK_ULONG ulID,                 /* persistent operation id */
+  CK_BYTE_PTR pData,             /* location for the data */
+  CK_ULONG ulData
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_WrapKeyAuthenticated)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,
+  CK_MECHANISM_PTR pMechanism,
+  CK_OBJECT_HANDLE hWrappingKey,
+  CK_OBJECT_HANDLE hKey,
+  CK_BYTE_PTR pAssociatedData,
+  CK_ULONG ulAssociatedDataLen,
+  CK_BYTE_PTR pWrappedKey,
+  CK_ULONG_PTR pulWrappedKeyLen
+);
+#endif
+
+CK_PKCS11_FUNCTION_INFO(C_UnwrapKeyAuthenticated)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,
+  CK_MECHANISM_PTR pMechanism,
+  CK_OBJECT_HANDLE hUnwrappingKey,
+  CK_BYTE_PTR pWrappedKey,
+  CK_ULONG ulWrappedKeyLen,
+  CK_ATTRIBUTE_PTR pTemplate,
+  CK_ULONG ulAttributeCount,
+  CK_BYTE_PTR pAssociatedData,
+  CK_ULONG ulAssociatedDataLen,
+  CK_OBJECT_HANDLE_PTR phKey
+);
+#endif
+
+#endif /* CK_PKCS11_3_0_ONLY */
+#endif /* CK_PKCS11_2_0_ONLY */

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
@@ -1,11 +1,12 @@
-/*
- * PKCS #11 Specification Version 3.1
- * OASIS Standard
- * 23 July 2023
- * Copyright (c) OASIS Open 2023. All Rights Reserved.
- * Source: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/os/include/pkcs11-v3.1/
- * Latest stage of narrative specification: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html
- * TC IPR Statement: https://www.oasis-open.org/committees/pkcs11/ipr.php
+/* Copyright (c) OASIS Open 2016, 2019, 2024. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.2/pkcs11-spec-v3.2.html
  */
 
 /* See top of pkcs11.h for information about the macros that
@@ -17,7 +18,7 @@
 #define _PKCS11T_H_ 1
 
 #define CRYPTOKI_VERSION_MAJOR          3
-#define CRYPTOKI_VERSION_MINOR          1
+#define CRYPTOKI_VERSION_MINOR          2
 #define CRYPTOKI_VERSION_AMENDMENT      0
 
 #define CK_TRUE         1
@@ -64,6 +65,7 @@ typedef CK_CHAR     CK_PTR   CK_CHAR_PTR;
 typedef CK_UTF8CHAR CK_PTR   CK_UTF8CHAR_PTR;
 typedef CK_ULONG    CK_PTR   CK_ULONG_PTR;
 typedef void        CK_PTR   CK_VOID_PTR;
+typedef CK_ULONG    CK_PTR   CK_FLAGS_PTR;
 
 /* Pointer to a CK_VOID_PTR-- i.e., pointer to pointer to void */
 typedef CK_VOID_PTR CK_PTR CK_VOID_PTR_PTR;
@@ -76,19 +78,19 @@ typedef CK_VOID_PTR CK_PTR CK_VOID_PTR_PTR;
 
 
 typedef struct CK_VERSION {
-    CK_BYTE major;  /* integer portion of version number */
-    CK_BYTE minor;  /* 1/100ths portion of version number */
+  CK_BYTE       major;  /* integer portion of version number */
+  CK_BYTE       minor;  /* 1/100ths portion of version number */
 } CK_VERSION;
 
 typedef CK_VERSION CK_PTR CK_VERSION_PTR;
 
 
 typedef struct CK_INFO {
-    CK_VERSION  cryptokiVersion;        /* Cryptoki interface ver */
-    CK_UTF8CHAR manufacturerID[32];     /* blank padded */
-    CK_FLAGS    flags;                  /* must be zero */
-    CK_UTF8CHAR libraryDescription[32]; /* blank padded */
-    CK_VERSION  libraryVersion;         /* version of library */
+  CK_VERSION    cryptokiVersion;     /* Cryptoki interface ver */
+  CK_UTF8CHAR   manufacturerID[32];  /* blank padded */
+  CK_FLAGS      flags;               /* must be zero */
+  CK_UTF8CHAR   libraryDescription[32];  /* blank padded */
+  CK_VERSION    libraryVersion;          /* version of library */
 } CK_INFO;
 
 typedef CK_INFO CK_PTR    CK_INFO_PTR;
@@ -108,12 +110,12 @@ typedef CK_SLOT_ID CK_PTR CK_SLOT_ID_PTR;
 
 /* CK_SLOT_INFO provides information about a slot */
 typedef struct CK_SLOT_INFO {
-    CK_UTF8CHAR slotDescription[64];  /* blank padded */
-    CK_UTF8CHAR manufacturerID[32];   /* blank padded */
-    CK_FLAGS    flags;
+  CK_UTF8CHAR   slotDescription[64];  /* blank padded */
+  CK_UTF8CHAR   manufacturerID[32];   /* blank padded */
+  CK_FLAGS      flags;
 
-    CK_VERSION  hardwareVersion;      /* version of hardware */
-    CK_VERSION  firmwareVersion;      /* version of firmware */
+  CK_VERSION    hardwareVersion;  /* version of hardware */
+  CK_VERSION    firmwareVersion;  /* version of firmware */
 } CK_SLOT_INFO;
 
 /* flags: bit flags that provide capabilities of the slot
@@ -128,25 +130,25 @@ typedef CK_SLOT_INFO CK_PTR CK_SLOT_INFO_PTR;
 
 /* CK_TOKEN_INFO provides information about a token */
 typedef struct CK_TOKEN_INFO {
-    CK_UTF8CHAR label[32];            /* blank padded */
-    CK_UTF8CHAR manufacturerID[32];   /* blank padded */
-    CK_UTF8CHAR model[16];            /* blank padded */
-    CK_CHAR     serialNumber[16];     /* blank padded */
-    CK_FLAGS    flags;                /* see below */
+  CK_UTF8CHAR   label[32];           /* blank padded */
+  CK_UTF8CHAR   manufacturerID[32];  /* blank padded */
+  CK_UTF8CHAR   model[16];           /* blank padded */
+  CK_CHAR       serialNumber[16];    /* blank padded */
+  CK_FLAGS      flags;               /* see below */
 
-    CK_ULONG    ulMaxSessionCount;    /* max open sessions */
-    CK_ULONG    ulSessionCount;       /* sess. now open */
-    CK_ULONG    ulMaxRwSessionCount;  /* max R/W sessions */
-    CK_ULONG    ulRwSessionCount;     /* R/W sess. now open */
-    CK_ULONG    ulMaxPinLen;          /* in bytes */
-    CK_ULONG    ulMinPinLen;          /* in bytes */
-    CK_ULONG    ulTotalPublicMemory;  /* in bytes */
-    CK_ULONG    ulFreePublicMemory;   /* in bytes */
-    CK_ULONG    ulTotalPrivateMemory; /* in bytes */
-    CK_ULONG    ulFreePrivateMemory;  /* in bytes */
-    CK_VERSION  hardwareVersion;      /* version of hardware */
-    CK_VERSION  firmwareVersion;      /* version of firmware */
-    CK_CHAR     utcTime[16];          /* time */
+  CK_ULONG      ulMaxSessionCount;     /* max open sessions */
+  CK_ULONG      ulSessionCount;        /* sess. now open */
+  CK_ULONG      ulMaxRwSessionCount;   /* max R/W sessions */
+  CK_ULONG      ulRwSessionCount;      /* R/W sess. now open */
+  CK_ULONG      ulMaxPinLen;           /* in bytes */
+  CK_ULONG      ulMinPinLen;           /* in bytes */
+  CK_ULONG      ulTotalPublicMemory;   /* in bytes */
+  CK_ULONG      ulFreePublicMemory;    /* in bytes */
+  CK_ULONG      ulTotalPrivateMemory;  /* in bytes */
+  CK_ULONG      ulFreePrivateMemory;   /* in bytes */
+  CK_VERSION    hardwareVersion;       /* version of hardware */
+  CK_VERSION    firmwareVersion;       /* version of firmware */
+  CK_CHAR       utcTime[16];           /* time */
 } CK_TOKEN_INFO;
 
 /* The flags parameter is defined as follows:
@@ -245,7 +247,19 @@ typedef struct CK_TOKEN_INFO {
  */
 #define CKF_SO_PIN_TO_BE_CHANGED     0x00800000UL
 
+/* CKF_ERROR_STATE. If it is true, the token failed a FIPS 140
+ * self-test and entered an error state. */
 #define CKF_ERROR_STATE              0x01000000UL
+
+/*
+ * CKF_SEED_RANDOM_REQUIRED. If this is true  the token’s
+ * random number generator must be seeded or re-seeded using
+ * C_SeedRandom. */
+#define CKF_SEED_RANDOM_REQUIRED     0x02000000UL
+
+/* CKF_ASYNC_SESSION_SUPPORTED. If this is true the token
+ * supports asynchronous sessions. */
+#define CKF_ASYNC_SESSION_SUPPORTED  0x04000000UL
 
 typedef CK_TOKEN_INFO CK_PTR CK_TOKEN_INFO_PTR;
 
@@ -277,17 +291,18 @@ typedef CK_ULONG          CK_STATE;
 
 /* CK_SESSION_INFO provides information about a session */
 typedef struct CK_SESSION_INFO {
-    CK_SLOT_ID slotID;
-    CK_STATE   state;
-    CK_FLAGS   flags;          /* see below */
-    CK_ULONG   ulDeviceError;  /* device-dependent error code */
+  CK_SLOT_ID    slotID;
+  CK_STATE      state;
+  CK_FLAGS      flags;          /* see below */
+  CK_ULONG      ulDeviceError;  /* device-dependent error code */
 } CK_SESSION_INFO;
 
 /* The flags are defined in the following table:
- *      Bit Flag                Mask        Meaning
+ *      Bit Flag                    Mask         Meaning
  */
-#define CKF_RW_SESSION          0x00000002UL /* session is r/w */
-#define CKF_SERIAL_SESSION      0x00000004UL /* no parallel    */
+#define CKF_RW_SESSION              0x00000002UL /* session is r/w */
+#define CKF_SERIAL_SESSION          0x00000004UL /* no parallel    */
+#define CKF_ASYNC_SESSION           0x00000008UL /* session is async */
 
 typedef CK_SESSION_INFO CK_PTR CK_SESSION_INFO_PTR;
 
@@ -317,20 +332,22 @@ typedef CK_ULONG          CK_OBJECT_CLASS;
 #define CKO_MECHANISM         0x00000007UL
 #define CKO_OTP_KEY           0x00000008UL
 #define CKO_PROFILE           0x00000009UL
+#define CKO_VALIDATION        0x0000000aUL
+#define CKO_TRUST             0x0000000bUL
 
 #define CKO_VENDOR_DEFINED    0x80000000UL
 
 typedef CK_OBJECT_CLASS CK_PTR CK_OBJECT_CLASS_PTR;
 
 /* Profile ID's */
-#define CKP_INVALID_ID                0x00000000UL
-#define CKP_BASELINE_PROVIDER         0x00000001UL
-#define CKP_EXTENDED_PROVIDER         0x00000002UL
-#define CKP_AUTHENTICATION_TOKEN      0x00000003UL
-#define CKP_PUBLIC_CERTIFICATES_TOKEN 0x00000004UL
-#define CKP_COMPLETE_PROVIDER         0x00000005UL
-#define CKP_HKDF_TLS_TOKEN            0x00000006UL
-#define CKP_VENDOR_DEFINED            0x80000000UL
+#define CKP_INVALID_ID                0x00000000UL  /* Profile */
+#define CKP_BASELINE_PROVIDER         0x00000001UL  /* Profile */
+#define CKP_EXTENDED_PROVIDER         0x00000002UL  /* Profile */
+#define CKP_AUTHENTICATION_TOKEN      0x00000003UL  /* Profile */
+#define CKP_PUBLIC_CERTIFICATES_TOKEN 0x00000004UL  /* Profile */
+#define CKP_COMPLETE_PROVIDER         0x00000005UL  /* Profile */
+#define CKP_HKDF_TLS_TOKEN            0x00000006UL  /* Profile */
+#define CKP_VENDOR_DEFINED            0x80000000UL  /* Profile */
 
 
 /* CK_HW_FEATURE_TYPE is a value that identifies the hardware feature type
@@ -354,38 +371,38 @@ typedef CK_ULONG          CK_KEY_TYPE;
 #define CKK_ECDSA               0x00000003UL /* Deprecated */
 #define CKK_EC                  0x00000003UL
 #define CKK_X9_42_DH            0x00000004UL
-#define CKK_KEA                 0x00000005UL
+#define CKK_KEA                 0x00000005UL /* Historical */
 #define CKK_GENERIC_SECRET      0x00000010UL
-#define CKK_RC2                 0x00000011UL
-#define CKK_RC4                 0x00000012UL
-#define CKK_DES                 0x00000013UL
+#define CKK_RC2                 0x00000011UL /* Historical */
+#define CKK_RC4                 0x00000012UL /* Historical */
+#define CKK_DES                 0x00000013UL /* Historical */
 #define CKK_DES2                0x00000014UL
 #define CKK_DES3                0x00000015UL
-#define CKK_CAST                0x00000016UL
-#define CKK_CAST3               0x00000017UL
+#define CKK_CAST                0x00000016UL /* Historical */
+#define CKK_CAST3               0x00000017UL /* Historical */
 #define CKK_CAST5               0x00000018UL /* Deprecated */
-#define CKK_CAST128             0x00000018UL
-#define CKK_RC5                 0x00000019UL
-#define CKK_IDEA                0x0000001AUL
-#define CKK_SKIPJACK            0x0000001BUL
-#define CKK_BATON               0x0000001CUL
-#define CKK_JUNIPER             0x0000001DUL
-#define CKK_CDMF                0x0000001EUL
+#define CKK_CAST128             0x00000018UL /* Historical */
+#define CKK_RC5                 0x00000019UL /* Historical */
+#define CKK_IDEA                0x0000001AUL /* Historical */
+#define CKK_SKIPJACK            0x0000001BUL /* Historical */
+#define CKK_BATON               0x0000001CUL /* Historical */
+#define CKK_JUNIPER             0x0000001DUL /* Historical */
+#define CKK_CDMF                0x0000001EUL /* Historical */
 #define CKK_AES                 0x0000001FUL
 #define CKK_BLOWFISH            0x00000020UL
 #define CKK_TWOFISH             0x00000021UL
 #define CKK_SECURID             0x00000022UL
-#define CKK_HOTP                0x00000023UL
-#define CKK_ACTI                0x00000024UL
+#define CKK_HOTP                0x00000023UL /* Historical */
+#define CKK_ACTI                0x00000024UL /* Historical */
 #define CKK_CAMELLIA            0x00000025UL
 #define CKK_ARIA                0x00000026UL
 
 /* the following definitions were added in the 2.30 header file,
  * but never defined in the spec. */
-#define CKK_MD5_HMAC            0x00000027UL
+#define CKK_MD5_HMAC            0x00000027UL /* Historical */
 #define CKK_SHA_1_HMAC          0x00000028UL
-#define CKK_RIPEMD128_HMAC      0x00000029UL
-#define CKK_RIPEMD160_HMAC      0x0000002AUL
+#define CKK_RIPEMD128_HMAC      0x00000029UL /* Historical */
+#define CKK_RIPEMD160_HMAC      0x0000002AUL /* Historical */
 #define CKK_SHA256_HMAC         0x0000002BUL
 #define CKK_SHA384_HMAC         0x0000002CUL
 #define CKK_SHA512_HMAC         0x0000002DUL
@@ -416,6 +433,13 @@ typedef CK_ULONG          CK_KEY_TYPE;
 #define CKK_SHA512_256_HMAC     0x00000044UL
 #define CKK_SHA512_T_HMAC       0x00000045UL
 #define CKK_HSS                 0x00000046UL
+
+#define CKK_XMSS                0x00000047UL
+#define CKK_XMSSMT              0x00000048UL
+#define CKK_ML_KEM              0x00000049UL
+#define CKK_ML_DSA              0x0000004aUL
+#define CKK_SLH_DSA             0x0000004bUL
+
 
 #define CKK_VENDOR_DEFINED      0x80000000UL
 
@@ -615,6 +639,39 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 #define CKA_HSS_LMS_TYPES               0x0000061aUL
 #define CKA_HSS_LMOTS_TYPES             0x0000061bUL
 #define CKA_HSS_KEYS_REMAINING          0x0000061cUL
+/* new post-quantum (general) */
+#define CKA_PARAMETER_SET               0x0000061dUL
+/* validation objects */
+#define CKA_OBJECT_VALIDATION_FLAGS     0x0000061eUL
+#define CKA_VALIDATION_TYPE             0x0000061fUL
+#define CKA_VALIDATION_VERSION          0x00000620UL
+#define CKA_VALIDATION_LEVEL            0x00000621UL
+#define CKA_VALIDATION_MODULE_ID        0x00000622UL
+#define CKA_VALIDATION_FLAG             0x00000623UL
+#define CKA_VALIDATION_AUTHORITY_TYPE   0x00000624UL
+#define CKA_VALIDATION_COUNTRY          0x00000625UL
+#define CKA_VALIDATION_CERTIFICATE_IDENTIFIER 0x00000626UL
+#define CKA_VALIDATION_CERTIFICATE_URI  0x00000627UL
+#define CKA_VALIDATION_VENDOR_URI       0x00000628UL
+#define CKA_VALIDATION_PROFILE          0x00000629UL
+/* KEM */
+#define CKA_ENCAPSULATE_TEMPLATE        0x0000062aUL
+#define CKA_DECAPSULATE_TEMPLATE        0x0000062bUL
+/* trust objects */
+#define CKA_TRUST_SERVER_AUTH           0x0000062cUL
+#define CKA_TRUST_CLIENT_AUTH           0x0000062dUL
+#define CKA_TRUST_CODE_SIGNING          0x0000062eUL
+#define CKA_TRUST_EMAIL_PROTECTION      0x0000062fUL
+#define CKA_TRUST_IPSEC_IKE             0x00000630UL
+#define CKA_TRUST_TIME_STAMPING         0x00000631UL
+#define CKA_TRUST_OCSP_SIGNING          0x00000632UL
+#define CKA_ENCAPSULATE                 0x00000633UL
+#define CKA_DECAPSULATE                 0x00000634UL
+#define CKA_HASH_OF_CERTIFICATE         0x00000635UL
+/* linking pubic and private keys */
+#define CKA_PUBLIC_CRC64_VALUE          0x00000636UL
+/* new post-quantum (general) */
+#define CKA_SEED                        0x00000637UL
 
 #define CKA_VENDOR_DEFINED              0x80000000UL
 
@@ -622,18 +679,18 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
  * and value of an attribute
  */
 typedef struct CK_ATTRIBUTE {
-    CK_ATTRIBUTE_TYPE type;
-    CK_VOID_PTR       pValue;
-    CK_ULONG          ulValueLen;  /* in bytes */
+  CK_ATTRIBUTE_TYPE type;
+  CK_VOID_PTR       pValue;
+  CK_ULONG          ulValueLen;  /* in bytes */
 } CK_ATTRIBUTE;
 
 typedef CK_ATTRIBUTE CK_PTR CK_ATTRIBUTE_PTR;
 
 /* CK_DATE is a structure that defines a date */
 typedef struct CK_DATE{
-    CK_CHAR year[4];   /* the year ("1900" - "9999") */
-    CK_CHAR month[2];  /* the month ("01" - "12") */
-    CK_CHAR day[2];    /* the day   ("01" - "31") */
+  CK_CHAR       year[4];   /* the year ("1900" - "9999") */
+  CK_CHAR       month[2];  /* the month ("01" - "12") */
+  CK_CHAR       day[2];    /* the day   ("01" - "31") */
 } CK_DATE;
 
 
@@ -715,23 +772,23 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_SHA3_224_RSA_PKCS          0x00000066UL
 #define CKM_SHA3_224_RSA_PKCS_PSS      0x00000067UL
 
-#define CKM_RC2_KEY_GEN                0x00000100UL
-#define CKM_RC2_ECB                    0x00000101UL
-#define CKM_RC2_CBC                    0x00000102UL
-#define CKM_RC2_MAC                    0x00000103UL
+#define CKM_RC2_KEY_GEN                0x00000100UL /* Historical */
+#define CKM_RC2_ECB                    0x00000101UL /* Historical */
+#define CKM_RC2_CBC                    0x00000102UL /* Historical */
+#define CKM_RC2_MAC                    0x00000103UL /* Historical */
 
-#define CKM_RC2_MAC_GENERAL            0x00000104UL
-#define CKM_RC2_CBC_PAD                0x00000105UL
+#define CKM_RC2_MAC_GENERAL            0x00000104UL /* Historical */
+#define CKM_RC2_CBC_PAD                0x00000105UL /* Historical */
 
-#define CKM_RC4_KEY_GEN                0x00000110UL
-#define CKM_RC4                        0x00000111UL
-#define CKM_DES_KEY_GEN                0x00000120UL
-#define CKM_DES_ECB                    0x00000121UL
-#define CKM_DES_CBC                    0x00000122UL
-#define CKM_DES_MAC                    0x00000123UL
+#define CKM_RC4_KEY_GEN                0x00000110UL /* Historical */
+#define CKM_RC4                        0x00000111UL /* Historical */
+#define CKM_DES_KEY_GEN                0x00000120UL /* Historical */
+#define CKM_DES_ECB                    0x00000121UL /* Historical */
+#define CKM_DES_CBC                    0x00000122UL /* Historical */
+#define CKM_DES_MAC                    0x00000123UL /* Historical */
 
-#define CKM_DES_MAC_GENERAL            0x00000124UL
-#define CKM_DES_CBC_PAD                0x00000125UL
+#define CKM_DES_MAC_GENERAL            0x00000124UL /* Historical */
+#define CKM_DES_CBC_PAD                0x00000125UL /* Historical */
 
 #define CKM_DES2_KEY_GEN               0x00000130UL
 #define CKM_DES3_KEY_GEN               0x00000131UL
@@ -743,39 +800,39 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_DES3_CBC_PAD               0x00000136UL
 #define CKM_DES3_CMAC_GENERAL          0x00000137UL
 #define CKM_DES3_CMAC                  0x00000138UL
-#define CKM_CDMF_KEY_GEN               0x00000140UL
-#define CKM_CDMF_ECB                   0x00000141UL
-#define CKM_CDMF_CBC                   0x00000142UL
-#define CKM_CDMF_MAC                   0x00000143UL
-#define CKM_CDMF_MAC_GENERAL           0x00000144UL
-#define CKM_CDMF_CBC_PAD               0x00000145UL
+#define CKM_CDMF_KEY_GEN               0x00000140UL /* Historical */
+#define CKM_CDMF_ECB                   0x00000141UL /* Historical */
+#define CKM_CDMF_CBC                   0x00000142UL /* Historical */
+#define CKM_CDMF_MAC                   0x00000143UL /* Historical */
+#define CKM_CDMF_MAC_GENERAL           0x00000144UL /* Historical */
+#define CKM_CDMF_CBC_PAD               0x00000145UL /* Historical */
 
 #define CKM_DES_OFB64                  0x00000150UL
 #define CKM_DES_OFB8                   0x00000151UL
 #define CKM_DES_CFB64                  0x00000152UL
 #define CKM_DES_CFB8                   0x00000153UL
 
-#define CKM_MD2                        0x00000200UL
+#define CKM_MD2                        0x00000200UL /* Historical */
 
-#define CKM_MD2_HMAC                   0x00000201UL
-#define CKM_MD2_HMAC_GENERAL           0x00000202UL
+#define CKM_MD2_HMAC                   0x00000201UL /* Historical */
+#define CKM_MD2_HMAC_GENERAL           0x00000202UL /* Historical */
 
-#define CKM_MD5                        0x00000210UL
+#define CKM_MD5                        0x00000210UL /* Historical */
 
-#define CKM_MD5_HMAC                   0x00000211UL
-#define CKM_MD5_HMAC_GENERAL           0x00000212UL
+#define CKM_MD5_HMAC                   0x00000211UL /* Historical */
+#define CKM_MD5_HMAC_GENERAL           0x00000212UL /* Historical */
 
 #define CKM_SHA_1                      0x00000220UL
 
 #define CKM_SHA_1_HMAC                 0x00000221UL
 #define CKM_SHA_1_HMAC_GENERAL         0x00000222UL
 
-#define CKM_RIPEMD128                  0x00000230UL
-#define CKM_RIPEMD128_HMAC             0x00000231UL
-#define CKM_RIPEMD128_HMAC_GENERAL     0x00000232UL
-#define CKM_RIPEMD160                  0x00000240UL
-#define CKM_RIPEMD160_HMAC             0x00000241UL
-#define CKM_RIPEMD160_HMAC_GENERAL     0x00000242UL
+#define CKM_RIPEMD128                  0x00000230UL /* Historical */
+#define CKM_RIPEMD128_HMAC             0x00000231UL /* Historical */
+#define CKM_RIPEMD128_HMAC_GENERAL     0x00000232UL /* Historical */
+#define CKM_RIPEMD160                  0x00000240UL /* Historical */
+#define CKM_RIPEMD160_HMAC             0x00000241UL /* Historical */
+#define CKM_RIPEMD160_HMAC_GENERAL     0x00000242UL /* Historical */
 
 #define CKM_SHA256                     0x00000250UL
 #define CKM_SHA256_HMAC                0x00000251UL
@@ -814,43 +871,43 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_SHA3_512_KEY_GEN           0x000002d3UL
 
 
-#define CKM_CAST_KEY_GEN               0x00000300UL
-#define CKM_CAST_ECB                   0x00000301UL
-#define CKM_CAST_CBC                   0x00000302UL
-#define CKM_CAST_MAC                   0x00000303UL
-#define CKM_CAST_MAC_GENERAL           0x00000304UL
-#define CKM_CAST_CBC_PAD               0x00000305UL
-#define CKM_CAST3_KEY_GEN              0x00000310UL
-#define CKM_CAST3_ECB                  0x00000311UL
-#define CKM_CAST3_CBC                  0x00000312UL
-#define CKM_CAST3_MAC                  0x00000313UL
-#define CKM_CAST3_MAC_GENERAL          0x00000314UL
-#define CKM_CAST3_CBC_PAD              0x00000315UL
+#define CKM_CAST_KEY_GEN               0x00000300UL /* Historical */
+#define CKM_CAST_ECB                   0x00000301UL /* Historical */
+#define CKM_CAST_CBC                   0x00000302UL /* Historical */
+#define CKM_CAST_MAC                   0x00000303UL /* Historical */
+#define CKM_CAST_MAC_GENERAL           0x00000304UL /* Historical */
+#define CKM_CAST_CBC_PAD               0x00000305UL /* Historical */
+#define CKM_CAST3_KEY_GEN              0x00000310UL /* Historical */
+#define CKM_CAST3_ECB                  0x00000311UL /* Historical */
+#define CKM_CAST3_CBC                  0x00000312UL /* Historical */
+#define CKM_CAST3_MAC                  0x00000313UL /* Historical */
+#define CKM_CAST3_MAC_GENERAL          0x00000314UL /* Historical */
+#define CKM_CAST3_CBC_PAD              0x00000315UL /* Historical */
 /* Note that CAST128 and CAST5 are the same algorithm */
-#define CKM_CAST5_KEY_GEN              0x00000320UL
-#define CKM_CAST128_KEY_GEN            0x00000320UL
-#define CKM_CAST5_ECB                  0x00000321UL
-#define CKM_CAST128_ECB                0x00000321UL
+#define CKM_CAST5_KEY_GEN              0x00000320UL /* Historical */
+#define CKM_CAST128_KEY_GEN            0x00000320UL /* Historical */
+#define CKM_CAST5_ECB                  0x00000321UL /* Historical */
+#define CKM_CAST128_ECB                0x00000321UL /* Historical */
 #define CKM_CAST5_CBC                  0x00000322UL /* Deprecated */
-#define CKM_CAST128_CBC                0x00000322UL
+#define CKM_CAST128_CBC                0x00000322UL /* Historical */
 #define CKM_CAST5_MAC                  0x00000323UL /* Deprecated */
-#define CKM_CAST128_MAC                0x00000323UL
+#define CKM_CAST128_MAC                0x00000323UL /* Historical */
 #define CKM_CAST5_MAC_GENERAL          0x00000324UL /* Deprecated */
-#define CKM_CAST128_MAC_GENERAL        0x00000324UL
+#define CKM_CAST128_MAC_GENERAL        0x00000324UL /* Historical */
 #define CKM_CAST5_CBC_PAD              0x00000325UL /* Deprecated */
-#define CKM_CAST128_CBC_PAD            0x00000325UL
-#define CKM_RC5_KEY_GEN                0x00000330UL
-#define CKM_RC5_ECB                    0x00000331UL
-#define CKM_RC5_CBC                    0x00000332UL
-#define CKM_RC5_MAC                    0x00000333UL
-#define CKM_RC5_MAC_GENERAL            0x00000334UL
-#define CKM_RC5_CBC_PAD                0x00000335UL
-#define CKM_IDEA_KEY_GEN               0x00000340UL
-#define CKM_IDEA_ECB                   0x00000341UL
-#define CKM_IDEA_CBC                   0x00000342UL
-#define CKM_IDEA_MAC                   0x00000343UL
-#define CKM_IDEA_MAC_GENERAL           0x00000344UL
-#define CKM_IDEA_CBC_PAD               0x00000345UL
+#define CKM_CAST128_CBC_PAD            0x00000325UL /* Historical */
+#define CKM_RC5_KEY_GEN                0x00000330UL /* Historical */
+#define CKM_RC5_ECB                    0x00000331UL /* Historical */
+#define CKM_RC5_CBC                    0x00000332UL /* Historical */
+#define CKM_RC5_MAC                    0x00000333UL /* Historical */
+#define CKM_RC5_MAC_GENERAL            0x00000334UL /* Historical */
+#define CKM_RC5_CBC_PAD                0x00000335UL /* Historical */
+#define CKM_IDEA_KEY_GEN               0x00000340UL /* Historical */
+#define CKM_IDEA_ECB                   0x00000341UL /* Historical */
+#define CKM_IDEA_CBC                   0x00000342UL /* Historical */
+#define CKM_IDEA_MAC                   0x00000343UL /* Historical */
+#define CKM_IDEA_MAC_GENERAL           0x00000344UL /* Historical */
+#define CKM_IDEA_CBC_PAD               0x00000345UL /* Historical */
 #define CKM_GENERIC_SECRET_KEY_GEN     0x00000350UL
 #define CKM_CONCATENATE_BASE_AND_KEY   0x00000360UL
 #define CKM_CONCATENATE_BASE_AND_DATA  0x00000362UL
@@ -871,8 +928,8 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 
 #define CKM_SSL3_MD5_MAC               0x00000380UL
 #define CKM_SSL3_SHA1_MAC              0x00000381UL
-#define CKM_MD5_KEY_DERIVATION         0x00000390UL
-#define CKM_MD2_KEY_DERIVATION         0x00000391UL
+#define CKM_MD5_KEY_DERIVATION         0x00000390UL /* Historical */
+#define CKM_MD2_KEY_DERIVATION         0x00000391UL /* Historical */
 #define CKM_SHA1_KEY_DERIVATION        0x00000392UL
 
 #define CKM_SHA256_KEY_DERIVATION      0x00000393UL
@@ -892,16 +949,16 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_SHAKE_128_KEY_DERIVE CKM_SHAKE_128_KEY_DERIVATION
 #define CKM_SHAKE_256_KEY_DERIVE CKM_SHAKE_256_KEY_DERIVATION
 
-#define CKM_PBE_MD2_DES_CBC            0x000003a0UL
-#define CKM_PBE_MD5_DES_CBC            0x000003a1UL
-#define CKM_PBE_MD5_CAST_CBC           0x000003a2UL
-#define CKM_PBE_MD5_CAST3_CBC          0x000003a3UL
+#define CKM_PBE_MD2_DES_CBC            0x000003a0UL /* Historical */
+#define CKM_PBE_MD5_DES_CBC            0x000003a1UL /* Historical */
+#define CKM_PBE_MD5_CAST_CBC           0x000003a2UL /* Historical */
+#define CKM_PBE_MD5_CAST3_CBC          0x000003a3UL /* Historical */
 #define CKM_PBE_MD5_CAST5_CBC          0x000003a4UL /* Deprecated */
-#define CKM_PBE_MD5_CAST128_CBC        0x000003a4UL
+#define CKM_PBE_MD5_CAST128_CBC        0x000003a4UL /* Historical */
 #define CKM_PBE_SHA1_CAST5_CBC         0x000003a5UL /* Deprecated */
-#define CKM_PBE_SHA1_CAST128_CBC       0x000003a5UL
-#define CKM_PBE_SHA1_RC4_128           0x000003a6UL
-#define CKM_PBE_SHA1_RC4_40            0x000003a7UL
+#define CKM_PBE_SHA1_CAST128_CBC       0x000003a5UL /* Historical */
+#define CKM_PBE_SHA1_RC4_128           0x000003a6UL /* Historical */
+#define CKM_PBE_SHA1_RC4_40            0x000003a7UL /* Historical */
 #define CKM_PBE_SHA1_DES3_EDE_CBC      0x000003a8UL
 #define CKM_PBE_SHA1_DES2_EDE_CBC      0x000003a9UL
 #define CKM_PBE_SHA1_RC2_128_CBC       0x000003aaUL
@@ -945,7 +1002,7 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_CAMELLIA_CBC_PAD           0x00000555UL
 #define CKM_CAMELLIA_ECB_ENCRYPT_DATA  0x00000556UL
 #define CKM_CAMELLIA_CBC_ENCRYPT_DATA  0x00000557UL
-#define CKM_CAMELLIA_CTR               0x00000558UL
+#define CKM_CAMELLIA_CTR               0x00000558UL /* Historical */
 
 #define CKM_ARIA_KEY_GEN               0x00000560UL
 #define CKM_ARIA_ECB                   0x00000561UL
@@ -965,28 +1022,28 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_SEED_ECB_ENCRYPT_DATA      0x00000656UL
 #define CKM_SEED_CBC_ENCRYPT_DATA      0x00000657UL
 
-#define CKM_SKIPJACK_KEY_GEN           0x00001000UL
-#define CKM_SKIPJACK_ECB64             0x00001001UL
-#define CKM_SKIPJACK_CBC64             0x00001002UL
-#define CKM_SKIPJACK_OFB64             0x00001003UL
-#define CKM_SKIPJACK_CFB64             0x00001004UL
-#define CKM_SKIPJACK_CFB32             0x00001005UL
-#define CKM_SKIPJACK_CFB16             0x00001006UL
-#define CKM_SKIPJACK_CFB8              0x00001007UL
-#define CKM_SKIPJACK_WRAP              0x00001008UL
-#define CKM_SKIPJACK_PRIVATE_WRAP      0x00001009UL
-#define CKM_SKIPJACK_RELAYX            0x0000100aUL
-#define CKM_KEA_KEY_PAIR_GEN           0x00001010UL
-#define CKM_KEA_KEY_DERIVE             0x00001011UL
-#define CKM_KEA_DERIVE                 0x00001012UL
-#define CKM_FORTEZZA_TIMESTAMP         0x00001020UL
-#define CKM_BATON_KEY_GEN              0x00001030UL
-#define CKM_BATON_ECB128               0x00001031UL
-#define CKM_BATON_ECB96                0x00001032UL
-#define CKM_BATON_CBC128               0x00001033UL
-#define CKM_BATON_COUNTER              0x00001034UL
-#define CKM_BATON_SHUFFLE              0x00001035UL
-#define CKM_BATON_WRAP                 0x00001036UL
+#define CKM_SKIPJACK_KEY_GEN           0x00001000UL /* Historical */
+#define CKM_SKIPJACK_ECB64             0x00001001UL /* Historical */
+#define CKM_SKIPJACK_CBC64             0x00001002UL /* Historical */
+#define CKM_SKIPJACK_OFB64             0x00001003UL /* Historical */
+#define CKM_SKIPJACK_CFB64             0x00001004UL /* Historical */
+#define CKM_SKIPJACK_CFB32             0x00001005UL /* Historical */
+#define CKM_SKIPJACK_CFB16             0x00001006UL /* Historical */
+#define CKM_SKIPJACK_CFB8              0x00001007UL /* Historical */
+#define CKM_SKIPJACK_WRAP              0x00001008UL /* Historical */
+#define CKM_SKIPJACK_PRIVATE_WRAP      0x00001009UL /* Historical */
+#define CKM_SKIPJACK_RELAYX            0x0000100aUL /* Historical */
+#define CKM_KEA_KEY_PAIR_GEN           0x00001010UL /* Historical */
+#define CKM_KEA_KEY_DERIVE             0x00001011UL /* Historical */
+#define CKM_KEA_DERIVE                 0x00001012UL /* Historical */
+#define CKM_FORTEZZA_TIMESTAMP         0x00001020UL /* Historical */
+#define CKM_BATON_KEY_GEN              0x00001030UL /* Historical */
+#define CKM_BATON_ECB128               0x00001031UL /* Historical */
+#define CKM_BATON_ECB96                0x00001032UL /* Historical */
+#define CKM_BATON_CBC128               0x00001033UL /* Historical */
+#define CKM_BATON_COUNTER              0x00001034UL /* Historical */
+#define CKM_BATON_SHUFFLE              0x00001035UL /* Historical */
+#define CKM_BATON_WRAP                 0x00001036UL /* Historical */
 
 #define CKM_ECDSA_KEY_PAIR_GEN         0x00001040UL /* Deprecated */
 #define CKM_EC_KEY_PAIR_GEN            0x00001040UL
@@ -1006,12 +1063,12 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_ECDH_AES_KEY_WRAP          0x00001053UL
 #define CKM_RSA_AES_KEY_WRAP           0x00001054UL
 
-#define CKM_JUNIPER_KEY_GEN            0x00001060UL
-#define CKM_JUNIPER_ECB128             0x00001061UL
-#define CKM_JUNIPER_CBC128             0x00001062UL
-#define CKM_JUNIPER_COUNTER            0x00001063UL
-#define CKM_JUNIPER_SHUFFLE            0x00001064UL
-#define CKM_JUNIPER_WRAP               0x00001065UL
+#define CKM_JUNIPER_KEY_GEN            0x00001060UL /* Historical */
+#define CKM_JUNIPER_ECB128             0x00001061UL /* Historical */
+#define CKM_JUNIPER_CBC128             0x00001062UL /* Historical */
+#define CKM_JUNIPER_COUNTER            0x00001063UL /* Historical */
+#define CKM_JUNIPER_SHUFFLE            0x00001064UL /* Historical */
+#define CKM_JUNIPER_WRAP               0x00001065UL /* Historical */
 #define CKM_FASTHASH                   0x00001070UL
 
 #define CKM_AES_XTS                    0x00001071UL
@@ -1067,7 +1124,7 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_DH_PKCS_PARAMETER_GEN      0x00002001UL
 #define CKM_X9_42_DH_PARAMETER_GEN     0x00002002UL
 #define CKM_DSA_PROBABILISTIC_PARAMETER_GEN 0x00002003UL
-#define CKM_DSA_PROBABLISTIC_PARAMETER_GEN CKM_DSA_PROBABILISTIC_PARAMETER_GEN
+#define CKM_DSA_PROBABLISTIC_PARAMETER_GEN CKM_DSA_PROBABILISTIC_PARAMETER_GEN /* Depricated */
 #define CKM_DSA_SHAWE_TAYLOR_PARAMETER_GEN    0x00002004UL
 #define CKM_DSA_FIPS_G_GEN               0x00002005UL
 
@@ -1147,6 +1204,48 @@ typedef CK_ULONG          CK_MECHANISM_TYPE;
 #define CKM_HSS_KEY_PAIR_GEN           0x00004032UL
 #define CKM_HSS                        0x00004033UL
 
+#define CKM_XMSS_KEY_PAIR_GEN          0x00004034UL
+#define CKM_XMSSMT_KEY_PAIR_GEN        0x00004035UL
+#define CKM_XMSS                       0x00004036UL
+#define CKM_XMSSMT                     0x00004037UL
+
+#define CKM_ECDH_X_AES_KEY_WRAP        0x00004038UL
+#define CKM_ECDH_COF_AES_KEY_WRAP      0x00004039UL
+#define CKM_PUB_KEY_FROM_PRIV_KEY      0x0000403aUL
+
+#define CKM_ML_KEM_KEY_PAIR_GEN        0x0000000fUL
+#define CKM_ML_KEM                     0x00000017UL
+
+#define CKM_ML_DSA_KEY_PAIR_GEN        0x0000001cUL
+#define CKM_ML_DSA                     0x0000001dUL
+#define CKM_HASH_ML_DSA                0x0000001fUL
+#define CKM_HASH_ML_DSA_SHA224         0x00000023UL
+#define CKM_HASH_ML_DSA_SHA256         0x00000024UL
+#define CKM_HASH_ML_DSA_SHA384         0x00000025UL
+#define CKM_HASH_ML_DSA_SHA512         0x00000026UL
+#define CKM_HASH_ML_DSA_SHA3_224       0x00000027UL
+#define CKM_HASH_ML_DSA_SHA3_256       0x00000028UL
+#define CKM_HASH_ML_DSA_SHA3_384       0x00000029UL
+#define CKM_HASH_ML_DSA_SHA3_512       0x0000002aUL
+#define CKM_HASH_ML_DSA_SHAKE128       0x0000002bUL
+#define CKM_HASH_ML_DSA_SHAKE256       0x0000002cUL
+
+#define CKM_SLH_DSA_KEY_PAIR_GEN       0x0000002dUL
+#define CKM_SLH_DSA                    0x0000002eUL
+#define CKM_HASH_SLH_DSA               0x00000034UL
+#define CKM_HASH_SLH_DSA_SHA224        0x00000036UL
+#define CKM_HASH_SLH_DSA_SHA256        0x00000037UL
+#define CKM_HASH_SLH_DSA_SHA384        0x00000038UL
+#define CKM_HASH_SLH_DSA_SHA512        0x00000039UL
+#define CKM_HASH_SLH_DSA_SHA3_224      0x0000003aUL
+#define CKM_HASH_SLH_DSA_SHA3_256      0x0000003bUL
+#define CKM_HASH_SLH_DSA_SHA3_384      0x0000003cUL
+#define CKM_HASH_SLH_DSA_SHA3_512      0x0000003dUL
+#define CKM_HASH_SLH_DSA_SHAKE128      0x0000003eUL
+#define CKM_HASH_SLH_DSA_SHAKE256      0x0000003fUL
+
+#define CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE    0x00000056UL
+#define CKM_TLS12_EXTENDED_MASTER_KEY_DERIVE_DH 0x00000057UL
 
 #define CKM_VENDOR_DEFINED             0x80000000UL
 
@@ -1157,9 +1256,9 @@ typedef CK_MECHANISM_TYPE CK_PTR CK_MECHANISM_TYPE_PTR;
  * mechanism
  */
 typedef struct CK_MECHANISM {
-    CK_MECHANISM_TYPE mechanism;
-    CK_VOID_PTR       pParameter;
-    CK_ULONG          ulParameterLen;  /* in bytes */
+  CK_MECHANISM_TYPE mechanism;
+  CK_VOID_PTR       pParameter;
+  CK_ULONG          ulParameterLen;  /* in bytes */
 } CK_MECHANISM;
 
 typedef CK_MECHANISM CK_PTR CK_MECHANISM_PTR;
@@ -1169,9 +1268,9 @@ typedef CK_MECHANISM CK_PTR CK_MECHANISM_PTR;
  * mechanism
  */
 typedef struct CK_MECHANISM_INFO {
-    CK_ULONG ulMinKeySize;
-    CK_ULONG ulMaxKeySize;
-    CK_FLAGS flags;
+    CK_ULONG    ulMinKeySize;
+    CK_ULONG    ulMaxKeySize;
+    CK_FLAGS    flags;
 } CK_MECHANISM_INFO;
 
 /* The flags are defined as follows:
@@ -1211,6 +1310,9 @@ typedef struct CK_MECHANISM_INFO {
 #define CKF_EC_UNCOMPRESS      0x01000000UL
 #define CKF_EC_COMPRESS        0x02000000UL
 #define CKF_EC_CURVENAME       0x04000000UL
+
+#define CKF_ENCAPSULATE        0x10000000UL
+#define CKF_DECAPSULATE        0x20000000UL
 
 #define CKF_EXTENSION          0x80000000UL
 
@@ -1345,14 +1447,21 @@ typedef CK_ULONG          CK_RV;
 #define CKR_OPERATION_CANCEL_FAILED           0x00000202UL
 #define CKR_KEY_EXHAUSTED                     0x00000203UL
 
+#define CKR_PENDING                           0x00000204UL
+#define CKR_SESSION_ASYNC_NOT_SUPPORTED       0x00000205UL
+#define CKR_SEED_RANDOM_REQUIRED              0x00000206UL
+#define CKR_OPERATION_NOT_VALIDATED           0x00000207UL
+#define CKR_TOKEN_NOT_INITIALIZED             0x00000208UL
+#define CKR_PARAMETER_SET_NOT_SUPPORTED       0x00000209UL
+
 #define CKR_VENDOR_DEFINED                    0x80000000UL
 
 
 /* CK_NOTIFY is an application callback that processes events */
 typedef CK_CALLBACK_FUNCTION(CK_RV, CK_NOTIFY)(
-    CK_SESSION_HANDLE hSession,     /* the session's handle */
-    CK_NOTIFICATION   event,
-    CK_VOID_PTR       pApplication  /* passed to C_OpenSession */
+  CK_SESSION_HANDLE hSession,     /* the session's handle */
+  CK_NOTIFICATION   event,
+  CK_VOID_PTR       pApplication  /* passed to C_OpenSession */
 );
 
 
@@ -1362,17 +1471,20 @@ typedef CK_CALLBACK_FUNCTION(CK_RV, CK_NOTIFY)(
  */
 typedef struct CK_FUNCTION_LIST CK_FUNCTION_LIST;
 typedef struct CK_FUNCTION_LIST_3_0 CK_FUNCTION_LIST_3_0;
+typedef struct CK_FUNCTION_LIST_3_2 CK_FUNCTION_LIST_3_2;
 
 typedef CK_FUNCTION_LIST CK_PTR CK_FUNCTION_LIST_PTR;
 typedef CK_FUNCTION_LIST_3_0 CK_PTR CK_FUNCTION_LIST_3_0_PTR;
+typedef CK_FUNCTION_LIST_3_2 CK_PTR CK_FUNCTION_LIST_3_2_PTR;
 
 typedef CK_FUNCTION_LIST_PTR CK_PTR CK_FUNCTION_LIST_PTR_PTR;
 typedef CK_FUNCTION_LIST_3_0_PTR CK_PTR CK_FUNCTION_LIST_3_0_PTR_PTR;
+typedef CK_FUNCTION_LIST_3_2_PTR CK_PTR CK_FUNCTION_LIST_3_2_PTR_PTR;
 
 typedef struct CK_INTERFACE {
-    CK_CHAR     *pInterfaceName;
-    CK_VOID_PTR pFunctionList;
-    CK_FLAGS    flags;
+      CK_UTF8CHAR_PTR pInterfaceName;
+      CK_VOID_PTR     pFunctionList;
+      CK_FLAGS        flags;
 } CK_INTERFACE;
 
 typedef CK_INTERFACE CK_PTR CK_INTERFACE_PTR;
@@ -1385,7 +1497,7 @@ typedef CK_INTERFACE_PTR CK_PTR CK_INTERFACE_PTR_PTR;
  * mutex object
  */
 typedef CK_CALLBACK_FUNCTION(CK_RV, CK_CREATEMUTEX)(
-    CK_VOID_PTR_PTR ppMutex  /* location to receive ptr to mutex */
+  CK_VOID_PTR_PTR ppMutex  /* location to receive ptr to mutex */
 );
 
 
@@ -1393,13 +1505,13 @@ typedef CK_CALLBACK_FUNCTION(CK_RV, CK_CREATEMUTEX)(
  * mutex object
  */
 typedef CK_CALLBACK_FUNCTION(CK_RV, CK_DESTROYMUTEX)(
-    CK_VOID_PTR pMutex  /* pointer to mutex */
+  CK_VOID_PTR pMutex  /* pointer to mutex */
 );
 
 
 /* CK_LOCKMUTEX is an application callback for locking a mutex */
 typedef CK_CALLBACK_FUNCTION(CK_RV, CK_LOCKMUTEX)(
-    CK_VOID_PTR pMutex  /* pointer to mutex */
+  CK_VOID_PTR pMutex  /* pointer to mutex */
 );
 
 
@@ -1407,7 +1519,7 @@ typedef CK_CALLBACK_FUNCTION(CK_RV, CK_LOCKMUTEX)(
  * mutex
  */
 typedef CK_CALLBACK_FUNCTION(CK_RV, CK_UNLOCKMUTEX)(
-    CK_VOID_PTR pMutex  /* pointer to mutex */
+  CK_VOID_PTR pMutex  /* pointer to mutex */
 );
 
 /* Get functionlist flags */
@@ -1417,12 +1529,12 @@ typedef CK_CALLBACK_FUNCTION(CK_RV, CK_UNLOCKMUTEX)(
  * C_Initialize
  */
 typedef struct CK_C_INITIALIZE_ARGS {
-    CK_CREATEMUTEX  CreateMutex;
-    CK_DESTROYMUTEX DestroyMutex;
-    CK_LOCKMUTEX    LockMutex;
-    CK_UNLOCKMUTEX  UnlockMutex;
-    CK_FLAGS        flags;
-    CK_VOID_PTR     pReserved;
+  CK_CREATEMUTEX CreateMutex;
+  CK_DESTROYMUTEX DestroyMutex;
+  CK_LOCKMUTEX LockMutex;
+  CK_UNLOCKMUTEX UnlockMutex;
+  CK_FLAGS flags;
+  CK_VOID_PTR pReserved;
 } CK_C_INITIALIZE_ARGS;
 
 /* flags: bit flags that provide capabilities of the slot
@@ -1476,11 +1588,11 @@ typedef CK_RSA_PKCS_OAEP_SOURCE_TYPE CK_PTR CK_RSA_PKCS_OAEP_SOURCE_TYPE_PTR;
  * CKM_RSA_PKCS_OAEP mechanism.
  */
 typedef struct CK_RSA_PKCS_OAEP_PARAMS {
-    CK_MECHANISM_TYPE            hashAlg;
-    CK_RSA_PKCS_MGF_TYPE         mgf;
-    CK_RSA_PKCS_OAEP_SOURCE_TYPE source;
-    CK_VOID_PTR                  pSourceData;
-    CK_ULONG                     ulSourceDataLen;
+        CK_MECHANISM_TYPE hashAlg;
+        CK_RSA_PKCS_MGF_TYPE mgf;
+        CK_RSA_PKCS_OAEP_SOURCE_TYPE source;
+        CK_VOID_PTR pSourceData;
+        CK_ULONG ulSourceDataLen;
 } CK_RSA_PKCS_OAEP_PARAMS;
 
 typedef CK_RSA_PKCS_OAEP_PARAMS CK_PTR CK_RSA_PKCS_OAEP_PARAMS_PTR;
@@ -1489,9 +1601,9 @@ typedef CK_RSA_PKCS_OAEP_PARAMS CK_PTR CK_RSA_PKCS_OAEP_PARAMS_PTR;
  * CKM_RSA_PKCS_PSS mechanism(s).
  */
 typedef struct CK_RSA_PKCS_PSS_PARAMS {
-    CK_MECHANISM_TYPE    hashAlg;
-    CK_RSA_PKCS_MGF_TYPE mgf;
-    CK_ULONG             sLen;
+        CK_MECHANISM_TYPE    hashAlg;
+        CK_RSA_PKCS_MGF_TYPE mgf;
+        CK_ULONG             sLen;
 } CK_RSA_PKCS_PSS_PARAMS;
 
 typedef CK_RSA_PKCS_PSS_PARAMS CK_PTR CK_RSA_PKCS_PSS_PARAMS_PTR;
@@ -1534,11 +1646,11 @@ typedef CK_EC_KDF_TYPE CK_PTR CK_EC_KDF_TYPE_PTR;
  * where each party contributes one key pair.
  */
 typedef struct CK_ECDH1_DERIVE_PARAMS {
-    CK_EC_KDF_TYPE kdf;
-    CK_ULONG       ulSharedDataLen;
-    CK_BYTE_PTR    pSharedData;
-    CK_ULONG       ulPublicDataLen;
-    CK_BYTE_PTR    pPublicData;
+  CK_EC_KDF_TYPE kdf;
+  CK_ULONG ulSharedDataLen;
+  CK_BYTE_PTR pSharedData;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
 } CK_ECDH1_DERIVE_PARAMS;
 
 typedef CK_ECDH1_DERIVE_PARAMS CK_PTR CK_ECDH1_DERIVE_PARAMS_PTR;
@@ -1548,30 +1660,30 @@ typedef CK_ECDH1_DERIVE_PARAMS CK_PTR CK_ECDH1_DERIVE_PARAMS_PTR;
  * CKM_ECMQV_DERIVE mechanism, where each party contributes two key pairs.
  */
 typedef struct CK_ECDH2_DERIVE_PARAMS {
-    CK_EC_KDF_TYPE   kdf;
-    CK_ULONG         ulSharedDataLen;
-    CK_BYTE_PTR      pSharedData;
-    CK_ULONG         ulPublicDataLen;
-    CK_BYTE_PTR      pPublicData;
-    CK_ULONG         ulPrivateDataLen;
-    CK_OBJECT_HANDLE hPrivateData;
-    CK_ULONG         ulPublicDataLen2;
-    CK_BYTE_PTR      pPublicData2;
+  CK_EC_KDF_TYPE kdf;
+  CK_ULONG ulSharedDataLen;
+  CK_BYTE_PTR pSharedData;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
 } CK_ECDH2_DERIVE_PARAMS;
 
 typedef CK_ECDH2_DERIVE_PARAMS CK_PTR CK_ECDH2_DERIVE_PARAMS_PTR;
 
 typedef struct CK_ECMQV_DERIVE_PARAMS {
-    CK_EC_KDF_TYPE   kdf;
-    CK_ULONG         ulSharedDataLen;
-    CK_BYTE_PTR      pSharedData;
-    CK_ULONG         ulPublicDataLen;
-    CK_BYTE_PTR      pPublicData;
-    CK_ULONG         ulPrivateDataLen;
-    CK_OBJECT_HANDLE hPrivateData;
-    CK_ULONG         ulPublicDataLen2;
-    CK_BYTE_PTR      pPublicData2;
-    CK_OBJECT_HANDLE publicKey;
+  CK_EC_KDF_TYPE kdf;
+  CK_ULONG ulSharedDataLen;
+  CK_BYTE_PTR pSharedData;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
+  CK_OBJECT_HANDLE publicKey;
 } CK_ECMQV_DERIVE_PARAMS;
 
 typedef CK_ECMQV_DERIVE_PARAMS CK_PTR CK_ECMQV_DERIVE_PARAMS_PTR;
@@ -1587,11 +1699,11 @@ typedef CK_X9_42_DH_KDF_TYPE CK_PTR CK_X9_42_DH_KDF_TYPE_PTR;
  * contributes one key pair
  */
 typedef struct CK_X9_42_DH1_DERIVE_PARAMS {
-    CK_X9_42_DH_KDF_TYPE kdf;
-    CK_ULONG             ulOtherInfoLen;
-    CK_BYTE_PTR          pOtherInfo;
-    CK_ULONG             ulPublicDataLen;
-    CK_BYTE_PTR          pPublicData;
+  CK_X9_42_DH_KDF_TYPE kdf;
+  CK_ULONG ulOtherInfoLen;
+  CK_BYTE_PTR pOtherInfo;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
 } CK_X9_42_DH1_DERIVE_PARAMS;
 
 typedef struct CK_X9_42_DH1_DERIVE_PARAMS CK_PTR CK_X9_42_DH1_DERIVE_PARAMS_PTR;
@@ -1601,30 +1713,30 @@ typedef struct CK_X9_42_DH1_DERIVE_PARAMS CK_PTR CK_X9_42_DH1_DERIVE_PARAMS_PTR;
  * mechanisms, where each party contributes two key pairs
  */
 typedef struct CK_X9_42_DH2_DERIVE_PARAMS {
-    CK_X9_42_DH_KDF_TYPE kdf;
-    CK_ULONG             ulOtherInfoLen;
-    CK_BYTE_PTR          pOtherInfo;
-    CK_ULONG             ulPublicDataLen;
-    CK_BYTE_PTR          pPublicData;
-    CK_ULONG             ulPrivateDataLen;
-    CK_OBJECT_HANDLE     hPrivateData;
-    CK_ULONG             ulPublicDataLen2;
-    CK_BYTE_PTR          pPublicData2;
+  CK_X9_42_DH_KDF_TYPE kdf;
+  CK_ULONG ulOtherInfoLen;
+  CK_BYTE_PTR pOtherInfo;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
 } CK_X9_42_DH2_DERIVE_PARAMS;
 
 typedef CK_X9_42_DH2_DERIVE_PARAMS CK_PTR CK_X9_42_DH2_DERIVE_PARAMS_PTR;
 
 typedef struct CK_X9_42_MQV_DERIVE_PARAMS {
-    CK_X9_42_DH_KDF_TYPE kdf;
-    CK_ULONG             ulOtherInfoLen;
-    CK_BYTE_PTR          pOtherInfo;
-    CK_ULONG             ulPublicDataLen;
-    CK_BYTE_PTR          pPublicData;
-    CK_ULONG             ulPrivateDataLen;
-    CK_OBJECT_HANDLE     hPrivateData;
-    CK_ULONG             ulPublicDataLen2;
-    CK_BYTE_PTR          pPublicData2;
-    CK_OBJECT_HANDLE     publicKey;
+  CK_X9_42_DH_KDF_TYPE kdf;
+  CK_ULONG ulOtherInfoLen;
+  CK_BYTE_PTR pOtherInfo;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
+  CK_OBJECT_HANDLE publicKey;
 } CK_X9_42_MQV_DERIVE_PARAMS;
 
 typedef CK_X9_42_MQV_DERIVE_PARAMS CK_PTR CK_X9_42_MQV_DERIVE_PARAMS_PTR;
@@ -1633,12 +1745,12 @@ typedef CK_X9_42_MQV_DERIVE_PARAMS CK_PTR CK_X9_42_MQV_DERIVE_PARAMS_PTR;
  * CKM_KEA_DERIVE mechanism
  */
 typedef struct CK_KEA_DERIVE_PARAMS {
-    CK_BBOOL    isSender;
-    CK_ULONG    ulRandomLen;
-    CK_BYTE_PTR pRandomA;
-    CK_BYTE_PTR pRandomB;
-    CK_ULONG    ulPublicDataLen;
-    CK_BYTE_PTR pPublicData;
+  CK_BBOOL      isSender;
+  CK_ULONG      ulRandomLen;
+  CK_BYTE_PTR   pRandomA;
+  CK_BYTE_PTR   pRandomB;
+  CK_ULONG      ulPublicDataLen;
+  CK_BYTE_PTR   pPublicData;
 } CK_KEA_DERIVE_PARAMS;
 
 typedef CK_KEA_DERIVE_PARAMS CK_PTR CK_KEA_DERIVE_PARAMS_PTR;
@@ -1657,8 +1769,8 @@ typedef CK_RC2_PARAMS CK_PTR CK_RC2_PARAMS_PTR;
  * mechanism
  */
 typedef struct CK_RC2_CBC_PARAMS {
-    CK_ULONG ulEffectiveBits;  /* effective bits (1-1024) */
-    CK_BYTE  iv[8];            /* IV for CBC mode */
+  CK_ULONG      ulEffectiveBits;  /* effective bits (1-1024) */
+  CK_BYTE       iv[8];            /* IV for CBC mode */
 } CK_RC2_CBC_PARAMS;
 
 typedef CK_RC2_CBC_PARAMS CK_PTR CK_RC2_CBC_PARAMS_PTR;
@@ -1668,20 +1780,20 @@ typedef CK_RC2_CBC_PARAMS CK_PTR CK_RC2_CBC_PARAMS_PTR;
  * CKM_RC2_MAC_GENERAL mechanism
  */
 typedef struct CK_RC2_MAC_GENERAL_PARAMS {
-    CK_ULONG ulEffectiveBits;  /* effective bits (1-1024) */
-    CK_ULONG ulMacLength;      /* Length of MAC in bytes */
+  CK_ULONG      ulEffectiveBits;  /* effective bits (1-1024) */
+  CK_ULONG      ulMacLength;      /* Length of MAC in bytes */
 } CK_RC2_MAC_GENERAL_PARAMS;
 
 typedef CK_RC2_MAC_GENERAL_PARAMS CK_PTR \
-        CK_RC2_MAC_GENERAL_PARAMS_PTR;
+  CK_RC2_MAC_GENERAL_PARAMS_PTR;
 
 
 /* CK_RC5_PARAMS provides the parameters to the CKM_RC5_ECB and
  * CKM_RC5_MAC mechanisms
  */
 typedef struct CK_RC5_PARAMS {
-    CK_ULONG ulWordsize;  /* wordsize in bits */
-    CK_ULONG ulRounds;    /* number of rounds */
+  CK_ULONG      ulWordsize;  /* wordsize in bits */
+  CK_ULONG      ulRounds;    /* number of rounds */
 } CK_RC5_PARAMS;
 
 typedef CK_RC5_PARAMS CK_PTR CK_RC5_PARAMS_PTR;
@@ -1691,10 +1803,10 @@ typedef CK_RC5_PARAMS CK_PTR CK_RC5_PARAMS_PTR;
  * mechanism
  */
 typedef struct CK_RC5_CBC_PARAMS {
-    CK_ULONG    ulWordsize;  /* wordsize in bits */
-    CK_ULONG    ulRounds;    /* number of rounds */
-    CK_BYTE_PTR pIv;         /* pointer to IV */
-    CK_ULONG    ulIvLen;     /* length of IV in bytes */
+  CK_ULONG      ulWordsize;  /* wordsize in bits */
+  CK_ULONG      ulRounds;    /* number of rounds */
+  CK_BYTE_PTR   pIv;         /* pointer to IV */
+  CK_ULONG      ulIvLen;     /* length of IV in bytes */
 } CK_RC5_CBC_PARAMS;
 
 typedef CK_RC5_CBC_PARAMS CK_PTR CK_RC5_CBC_PARAMS_PTR;
@@ -1704,13 +1816,13 @@ typedef CK_RC5_CBC_PARAMS CK_PTR CK_RC5_CBC_PARAMS_PTR;
  * CKM_RC5_MAC_GENERAL mechanism
  */
 typedef struct CK_RC5_MAC_GENERAL_PARAMS {
-    CK_ULONG ulWordsize;   /* wordsize in bits */
-    CK_ULONG ulRounds;     /* number of rounds */
-    CK_ULONG ulMacLength;  /* Length of MAC in bytes */
+  CK_ULONG      ulWordsize;   /* wordsize in bits */
+  CK_ULONG      ulRounds;     /* number of rounds */
+  CK_ULONG      ulMacLength;  /* Length of MAC in bytes */
 } CK_RC5_MAC_GENERAL_PARAMS;
 
 typedef CK_RC5_MAC_GENERAL_PARAMS CK_PTR \
-        CK_RC5_MAC_GENERAL_PARAMS_PTR;
+  CK_RC5_MAC_GENERAL_PARAMS_PTR;
 
 /* CK_MAC_GENERAL_PARAMS provides the parameters to most block
  * ciphers' MAC_GENERAL mechanisms.  Its value is the length of
@@ -1721,17 +1833,17 @@ typedef CK_ULONG          CK_MAC_GENERAL_PARAMS;
 typedef CK_MAC_GENERAL_PARAMS CK_PTR CK_MAC_GENERAL_PARAMS_PTR;
 
 typedef struct CK_DES_CBC_ENCRYPT_DATA_PARAMS {
-    CK_BYTE     iv[8];
-    CK_BYTE_PTR pData;
-    CK_ULONG    length;
+  CK_BYTE      iv[8];
+  CK_BYTE_PTR  pData;
+  CK_ULONG     length;
 } CK_DES_CBC_ENCRYPT_DATA_PARAMS;
 
 typedef CK_DES_CBC_ENCRYPT_DATA_PARAMS CK_PTR CK_DES_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
 typedef struct CK_AES_CBC_ENCRYPT_DATA_PARAMS {
-    CK_BYTE     iv[16];
-    CK_BYTE_PTR pData;
-    CK_ULONG    length;
+  CK_BYTE      iv[16];
+  CK_BYTE_PTR  pData;
+  CK_ULONG     length;
 } CK_AES_CBC_ENCRYPT_DATA_PARAMS;
 
 typedef CK_AES_CBC_ENCRYPT_DATA_PARAMS CK_PTR CK_AES_CBC_ENCRYPT_DATA_PARAMS_PTR;
@@ -1740,54 +1852,54 @@ typedef CK_AES_CBC_ENCRYPT_DATA_PARAMS CK_PTR CK_AES_CBC_ENCRYPT_DATA_PARAMS_PTR
  * CKM_SKIPJACK_PRIVATE_WRAP mechanism
  */
 typedef struct CK_SKIPJACK_PRIVATE_WRAP_PARAMS {
-    CK_ULONG    ulPasswordLen;
-    CK_BYTE_PTR pPassword;
-    CK_ULONG    ulPublicDataLen;
-    CK_BYTE_PTR pPublicData;
-    CK_ULONG    ulPAndGLen;
-    CK_ULONG    ulQLen;
-    CK_ULONG    ulRandomLen;
-    CK_BYTE_PTR pRandomA;
-    CK_BYTE_PTR pPrimeP;
-    CK_BYTE_PTR pBaseG;
-    CK_BYTE_PTR pSubprimeQ;
+  CK_ULONG      ulPasswordLen;
+  CK_BYTE_PTR   pPassword;
+  CK_ULONG      ulPublicDataLen;
+  CK_BYTE_PTR   pPublicData;
+  CK_ULONG      ulPAndGLen;
+  CK_ULONG      ulQLen;
+  CK_ULONG      ulRandomLen;
+  CK_BYTE_PTR   pRandomA;
+  CK_BYTE_PTR   pPrimeP;
+  CK_BYTE_PTR   pBaseG;
+  CK_BYTE_PTR   pSubprimeQ;
 } CK_SKIPJACK_PRIVATE_WRAP_PARAMS;
 
 typedef CK_SKIPJACK_PRIVATE_WRAP_PARAMS CK_PTR \
-        CK_SKIPJACK_PRIVATE_WRAP_PARAMS_PTR;
+  CK_SKIPJACK_PRIVATE_WRAP_PARAMS_PTR;
 
 
 /* CK_SKIPJACK_RELAYX_PARAMS provides the parameters to the
  * CKM_SKIPJACK_RELAYX mechanism
  */
 typedef struct CK_SKIPJACK_RELAYX_PARAMS {
-    CK_ULONG    ulOldWrappedXLen;
-    CK_BYTE_PTR pOldWrappedX;
-    CK_ULONG    ulOldPasswordLen;
-    CK_BYTE_PTR pOldPassword;
-    CK_ULONG    ulOldPublicDataLen;
-    CK_BYTE_PTR pOldPublicData;
-    CK_ULONG    ulOldRandomLen;
-    CK_BYTE_PTR pOldRandomA;
-    CK_ULONG    ulNewPasswordLen;
-    CK_BYTE_PTR pNewPassword;
-    CK_ULONG    ulNewPublicDataLen;
-    CK_BYTE_PTR pNewPublicData;
-    CK_ULONG    ulNewRandomLen;
-    CK_BYTE_PTR pNewRandomA;
+  CK_ULONG      ulOldWrappedXLen;
+  CK_BYTE_PTR   pOldWrappedX;
+  CK_ULONG      ulOldPasswordLen;
+  CK_BYTE_PTR   pOldPassword;
+  CK_ULONG      ulOldPublicDataLen;
+  CK_BYTE_PTR   pOldPublicData;
+  CK_ULONG      ulOldRandomLen;
+  CK_BYTE_PTR   pOldRandomA;
+  CK_ULONG      ulNewPasswordLen;
+  CK_BYTE_PTR   pNewPassword;
+  CK_ULONG      ulNewPublicDataLen;
+  CK_BYTE_PTR   pNewPublicData;
+  CK_ULONG      ulNewRandomLen;
+  CK_BYTE_PTR   pNewRandomA;
 } CK_SKIPJACK_RELAYX_PARAMS;
 
 typedef CK_SKIPJACK_RELAYX_PARAMS CK_PTR \
-        CK_SKIPJACK_RELAYX_PARAMS_PTR;
+  CK_SKIPJACK_RELAYX_PARAMS_PTR;
 
 
 typedef struct CK_PBE_PARAMS {
-    CK_BYTE_PTR     pInitVector;
-    CK_UTF8CHAR_PTR pPassword;
-    CK_ULONG        ulPasswordLen;
-    CK_BYTE_PTR     pSalt;
-    CK_ULONG        ulSaltLen;
-    CK_ULONG        ulIteration;
+  CK_BYTE_PTR      pInitVector;
+  CK_UTF8CHAR_PTR  pPassword;
+  CK_ULONG         ulPasswordLen;
+  CK_BYTE_PTR      pSalt;
+  CK_ULONG         ulSaltLen;
+  CK_ULONG         ulIteration;
 } CK_PBE_PARAMS;
 
 typedef CK_PBE_PARAMS CK_PTR CK_PBE_PARAMS_PTR;
@@ -1797,134 +1909,134 @@ typedef CK_PBE_PARAMS CK_PTR CK_PBE_PARAMS_PTR;
  * CKM_KEY_WRAP_SET_OAEP mechanism
  */
 typedef struct CK_KEY_WRAP_SET_OAEP_PARAMS {
-    CK_BYTE     bBC;     /* block contents byte */
-    CK_BYTE_PTR pX;      /* extra data */
-    CK_ULONG    ulXLen;  /* length of extra data in bytes */
+  CK_BYTE       bBC;     /* block contents byte */
+  CK_BYTE_PTR   pX;      /* extra data */
+  CK_ULONG      ulXLen;  /* length of extra data in bytes */
 } CK_KEY_WRAP_SET_OAEP_PARAMS;
 
 typedef CK_KEY_WRAP_SET_OAEP_PARAMS CK_PTR CK_KEY_WRAP_SET_OAEP_PARAMS_PTR;
 
 typedef struct CK_SSL3_RANDOM_DATA {
-    CK_BYTE_PTR pClientRandom;
-    CK_ULONG    ulClientRandomLen;
-    CK_BYTE_PTR pServerRandom;
-    CK_ULONG    ulServerRandomLen;
+  CK_BYTE_PTR  pClientRandom;
+  CK_ULONG     ulClientRandomLen;
+  CK_BYTE_PTR  pServerRandom;
+  CK_ULONG     ulServerRandomLen;
 } CK_SSL3_RANDOM_DATA;
 
 
 typedef struct CK_SSL3_MASTER_KEY_DERIVE_PARAMS {
-    CK_SSL3_RANDOM_DATA RandomInfo;
-    CK_VERSION_PTR      pVersion;
+  CK_SSL3_RANDOM_DATA RandomInfo;
+  CK_VERSION_PTR pVersion;
 } CK_SSL3_MASTER_KEY_DERIVE_PARAMS;
 
 typedef struct CK_SSL3_MASTER_KEY_DERIVE_PARAMS CK_PTR \
-        CK_SSL3_MASTER_KEY_DERIVE_PARAMS_PTR;
+  CK_SSL3_MASTER_KEY_DERIVE_PARAMS_PTR;
 
 typedef struct CK_SSL3_KEY_MAT_OUT {
-    CK_OBJECT_HANDLE hClientMacSecret;
-    CK_OBJECT_HANDLE hServerMacSecret;
-    CK_OBJECT_HANDLE hClientKey;
-    CK_OBJECT_HANDLE hServerKey;
-    CK_BYTE_PTR      pIVClient;
-    CK_BYTE_PTR      pIVServer;
+  CK_OBJECT_HANDLE hClientMacSecret;
+  CK_OBJECT_HANDLE hServerMacSecret;
+  CK_OBJECT_HANDLE hClientKey;
+  CK_OBJECT_HANDLE hServerKey;
+  CK_BYTE_PTR      pIVClient;
+  CK_BYTE_PTR      pIVServer;
 } CK_SSL3_KEY_MAT_OUT;
 
 typedef CK_SSL3_KEY_MAT_OUT CK_PTR CK_SSL3_KEY_MAT_OUT_PTR;
 
 
 typedef struct CK_SSL3_KEY_MAT_PARAMS {
-    CK_ULONG                ulMacSizeInBits;
-    CK_ULONG                ulKeySizeInBits;
-    CK_ULONG                ulIVSizeInBits;
-    CK_BBOOL                bIsExport;
-    CK_SSL3_RANDOM_DATA     RandomInfo;
-    CK_SSL3_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
+  CK_ULONG                ulMacSizeInBits;
+  CK_ULONG                ulKeySizeInBits;
+  CK_ULONG                ulIVSizeInBits;
+  CK_BBOOL                bIsExport;
+  CK_SSL3_RANDOM_DATA     RandomInfo;
+  CK_SSL3_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
 } CK_SSL3_KEY_MAT_PARAMS;
 
 typedef CK_SSL3_KEY_MAT_PARAMS CK_PTR CK_SSL3_KEY_MAT_PARAMS_PTR;
 
 typedef struct CK_TLS_PRF_PARAMS {
-    CK_BYTE_PTR  pSeed;
-    CK_ULONG     ulSeedLen;
-    CK_BYTE_PTR  pLabel;
-    CK_ULONG     ulLabelLen;
-    CK_BYTE_PTR  pOutput;
-    CK_ULONG_PTR pulOutputLen;
+  CK_BYTE_PTR  pSeed;
+  CK_ULONG     ulSeedLen;
+  CK_BYTE_PTR  pLabel;
+  CK_ULONG     ulLabelLen;
+  CK_BYTE_PTR  pOutput;
+  CK_ULONG_PTR pulOutputLen;
 } CK_TLS_PRF_PARAMS;
 
 typedef CK_TLS_PRF_PARAMS CK_PTR CK_TLS_PRF_PARAMS_PTR;
 
 typedef struct CK_WTLS_RANDOM_DATA {
-    CK_BYTE_PTR pClientRandom;
-    CK_ULONG    ulClientRandomLen;
-    CK_BYTE_PTR pServerRandom;
-    CK_ULONG    ulServerRandomLen;
+  CK_BYTE_PTR pClientRandom;
+  CK_ULONG    ulClientRandomLen;
+  CK_BYTE_PTR pServerRandom;
+  CK_ULONG    ulServerRandomLen;
 } CK_WTLS_RANDOM_DATA;
 
 typedef CK_WTLS_RANDOM_DATA CK_PTR CK_WTLS_RANDOM_DATA_PTR;
 
 typedef struct CK_WTLS_MASTER_KEY_DERIVE_PARAMS {
-    CK_MECHANISM_TYPE   DigestMechanism;
-    CK_WTLS_RANDOM_DATA RandomInfo;
-    CK_BYTE_PTR         pVersion;
+  CK_MECHANISM_TYPE   DigestMechanism;
+  CK_WTLS_RANDOM_DATA RandomInfo;
+  CK_BYTE_PTR         pVersion;
 } CK_WTLS_MASTER_KEY_DERIVE_PARAMS;
 
 typedef CK_WTLS_MASTER_KEY_DERIVE_PARAMS CK_PTR \
-        CK_WTLS_MASTER_KEY_DERIVE_PARAMS_PTR;
+  CK_WTLS_MASTER_KEY_DERIVE_PARAMS_PTR;
 
 typedef struct CK_WTLS_PRF_PARAMS {
-    CK_MECHANISM_TYPE DigestMechanism;
-    CK_BYTE_PTR       pSeed;
-    CK_ULONG          ulSeedLen;
-    CK_BYTE_PTR       pLabel;
-    CK_ULONG          ulLabelLen;
-    CK_BYTE_PTR       pOutput;
-    CK_ULONG_PTR      pulOutputLen;
+  CK_MECHANISM_TYPE DigestMechanism;
+  CK_BYTE_PTR       pSeed;
+  CK_ULONG          ulSeedLen;
+  CK_BYTE_PTR       pLabel;
+  CK_ULONG          ulLabelLen;
+  CK_BYTE_PTR       pOutput;
+  CK_ULONG_PTR      pulOutputLen;
 } CK_WTLS_PRF_PARAMS;
 
 typedef CK_WTLS_PRF_PARAMS CK_PTR CK_WTLS_PRF_PARAMS_PTR;
 
 typedef struct CK_WTLS_KEY_MAT_OUT {
-    CK_OBJECT_HANDLE hMacSecret;
-    CK_OBJECT_HANDLE hKey;
-    CK_BYTE_PTR      pIV;
+  CK_OBJECT_HANDLE hMacSecret;
+  CK_OBJECT_HANDLE hKey;
+  CK_BYTE_PTR      pIV;
 } CK_WTLS_KEY_MAT_OUT;
 
 typedef CK_WTLS_KEY_MAT_OUT CK_PTR CK_WTLS_KEY_MAT_OUT_PTR;
 
 typedef struct CK_WTLS_KEY_MAT_PARAMS {
-    CK_MECHANISM_TYPE       DigestMechanism;
-    CK_ULONG                ulMacSizeInBits;
-    CK_ULONG                ulKeySizeInBits;
-    CK_ULONG                ulIVSizeInBits;
-    CK_ULONG                ulSequenceNumber;
-    CK_BBOOL                bIsExport;
-    CK_WTLS_RANDOM_DATA     RandomInfo;
-    CK_WTLS_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
+  CK_MECHANISM_TYPE       DigestMechanism;
+  CK_ULONG                ulMacSizeInBits;
+  CK_ULONG                ulKeySizeInBits;
+  CK_ULONG                ulIVSizeInBits;
+  CK_ULONG                ulSequenceNumber;
+  CK_BBOOL                bIsExport;
+  CK_WTLS_RANDOM_DATA     RandomInfo;
+  CK_WTLS_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
 } CK_WTLS_KEY_MAT_PARAMS;
 
 typedef CK_WTLS_KEY_MAT_PARAMS CK_PTR CK_WTLS_KEY_MAT_PARAMS_PTR;
 
 typedef struct CK_CMS_SIG_PARAMS {
-    CK_OBJECT_HANDLE certificateHandle;
-    CK_MECHANISM_PTR pSigningMechanism;
-    CK_MECHANISM_PTR pDigestMechanism;
-    CK_UTF8CHAR_PTR  pContentType;
-    CK_BYTE_PTR      pRequestedAttributes;
-    CK_ULONG         ulRequestedAttributesLen;
-    CK_BYTE_PTR      pRequiredAttributes;
-    CK_ULONG         ulRequiredAttributesLen;
+  CK_OBJECT_HANDLE      certificateHandle;
+  CK_MECHANISM_PTR      pSigningMechanism;
+  CK_MECHANISM_PTR      pDigestMechanism;
+  CK_UTF8CHAR_PTR       pContentType;
+  CK_BYTE_PTR           pRequestedAttributes;
+  CK_ULONG              ulRequestedAttributesLen;
+  CK_BYTE_PTR           pRequiredAttributes;
+  CK_ULONG              ulRequiredAttributesLen;
 } CK_CMS_SIG_PARAMS;
 
 typedef CK_CMS_SIG_PARAMS CK_PTR CK_CMS_SIG_PARAMS_PTR;
 
 typedef struct CK_KEY_DERIVATION_STRING_DATA {
-    CK_BYTE_PTR pData;
-    CK_ULONG    ulLen;
+  CK_BYTE_PTR pData;
+  CK_ULONG    ulLen;
 } CK_KEY_DERIVATION_STRING_DATA;
 
 typedef CK_KEY_DERIVATION_STRING_DATA CK_PTR \
-        CK_KEY_DERIVATION_STRING_DATA_PTR;
+  CK_KEY_DERIVATION_STRING_DATA_PTR;
 
 
 /* The CK_EXTRACT_PARAMS is used for the
@@ -1943,7 +2055,7 @@ typedef CK_EXTRACT_PARAMS CK_PTR CK_EXTRACT_PARAMS_PTR;
 typedef CK_ULONG CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE;
 
 typedef CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE CK_PTR \
-        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE_PTR;
+                        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE_PTR;
 
 #define CKP_PKCS5_PBKD2_HMAC_SHA1          0x00000001UL
 #define CKP_PKCS5_PBKD2_HMAC_GOSTR3411     0x00000002UL
@@ -1961,7 +2073,7 @@ typedef CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE CK_PTR \
 typedef CK_ULONG CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE;
 
 typedef CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE CK_PTR \
-        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE_PTR;
+                        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE_PTR;
 
 /* The following salt value sources are defined in PKCS #5 v2.0. */
 #define CKZ_SALT_SPECIFIED        0x00000001UL
@@ -1970,15 +2082,15 @@ typedef CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE CK_PTR \
  * parameters to the CKM_PKCS5_PBKD2 mechanism.
  */
 typedef struct CK_PKCS5_PBKD2_PARAMS {
-    CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE           saltSource;
-    CK_VOID_PTR                                pSaltSourceData;
-    CK_ULONG                                   ulSaltSourceDataLen;
-    CK_ULONG                                   iterations;
-    CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE prf;
-    CK_VOID_PTR                                pPrfData;
-    CK_ULONG                                   ulPrfDataLen;
-    CK_UTF8CHAR_PTR                            pPassword;
-    CK_ULONG_PTR                               ulPasswordLen;
+        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE           saltSource;
+        CK_VOID_PTR                                pSaltSourceData;
+        CK_ULONG                                   ulSaltSourceDataLen;
+        CK_ULONG                                   iterations;
+        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE prf;
+        CK_VOID_PTR                                pPrfData;
+        CK_ULONG                                   ulPrfDataLen;
+        CK_UTF8CHAR_PTR                            pPassword;
+        CK_ULONG_PTR                               ulPasswordLen;
 } CK_PKCS5_PBKD2_PARAMS;
 
 typedef CK_PKCS5_PBKD2_PARAMS CK_PTR CK_PKCS5_PBKD2_PARAMS_PTR;
@@ -1988,15 +2100,15 @@ typedef CK_PKCS5_PBKD2_PARAMS CK_PTR CK_PKCS5_PBKD2_PARAMS_PTR;
  * noting that the ulPasswordLen field is a CK_ULONG and not a CK_ULONG_PTR.
  */
 typedef struct CK_PKCS5_PBKD2_PARAMS2 {
-    CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE           saltSource;
-    CK_VOID_PTR                                pSaltSourceData;
-    CK_ULONG                                   ulSaltSourceDataLen;
-    CK_ULONG                                   iterations;
-    CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE prf;
-    CK_VOID_PTR                                pPrfData;
-    CK_ULONG                                   ulPrfDataLen;
-    CK_UTF8CHAR_PTR                            pPassword;
-    CK_ULONG                                   ulPasswordLen;
+        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE saltSource;
+        CK_VOID_PTR pSaltSourceData;
+        CK_ULONG ulSaltSourceDataLen;
+        CK_ULONG iterations;
+        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE prf;
+        CK_VOID_PTR pPrfData;
+        CK_ULONG ulPrfDataLen;
+        CK_UTF8CHAR_PTR pPassword;
+        CK_ULONG ulPasswordLen;
 } CK_PKCS5_PBKD2_PARAMS2;
 
 typedef CK_PKCS5_PBKD2_PARAMS2 CK_PTR CK_PKCS5_PBKD2_PARAMS2_PTR;
@@ -2006,22 +2118,22 @@ typedef CK_OTP_PARAM_TYPE CK_PARAM_TYPE; /* backward compatibility */
 
 typedef struct CK_OTP_PARAM {
     CK_OTP_PARAM_TYPE type;
-    CK_VOID_PTR       pValue;
-    CK_ULONG          ulValueLen;
+    CK_VOID_PTR pValue;
+    CK_ULONG ulValueLen;
 } CK_OTP_PARAM;
 
 typedef CK_OTP_PARAM CK_PTR CK_OTP_PARAM_PTR;
 
 typedef struct CK_OTP_PARAMS {
     CK_OTP_PARAM_PTR pParams;
-    CK_ULONG         ulCount;
+    CK_ULONG ulCount;
 } CK_OTP_PARAMS;
 
 typedef CK_OTP_PARAMS CK_PTR CK_OTP_PARAMS_PTR;
 
 typedef struct CK_OTP_SIGNATURE_INFO {
     CK_OTP_PARAM_PTR pParams;
-    CK_ULONG         ulCount;
+    CK_ULONG ulCount;
 } CK_OTP_SIGNATURE_INFO;
 
 typedef CK_OTP_SIGNATURE_INFO CK_PTR CK_OTP_SIGNATURE_INFO_PTR;
@@ -2043,28 +2155,28 @@ typedef CK_OTP_SIGNATURE_INFO CK_PTR CK_OTP_SIGNATURE_INFO_PTR;
 #define CKF_USER_FRIENDLY_OTP 0x00000020UL
 
 typedef struct CK_KIP_PARAMS {
-    CK_MECHANISM_PTR pMechanism;
-    CK_OBJECT_HANDLE hKey;
-    CK_BYTE_PTR      pSeed;
-    CK_ULONG         ulSeedLen;
+    CK_MECHANISM_PTR  pMechanism;
+    CK_OBJECT_HANDLE  hKey;
+    CK_BYTE_PTR       pSeed;
+    CK_ULONG          ulSeedLen;
 } CK_KIP_PARAMS;
 
 typedef CK_KIP_PARAMS CK_PTR CK_KIP_PARAMS_PTR;
 
 typedef struct CK_AES_CTR_PARAMS {
     CK_ULONG ulCounterBits;
-    CK_BYTE  cb[16];
+    CK_BYTE cb[16];
 } CK_AES_CTR_PARAMS;
 
 typedef CK_AES_CTR_PARAMS CK_PTR CK_AES_CTR_PARAMS_PTR;
 
 typedef struct CK_GCM_PARAMS {
-    CK_BYTE_PTR pIv;
-    CK_ULONG    ulIvLen;
-    CK_ULONG    ulIvBits;
-    CK_BYTE_PTR pAAD;
-    CK_ULONG    ulAADLen;
-    CK_ULONG    ulTagBits;
+    CK_BYTE_PTR       pIv;
+    CK_ULONG          ulIvLen;
+    CK_ULONG          ulIvBits;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulTagBits;
 } CK_GCM_PARAMS;
 
 typedef CK_GCM_PARAMS CK_PTR CK_GCM_PARAMS_PTR;
@@ -2077,102 +2189,127 @@ typedef CK_ULONG CK_GENERATOR_FUNCTION;
 #define CKG_GENERATE_COUNTER_XOR 0x00000004UL
 
 typedef struct CK_GCM_MESSAGE_PARAMS {
-    CK_BYTE_PTR           pIv;
-    CK_ULONG              ulIvLen;
-    CK_ULONG              ulIvFixedBits;
+    CK_BYTE_PTR       pIv;
+    CK_ULONG          ulIvLen;
+    CK_ULONG          ulIvFixedBits;
     CK_GENERATOR_FUNCTION ivGenerator;
-    CK_BYTE_PTR           pTag;
-    CK_ULONG              ulTagBits;
+    CK_BYTE_PTR       pTag;
+    CK_ULONG          ulTagBits;
 } CK_GCM_MESSAGE_PARAMS;
 
 typedef CK_GCM_MESSAGE_PARAMS CK_PTR CK_GCM_MESSAGE_PARAMS_PTR;
 
+typedef struct CK_GCM_WRAP_PARAMS {
+  CK_BYTE_PTR     pIv;
+  CK_ULONG        ulIvLen;
+  CK_ULONG        ulIvFixedBits;
+  CK_GENERATOR_FUNCTION   ivGenerator;
+  CK_BYTE_PTR     pAAD;
+  CK_ULONG        ulAADLen;
+  CK_ULONG        ulTagBits;
+} CK_GCM_WRAP_PARAMS;
+
+typedef CK_GCM_WRAP_PARAMS CK_PTR CK_GCM_WRAP_PARAMS_PTR;
+
 typedef struct CK_CCM_PARAMS {
-    CK_ULONG    ulDataLen;
-    CK_BYTE_PTR pNonce;
-    CK_ULONG    ulNonceLen;
-    CK_BYTE_PTR pAAD;
-    CK_ULONG    ulAADLen;
-    CK_ULONG    ulMACLen;
+    CK_ULONG          ulDataLen;
+    CK_BYTE_PTR       pNonce;
+    CK_ULONG          ulNonceLen;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulMACLen;
 } CK_CCM_PARAMS;
 
 typedef CK_CCM_PARAMS CK_PTR CK_CCM_PARAMS_PTR;
 
 typedef struct CK_CCM_MESSAGE_PARAMS {
-    CK_ULONG              ulDataLen; /*plaintext or ciphertext*/
-    CK_BYTE_PTR           pNonce;
-    CK_ULONG              ulNonceLen;
-    CK_ULONG              ulNonceFixedBits;
+    CK_ULONG          ulDataLen; /*plaintext or ciphertext*/
+    CK_BYTE_PTR       pNonce;
+    CK_ULONG          ulNonceLen;
+    CK_ULONG          ulNonceFixedBits;
     CK_GENERATOR_FUNCTION nonceGenerator;
-    CK_BYTE_PTR           pMAC;
-    CK_ULONG              ulMACLen;
+    CK_BYTE_PTR       pMAC;
+    CK_ULONG          ulMACLen;
 } CK_CCM_MESSAGE_PARAMS;
 
 typedef CK_CCM_MESSAGE_PARAMS CK_PTR CK_CCM_MESSAGE_PARAMS_PTR;
 
+typedef struct CK_CCM_WRAP_PARAMS {
+        CK_ULONG        ulDataLen; /*wrappedkey data*/
+        CK_BYTE_PTR     pNonce;
+        CK_ULONG        ulNonceLen;
+        CK_ULONG        ulNonceFixedBits;
+        CK_GENERATOR_FUNCTION   nonceGenerator;
+        CK_BYTE_PTR     pAAD;
+        CK_ULONG        ulAADLen;
+        CK_ULONG        ulMACLen;
+}       CK_CCM_WRAP_PARAMS;
+
+typedef CK_CCM_WRAP_PARAMS CK_PTR CK_CCM_WRAP_PARAMS_PTR;
+
 /* Deprecated. Use CK_GCM_PARAMS */
 typedef struct CK_AES_GCM_PARAMS {
-    CK_BYTE_PTR pIv;
-    CK_ULONG    ulIvLen;
-    CK_ULONG    ulIvBits;
-    CK_BYTE_PTR pAAD;
-    CK_ULONG    ulAADLen;
-    CK_ULONG    ulTagBits;
+  CK_BYTE_PTR pIv;
+  CK_ULONG ulIvLen;
+  CK_ULONG ulIvBits;
+  CK_BYTE_PTR pAAD;
+  CK_ULONG ulAADLen;
+  CK_ULONG ulTagBits;
 } CK_AES_GCM_PARAMS;
 
 typedef CK_AES_GCM_PARAMS CK_PTR CK_AES_GCM_PARAMS_PTR;
 
 /* Deprecated. Use CK_CCM_PARAMS */
 typedef struct CK_AES_CCM_PARAMS {
-    CK_ULONG    ulDataLen;
-    CK_BYTE_PTR pNonce;
-    CK_ULONG    ulNonceLen;
-    CK_BYTE_PTR pAAD;
-    CK_ULONG    ulAADLen;
-    CK_ULONG    ulMACLen;
+    CK_ULONG          ulDataLen;
+    CK_BYTE_PTR       pNonce;
+    CK_ULONG          ulNonceLen;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulMACLen;
 } CK_AES_CCM_PARAMS;
 
 typedef CK_AES_CCM_PARAMS CK_PTR CK_AES_CCM_PARAMS_PTR;
 
 typedef struct CK_CAMELLIA_CTR_PARAMS {
-    CK_ULONG ulCounterBits;
-    CK_BYTE  cb[16];
+    CK_ULONG          ulCounterBits;
+    CK_BYTE           cb[16];
 } CK_CAMELLIA_CTR_PARAMS;
 
 typedef CK_CAMELLIA_CTR_PARAMS CK_PTR CK_CAMELLIA_CTR_PARAMS_PTR;
 
 typedef struct CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS {
-    CK_BYTE     iv[16];
-    CK_BYTE_PTR pData;
-    CK_ULONG    length;
+    CK_BYTE           iv[16];
+    CK_BYTE_PTR       pData;
+    CK_ULONG          length;
 } CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS;
 
 typedef CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
-        CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
+                                CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
 typedef struct CK_ARIA_CBC_ENCRYPT_DATA_PARAMS {
-    CK_BYTE     iv[16];
-    CK_BYTE_PTR pData;
-    CK_ULONG    length;
+    CK_BYTE           iv[16];
+    CK_BYTE_PTR       pData;
+    CK_ULONG          length;
 } CK_ARIA_CBC_ENCRYPT_DATA_PARAMS;
 
 typedef CK_ARIA_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
-        CK_ARIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
+                                CK_ARIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
 typedef struct CK_DSA_PARAMETER_GEN_PARAM {
-    CK_MECHANISM_TYPE hash;
-    CK_BYTE_PTR       pSeed;
-    CK_ULONG          ulSeedLen;
-    CK_ULONG          ulIndex;
+    CK_MECHANISM_TYPE  hash;
+    CK_BYTE_PTR        pSeed;
+    CK_ULONG           ulSeedLen;
+    CK_ULONG           ulIndex;
 } CK_DSA_PARAMETER_GEN_PARAM;
 
 typedef CK_DSA_PARAMETER_GEN_PARAM CK_PTR CK_DSA_PARAMETER_GEN_PARAM_PTR;
 
 typedef struct CK_ECDH_AES_KEY_WRAP_PARAMS {
-    CK_ULONG       ulAESKeyBits;
-    CK_EC_KDF_TYPE kdf;
-    CK_ULONG       ulSharedDataLen;
-    CK_BYTE_PTR    pSharedData;
+    CK_ULONG           ulAESKeyBits;
+    CK_EC_KDF_TYPE     kdf;
+    CK_ULONG           ulSharedDataLen;
+    CK_BYTE_PTR        pSharedData;
 } CK_ECDH_AES_KEY_WRAP_PARAMS;
 
 typedef CK_ECDH_AES_KEY_WRAP_PARAMS CK_PTR CK_ECDH_AES_KEY_WRAP_PARAMS_PTR;
@@ -2182,80 +2319,90 @@ typedef CK_ULONG CK_JAVA_MIDP_SECURITY_DOMAIN;
 typedef CK_ULONG CK_CERTIFICATE_CATEGORY;
 
 typedef struct CK_RSA_AES_KEY_WRAP_PARAMS {
-    CK_ULONG                    ulAESKeyBits;
-    CK_RSA_PKCS_OAEP_PARAMS_PTR pOAEPParams;
+    CK_ULONG                      ulAESKeyBits;
+    CK_RSA_PKCS_OAEP_PARAMS_PTR   pOAEPParams;
 } CK_RSA_AES_KEY_WRAP_PARAMS;
 
 typedef CK_RSA_AES_KEY_WRAP_PARAMS CK_PTR CK_RSA_AES_KEY_WRAP_PARAMS_PTR;
 
 typedef struct CK_TLS12_MASTER_KEY_DERIVE_PARAMS {
-    CK_SSL3_RANDOM_DATA RandomInfo;
-    CK_VERSION_PTR      pVersion;
-    CK_MECHANISM_TYPE   prfHashMechanism;
+    CK_SSL3_RANDOM_DATA       RandomInfo;
+    CK_VERSION_PTR            pVersion;
+    CK_MECHANISM_TYPE         prfHashMechanism;
 } CK_TLS12_MASTER_KEY_DERIVE_PARAMS;
 
 typedef CK_TLS12_MASTER_KEY_DERIVE_PARAMS CK_PTR \
-        CK_TLS12_MASTER_KEY_DERIVE_PARAMS_PTR;
+                                CK_TLS12_MASTER_KEY_DERIVE_PARAMS_PTR;
 
 typedef struct CK_TLS12_KEY_MAT_PARAMS {
-    CK_ULONG                ulMacSizeInBits;
-    CK_ULONG                ulKeySizeInBits;
-    CK_ULONG                ulIVSizeInBits;
-    CK_BBOOL                bIsExport;
-    CK_SSL3_RANDOM_DATA     RandomInfo;
-    CK_SSL3_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
-    CK_MECHANISM_TYPE       prfHashMechanism;
+    CK_ULONG                  ulMacSizeInBits;
+    CK_ULONG                  ulKeySizeInBits;
+    CK_ULONG                  ulIVSizeInBits;
+    CK_BBOOL                  bIsExport;
+    CK_SSL3_RANDOM_DATA       RandomInfo;
+    CK_SSL3_KEY_MAT_OUT_PTR   pReturnedKeyMaterial;
+    CK_MECHANISM_TYPE         prfHashMechanism;
 } CK_TLS12_KEY_MAT_PARAMS;
 
 typedef CK_TLS12_KEY_MAT_PARAMS CK_PTR CK_TLS12_KEY_MAT_PARAMS_PTR;
 
 typedef struct CK_TLS_KDF_PARAMS {
-    CK_MECHANISM_TYPE   prfMechanism;
-    CK_BYTE_PTR         pLabel;
-    CK_ULONG            ulLabelLength;
-    CK_SSL3_RANDOM_DATA RandomInfo;
-    CK_BYTE_PTR         pContextData;
-    CK_ULONG            ulContextDataLength;
+    CK_MECHANISM_TYPE         prfMechanism;
+    CK_BYTE_PTR               pLabel;
+    CK_ULONG                  ulLabelLength;
+    CK_SSL3_RANDOM_DATA       RandomInfo;
+    CK_BYTE_PTR               pContextData;
+    CK_ULONG                  ulContextDataLength;
 } CK_TLS_KDF_PARAMS;
 
 typedef CK_TLS_KDF_PARAMS CK_PTR CK_TLS_KDF_PARAMS_PTR;
 
 typedef struct CK_TLS_MAC_PARAMS {
-    CK_MECHANISM_TYPE prfHashMechanism;
-    CK_ULONG          ulMacLength;
-    CK_ULONG          ulServerOrClient;
+    CK_MECHANISM_TYPE         prfHashMechanism;
+    CK_ULONG                  ulMacLength;
+    CK_ULONG                  ulServerOrClient;
 } CK_TLS_MAC_PARAMS;
 
 typedef CK_TLS_MAC_PARAMS CK_PTR CK_TLS_MAC_PARAMS_PTR;
 
+typedef struct CK_TLS12_EXTENDED_MASTER_KEY_DERIVE_PARAMS {
+  CK_MECHANISM_TYPE prfHashMechanism;
+  CK_BYTE_PTR pSessionHash;
+  CK_ULONG ulSessionHashLen;
+  CK_VERSION_PTR pVersion;
+} CK_TLS12_EXTENDED_MASTER_KEY_DERIVE_PARAMS;
+
+typedef CK_TLS12_EXTENDED_MASTER_KEY_DERIVE_PARAMS CK_PTR
+        CK_TLS12_EXTENDED_MASTER_KEY_DERIVE_PARAMS_PTR;
+
 typedef struct CK_GOSTR3410_DERIVE_PARAMS {
-    CK_EC_KDF_TYPE kdf;
-    CK_BYTE_PTR    pPublicData;
-    CK_ULONG       ulPublicDataLen;
-    CK_BYTE_PTR    pUKM;
-    CK_ULONG       ulUKMLen;
+    CK_EC_KDF_TYPE            kdf;
+    CK_BYTE_PTR               pPublicData;
+    CK_ULONG                  ulPublicDataLen;
+    CK_BYTE_PTR               pUKM;
+    CK_ULONG                  ulUKMLen;
 } CK_GOSTR3410_DERIVE_PARAMS;
 
 typedef CK_GOSTR3410_DERIVE_PARAMS CK_PTR CK_GOSTR3410_DERIVE_PARAMS_PTR;
 
 typedef struct CK_GOSTR3410_KEY_WRAP_PARAMS {
-    CK_BYTE_PTR      pWrapOID;
-    CK_ULONG         ulWrapOIDLen;
-    CK_BYTE_PTR      pUKM;
-    CK_ULONG         ulUKMLen;
-    CK_OBJECT_HANDLE hKey;
+    CK_BYTE_PTR               pWrapOID;
+    CK_ULONG                  ulWrapOIDLen;
+    CK_BYTE_PTR               pUKM;
+    CK_ULONG                  ulUKMLen;
+    CK_OBJECT_HANDLE          hKey;
 } CK_GOSTR3410_KEY_WRAP_PARAMS;
 
 typedef CK_GOSTR3410_KEY_WRAP_PARAMS CK_PTR CK_GOSTR3410_KEY_WRAP_PARAMS_PTR;
 
 typedef struct CK_SEED_CBC_ENCRYPT_DATA_PARAMS {
-    CK_BYTE     iv[16];
-    CK_BYTE_PTR pData;
-    CK_ULONG    length;
+    CK_BYTE                   iv[16];
+    CK_BYTE_PTR               pData;
+    CK_ULONG                  length;
 } CK_SEED_CBC_ENCRYPT_DATA_PARAMS;
 
 typedef CK_SEED_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
-        CK_SEED_CBC_ENCRYPT_DATA_PARAMS_PTR;
+                                        CK_SEED_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
 /*
  * New PKCS 11 v3.0 data structures.
@@ -2272,12 +2419,13 @@ typedef CK_MECHANISM_TYPE CK_SP800_108_PRF_TYPE;
 #define CK_SP800_108_DKM_LENGTH         0x00000003UL
 #define CK_SP800_108_BYTE_ARRAY         0x00000004UL
 #define CK_SP800_108_COUNTER            CK_SP800_108_OPTIONAL_COUNTER
+#define CK_SP800_108_KEY_HANDLE         0x00000005UL
 
 typedef struct CK_PRF_DATA_PARAM
 {
-    CK_PRF_DATA_TYPE type;
-    CK_VOID_PTR      pValue;
-    CK_ULONG         ulValueLen;
+   CK_PRF_DATA_TYPE    type;
+   CK_VOID_PTR         pValue;
+   CK_ULONG            ulValueLen;
 } CK_PRF_DATA_PARAM;
 
 typedef CK_PRF_DATA_PARAM CK_PTR CK_PRF_DATA_PARAM_PTR;
@@ -2285,8 +2433,8 @@ typedef CK_PRF_DATA_PARAM CK_PTR CK_PRF_DATA_PARAM_PTR;
 
 typedef struct CK_SP800_108_COUNTER_FORMAT
 {
-    CK_BBOOL bLittleEndian;
-    CK_ULONG ulWidthInBits;
+   CK_BBOOL           bLittleEndian;
+   CK_ULONG     ulWidthInBits;
 } CK_SP800_108_COUNTER_FORMAT;
 
 typedef CK_SP800_108_COUNTER_FORMAT CK_PTR CK_SP800_108_COUNTER_FORMAT_PTR;
@@ -2297,52 +2445,52 @@ typedef CK_ULONG CK_SP800_108_DKM_LENGTH_METHOD;
 
 typedef struct CK_SP800_108_DKM_LENGTH_FORMAT
 {
-    CK_SP800_108_DKM_LENGTH_METHOD dkmLengthMethod;
-    CK_BBOOL                       bLittleEndian;
-    CK_ULONG                       ulWidthInBits;
+   CK_SP800_108_DKM_LENGTH_METHOD  dkmLengthMethod;
+   CK_BBOOL                        bLittleEndian;
+   CK_ULONG                  ulWidthInBits;
 } CK_SP800_108_DKM_LENGTH_FORMAT;
 
 typedef CK_SP800_108_DKM_LENGTH_FORMAT \
-        CK_PTR CK_SP800_108_DKM_LENGTH_FORMAT_PTR;
+                                CK_PTR CK_SP800_108_DKM_LENGTH_FORMAT_PTR;
 
 typedef struct CK_DERIVED_KEY
 {
-    CK_ATTRIBUTE_PTR     pTemplate;
-    CK_ULONG             ulAttributeCount;
-    CK_OBJECT_HANDLE_PTR phKey;
+   CK_ATTRIBUTE_PTR     pTemplate;
+   CK_ULONG             ulAttributeCount;
+   CK_OBJECT_HANDLE_PTR phKey;
 } CK_DERIVED_KEY;
 
 typedef CK_DERIVED_KEY CK_PTR CK_DERIVED_KEY_PTR;
 
 typedef struct CK_SP800_108_KDF_PARAMS
 {
-    CK_SP800_108_PRF_TYPE prfType;
-    CK_ULONG              ulNumberOfDataParams;
-    CK_PRF_DATA_PARAM_PTR pDataParams;
-    CK_ULONG              ulAdditionalDerivedKeys;
-    CK_DERIVED_KEY_PTR    pAdditionalDerivedKeys;
+   CK_SP800_108_PRF_TYPE prfType;
+   CK_ULONG               ulNumberOfDataParams;
+   CK_PRF_DATA_PARAM_PTR  pDataParams;
+   CK_ULONG             ulAdditionalDerivedKeys;
+   CK_DERIVED_KEY_PTR   pAdditionalDerivedKeys;
 } CK_SP800_108_KDF_PARAMS;
 
 typedef CK_SP800_108_KDF_PARAMS CK_PTR CK_SP800_108_KDF_PARAMS_PTR;
 
 typedef struct CK_SP800_108_FEEDBACK_KDF_PARAMS
 {
-    CK_SP800_108_PRF_TYPE prfType;
-    CK_ULONG              ulNumberOfDataParams;
-    CK_PRF_DATA_PARAM_PTR pDataParams;
-    CK_ULONG              ulIVLen;
-    CK_BYTE_PTR           pIV;
-    CK_ULONG              ulAdditionalDerivedKeys;
-    CK_DERIVED_KEY_PTR    pAdditionalDerivedKeys;
+   CK_SP800_108_PRF_TYPE prfType;
+   CK_ULONG               ulNumberOfDataParams;
+   CK_PRF_DATA_PARAM_PTR  pDataParams;
+   CK_ULONG               ulIVLen;
+   CK_BYTE_PTR            pIV;
+   CK_ULONG             ulAdditionalDerivedKeys;
+   CK_DERIVED_KEY_PTR   pAdditionalDerivedKeys;
 } CK_SP800_108_FEEDBACK_KDF_PARAMS;
 
 typedef CK_SP800_108_FEEDBACK_KDF_PARAMS \
-        CK_PTR CK_SP800_108_FEEDBACK_KDF_PARAMS_PTR;
+                               CK_PTR CK_SP800_108_FEEDBACK_KDF_PARAMS_PTR;
 
 /* EDDSA */
 typedef struct CK_EDDSA_PARAMS {
-    CK_BBOOL    phFlag;
-    CK_ULONG    ulContextDataLen;
+    CK_BBOOL phFlag;
+    CK_ULONG ulContextDataLen;
     CK_BYTE_PTR pContextData;
 } CK_EDDSA_PARAMS;
 
@@ -2366,23 +2514,23 @@ typedef struct CK_SALSA20_PARAMS {
 typedef CK_SALSA20_PARAMS CK_PTR CK_SALSA20_PARAMS_PTR;
 
 typedef struct CK_SALSA20_CHACHA20_POLY1305_PARAMS {
-    CK_BYTE_PTR pNonce;
-    CK_ULONG    ulNonceLen;
-    CK_BYTE_PTR pAAD;
-    CK_ULONG    ulAADLen;
+  CK_BYTE_PTR   pNonce;
+  CK_ULONG  ulNonceLen;
+  CK_BYTE_PTR pAAD;
+  CK_ULONG ulAADLen;
 } CK_SALSA20_CHACHA20_POLY1305_PARAMS;
 
 typedef CK_SALSA20_CHACHA20_POLY1305_PARAMS \
-        CK_PTR CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR;
+                                CK_PTR CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR;
 
 typedef struct CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS {
-    CK_BYTE_PTR pNonce;
-    CK_ULONG    ulNonceLen;
-    CK_BYTE_PTR pTag;
+  CK_BYTE_PTR   pNonce;
+  CK_ULONG  ulNonceLen;
+  CK_BYTE_PTR pTag;
 } CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS;
 
 typedef CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS \
-        CK_PTR CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS_PTR;
+            CK_PTR CK_SALSA20_CHACHA20_POLY1305_MSG_PARAMS_PTR;
 
 typedef CK_ULONG CK_X3DH_KDF_TYPE;
 typedef CK_X3DH_KDF_TYPE CK_PTR CK_X3DH_KDF_TYPE_PTR;
@@ -2392,50 +2540,50 @@ typedef struct CK_X3DH_INITIATE_PARAMS {
     CK_X3DH_KDF_TYPE kdf;
     CK_OBJECT_HANDLE pPeer_identity;
     CK_OBJECT_HANDLE pPeer_prekey;
-    CK_BYTE_PTR      pPrekey_signature;
-    CK_BYTE_PTR      pOnetime_key;
+    CK_BYTE_PTR pPrekey_signature;
+    CK_BYTE_PTR pOnetime_key;
     CK_OBJECT_HANDLE pOwn_identity;
     CK_OBJECT_HANDLE pOwn_ephemeral;
 } CK_X3DH_INITIATE_PARAMS;
 
 typedef struct CK_X3DH_RESPOND_PARAMS {
     CK_X3DH_KDF_TYPE kdf;
-    CK_BYTE_PTR      pIdentity_id;
-    CK_BYTE_PTR      pPrekey_id;
-    CK_BYTE_PTR      pOnetime_id;
+    CK_BYTE_PTR pIdentity_id;
+    CK_BYTE_PTR pPrekey_id;
+    CK_BYTE_PTR pOnetime_id;
     CK_OBJECT_HANDLE pInitiator_identity;
-    CK_BYTE_PTR      pInitiator_ephemeral;
+    CK_BYTE_PTR pInitiator_ephemeral;
 } CK_X3DH_RESPOND_PARAMS;
 
 typedef CK_ULONG CK_X2RATCHET_KDF_TYPE;
 typedef CK_X2RATCHET_KDF_TYPE CK_PTR CK_X2RATCHET_KDF_TYPE_PTR;
 
 typedef struct CK_X2RATCHET_INITIALIZE_PARAMS {
-    CK_BYTE_PTR           sk;
-    CK_OBJECT_HANDLE      peer_public_prekey;
-    CK_OBJECT_HANDLE      peer_public_identity;
-    CK_OBJECT_HANDLE      own_public_identity;
-    CK_BBOOL              bEncryptedHeader;
-    CK_ULONG              eCurve;
-    CK_MECHANISM_TYPE     aeadMechanism;
-    CK_X2RATCHET_KDF_TYPE kdfMechanism;
+    CK_BYTE_PTR         sk;
+    CK_OBJECT_HANDLE    peer_public_prekey;
+    CK_OBJECT_HANDLE    peer_public_identity;
+    CK_OBJECT_HANDLE    own_public_identity;
+    CK_BBOOL        bEncryptedHeader;
+    CK_ULONG        eCurve;
+    CK_MECHANISM_TYPE   aeadMechanism;
+    CK_X2RATCHET_KDF_TYPE   kdfMechanism;
 } CK_X2RATCHET_INITIALIZE_PARAMS;
 
 typedef CK_X2RATCHET_INITIALIZE_PARAMS \
-        CK_PTR CK_X2RATCHET_INITIALIZE_PARAMS_PTR;
+                              CK_PTR CK_X2RATCHET_INITIALIZE_PARAMS_PTR;
 
 typedef struct CK_X2RATCHET_RESPOND_PARAMS {
-    CK_BYTE_PTR           sk;
-    CK_OBJECT_HANDLE      own_prekey;
-    CK_OBJECT_HANDLE      initiator_identity;
-    CK_OBJECT_HANDLE      own_public_identity;
-    CK_BBOOL              bEncryptedHeader;
-    CK_ULONG              eCurve;
-    CK_MECHANISM_TYPE     aeadMechanism;
-    CK_X2RATCHET_KDF_TYPE kdfMechanism;
+    CK_BYTE_PTR             sk;
+    CK_OBJECT_HANDLE        own_prekey;
+    CK_OBJECT_HANDLE        initiator_identity;
+    CK_OBJECT_HANDLE        own_public_identity;
+    CK_BBOOL            bEncryptedHeader;
+    CK_ULONG            eCurve;
+    CK_MECHANISM_TYPE       aeadMechanism;
+    CK_X2RATCHET_KDF_TYPE   kdfMechanism;
 } CK_X2RATCHET_RESPOND_PARAMS;
 typedef CK_X2RATCHET_RESPOND_PARAMS \
-        CK_PTR CK_X2RATCHET_RESPOND_PARAMS_PTR;
+                CK_PTR CK_X2RATCHET_RESPOND_PARAMS_PTR;
 
 typedef CK_ULONG CK_XEDDSA_HASH_TYPE;
 typedef CK_XEDDSA_HASH_TYPE CK_PTR CK_XEDDSA_HASH_TYPE_PTR;
@@ -2448,15 +2596,15 @@ typedef CK_XEDDSA_PARAMS CK_PTR CK_XEDDSA_PARAMS_PTR;
 
 /* HKDF params */
 typedef struct CK_HKDF_PARAMS {
-    CK_BBOOL          bExtract;
-    CK_BBOOL          bExpand;
-    CK_MECHANISM_TYPE prfHashMechanism;
-    CK_ULONG          ulSaltType;
-    CK_BYTE_PTR       pSalt;
-    CK_ULONG          ulSaltLen;
-    CK_OBJECT_HANDLE  hSaltKey;
-    CK_BYTE_PTR       pInfo;
-    CK_ULONG          ulInfoLen;
+   CK_BBOOL bExtract;
+   CK_BBOOL bExpand;
+   CK_MECHANISM_TYPE prfHashMechanism;
+   CK_ULONG ulSaltType;
+   CK_BYTE_PTR pSalt;
+   CK_ULONG ulSaltLen;
+   CK_OBJECT_HANDLE hSaltKey;
+   CK_BYTE_PTR pInfo;
+   CK_ULONG ulInfoLen;
 } CK_HKDF_PARAMS;
 typedef CK_HKDF_PARAMS CK_PTR CK_HKDF_PARAMS_PTR;
 
@@ -2470,54 +2618,142 @@ typedef CK_ULONG                   CK_LMS_TYPE;
 typedef CK_ULONG                   CK_LMOTS_TYPE;
 
 typedef struct specifiedParams {
-    CK_HSS_LEVELS levels;
-    CK_LMS_TYPE   lm_type[8];
-    CK_LMOTS_TYPE lm_ots_type[8];
+  CK_HSS_LEVELS levels;
+  CK_LMS_TYPE lm_type[8];
+  CK_LMOTS_TYPE lm_ots_type[8];
 } specifiedParams;
 
 /* IKE Params */
 typedef struct CK_IKE2_PRF_PLUS_DERIVE_PARAMS {
-    CK_MECHANISM_TYPE prfMechanism;
-    CK_BBOOL          bHasSeedKey;
-    CK_OBJECT_HANDLE  hSeedKey;
-    CK_BYTE_PTR       pSeedData;
-    CK_ULONG          ulSeedDataLen;
+  CK_MECHANISM_TYPE prfMechanism;
+  CK_BBOOL      bHasSeedKey;
+  CK_OBJECT_HANDLE hSeedKey;
+  CK_BYTE_PTR pSeedData;
+  CK_ULONG    ulSeedDataLen;
 } CK_IKE2_PRF_PLUS_DERIVE_PARAMS;
 typedef CK_IKE2_PRF_PLUS_DERIVE_PARAMS CK_PTR CK_IKE2_PRF_PLUS_DERIVE_PARAMS_PTR;
 
 typedef struct CK_IKE_PRF_DERIVE_PARAMS {
-    CK_MECHANISM_TYPE prfMechanism;
-    CK_BBOOL          bDataAsKey;
-    CK_BBOOL          bRekey;
-    CK_BYTE_PTR       pNi;
-    CK_ULONG          ulNiLen;
-    CK_BYTE_PTR       pNr;
-    CK_ULONG          ulNrLen;
-    CK_OBJECT_HANDLE  hNewKey;
+  CK_MECHANISM_TYPE prfMechanism;
+  CK_BBOOL bDataAsKey;
+  CK_BBOOL bRekey;
+  CK_BYTE_PTR pNi;
+  CK_ULONG    ulNiLen;
+  CK_BYTE_PTR pNr;
+  CK_ULONG    ulNrLen;
+  CK_OBJECT_HANDLE hNewKey;
 } CK_IKE_PRF_DERIVE_PARAMS;
 typedef CK_IKE_PRF_DERIVE_PARAMS CK_PTR CK_IKE_PRF_DERIVE_PARAMS_PTR;
 
 typedef struct CK_IKE1_PRF_DERIVE_PARAMS {
-    CK_MECHANISM_TYPE prfMechanism;
-    CK_BBOOL          bHasPrevKey;
-    CK_OBJECT_HANDLE  hKeygxy;
-    CK_OBJECT_HANDLE  hPrevKey;
-    CK_BYTE_PTR       pCKYi;
-    CK_ULONG          ulCKYiLen;
-    CK_BYTE_PTR       pCKYr;
-    CK_ULONG          ulCKYrLen;
-    CK_BYTE           keyNumber;
+  CK_MECHANISM_TYPE prfMechanism;
+  CK_BBOOL bHasPrevKey;
+  CK_OBJECT_HANDLE hKeygxy;
+  CK_OBJECT_HANDLE hPrevKey;
+  CK_BYTE_PTR pCKYi;
+  CK_ULONG    ulCKYiLen;
+  CK_BYTE_PTR pCKYr;
+  CK_ULONG    ulCKYrLen;
+  CK_BYTE     keyNumber;
 } CK_IKE1_PRF_DERIVE_PARAMS;
 typedef CK_IKE1_PRF_DERIVE_PARAMS CK_PTR CK_IKE1_PRF_DERIVE_PARAMS_PTR;
 
 typedef struct CK_IKE1_EXTENDED_DERIVE_PARAMS {
     CK_MECHANISM_TYPE prfMechanism;
-    CK_BBOOL          bHasKeygxy;
-    CK_OBJECT_HANDLE  hKeygxy;
-    CK_BYTE_PTR       pExtraData;
-    CK_ULONG          ulExtraDataLen;
+    CK_BBOOL bHasKeygxy;
+    CK_OBJECT_HANDLE hKeygxy;
+    CK_BYTE_PTR pExtraData;
+    CK_ULONG ulExtraDataLen;
 } CK_IKE1_EXTENDED_DERIVE_PARAMS;
 typedef CK_IKE1_EXTENDED_DERIVE_PARAMS CK_PTR CK_IKE1_EXTENDED_DERIVE_PARAMS_PTR;
+
+/* async */
+typedef struct CK_ASYNC_DATA {
+  CK_ULONG ulVersion;
+  CK_BYTE_PTR pValue;
+  CK_ULONG ulValue;
+  CK_OBJECT_HANDLE hObject;
+  CK_OBJECT_HANDLE hAdditionalObject;
+} CK_ASYNC_DATA;
+typedef CK_ASYNC_DATA CK_PTR CK_ASYNC_DATA_PTR;
+
+/* validation */
+typedef CK_ULONG CK_SESSION_VALIDATION_FLAGS_TYPE;
+#define CKS_LAST_VALIDATION_OK 0x00000001UL
+
+typedef CK_ULONG CK_VALIDATION_TYPE;
+typedef CK_VALIDATION_TYPE CK_PTR CK_VALIDATION_TYPE_PTR;
+#define CKV_AUTHORITY_TYPE_UNSPECIFIED     0x00000000UL
+#define CKV_AUTHORITY_TYPE_NIST_CMVP       0x00000001UL
+#define CKV_AUTHORITY_TYPE_COMMON_CRITERIA 0x00000002UL
+
+typedef CK_ULONG CK_VALIDATION_AUTHORITY_TYPE;
+typedef CK_VALIDATION_AUTHORITY_TYPE CK_PTR CK_VALIDATION_AUTHORITY_TYPE_PTR;
+#define CKV_TYPE_UNSPECIFIED 0x00000000UL
+#define CKV_TYPE_SOFTWARE    0x00000001UL
+#define CKV_TYPE_HARDWARE    0x00000002UL
+#define CKV_TYPE_FIRMWARE    0x00000003UL
+#define CKV_TYPE_HYBRID      0x00000004UL
+
+/* XMSS */
+typedef CK_ULONG CK_XMSSMT_PARAMETER_SET_TYPE;
+typedef CK_ULONG CK_XMSS_PARAMETER_SET_TYPE;
+
+/* generic PQ mechanism parameters */
+typedef CK_ULONG CK_HEDGE_TYPE;
+#define CKH_HEDGE_PREFERRED        0x00000000UL
+#define CKH_HEDGE_REQUIRED         0x00000001UL
+#define CKH_DETERMINISTIC_REQUIRED 0x00000002UL
+
+typedef struct CK_SIGN_ADDITIONAL_CONTEXT {
+     CK_HEDGE_TYPE   hedgeVariant;
+     CK_BYTE_PTR     pContext;
+     CK_ULONG        ulContextLen;
+} CK_SIGN_ADDITIONAL_CONTEXT;
+
+typedef struct CK_HASH_SIGN_ADDITIONAL_CONTEXT {
+     CK_HEDGE_TYPE     hedgeVariant;
+     CK_BYTE_PTR       pContext;
+     CK_ULONG          ulContextLen;
+     CK_MECHANISM_TYPE hash;
+} CK_HASH_SIGN_ADDITIONAL_CONTEXT;
+
+
+/* ML-DSA values for CKA_PARAMETER_SETS */
+typedef CK_ULONG CK_ML_DSA_PARAMETER_SET_TYPE;
+#define CKP_ML_DSA_44          0x00000001UL
+#define CKP_ML_DSA_65          0x00000002UL
+#define CKP_ML_DSA_87          0x00000003UL
+
+/* SLH-DSA values for CKA_PARAMETER_SETS */
+typedef CK_ULONG CK_SLH_DSA_PARAMETER_SET_TYPE;
+#define CKP_SLH_DSA_SHA2_128S  0x00000001UL
+#define CKP_SLH_DSA_SHAKE_128S 0x00000002UL
+#define CKP_SLH_DSA_SHA2_128F  0x00000003UL
+#define CKP_SLH_DSA_SHAKE_128F 0x00000004UL
+#define CKP_SLH_DSA_SHA2_192S  0x00000005UL
+#define CKP_SLH_DSA_SHAKE_192S 0x00000006UL
+#define CKP_SLH_DSA_SHA2_192F  0x00000007UL
+#define CKP_SLH_DSA_SHAKE_192F 0x00000008UL
+#define CKP_SLH_DSA_SHA2_256S  0x00000009UL
+#define CKP_SLH_DSA_SHAKE_256S 0x0000000aUL
+#define CKP_SLH_DSA_SHA2_256F  0x0000000bUL
+#define CKP_SLH_DSA_SHAKE_256F 0x0000000cUL
+
+/* ML-KEM values for CKA_PARAMETER_SETS */
+typedef CK_ULONG CK_ML_KEM_PARAMETER_SET_TYPE;
+#define CKP_ML_KEM_512         0x00000001UL
+#define CKP_ML_KEM_768         0x00000002UL
+#define CKP_ML_KEM_1024        0x00000003UL
+
+/* Trust values for CKA_TRUST_* */
+typedef CK_ULONG CK_TRUST;
+#define CKT_TRUST_UNKNOWN           0x00000000UL
+#define CKT_TRUSTED                 0x00000001UL
+#define CKT_TRUST_ANCHOR            0x00000002UL
+#define CKT_NOT_TRUSTED             0x00000003UL
+#define CKT_TRUST_MUST_VERIFY_TRUST 0x00000004UL
+
 
 #endif /* _PKCS11T_H_ */
 


### PR DESCRIPTION
Hi, this is a clean backport of 7e28af20ee76808d66ac5ce4d254539bac5c8e72

While updating the PKCS#11 headers from v3.1 to v3.2, I copied the files from the upstream specification repository.
Unfortunately, the upstream versions of the following files contain tab characters in some of the newer additions:

src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11f.h

git pr create --jcheck reported whitespace violations for these tabs.
To make it pass, I replaced the tabs with (4) spaces.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8388412](https://bugs.openjdk.org/browse/JDK-8388412) needs maintainer approval

### Issue
 * [JDK-8388412](https://bugs.openjdk.org/browse/JDK-8388412): Update PKCS#11 Cryptographic Token Interface to v3.2 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2972/head:pull/2972` \
`$ git checkout pull/2972`

Update a local copy of the PR: \
`$ git checkout pull/2972` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2972`

View PR using the GUI difftool: \
`$ git pr show -t 2972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2972.diff">https://git.openjdk.org/jdk21u-dev/pull/2972.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2972#issuecomment-5114163193)
</details>
