### PR TITLE
8387593: Using XOR mode to clear the content leaves some traces in metal

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -161,35 +161,21 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                 case sun_java2d_pipe_BufferedOpCodes_DRAW_POLY:
                 {
                     CHECK_PREVIOUS_OP(MTL_OP_OTHER);
-                    jint nPoints      = NEXT_INT(b);
-                    jboolean isClosed = NEXT_BOOLEAN(b);
-                    jint transX       = NEXT_INT(b);
-                    jint transY       = NEXT_INT(b);
-                    jint *xPoints = (jint *)b;
-                    jint *yPoints = ((jint *)b) + nPoints;
 
                     if ([mtlc useXORComposite]) {
                         commitEncodedCommands();
                         J2dTraceLn(J2D_TRACE_VERBOSE,
                                    "DRAW_POLY in XOR mode - Force commit earlier draw calls before DRAW_POLY.");
 
-                        // draw separate (N-1) lines using N points
-                        for(int point = 0; point < nPoints-1; point++) {
-                            jint x1 = xPoints[point] + transX;
-                            jint y1 = yPoints[point] + transY;
-                            jint x2 = xPoints[point + 1] + transX;
-                            jint y2 = yPoints[point + 1] + transY;
-                            MTLRenderer_DrawLine(mtlc, dstOps, x1, y1, x2, y2);
-                        }
-
-                        if (isClosed) {
-                            MTLRenderer_DrawLine(mtlc, dstOps, xPoints[0] + transX, yPoints[0] + transY,
-                                                 xPoints[nPoints-1] + transX, yPoints[nPoints-1] + transY);
-                        }
-                    } else {
-                        MTLRenderer_DrawPoly(mtlc, dstOps, nPoints, isClosed, transX, transY, xPoints, yPoints);
                     }
 
+                    jint nPoints      = NEXT_INT(b);
+                    jboolean isClosed = NEXT_BOOLEAN(b);
+                    jint transX       = NEXT_INT(b);
+                    jint transY       = NEXT_INT(b);
+                    jint *xPoints = (jint *)b;
+                    jint *yPoints = ((jint *)b) + nPoints;
+                    MTLRenderer_DrawPoly(mtlc, dstOps, nPoints, isClosed, transX, transY, xPoints, yPoints);
                     SKIP_BYTES(b, nPoints * BYTES_PER_POLY_POINT);
                     break;
                 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/shaders.metal
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/shaders.metal
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,13 +84,11 @@ struct GradShaderInOut {
 struct ColShaderInOut_XOR {
     float4 position [[position]];
     float  ptSize [[point_size]];
-    float2 orig_pos;
     half4  color;
 };
 
 struct TxtShaderInOut_XOR {
     float4 position [[position]];
-    float2 orig_pos;
     float2 texCoords;
     float2 tpCoords;
 };
@@ -677,7 +675,6 @@ vertex ColShaderInOut_XOR vert_col_xorMode(VertexInput in [[stage_in]],
     float4 pos4 = float4(in.position, 0.0, 1.0);
     out.position = transform.transformMatrix*pos4;
     out.ptSize = 1.0;
-    out.orig_pos = in.position;
     out.color = half4(uniforms.color.r, uniforms.color.g, uniforms.color.b, uniforms.color.a);
     return out;
 }
@@ -685,7 +682,7 @@ vertex ColShaderInOut_XOR vert_col_xorMode(VertexInput in [[stage_in]],
 fragment half4 frag_col_xorMode(ColShaderInOut_XOR in [[stage_in]],
         texture2d<float, access::read> renderTexture [[texture(0)]])
 {
-    uint2 texCoord = {(unsigned int)(in.orig_pos.x), (unsigned int)(in.orig_pos.y)};
+    uint2 texCoord = {(unsigned int)(in.position.x), (unsigned int)(in.position.y)};
 
     float4 pixelColor = renderTexture.read(texCoord);
     half4 color = in.color;
@@ -707,7 +704,6 @@ vertex TxtShaderInOut_XOR vert_txt_xorMode(
     TxtShaderInOut_XOR out;
     float4 pos4 = float4(in.position, 0.0, 1.0);
     out.position = transform.transformMatrix*pos4;
-    out.orig_pos = in.position;
     out.texCoords = in.texCoords;
     return out;
 }
@@ -719,7 +715,7 @@ fragment half4 frag_txt_xorMode(
         constant TxtFrameUniforms& uniforms [[buffer(1)]],
         sampler textureSampler [[sampler(0)]])
 {
-    uint2 texCoord = {(unsigned int)(vert.orig_pos.x), (unsigned int)(vert.orig_pos.y)};
+    uint2 texCoord = {(unsigned int)(vert.position.x), (unsigned int)(vert.position.y)};
     float4 bgColor = backgroundTexture.read(texCoord);
 
     float4 pixelColor = renderTexture.sample(textureSampler, vert.texCoords);

--- a/test/jdk/java/awt/Graphics2D/ClearPolyLineUsingXORTest.java
+++ b/test/jdk/java/awt/Graphics2D/ClearPolyLineUsingXORTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @key     headful
+ * @bug     8387593
+ * @summary Tests that clearing a polyline using XOR mode does not
+ *          leave any traces. Using uiScale 1 helps us to
+ *          reproduce the issue.
+ * @run     main/othervm -Dsun.java2d.uiScale=1 ClearPolyLineUsingXORTest
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.image.BufferedImage;
+import java.awt.image.VolatileImage;
+
+public class ClearPolyLineUsingXORTest {
+    private static final int SIZE = 500;
+
+    private static BufferedImage clearUsingXOR(GraphicsConfiguration gc) {
+        VolatileImage vImg = gc.createCompatibleVolatileImage(SIZE, SIZE);
+        int attempt = 0;
+        while (true) {
+            if (++attempt > 10) {
+                throw new RuntimeException("Unable to use VolatileImage after "
+                    + attempt + " attempts");
+            }
+
+            int status = vImg.validate(gc);
+            if (status == VolatileImage.IMAGE_INCOMPATIBLE) {
+                vImg = gc.createCompatibleVolatileImage(SIZE, SIZE);
+            }
+
+            Graphics2D g2d = vImg.createGraphics();
+            g2d.setBackground(Color.BLACK);
+            g2d.clearRect(0, 0, 500, 500);
+
+            int min = 10;
+            int max = 210;
+            int mid = 110;
+
+            int xdp[] = {min, max, min, max, min, max};
+            int ydp[] = {min, min, mid, max, max, mid};
+
+            g2d.setXORMode(Color.GREEN);
+            g2d.drawPolygon(xdp, ydp, xdp.length);
+            g2d.drawPolygon(xdp, ydp, xdp.length);
+
+            BufferedImage snapshot = vImg.getSnapshot();
+            if (vImg.contentsLost()) {
+                continue;
+            }
+            return snapshot;
+        }
+    }
+    public static void main(String[] args) {
+        GraphicsConfiguration gc =
+            GraphicsEnvironment.getLocalGraphicsEnvironment().
+                getDefaultScreenDevice().getDefaultConfiguration();
+        BufferedImage bImg = clearUsingXOR(gc);
+
+        for (int x = 0; x < SIZE; x++) {
+            for (int y = 0; y < SIZE; y++) {
+                if (bImg.getRGB(x, y) != Color.BLACK.getRGB()) {
+                    throw new RuntimeException("Clear using XOR is not" +
+                        " working at x: " + x + " y: " + y);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.13-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8387593](https://bugs.openjdk.org/browse/JDK-8387593) needs maintainer approval

### Issue
 * [JDK-8387593](https://bugs.openjdk.org/browse/JDK-8387593): Using XOR mode to clear the content leaves some traces in metal (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2976/head:pull/2976` \
`$ git checkout pull/2976`

Update a local copy of the PR: \
`$ git checkout pull/2976` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2976`

View PR using the GUI difftool: \
`$ git pr show -t 2976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2976.diff">https://git.openjdk.org/jdk21u-dev/pull/2976.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2976#issuecomment-5105004979)
</details>
