### PR TITLE
8345057: ML_KEM NamedParameterSpec constants removed by ML-DSA integration

### DIFF
--- a/test/jdk/java/security/spec/TestNamedParameterSpec.java
+++ b/test/jdk/java/security/spec/TestNamedParameterSpec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8345057
+ * @summary Test the existence of constants inside the
+ *         java.security.spec.NamedParameterSpec class.
+ * @run main TestNamedParameterSpec
+ */
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.security.spec.NamedParameterSpec;
+import java.util.Arrays;
+import java.util.TreeSet;
+
+public class TestNamedParameterSpec {
+
+    // names of the static fields in NamedParameterSpec class
+    private static String[] EXPECTED = {
+        "ED25519", "ED448", "X25519", "X448",
+        "ML_DSA_44", "ML_DSA_65", "ML_DSA_87",
+        "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
+    };
+
+    public static void main(String[] args) throws Exception {
+        Arrays.sort(EXPECTED);
+        var actual = getSortedConstNames(NamedParameterSpec.class);
+        // both arrays should be sorted before comparison
+        if (Arrays.compare(EXPECTED, actual) != 0) {
+            System.out.println("expected: " + Arrays.toString(EXPECTED));
+            System.out.println("actual: " + Arrays.toString(actual));
+            throw new RuntimeException("Name check failed");
+        }
+        System.out.println("Test Passed");
+    }
+
+    public static String[] getSortedConstNames(Class<?> clazz) {
+        TreeSet<String> names = new TreeSet<String>();
+        for (Field field : clazz.getDeclaredFields()) {
+            int mods = field.getModifiers();
+            if (Modifier.isPublic(mods) && Modifier.isStatic(mods)
+                    && Modifier.isFinal(mods)){
+                names.add(field.getName());
+            }
+        }
+        return names.toArray(new String[0]);
+    }
+}

