### PR TITLE
8189441: Define algorithm names for keys derived from KeyAgreement

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DHKeyAgreement.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,11 +393,10 @@ extends KeyAgreementSpi {
             throw new NoSuchAlgorithmException("null algorithm");
         }
 
-        if (!algorithm.equalsIgnoreCase("TlsPremasterSecret") &&
-            !AllowKDF.VALUE) {
-
-            throw new NoSuchAlgorithmException("Unsupported secret key "
-                                               + "algorithm: " + algorithm);
+        if (!KeyUtil.isSupportedKeyAgreementOutputAlgorithm(algorithm) &&
+                !AllowKDF.VALUE) {
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
         }
 
         byte[] secret = engineGenerateSecret();
@@ -435,13 +434,17 @@ extends KeyAgreementSpi {
                 throw new InvalidKeyException("Key material is too short");
             }
             return skey;
-        } else if (algorithm.equals("TlsPremasterSecret")) {
-            // remove leading zero bytes per RFC 5246 Section 8.1.2
-            return new SecretKeySpec(
+        } else if (KeyUtil.isSupportedKeyAgreementOutputAlgorithm(algorithm)) {
+            if (algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
+                // remove leading zero bytes per RFC 5246 Section 8.1.2
+                return new SecretKeySpec(
                         KeyUtil.trimZeroes(secret), "TlsPremasterSecret");
+            } else {
+                return new SecretKeySpec(secret, algorithm);
+            }
         } else {
-            throw new NoSuchAlgorithmException("Unsupported secret key "
-                                               + "algorithm: "+ algorithm);
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
         }
     }
 }

