### PR TITLE
8339331: GCC fortify error in vm_version_linux_aarch64.cpp

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -185,7 +185,14 @@ static bool read_fully(const char *fname, char *buf, size_t buflen) {
   assert(buflen >= 1, "invalid argument");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
+    PRAGMA_DIAG_PUSH
+    PRAGMA_NONNULL_IGNORED
+    // Suppress false positive gcc warning, which may be an example of
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87489
+    // The warning also hasn't been seen with vanilla gcc release, so may also
+    // involve some distro-specific gcc patch.
     ssize_t read_sz = ::read(fd, buf, buflen);
+    PRAGMA_DIAG_POP
     ::close(fd);
 
     // Skip if the contents is just "\n" because some machine only sets


### PR DESCRIPTION
A clean backport of JDK-8339331: GCC fortify error in vm_version_linux_aarch64.cpp

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8339331](https://bugs.openjdk.org/browse/JDK-8339331) needs maintainer approval

### Issue
 * [JDK-8339331](https://bugs.openjdk.org/browse/JDK-8339331): GCC fortify error in vm_version_linux_aarch64.cpp (**Bug** - P4 - Approved)


### Reviewers without OpenJDK IDs
 * @sendaoYan (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3002/head:pull/3002` \
`$ git checkout pull/3002`

Update a local copy of the PR: \
`$ git checkout pull/3002` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3002`

View PR using the GUI difftool: \
`$ git pr show -t 3002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3002.diff">https://git.openjdk.org/jdk21u-dev/pull/3002.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3002#issuecomment-5232187525)
</details>
