### PR TITLE
8389492: [21u] java/io/Serializable/records/ProhibitedMethods.java fails after JDK-8307843 backport in othervm mode

### DIFF
--- a/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
+++ b/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
@@ -295,7 +295,7 @@ public class ProhibitedMethods {
             MethodVisitor mv = cv.visitMethod(ACC_PRIVATE, READ_OBJECT_NAME, READ_OBJECT_DESC, null, null);
             mv.visitCode();
             mv.visitLdcInsn(READ_OBJECT_NAME + " should not be invoked");
-            mv.visitMethodInsn(INVOKESTATIC, "org/testng/Assert", "fail", "(Ljava/lang/String;)V", false);
+            mv.visitMethodInsn(INVOKESTATIC, "org/junit/jupiter/api/Assertions", "fail", "(Ljava/lang/String;)Ljava/lang/Object;", false);
             mv.visitInsn(RETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
@@ -314,7 +314,7 @@ public class ProhibitedMethods {
             MethodVisitor mv = cv.visitMethod(ACC_PRIVATE, READ_OBJECT_NO_DATA_NAME, READ_OBJECT_NO_DATA_DESC, null, null);
             mv.visitCode();
             mv.visitLdcInsn(READ_OBJECT_NO_DATA_NAME + " should not be invoked");
-            mv.visitMethodInsn(INVOKESTATIC, "org/testng/Assert", "fail", "(Ljava/lang/String;)V", false);
+            mv.visitMethodInsn(INVOKESTATIC, "org/junit/jupiter/api/Assertions", "fail", "(Ljava/lang/String;)Ljava/lang/Object;", false);
             mv.visitInsn(RETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();

--- a/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
+++ b/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
@@ -372,3 +372,4 @@ public class ProhibitedMethods {
         }
     }
 }
+


### PR DESCRIPTION
This PR fixes the generated bytecode in ProhibitedMethods.java to call JUnit 5 Assertions.fail instead of the removed TestNG Assert.fail.

The initial backport ([JDK-8373623](https://github.com/openjdk/jdk21u-dev/pull/2815)) testing passed because ```make test``` loaded the TestNG classes, which does not happen when JTREG is run directly.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

```make test TEST=test/jdk/java/io/Serializable/records/ProhibitedMethods.java```

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/30704768/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/30704769/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/30704770/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/30704772/linux-aarch64-specific-test.log)

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk test/jdk/java/io/Serializable/records/ProhibitedMethods.java```

Results:

[ProhibitedMethods.jtr.windows-x64.log](https://github.com/user-attachments/files/30704801/ProhibitedMethods.jtr.windows-x64.log)
[ProhibitedMethods.jtr.macos-aarch64.log](https://github.com/user-attachments/files/30704802/ProhibitedMethods.jtr.macos-aarch64.log)
[ProhibitedMethods.jtr.linux-x64.log](https://github.com/user-attachments/files/30704803/ProhibitedMethods.jtr.linux-x64.log)
[ProhibitedMethods.jtr.linux-aarch64.log](https://github.com/user-attachments/files/30704804/ProhibitedMethods.jtr.linux-aarch64.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8389492](https://bugs.openjdk.org/browse/JDK-8389492) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389492](https://bugs.openjdk.org/browse/JDK-8389492): [21u] java/io/Serializable/records/ProhibitedMethods.java fails after JDK-8307843 backport in othervm mode (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2989/head:pull/2989` \
`$ git checkout pull/2989`

Update a local copy of the PR: \
`$ git checkout pull/2989` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2989`

View PR using the GUI difftool: \
`$ git pr show -t 2989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2989.diff">https://git.openjdk.org/jdk21u-dev/pull/2989.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2989#issuecomment-5179513490)
</details>