--- a/test/jdk/java/security/spec/TestNamedParameterSpec.java
+++ b/test/jdk/java/security/spec/TestNamedParameterSpec.java
@@ -39,8 +39,6 @@ public class TestNamedParameterSpec {
     // names of the static fields in NamedParameterSpec class
     private static String[] EXPECTED = {
         "ED25519", "ED448", "X25519", "X448",
-        "ML_DSA_44", "ML_DSA_65", "ML_DSA_87",
-        "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024",
     };
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/security/provider/acvp/Launcher.java
+++ b/test/jdk/sun/security/provider/acvp/Launcher.java
@@ -30,7 +30,7 @@ import java.security.Security;
 
 /*
  * @test
- * @bug 8342442
+ * @bug 8342442 8345057
  * @library /test/lib
  * @modules java.base/sun.security.provider
  */

--- a/test/jdk/sun/security/provider/acvp/ML_DSA_Test.java
+++ b/test/jdk/sun/security/provider/acvp/ML_DSA_Test.java
@@ -51,9 +51,9 @@ public class ML_DSA_Test {
 
     static NamedParameterSpec genParams(String pname) {
        return switch (pname) {
-            case "ML-DSA-44" -> NamedParameterSpec.ML_DSA_44;
-            case "ML-DSA-65" -> NamedParameterSpec.ML_DSA_65;
-            case "ML-DSA-87" -> NamedParameterSpec.ML_DSA_87;
+            case "ML-DSA-44" -> new NamedParameterSpec(pname);
+            case "ML-DSA-65" -> new NamedParameterSpec(pname);
+            case "ML-DSA-87" -> new NamedParameterSpec(pname);
             default -> throw new RuntimeException("Unknown params: " + pname);
 
         };

--- a/test/jdk/sun/security/provider/acvp/ML_DSA_Test.java
+++ b/test/jdk/sun/security/provider/acvp/ML_DSA_Test.java
@@ -49,6 +49,16 @@ public class ML_DSA_Test {
         }
     }
 
+    static NamedParameterSpec genParams(String pname) {
+       return switch (pname) {
+            case "ML-DSA-44" -> NamedParameterSpec.ML_DSA_44;
+            case "ML-DSA-65" -> NamedParameterSpec.ML_DSA_65;
+            case "ML-DSA-87" -> NamedParameterSpec.ML_DSA_87;
+            default -> throw new RuntimeException("Unknown params: " + pname);
+
+        };
+    }
+
     static void keyGenTest(JSONValue kat, Provider p) throws Exception {
         var g = p == null
                 ? KeyPairGenerator.getInstance("ML-DSA")
@@ -58,7 +68,7 @@ public class ML_DSA_Test {
                 : KeyFactory.getInstance("ML-DSA", p);
         for (var t : kat.get("testGroups").asArray()) {
             var pname = t.get("parameterSet").asString();
-            var np = new NamedParameterSpec(pname);
+            var np = genParams(pname);
             System.out.println(">> " + pname);
             for (var c : t.get("tests").asArray()) {
                 System.out.print(c.get("tcId").asString() + " ");

--- a/test/jdk/sun/security/provider/acvp/ML_KEM_Test.java
+++ b/test/jdk/sun/security/provider/acvp/ML_KEM_Test.java
@@ -43,6 +43,15 @@ public class ML_KEM_Test {
         }
     }
 
+    static NamedParameterSpec genParams(String pname) {
+       return switch (pname) {
+            case "ML-KEM-512" -> NamedParameterSpec.ML_KEM_512;
+            case "ML-KEM-768" -> NamedParameterSpec.ML_KEM_768;
+            case "ML-KEM-1024" -> NamedParameterSpec.ML_KEM_1024;
+            default -> throw new RuntimeException("Unknown params: " + pname);
+        };
+    }
+
     static void keyGenTest(JSONValue kat, Provider p) throws Exception {
         var g = p == null
                 ? KeyPairGenerator.getInstance("ML-KEM")
@@ -52,7 +61,7 @@ public class ML_KEM_Test {
                 : KeyFactory.getInstance("ML-KEM", p);
         for (var t : kat.get("testGroups").asArray()) {
             var pname = t.get("parameterSet").asString();
-            var np = new NamedParameterSpec(pname);
+            var np = genParams(pname);
             System.out.println(">> " + pname);
             for (var c : t.get("tests").asArray()) {
                 System.out.print(c.get("tcId").asString() + " ");

--- a/test/jdk/sun/security/provider/acvp/ML_KEM_Test.java
+++ b/test/jdk/sun/security/provider/acvp/ML_KEM_Test.java
@@ -45,9 +45,9 @@ public class ML_KEM_Test {
 
     static NamedParameterSpec genParams(String pname) {
        return switch (pname) {
-            case "ML-KEM-512" -> NamedParameterSpec.ML_KEM_512;
-            case "ML-KEM-768" -> NamedParameterSpec.ML_KEM_768;
-            case "ML-KEM-1024" -> NamedParameterSpec.ML_KEM_1024;
+            case "ML-KEM-512" -> new NamedParameterSpec(pname);
+            case "ML-KEM-768" -> new NamedParameterSpec(pname);
+            case "ML-KEM-1024" -> new NamedParameterSpec(pname);
             default -> throw new RuntimeException("Unknown params: " + pname);
         };
     }


### PR DESCRIPTION
I backport this to get the new test into 21. A test is always welcome, and it simplifies later test backports.

I need to omit the change to NamedParameterSpec.java. We did not backport the new names to 21, so 
I can not add them here.

Also, I had to adapt the test to the missing names.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8345057](https://bugs.openjdk.org/browse/JDK-8345057) needs maintainer approval

### Issue
 * [JDK-8345057](https://bugs.openjdk.org/browse/JDK-8345057): ML_KEM NamedParameterSpec constants removed by ML-DSA integration (**Bug** - P2 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2984/head:pull/2984` \
`$ git checkout pull/2984`

Update a local copy of the PR: \
`$ git checkout pull/2984` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2984`

View PR using the GUI difftool: \
`$ git pr show -t 2984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2984.diff">https://git.openjdk.org/jdk21u-dev/pull/2984.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2984#issuecomment-5142798881)
</details>
