### PR TITLE
8347608: Optimize Java implementation of ML-KEM

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ML_KEM.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ML_KEM.java
@@ -422,7 +422,7 @@ public final class ML_KEM {
 
     private K_PKE_CipherText kPkeEncrypt(
             K_PKE_EncryptionKey publicKey, byte[] message, byte[] sigma) {
-        short[][] zeroes = new short[mlKem_k][ML_KEM_N];
+        short[][] zeroes = shortMatrixAlloc(mlKem_k, ML_KEM_N);
         byte[] pkBytes = publicKey.keyBytes;
         byte[] rho = Arrays.copyOfRange(pkBytes,
                 pkBytes.length - 32, pkBytes.length);
@@ -511,7 +511,7 @@ public final class ML_KEM {
         System.arraycopy(rho, 0, seedBuf, 0, rho.length);
         seedBuf[rhoLen + 2] = 0x1F;
         seedBuf[XOF_BLOCK_LEN - 1] = (byte)0x80;
-        byte[][] xofBufArr = new byte[nrPar][XOF_BLOCK_LEN + XOF_PAD];
+        byte[][] xofBufArr = byteMatrixAlloc(nrPar, XOF_BLOCK_LEN + XOF_PAD);
         int[] iIndex = new int[nrPar];
         int[] jIndex = new int[nrPar];
 
@@ -1179,5 +1179,23 @@ public final class ML_KEM {
         int m = ((MONT_Q_INV_MOD_R * aLow) << (32 - MONT_R_BITS)) >> (32 - MONT_R_BITS);
 
         return (aHigh - ((m * MONT_Q) >> MONT_R_BITS)); // subtract signed high product
+    }
+
+    // For multidimensional array initialization, manually allocating each entry is
+    // faster than doing the entire initialization in one go
+    static short[][] shortMatrixAlloc(int first, int second) {
+        short[][] res = new short[first][];
+        for (int i = 0; i < first; i++) {
+            res[i] = new short[second];
+        }
+        return res;
+    }
+
+    static byte[][] byteMatrixAlloc(int first, int second) {
+        byte[][] res = new byte[first][];
+        for (int i = 0; i < first; i++) {
+            res[i] = new byte[second];
+        }
+        return res;
     }
 }


### PR DESCRIPTION
I backport this for parity with 21.0.13-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8347608](https://bugs.openjdk.org/browse/JDK-8347608) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8347608](https://bugs.openjdk.org/browse/JDK-8347608): Optimize Java implementation of ML-KEM (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2995/head:pull/2995` \
`$ git checkout pull/2995`

Update a local copy of the PR: \
`$ git checkout pull/2995` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2995`

View PR using the GUI difftool: \
`$ git pr show -t 2995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2995.diff">https://git.openjdk.org/jdk21u-dev/pull/2995.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2995#issuecomment-5218307021)
</details>
