### PR TITLE
8377991: TestLimitsUpdating.java fails with runtime exception even after JDK-8370492 is fixed

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
+++ b/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
- * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -49,8 +49,12 @@ import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
 
 public class TestLimitsUpdating {
+    private static final int CPU_PERIOD = 100_000;
+    private static final int INITIAL_CPU_COUNT = 1;
+    private static final int UPDATED_CPU_COUNT = 2;
     private static final String TARGET_CONTAINER = "limitsUpdatingHS_" + Runtime.getRuntime().version().major();
     private static final String imageName = Common.imageName("limitsUpdating");
 
@@ -68,6 +72,10 @@ public class TestLimitsUpdating {
     }
 
     private static void testLimitUpdates() throws Exception {
+        if (Runtime.getRuntime().availableProcessors() < UPDATED_CPU_COUNT) {
+            throw new SkippedException("Need at least " + UPDATED_CPU_COUNT
+                    + " available CPUs to test CPU limit updates");
+        }
         File sharedtmpdir = new File("test-sharedtmp");
         File flag = new File(sharedtmpdir, "limitsUpdated"); // shared with LimitUpdateChecker
         File started = new File(sharedtmpdir, "started"); // shared with LimitUpdateChecker
@@ -77,8 +85,8 @@ public class TestLimitsUpdating {
         DockerRunOptions opts = new DockerRunOptions(imageName, "/jdk/bin/java", "LimitUpdateChecker");
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
         opts.addDockerOpts("--volume", sharedtmpdir.getAbsolutePath() + ":/tmp");
-        opts.addDockerOpts("--cpu-period", "100000");
-        opts.addDockerOpts("--cpu-quota", "200000");
+        opts.addDockerOpts("--cpu-period", Integer.toString(CPU_PERIOD));
+        opts.addDockerOpts("--cpu-quota", Integer.toString(INITIAL_CPU_COUNT * CPU_PERIOD));
         opts.addDockerOpts("--memory", "500m");
         opts.addDockerOpts("--memory-swap", "500m");
         opts.addDockerOpts("--name", TARGET_CONTAINER);
@@ -103,7 +111,7 @@ public class TestLimitsUpdating {
             Thread.sleep(100);
         }
 
-        final List<String> containerCommand = getContainerUpdate(300_000, 100_000, "300m");
+        final List<String> containerCommand = getContainerUpdate(UPDATED_CPU_COUNT * CPU_PERIOD, CPU_PERIOD, "300m");
         // Run the update command so as to increase resources once the container signaled it has started.
         Thread t2 = new Thread() {
                 public void run() {
@@ -126,8 +134,8 @@ public class TestLimitsUpdating {
 
         // Do assertions based on the output in target container
         OutputAnalyzer targetOut = out[0];
-        targetOut.shouldContain("active_processor_count: 2"); // initial value
-        targetOut.shouldContain("active_processor_count: 3"); // updated value
+        targetOut.shouldContain("active_processor_count: 1"); // initial value
+        targetOut.shouldContain("active_processor_count: 2"); // updated value
         targetOut.shouldContain("memory_limit_in_bytes: 512000 k"); // initial value
         targetOut.shouldContain("memory_and_swap_limit_in_bytes: 512000 k"); // initial value
         targetOut.shouldContain("memory_limit_in_bytes: 307200 k"); // updated value

--- a/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
+++ b/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,9 +48,13 @@ import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
 
 public class TestLimitsUpdating {
     private static final long M = 1024 * 1024;
+    private static final int CPU_PERIOD = 100_000;
+    private static final int INITIAL_CPU_COUNT = 1;
+    private static final int UPDATED_CPU_COUNT = 2;
     private static final String TARGET_CONTAINER = "limitsUpdatingJDK_" + Runtime.getRuntime().version().major();
     private static final String imageName = Common.imageName("limitsUpdatingJDK");
 
@@ -67,6 +71,10 @@ public class TestLimitsUpdating {
     }
 
     private static void testLimitUpdates() throws Exception {
+        if (Runtime.getRuntime().availableProcessors() < UPDATED_CPU_COUNT) {
+            throw new SkippedException("Need at least " + UPDATED_CPU_COUNT
+                    + " available CPUs to test CPU limit updates");
+        }
         File sharedtmpdir = new File("jdk-sharedtmp");
         File flag = new File(sharedtmpdir, "limitsUpdated"); // shared with LimitUpdateChecker
         File started = new File(sharedtmpdir, "started"); // shared with LimitUpdateChecker
@@ -76,8 +84,8 @@ public class TestLimitsUpdating {
         DockerRunOptions opts = new DockerRunOptions(imageName, "/jdk/bin/java", "LimitUpdateChecker");
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
         opts.addDockerOpts("--volume", sharedtmpdir.getAbsolutePath() + ":/tmp");
-        opts.addDockerOpts("--cpu-period", "100000");
-        opts.addDockerOpts("--cpu-quota", "200000");
+        opts.addDockerOpts("--cpu-period", Integer.toString(CPU_PERIOD));
+        opts.addDockerOpts("--cpu-quota", Integer.toString(INITIAL_CPU_COUNT * CPU_PERIOD));
         opts.addDockerOpts("--memory", "500m");
         opts.addDockerOpts("--memory-swap", "500m");
         opts.addDockerOpts("--name", TARGET_CONTAINER);
@@ -106,7 +114,7 @@ public class TestLimitsUpdating {
             Thread.sleep(100);
         }
 
-        final List<String> containerCommand = getContainerUpdate(300_000, 100_000, "300m");
+        final List<String> containerCommand = getContainerUpdate(UPDATED_CPU_COUNT * CPU_PERIOD, CPU_PERIOD, "300m");
         // Run the update command so as to increase resources once the container signaled it has started.
         Thread t2 = new Thread() {
                 public void run() {
@@ -129,10 +137,10 @@ public class TestLimitsUpdating {
 
         // Do assertions based on the output in target container
         OutputAnalyzer targetOut = out[0];
-        targetOut.shouldContain("Runtime.availableProcessors: 2");                  // initial value
-        targetOut.shouldContain("OperatingSystemMXBean.getAvailableProcessors: 2"); // initial value
-        targetOut.shouldContain("Runtime.availableProcessors: 3");                  // updated value
-        targetOut.shouldContain("OperatingSystemMXBean.getAvailableProcessors: 3"); // updated value
+        targetOut.shouldContain("Runtime.availableProcessors: 1");                  // initial value
+        targetOut.shouldContain("OperatingSystemMXBean.getAvailableProcessors: 1"); // initial value
+        targetOut.shouldContain("Runtime.availableProcessors: 2");                  // updated value
+        targetOut.shouldContain("OperatingSystemMXBean.getAvailableProcessors: 2"); // updated value
         long memoryInBytes = 500 * M;
         targetOut.shouldContain("Metrics.getMemoryLimit() == " + memoryInBytes);    // initial value
         targetOut.shouldContain("OperatingSystemMXBean.getTotalMemorySize: " + memoryInBytes); // initial value


### PR DESCRIPTION
I backport this for parity with 21.0.13-oracle.
Clean backport from 25

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8377991](https://bugs.openjdk.org/browse/JDK-8377991) needs maintainer approval

### Issue
 * [JDK-8377991](https://bugs.openjdk.org/browse/JDK-8377991): TestLimitsUpdating.java fails with runtime exception even after JDK-8370492 is fixed (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2973/head:pull/2973` \
`$ git checkout pull/2973`

Update a local copy of the PR: \
`$ git checkout pull/2973` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2973`

View PR using the GUI difftool: \
`$ git pr show -t 2973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2973.diff">https://git.openjdk.org/jdk21u-dev/pull/2973.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2973#issuecomment-5104183563)
</details>
