### PR TITLE
8338686: App classpath mismatch if a jar from the Class-Path attribute is on the classpath

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -815,7 +815,8 @@ bool ClassLoader::add_to_app_classpath_entries(JavaThread* current,
   ClassPathEntry* e = _app_classpath_entries;
   if (check_for_duplicates) {
     while (e != nullptr) {
-      if (strcmp(e->name(), entry->name()) == 0) {
+      if (strcmp(e->name(), entry->name()) == 0 &&
+          e->from_class_path_attr() == entry->from_class_path_attr()) {
         // entry already exists
         return false;
       }

--- a/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttr.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttr.java
@@ -27,6 +27,7 @@
  * @summary Class-Path: attribute in MANIFEST file
  * @requires vm.cds
  * @library /test/lib
+ * @compile test-classes/Hello.java
  * @run driver/timeout=240 ClassPathAttr
  */
 
@@ -44,6 +45,7 @@ public class ClassPathAttr {
   public static void main(String[] args) throws Exception {
     testNormalOps();
     testNonExistentJars();
+    testClassPathAttrJarOnCP();
   }
 
   static void testNormalOps() throws Exception {
@@ -124,6 +126,62 @@ public class ClassPathAttr {
       .assertNormalExit(output -> {
           output.shouldMatch("Archived non-system classes are disabled because the file .*cpattrX.jar exists");
         });
+  }
+
+  static void testClassPathAttrJarOnCP() throws Exception {
+    String helloJar = JarBuilder.getOrCreateHelloJar();
+    String jar1 = TestCommon.getTestJar("cpattr1.jar");
+    String cp = jar1 + File.pathSeparator + helloJar;
+
+    // The cpattr1.jar contains "Class-Path: cpattr2.jar".
+    // The cpattr2.jar contains "Class-Path: cpattr3.jar cpattr5_123456789_223456789_323456789_42345678.jar".
+    // With -cp cpattr1:hello.jar, the following shared paths should be stored in the CDS archive:
+    // cpattr1.jar:cpattr2.jar:cpattr3.jar:cpattr5_123456789_223456789_323456789_42345678.jari:hello.jar
+    TestCommon.testDump(cp, TestCommon.list("Hello"), "-Xlog:class+path");
+
+    // Run with the same -cp apattr1.jar:hello.jar. The Hello class should be
+    // loaded from the archive.
+    TestCommon.run("-Xlog:class+path,class+load",
+                   "-cp", cp,
+                   "Hello")
+              .assertNormalExit(output -> {
+                  output.shouldContain("Hello source: shared objects file");
+                });
+
+    // Run with -cp apattr1.jar:cpattr2.jar:hello.jar. App classpath mismatch should be detected.
+    String jar2 = TestCommon.getTestJar("cpattr2.jar");
+    cp = jar1 + File.pathSeparator + jar2 + File.pathSeparator + helloJar;
+    TestCommon.run("-Xlog:class+path,class+load",
+                   "-cp", cp,
+                   "Hello")
+              .assertAbnormalExit(output -> {
+                  output.shouldMatch(".*APP classpath mismatch, actual: -Djava.class.path=.*cpattr1.jar.*cpattr2.jar.*hello.jar")
+              .shouldContain("Unable to use shared archive.");
+                });
+
+    // Run with different -cp cpattr2.jar:hello.jar. App classpath mismatch should be detected.
+    cp = jar2 + File.pathSeparator + helloJar;
+    TestCommon.run("-Xlog:class+path,class+load",
+                   "-cp", cp,
+                   "Hello")
+              .assertAbnormalExit(output -> {
+                  output.shouldMatch(".*APP classpath mismatch, actual: -Djava.class.path=.*cpattr2.jar.*hello.jar")
+              .shouldContain("Unable to use shared archive.");
+                });
+
+    // Dumping with -cp cpattr1.jar:cpattr2.jar:hello.jar
+    // The cpattr2.jar is from the Class-Path: attribute of cpattr1.jar.
+    cp = jar1 + File.pathSeparator + jar2 + File.pathSeparator + helloJar;
+    TestCommon.testDump(cp, TestCommon.list("Hello"), "-Xlog:class+path");
+
+    // Run with the same -cp as dump time. The Hello class should be loaded from the archive.
+    TestCommon.run("-Xlog:class+path,class+load",
+                   "-cp", cp,
+                   "Hello")
+              .assertNormalExit(output -> {
+                  output.shouldContain("Hello source: shared objects file");
+                });
+
   }
 
   private static void buildCpAttr(String jarName, String manifest, String enclosingClassName, String ...testClassNames) throws Exception {


### PR DESCRIPTION
Clean backport 8338686. I have run test cases`jdk/com/sun/jdi/cds`,`hotspot/jtreg/runtime/cds`, all test cases have passed.

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/com/sun/jdi/cds                        3     3     0     0   
   jtreg:test/hotspot/jtreg/runtime/cds                294   294     0     0   
==============================
TEST SUCCESS
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8338686](https://bugs.openjdk.org/browse/JDK-8338686) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8338686](https://bugs.openjdk.org/browse/JDK-8338686): App classpath mismatch if a jar from the Class-Path attribute is on the classpath (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2991/head:pull/2991` \
`$ git checkout pull/2991`

Update a local copy of the PR: \
`$ git checkout pull/2991` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2991`

View PR using the GUI difftool: \
`$ git pr show -t 2991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2991.diff">https://git.openjdk.org/jdk21u-dev/pull/2991.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2991#issuecomment-5189161234)
</details>
