### PR TITLE
8306281: function isWsl() returns false on WSL2

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1532,7 +1532,7 @@ var getVersionNumbers = function () {
 var isWsl = function (input) {
     return ( input.build_osenv == "wsl"
              || (input.build_os == "linux"
-                 && java.lang.System.getProperty("os.version").contains("Microsoft")));
+                 && java.lang.System.getProperty("os.version").toLowerCase().contains("microsoft")));
 }
 
 var error = function (s) {


### PR DESCRIPTION
I backport this for parity with 21.0.13-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8306281](https://bugs.openjdk.org/browse/JDK-8306281) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8306281: function isWsl() returns false on WSL2`

### Issue
 * [JDK-8306281](https://bugs.openjdk.org/browse/JDK-8306281): function isWsl() returns false on WSL2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2974/head:pull/2974` \
`$ git checkout pull/2974`

Update a local copy of the PR: \
`$ git checkout pull/2974` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2974/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2974`

View PR using the GUI difftool: \
`$ git pr show -t 2974`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2974.diff">https://git.openjdk.org/jdk21u-dev/pull/2974.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2974#issuecomment-5104324529)
</details>
