### PR TITLE
8354926: Remove remnants of debugging in the fix for JDK-8348561 and JDK-8349721

### DIFF
--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -38,7 +38,7 @@ enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 49000 ZGC_ONLY(+10000),
+  _compiler_stubs_code_size     = 50000 ZGC_ONLY(+10000),
   _final_stubs_code_size        = 20000 ZGC_ONLY(+100000)
 };
 

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -38,7 +38,7 @@ enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 47000 ZGC_ONLY(+10000),
+  _compiler_stubs_code_size     = 49000 ZGC_ONLY(+10000),
   _final_stubs_code_size        = 20000 ZGC_ONLY(+100000)
 };
 

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -38,7 +38,7 @@ enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 55000 ZGC_ONLY(+10000),
+  _compiler_stubs_code_size     = 45000 ZGC_ONLY(+10000),
   _final_stubs_code_size        = 20000 ZGC_ONLY(+100000)
 };
 

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -38,7 +38,7 @@ enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 45000 ZGC_ONLY(+10000),
+  _compiler_stubs_code_size     = 47000 ZGC_ONLY(+10000),
   _final_stubs_code_size        = 20000 ZGC_ONLY(+100000)
 };
 

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -38,7 +38,7 @@ enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 50000 ZGC_ONLY(+10000),
+  _compiler_stubs_code_size     = 53000 ZGC_ONLY(+10000),
   _final_stubs_code_size        = 20000 ZGC_ONLY(+100000)
 };
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -680,7 +680,6 @@ void VM_Version::initialize_cpu_information(void) {
   get_compatible_board(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len);
   desc_len = (int)strlen(_cpu_desc);
   snprintf(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _features_string);
-  fprintf(stderr, "_features_string = \"%s\"", _features_string);
 
   _initialized = true;
 }


### PR DESCRIPTION
I backport this for parity with 21.0.13-oracle

Adapted to other stub code handling.

Update: 
macos seems to need a lot more space than the other platforms, I needed to increase the stub code size to pass the build.

SAP nightly testing passed.
(all tier1-4, jck, others on 8 platforms, fastdbg and release)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8354926](https://bugs.openjdk.org/browse/JDK-8354926) needs maintainer approval

### Issue
 * [JDK-8354926](https://bugs.openjdk.org/browse/JDK-8354926): Remove remnants of debugging in the fix for JDK-8348561 and JDK-8349721 (**Enhancement** - P3 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3000/head:pull/3000` \
`$ git checkout pull/3000`

Update a local copy of the PR: \
`$ git checkout pull/3000` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3000`

View PR using the GUI difftool: \
`$ git pr show -t 3000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3000.diff">https://git.openjdk.org/jdk21u-dev/pull/3000.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3000#issuecomment-5237311300)
</details>