--- a/src/java.base/share/classes/javax/crypto/KeyAgreement.java
+++ b/src/java.base/share/classes/javax/crypto/KeyAgreement.java
@@ -661,18 +661,30 @@ public class KeyAgreement {
      * {@code generateSecret} to change the private information used in
      * subsequent operations.
      *
-     * @param algorithm the requested secret-key algorithm
+     * @param algorithm the requested secret key algorithm. This is different
+     *      from the {@code KeyAgreement} algorithm provided to the
+     *      {@code getInstance} method. See the SecretKey Algorithms section in the
+     *      <a href="{@docRoot}/../specs/security/standard-names.html#secretkey-algorithms">
+     *      Java Security Standard Algorithm Names Specification</a>
+     *      for information about standard secret key algorithm names.
+     *      Specify "Generic" if the output will be used as the input keying
+     *      material of a key derivation function (KDF).
      *
-     * @return the shared secret key
+     * @return the shared secret key. The length of the key material
+     *      may be adjusted to be compatible with the specified algorithm,
+     *      regardless of whether the key is extractable. If {@code algorithm}
+     *      is specified as "Generic" and it is supported by the implementation,
+     *      the full shared secret is returned.
      *
      * @exception IllegalStateException if this key agreement has not been
      * initialized or if {@code doPhase} has not been called to supply the
      * keys for all parties in the agreement
-     * @exception NoSuchAlgorithmException if the specified secret-key
-     * algorithm is not available
-     * @exception InvalidKeyException if the shared secret-key material cannot
+     * @exception NoSuchAlgorithmException if the specified secret key
+     * algorithm is not supported
+     * @exception InvalidKeyException if the shared secret key material cannot
      * be used to generate a secret key of the specified algorithm (e.g.,
      * the key material is too short)
+     * @spec security/standard-names.html Java Security Standard Algorithm Names
      */
     public final SecretKey generateSecret(String algorithm)
         throws IllegalStateException, NoSuchAlgorithmException,

--- a/src/java.base/share/classes/javax/crypto/KeyAgreement.java
+++ b/src/java.base/share/classes/javax/crypto/KeyAgreement.java
@@ -661,30 +661,18 @@ public class KeyAgreement {
      * {@code generateSecret} to change the private information used in
      * subsequent operations.
      *
-     * @param algorithm the requested secret key algorithm. This is different
-     *      from the {@code KeyAgreement} algorithm provided to the
-     *      {@code getInstance} method. See the SecretKey Algorithms section in the
-     *      <a href="{@docRoot}/../specs/security/standard-names.html#secretkey-algorithms">
-     *      Java Security Standard Algorithm Names Specification</a>
-     *      for information about standard secret key algorithm names.
-     *      Specify "Generic" if the output will be used as the input keying
-     *      material of a key derivation function (KDF).
+     * @param algorithm the requested secret key algorithm
      *
-     * @return the shared secret key. The length of the key material
-     *      may be adjusted to be compatible with the specified algorithm,
-     *      regardless of whether the key is extractable. If {@code algorithm}
-     *      is specified as "Generic" and it is supported by the implementation,
-     *      the full shared secret is returned.
+     * @return the shared secret key
      *
      * @exception IllegalStateException if this key agreement has not been
      * initialized or if {@code doPhase} has not been called to supply the
      * keys for all parties in the agreement
-     * @exception NoSuchAlgorithmException if the specified secret key
-     * algorithm is not supported
-     * @exception InvalidKeyException if the shared secret key material cannot
+     * @exception NoSuchAlgorithmException if the specified secret-key
+     * algorithm is not available
+     * @exception InvalidKeyException if the shared secret-key material cannot
      * be used to generate a secret key of the specified algorithm (e.g.,
      * the key material is too short)
-     * @spec security/standard-names.html Java Security Standard Algorithm Names
      */
     public final SecretKey generateSecret(String algorithm)
         throws IllegalStateException, NoSuchAlgorithmException,

--- a/src/java.base/share/classes/javax/crypto/KeyAgreementSpi.java
+++ b/src/java.base/share/classes/javax/crypto/KeyAgreementSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,18 +205,30 @@ public abstract class KeyAgreementSpi {
      * {@code generateSecret} to change the private information used in
      * subsequent operations.
      *
-     * @param algorithm the requested secret key algorithm
+     * @param algorithm the requested secret key algorithm. This is different
+     *      from the {@code KeyAgreement} algorithm provided to the
+     *      {@code getInstance} method. See the SecretKey Algorithms section in the
+     *      <a href="{@docRoot}/../specs/security/standard-names.html#secretkey-algorithms">
+     *      Java Security Standard Algorithm Names Specification</a>
+     *      for information about standard secret key algorithm names.
+     *      Specify "Generic" if the output will be used as the input keying
+     *      material of a key derivation function (KDF).
      *
-     * @return the shared secret key
+     * @return the shared secret key. The length of the key material
+     *      may be adjusted to be compatible with the specified algorithm,
+     *      regardless of whether the key is extractable. If {@code algorithm}
+     *      is specified as "Generic" and it is supported by the implementation,
+     *      the full shared secret is returned.
      *
      * @exception IllegalStateException if this key agreement has not been
      * initialized or if {@code doPhase} has not been called to supply the
      * keys for all parties in the agreement
-     * @exception NoSuchAlgorithmException if the requested secret key
-     * algorithm is not available
+     * @exception NoSuchAlgorithmException if the specified secret key
+     * algorithm is not supported
      * @exception InvalidKeyException if the shared secret key material cannot
      * be used to generate a secret key of the requested algorithm type (e.g.,
      * the key material is too short)
+     * @spec security/standard-names.html Java Security Standard Algorithm Names
      */
     protected abstract SecretKey engineGenerateSecret(String algorithm)
         throws IllegalStateException, NoSuchAlgorithmException,

--- a/src/java.base/share/classes/javax/crypto/KeyAgreementSpi.java
+++ b/src/java.base/share/classes/javax/crypto/KeyAgreementSpi.java
@@ -205,30 +205,18 @@ public abstract class KeyAgreementSpi {
      * {@code generateSecret} to change the private information used in
      * subsequent operations.
      *
-     * @param algorithm the requested secret key algorithm. This is different
-     *      from the {@code KeyAgreement} algorithm provided to the
-     *      {@code getInstance} method. See the SecretKey Algorithms section in the
-     *      <a href="{@docRoot}/../specs/security/standard-names.html#secretkey-algorithms">
-     *      Java Security Standard Algorithm Names Specification</a>
-     *      for information about standard secret key algorithm names.
-     *      Specify "Generic" if the output will be used as the input keying
-     *      material of a key derivation function (KDF).
+     * @param algorithm the requested secret key algorithm
      *
-     * @return the shared secret key. The length of the key material
-     *      may be adjusted to be compatible with the specified algorithm,
-     *      regardless of whether the key is extractable. If {@code algorithm}
-     *      is specified as "Generic" and it is supported by the implementation,
-     *      the full shared secret is returned.
+     * @return the shared secret key
      *
      * @exception IllegalStateException if this key agreement has not been
      * initialized or if {@code doPhase} has not been called to supply the
      * keys for all parties in the agreement
-     * @exception NoSuchAlgorithmException if the specified secret key
-     * algorithm is not supported
+     * @exception NoSuchAlgorithmException if the requested secret key
+     * algorithm is not available
      * @exception InvalidKeyException if the shared secret key material cannot
      * be used to generate a secret key of the requested algorithm type (e.g.,
      * the key material is too short)
-     * @spec security/standard-names.html Java Security Standard Algorithm Names
      */
     protected abstract SecretKey engineGenerateSecret(String algorithm)
         throws IllegalStateException, NoSuchAlgorithmException,

--- a/src/java.base/share/classes/sun/security/util/KeyUtil.java
+++ b/src/java.base/share/classes/sun/security/util/KeyUtil.java
@@ -450,5 +450,10 @@ public final class KeyUtil {
         }
         return null;
     }
+
+    public static boolean isSupportedKeyAgreementOutputAlgorithm(String alg) {
+        return alg.equalsIgnoreCase("TlsPremasterSecret")
+                || alg.equalsIgnoreCase("Generic");
+    }
 }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11ECDHKeyAgreement.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11ECDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@ import javax.crypto.*;
 
 import static sun.security.pkcs11.TemplateManager.*;
 import sun.security.pkcs11.wrapper.*;
+import sun.security.util.KeyUtil;
+
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 
 /**
@@ -168,9 +170,9 @@ final class P11ECDHKeyAgreement extends KeyAgreementSpi {
         if (algorithm == null) {
             throw new NoSuchAlgorithmException("Algorithm must not be null");
         }
-        if (!algorithm.equals("TlsPremasterSecret")) {
-            throw new NoSuchAlgorithmException
-                ("Only supported for algorithm TlsPremasterSecret");
+        if (!KeyUtil.isSupportedKeyAgreementOutputAlgorithm(algorithm)) {
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
         }
         return nativeGenerateSecret(algorithm);
     }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyAgreement.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -274,20 +274,19 @@ final class P11KeyAgreement extends KeyAgreementSpi {
             throw new NoSuchAlgorithmException("Algorithm must not be null");
         }
 
-        if (algorithm.equals("TlsPremasterSecret")) {
+        if (KeyUtil.isSupportedKeyAgreementOutputAlgorithm(algorithm)) {
             // For now, only perform native derivation for TlsPremasterSecret
-            // as that is required for FIPS compliance.
+            // and Generic algorithms. TlsPremasterSecret is required for
+            // FIPS compliance and Generic is required for input to KDF.
             // For other algorithms, there are unresolved issues regarding
             // how this should work in JCE plus a Solaris truncation bug.
             // (bug not yet filed).
             return nativeGenerateSecret(algorithm);
         }
 
-        if (!algorithm.equalsIgnoreCase("TlsPremasterSecret") &&
-            !AllowKDF.VALUE) {
-
-            throw new NoSuchAlgorithmException("Unsupported secret key "
-                                               + "algorithm: " + algorithm);
+        if (!AllowKDF.VALUE) {
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
         }
 
         byte[] secret = engineGenerateSecret();
@@ -301,8 +300,6 @@ final class P11KeyAgreement extends KeyAgreementSpi {
             keyLen = 24;
         } else if (algorithm.equalsIgnoreCase("Blowfish")) {
             keyLen = Math.min(56, secret.length);
-        } else if (algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
-            keyLen = secret.length;
         } else {
             throw new NoSuchAlgorithmException
                 ("Unknown algorithm " + algorithm);
@@ -346,7 +343,8 @@ final class P11KeyAgreement extends KeyAgreementSpi {
             int keyLen = (int)lenAttributes[0].getLong();
             SecretKey key = P11Key.secretKey
                         (session, keyID, algorithm, keyLen << 3, attributes);
-            if ("RAW".equals(key.getFormat())) {
+            if ("RAW".equals(key.getFormat())
+                    && algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
                 // Workaround for Solaris bug 6318543.
                 // Strip leading zeroes ourselves if possible (key not sensitive).
                 // This should be removed once the Solaris fix is available

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import sun.security.ec.point.Point;
 import sun.security.util.ArrayUtil;
 import sun.security.util.CurveDB;
 import sun.security.util.ECUtil;
+import sun.security.util.KeyUtil;
 import sun.security.util.NamedCurve;
 import sun.security.util.math.ImmutableIntegerModuloP;
 import sun.security.util.math.IntegerFieldModuloP;
@@ -253,11 +254,11 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         if (algorithm == null) {
             throw new NoSuchAlgorithmException("Algorithm must not be null");
         }
-        if (!(algorithm.equals("TlsPremasterSecret"))) {
-            throw new NoSuchAlgorithmException
-                ("Only supported for algorithm TlsPremasterSecret");
+        if (!KeyUtil.isSupportedKeyAgreementOutputAlgorithm(algorithm)) {
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
         }
-        return new SecretKeySpec(engineGenerateSecret(), "TlsPremasterSecret");
+        return new SecretKeySpec(engineGenerateSecret(), algorithm);
     }
 
     private static

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package sun.security.ec;
+
+import sun.security.util.KeyUtil;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -207,9 +209,9 @@ public class XDHKeyAgreement extends KeyAgreementSpi {
             throw new NoSuchAlgorithmException("Algorithm must not be null");
         }
 
-        if (!(algorithm.equals("TlsPremasterSecret"))) {
+        if (!KeyUtil.isSupportedKeyAgreementOutputAlgorithm(algorithm)) {
             throw new NoSuchAlgorithmException(
-                    "Only supported for algorithm TlsPremasterSecret");
+                    "Unsupported secret key algorithm: " + algorithm);
         }
         return new SecretKeySpec(engineGenerateSecret(), algorithm);
     }

--- a/test/jdk/java/security/KeyAgreement/Generic.java
+++ b/test/jdk/java/security/KeyAgreement/Generic.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8189441
+ * @library /test/lib /test/jdk/sun/security/pkcs11
+ * @summary make sure Generic is accepted by all KeyAgreement implementations
+ * @run main Generic builtin
+ * @run main/othervm Generic nss
+ * @run main/othervm -DCUSTOM_P11_CONFIG_NAME=p11-nss-sensitive.txt Generic nss
+ */
+import jdk.test.lib.Asserts;
+
+import javax.crypto.KeyAgreement;
+import java.security.KeyPairGenerator;
+import java.security.Provider;
+import java.security.Security;
+import java.util.List;
+
+public class Generic {
+
+    public static void main(String[] args) throws Exception {
+        if (args[0].equals("nss")) {
+            test(PKCS11Test.getSunPKCS11(PKCS11Test.getNssConfig()));
+        } else {
+            for (var p : Security.getProviders()) {
+                test(p);
+            }
+        }
+    }
+
+    static void test(Provider p) throws Exception {
+        for (var s : p.getServices()) {
+            if (s.getType().equalsIgnoreCase("KeyAgreement")) {
+                try {
+                    System.out.println(s.getProvider().getName() + "." + s.getAlgorithm());
+                    var g = KeyPairGenerator.getInstance(ka2kpg(s.getAlgorithm()), p);
+                    var kp1 = g.generateKeyPair();
+                    var kp2 = g.generateKeyPair();
+                    var ka = KeyAgreement.getInstance(s.getAlgorithm(), s.getProvider());
+                    for (var alg : List.of("TlsPremasterSecret", "Generic")) {
+                        ka.init(kp1.getPrivate());
+                        ka.doPhase(kp2.getPublic(), true);
+                        Asserts.assertEquals(
+                                ka.generateSecret(alg).getAlgorithm(), alg);
+                    }
+                } catch (Exception e) {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    // Find key algorithm from KeyAgreement algorithm
+    private static String ka2kpg(String ka) {
+        return ka.equals("ECDH") ? "EC" : ka;
+    }
+}

--- a/test/jdk/sun/security/pkcs11/nss/p11-nss-sensitive.txt
+++ b/test/jdk/sun/security/pkcs11/nss/p11-nss-sensitive.txt
@@ -49,10 +49,12 @@ attributes(*,CKO_PRIVATE_KEY,CKK_DH) = {
 # Make all private keys sensitive
 attributes(*,CKO_PRIVATE_KEY,*) = {
   CKA_SENSITIVE = true
+  CKA_EXTRACTABLE = false
 }
 
 
 # Make all secret keys sensitive
 attributes(*,CKO_SECRET_KEY,*) = {
   CKA_SENSITIVE = true
+  CKA_EXTRACTABLE = false
 }


### PR DESCRIPTION
I backport this for parity with 17.0.21-oracle, but to 21.

Resolved two Copyrights and file location of 
src/java.base/share/classes/sun/security/ec/ECDHKeyAgreement.java
src/java.base/share/classes/sun/security/ec/XDHKeyAgreement.java
as 
https://bugs.openjdk.org/browse/JDK-8308398: Move SunEC crypto provider into java.base
is not in 21.

There probably is a closed CSR for this, I asked to open up this.

Update: 
I removed the javadoc changes, so that no CSR is needed.  See discussion in JBS issue.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8189441](https://bugs.openjdk.org/browse/JDK-8189441) needs maintainer approval
- \[x\] Change requires CSR request [JDK-8387140](https://bugs.openjdk.org/browse/JDK-8387140) to be approved

### Issues
 * [JDK-8189441](https://bugs.openjdk.org/browse/JDK-8189441): Define algorithm names for keys derived from KeyAgreement (**Bug** - P4 - Approved)
 * [JDK-8387140](https://bugs.openjdk.org/browse/JDK-8387140): Define algorithm names for keys derived from KeyAgreement (**CSR**)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3004/head:pull/3004` \
`$ git checkout pull/3004`

Update a local copy of the PR: \
`$ git checkout pull/3004` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3004`

View PR using the GUI difftool: \
`$ git pr show -t 3004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3004.diff">https://git.openjdk.org/jdk21u-dev/pull/3004.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3004#issuecomment-5271681902)
</details>
