### PR TITLE
8378506: [macOS] Window content not updated when rendering to multiple windows

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,19 @@ jint mtlPreviousOp = MTL_OP_INIT;
 
 
 extern void MTLGC_DestroyMTLGraphicsConfig(jlong pConfigInfo);
+
+/**
+ * Triggers the display link for the current destination surface.
+ */
+static void MTLSD_Flush() {
+    if (dstOps != NULL) {
+        MTLSDOps *dstMTLOps = (MTLSDOps *)dstOps->privOps;
+        MTLLayer *layer = (MTLLayer*)dstMTLOps->layer;
+        if (layer != NULL) {
+            [layer startDisplayLink];
+        }
+    }
+}
 
 void MTLRenderQueue_CheckPreviousOp(jint op) {
 
@@ -575,6 +588,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                             [cbwrapper release];
                         }];
                         [commandbuf commit];
+                        MTLSD_Flush();
                     }
                     mtlc = [MTLContext setSurfacesEnv:env src:pSrc dst:pDst];
                     dstOps = (BMTLSDOps *)jlong_to_ptr(pDst);
@@ -602,6 +616,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                                     [cbwrapper release];
                                 }];
                                 [commandbuf commit];
+                                MTLSD_Flush();
                             }
                             mtlc = newMtlc;
                             dstOps = NULL;
@@ -871,14 +886,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                 [cbwrapper release];
             }];
             [commandbuf commit];
-            BMTLSDOps *dstOps = MTLRenderQueue_GetCurrentDestination();
-            if (dstOps != NULL) {
-                MTLSDOps *dstMTLOps = (MTLSDOps *)dstOps->privOps;
-                MTLLayer *layer = (MTLLayer*)dstMTLOps->layer;
-                if (layer != NULL) {
-                    [layer startDisplayLink];
-                }
-            }
+            MTLSD_Flush();
         }
         RESET_PREVIOUS_OP();
     }

--- a/src/java.desktop/share/native/common/java2d/opengl/OGLRenderQueue.c
+++ b/src/java.desktop/share/native/common/java2d/opengl/OGLRenderQueue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -433,6 +433,7 @@ Java_sun_java2d_opengl_OGLRenderQueue_flushBuffer
                 jlong pDst = NEXT_LONG(b);
                 if (oglc != NULL) {
                     RESET_PREVIOUS_OP();
+                    OGLSD_Flush(env);
                 }
                 oglc = OGLContext_SetSurfaces(env, pSrc, pDst);
                 dstOps = (OGLSDOps *)jlong_to_ptr(pDst);
@@ -443,6 +444,7 @@ Java_sun_java2d_opengl_OGLRenderQueue_flushBuffer
                 jlong pConfigInfo = NEXT_LONG(b);
                 if (oglc != NULL) {
                     RESET_PREVIOUS_OP();
+                    OGLSD_Flush(env);
                 }
                 oglc = OGLSD_SetScratchSurface(env, pConfigInfo);
                 dstOps = NULL;

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -248,7 +248,6 @@ sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
-sun/java2d/OpenGL/MultiWindowFillTest.java 8378506 macosx-all
 sun/java2d/OpenGL/OpaqueDest.java#id1 8367574 macosx-all
 sun/java2d/OpenGL/ScaleParamsOOB.java#id0 8377908 linux-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all

--- a/test/jdk/sun/java2d/OpenGL/MultiWindowFillTest.java
+++ b/test/jdk/sun/java2d/OpenGL/MultiWindowFillTest.java
@@ -34,7 +34,7 @@ import javax.imageio.ImageIO;
 
 /**
  * @test
- * @bug 8378201
+ * @bug 8378201 8378506
  * @key headful
  * @summary Verifies that window content survives a GL context switch to another
  *          window and back


### PR DESCRIPTION
Backporting JDK-8378506: [macOS] Window content not updated when rendering to multiple windows.

This PR flushes the previous destination surface when the render queue switches destinations, in both the OpenGL and Metal pipelines. The behavior change affects only macOS.

For parity with Oracle JDK. Already backported to 25.

Ran related test on macos-aarch64:

make test TEST=test/jdk/sun/java2d/OpenGL/MultiWindowFillTest.java

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/30788586/macos-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8378506](https://bugs.openjdk.org/browse/JDK-8378506) needs maintainer approval

### Issue
 * [JDK-8378506](https://bugs.openjdk.org/browse/JDK-8378506): [macOS] Window content not updated when rendering to multiple windows (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2992/head:pull/2992` \
`$ git checkout pull/2992`

Update a local copy of the PR: \
`$ git checkout pull/2992` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2992`

View PR using the GUI difftool: \
`$ git pr show -t 2992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2992.diff">https://git.openjdk.org/jdk21u-dev/pull/2992.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2992#issuecomment-5204837407)
</details>
