### PR TITLE
8332124: Jcmd should recognise options that look like requests for help

### DIFF
--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -401,7 +401,15 @@ void DCmd::parse_and_execute(DCmdSource source, outputStream* out,
       break;
     }
     if (line.is_executable()) {
+      // Allow for "<cmd> -h|-help|--help" to enable the help diagnostic command.
+      // Ignores any additional arguments.
       ResourceMark rm;
+      stringStream updated_line;
+      if (reorder_help_cmd(line, updated_line)) {
+        CmdLine updated_cmd(updated_line.base(), updated_line.size(), false);
+        line = updated_cmd;
+      }
+
       DCmd* command = DCmdFactory::create_local_DCmd(source, line, out, CHECK);
       assert(command != nullptr, "command error must be handled before this line");
       DCmdMark mark(command);
@@ -410,6 +418,25 @@ void DCmd::parse_and_execute(DCmdSource source, outputStream* out,
     }
     count++;
   }
+}
+
+bool DCmd::reorder_help_cmd(CmdLine line, stringStream &updated_line) {
+  stringStream args;
+  args.print("%s", line.args_addr());
+  char* rest = args.as_string();
+  char* token = strtok_r(rest, " ", &rest);
+  while (token != NULL) {
+    if (strcmp(token, "-h") == 0 || strcmp(token, "--help") == 0 ||
+        strcmp(token, "-help") == 0) {
+      updated_line.print("%s", "help ");
+      updated_line.write(line.cmd_addr(), line.cmd_len());
+      updated_line.write("\0", 1);
+      return true;
+    }
+    token = strtok_r(rest, " ", &rest);
+  }
+
+  return false;
 }
 
 void DCmdWithParser::parse(CmdLine* line, char delim, TRAPS) {

--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -313,6 +313,9 @@ public:
   // management.cpp every time.
   static void register_dcmds();
 
+  // Helper method to substitute help options "<cmd> -h|-help|--help"
+  // for "help <cmd>".
+  static bool reorder_help_cmd(CmdLine line, stringStream& updated_line);
 };
 
 class DCmdWithParser : public DCmd {

--- a/test/jdk/sun/tools/jcmd/TestJcmdSubcommandHelp.java
+++ b/test/jdk/sun/tools/jcmd/TestJcmdSubcommandHelp.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8332124
+ * @summary Test to verify jcmd accepts the "-help", "--help" and "-h" suboptions as a command argument
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main/othervm TestJcmdSubcommandHelp
+ *
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+
+public class TestJcmdSubcommandHelp {
+
+    private static final String HELP_ONE_DASH = "-help";
+    private static final String HELP_TWO_DASH = "--help";
+    private static final String SINGLE_H = "-h";
+    private static final String CMD = "VM.metaspace";
+    private static final String ILLEGAL = "IllegalArgumentException: Unknown argument";
+
+    public static void main(String[] args) throws Exception {
+
+        // Sanity check with empty input
+        OutputAnalyzer output = JcmdBase.jcmd();
+        output.shouldContain("The following commands are available:");
+
+        // Sanity check with existing usage for "help <cmd>"
+        output = JcmdBase.jcmd("help", CMD);
+        String expectedOutput = output.getOutput();
+        output.shouldNotContain("Unknown diagnostic command");
+
+        testExpectedUsage(HELP_ONE_DASH, expectedOutput);
+        testExpectedUsage(HELP_TWO_DASH, expectedOutput);
+        testExpectedUsage(SINGLE_H, expectedOutput);
+
+        testIgnoreAdditionalArgs(HELP_ONE_DASH, expectedOutput);
+        testIgnoreAdditionalArgs(HELP_TWO_DASH, expectedOutput);
+        testIgnoreAdditionalArgs(SINGLE_H, expectedOutput);
+
+        testIgnoreTrailingSpaces(HELP_ONE_DASH, expectedOutput);
+        testIgnoreTrailingSpaces(HELP_TWO_DASH, expectedOutput);
+        testIgnoreTrailingSpaces(SINGLE_H, expectedOutput);
+
+        testSimilarCommand(HELP_ONE_DASH + "less", ILLEGAL);
+        testSimilarCommand(HELP_TWO_DASH + "me", ILLEGAL);
+        testSimilarCommand(SINGLE_H + "ello", ILLEGAL);
+    }
+
+    private static void testExpectedUsage(String helpOption, String expectedOutput) throws Exception {
+        verifyOutput(new String[] {CMD, helpOption}, expectedOutput,
+                "Expected jcmd to accept '%s' suboption as a command argument and issue the same help output.".formatted(helpOption));
+    }
+
+    private static void testIgnoreAdditionalArgs(String helpOption, String expectedOutput) throws Exception {
+        verifyOutput(new String[] {CMD, helpOption, "basic"}, expectedOutput,
+                "Expected jcmd to accept '%s' suboption with additional arguments after help.".formatted(helpOption));
+    }
+
+    private static void testIgnoreTrailingSpaces(String helpOption, String expectedOutput) throws Exception {
+        verifyOutput(new String[] {CMD, "%s    ".formatted(helpOption)}, expectedOutput,
+                "Expected jcmd to accept '%s' suboption with trailing spaces".formatted(helpOption));
+    }
+
+    private static void testSimilarCommand(String helpOption, String expectedOutput) throws Exception {
+        verifyOutputContains(new String[] {CMD, helpOption}, expectedOutput,
+                "Expected jcmd to NOT accept '%s' suboption with trailing content".formatted(helpOption));
+    }
+
+    private static void verifyOutputContains(String[] args, String expectedOutput, String errorMessage) throws Exception {
+        OutputAnalyzer output = JcmdBase.jcmd(args);
+        String issuedOutput = output.getOutput();
+        if (!issuedOutput.contains(expectedOutput)) {
+            printDifferingOutputs(expectedOutput, issuedOutput);
+            throw new Exception(errorMessage);
+        }
+    }
+
+    private static void verifyOutput(String[] args, String expectedOutput, String errorMessage) throws Exception {
+        OutputAnalyzer output = JcmdBase.jcmd(args);
+        String issuedOutput = output.getOutput();
+        if (!expectedOutput.equals(issuedOutput)) {
+            printDifferingOutputs(expectedOutput, issuedOutput);
+            throw new Exception(errorMessage);
+        }
+    }
+
+    private static void printDifferingOutputs(String expectedOutput, String issuedOutput) {
+        System.out.println("Expected output: ");
+        System.out.println(expectedOutput);
+        System.out.println("Issued output: ");
+        System.out.println(issuedOutput);
+    }
+}


### PR DESCRIPTION
Clean backport 8332124.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8332124](https://bugs.openjdk.org/browse/JDK-8332124) needs maintainer approval

### Issue
 * [JDK-8332124](https://bugs.openjdk.org/browse/JDK-8332124): Jcmd should recognise options that look like requests for help (**Enhancement** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/2999/head:pull/2999` \
`$ git checkout pull/2999`

Update a local copy of the PR: \
`$ git checkout pull/2999` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/2999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2999`

View PR using the GUI difftool: \
`$ git pr show -t 2999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/2999.diff">https://git.openjdk.org/jdk21u-dev/pull/2999.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/2999#issuecomment-5225622374)
</details>
