### PR TITLE
8379516: Adjust JVM debug helper exports

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,20 +304,20 @@ class Command : public StackObj {
 
 int Command::level = 0;
 
-extern "C" JNIEXPORT void blob(CodeBlob* cb) {
+extern "C" NOINLINE void blob(CodeBlob* cb) {
   Command c("blob");
   cb->print();
 }
 
 
-extern "C" JNIEXPORT void dump_vtable(address p) {
+extern "C" NOINLINE void dump_vtable(address p) {
   Command c("dump_vtable");
   Klass* k = (Klass*)p;
   k->vtable().print();
 }
 
 
-extern "C" JNIEXPORT void nm(intptr_t p) {
+extern "C" NOINLINE void nm(intptr_t p) {
   // Actually we look through all CodeBlobs (the nm name has been kept for backwards compatibility)
   Command c("nm");
   CodeBlob* cb = CodeCache::find_blob((address)p);
@@ -329,7 +329,7 @@ extern "C" JNIEXPORT void nm(intptr_t p) {
 }
 
 
-extern "C" JNIEXPORT void disnm(intptr_t p) {
+extern "C" NOINLINE void disnm(intptr_t p) {
   Command c("disnm");
   CodeBlob* cb = CodeCache::find_blob((address) p);
   if (cb != nullptr) {
@@ -344,7 +344,7 @@ extern "C" JNIEXPORT void disnm(intptr_t p) {
 }
 
 
-extern "C" JNIEXPORT void printnm(intptr_t p) {
+extern "C" NOINLINE void printnm(intptr_t p) {
   char buffer[256];
   os::snprintf_checked(buffer, sizeof(buffer), "printnm: " INTPTR_FORMAT, p);
   Command c(buffer);
@@ -358,13 +358,13 @@ extern "C" JNIEXPORT void printnm(intptr_t p) {
 }
 
 
-extern "C" JNIEXPORT void universe() {
+extern "C" NOINLINE void universe() {
   Command c("universe");
   Universe::print_on(tty);
 }
 
 
-extern "C" JNIEXPORT void verify() {
+extern "C" NOINLINE void verify() {
   // try to run a verify on the entire system
   // note: this may not be safe if we're not at a safepoint; for debugging,
   // this manipulates the safepoint settings to avoid assertion failures
@@ -381,7 +381,7 @@ extern "C" JNIEXPORT void verify() {
 }
 
 
-extern "C" JNIEXPORT void pp(void* p) {
+extern "C" NOINLINE void pp(void* p) {
   Command c("pp");
   FlagSetting fl(DisplayVMOutput, true);
   if (p == nullptr) {
@@ -406,9 +406,7 @@ extern "C" JNIEXPORT void pp(void* p) {
 }
 
 
-extern "C" JNIEXPORT void findpc(intptr_t x);
-
-extern "C" JNIEXPORT void ps() { // print stack
+extern "C" NOINLINE void ps() { // print stack
   if (Thread::current_or_null() == nullptr) return;
   Command c("ps");
 
@@ -437,7 +435,7 @@ extern "C" JNIEXPORT void ps() { // print stack
   }
 }
 
-extern "C" JNIEXPORT void pfl() {
+extern "C" NOINLINE void pfl() {
   // print frame layout
   Command c("pfl");
   JavaThread* p = JavaThread::active();
@@ -449,7 +447,7 @@ extern "C" JNIEXPORT void pfl() {
   }
 }
 
-extern "C" JNIEXPORT void psf() { // print stack frames
+extern "C" NOINLINE void psf() { // print stack frames
   {
     Command c("psf");
     JavaThread* p = JavaThread::active();
@@ -463,19 +461,19 @@ extern "C" JNIEXPORT void psf() { // print stack frames
 }
 
 
-extern "C" JNIEXPORT void threads() {
+extern "C" NOINLINE void threads() {
   Command c("threads");
   Threads::print(false, true);
 }
 
 
-extern "C" JNIEXPORT void psd() {
+extern "C" NOINLINE void psd() {
   Command c("psd");
   SystemDictionary::print();
 }
 
 
-extern "C" JNIEXPORT void pss() { // print all stacks
+extern "C" NOINLINE void pss() { // print all stacks
   if (Thread::current_or_null() == nullptr) return;
   Command c("pss");
   Threads::print(true, PRODUCT_ONLY(false) NOT_PRODUCT(true));
@@ -483,7 +481,7 @@ extern "C" JNIEXPORT void pss() { // print all stacks
 
 // #ifndef PRODUCT
 
-extern "C" JNIEXPORT void debug() {               // to set things up for compiler debugging
+extern "C" NOINLINE void debug() {               // to set things up for compiler debugging
   Command c("debug");
   NOT_PRODUCT(WizardMode = true;)
   PrintCompilation = true;
@@ -492,7 +490,7 @@ extern "C" JNIEXPORT void debug() {               // to set things up for compil
 }
 
 
-extern "C" JNIEXPORT void ndebug() {              // undo debug()
+extern "C" NOINLINE void ndebug() {              // undo debug()
   Command c("ndebug");
   PrintCompilation = false;
   PrintInlining = PrintAssembly = false;
@@ -500,35 +498,35 @@ extern "C" JNIEXPORT void ndebug() {              // undo debug()
 }
 
 
-extern "C" JNIEXPORT void flush()  {
+extern "C" NOINLINE void flush()  {
   Command c("flush");
   tty->flush();
 }
 
-extern "C" JNIEXPORT void events() {
+extern "C" NOINLINE void events() {
   Command c("events");
   Events::print();
 }
 
-extern "C" JNIEXPORT Method* findm(intptr_t pc) {
+extern "C" NOINLINE Method* findm(intptr_t pc) {
   Command c("findm");
   nmethod* nm = CodeCache::find_nmethod((address)pc);
   return (nm == nullptr) ? (Method*)nullptr : nm->method();
 }
 
 
-extern "C" JNIEXPORT nmethod* findnm(intptr_t addr) {
+extern "C" NOINLINE nmethod* findnm(intptr_t addr) {
   Command c("findnm");
   return  CodeCache::find_nmethod((address)addr);
 }
 
-extern "C" JNIEXPORT void find(intptr_t x) {
+extern "C" NOINLINE void find(intptr_t x) {
   Command c("find");
   os::print_location(tty, x, false);
 }
 
 
-extern "C" JNIEXPORT void findpc(intptr_t x) {
+extern "C" NOINLINE void findpc(intptr_t x) {
   Command c("findpc");
   os::print_location(tty, x, true);
 }
@@ -542,21 +540,20 @@ extern "C" JNIEXPORT void findpc(intptr_t x) {
 //   call findclass("java/lang/Object", 0x3)             -> find j.l.Object and disasm all of its methods
 //   call findmethod("*ang/Object*", "wait", 0xff)       -> detailed disasm of all "wait" methods in j.l.Object
 //   call findmethod("*ang/Object*", "wait:(*J*)V", 0x1) -> list all "wait" methods in j.l.Object that have a long parameter
-extern "C" JNIEXPORT void findclass(const char* class_name_pattern, int flags) {
+extern "C" NOINLINE void findclass(const char* class_name_pattern, int flags) {
   Command c("findclass");
   ClassPrinter::print_flags_help(tty);
   ClassPrinter::print_classes(class_name_pattern, flags, tty);
 }
 
-extern "C" JNIEXPORT void findmethod(const char* class_name_pattern,
-                                     const char* method_pattern, int flags) {
+extern "C" NOINLINE void findmethod(const char* class_name_pattern, const char* method_pattern, int flags) {
   Command c("findmethod");
   ClassPrinter::print_flags_help(tty);
   ClassPrinter::print_methods(class_name_pattern, method_pattern, flags, tty);
 }
 
 // Need method pointer to find bcp
-extern "C" JNIEXPORT void findbcp(intptr_t method, intptr_t bcp) {
+extern "C" NOINLINE void findbcp(intptr_t method, intptr_t bcp) {
   Command c("findbcp");
   Method* mh = (Method*)method;
   if (!mh->is_native()) {
@@ -567,7 +564,7 @@ extern "C" JNIEXPORT void findbcp(intptr_t method, intptr_t bcp) {
 }
 
 // check and decode a single u5 value
-extern "C" JNIEXPORT u4 u5decode(intptr_t addr) {
+extern "C" NOINLINE u4 u5decode(intptr_t addr) {
   Command c("u5decode");
   u1* arr = (u1*)addr;
   size_t off = 0, lim = 5;
@@ -584,9 +581,7 @@ extern "C" JNIEXPORT u4 u5decode(intptr_t addr) {
 // there is no limit on the count of items printed; the
 // printing stops when an null is printed or at limit.
 // See documentation for UNSIGNED5::Reader::print(count).
-extern "C" JNIEXPORT intptr_t u5p(intptr_t addr,
-                                  intptr_t limit,
-                                  int count) {
+extern "C" NOINLINE intptr_t u5p(intptr_t addr, intptr_t limit, int count) {
   Command c("u5p");
   u1* arr = (u1*)addr;
   if (limit && limit < addr)  limit = addr;
@@ -599,10 +594,10 @@ extern "C" JNIEXPORT intptr_t u5p(intptr_t addr,
 
 // int versions of all methods to avoid having to type type casts in the debugger
 
-void pp(intptr_t p)          { pp((void*)p); }
-void pp(oop p)               { pp((void*)p); }
+NOINLINE void pp(intptr_t p)          { pp((void*)p); }
+NOINLINE void pp(oop p)               { pp((void*)p); }
 
-void help() {
+extern "C" NOINLINE void help() {
   Command c("help");
   tty->print_cr("basic");
   tty->print_cr("  pp(void* p)   - try to make sense of p");
@@ -634,7 +629,7 @@ void help() {
 }
 
 #ifndef PRODUCT
-extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native stack
+extern "C" NOINLINE void pns(void* sp, void* fp, void* pc) { // print native stack
   Command c("pns");
   static char buf[O_BUFLEN];
   Thread* t = Thread::current_or_null();
@@ -651,7 +646,7 @@ extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native st
 // WARNING: Only intended for use when debugging. Do not leave calls to
 // pns2() in committed source (product or debug).
 //
-extern "C" JNIEXPORT void pns2() { // print native stack
+extern "C" NOINLINE void pns2() { // print native stack
   Command c("pns2");
   static char buf[O_BUFLEN];
   address lastpc = nullptr;
@@ -665,6 +660,44 @@ extern "C" JNIEXPORT void pns2() { // print native stack
   }
 }
 #endif
+
+// just an exported helper; to avoid link time elimination of the referenced functions
+extern "C" JNIEXPORT void JVM_debug_helpers_keeper(void* p1, void* p2, void* p3, intptr_t ip, oop oh, address adr) {
+  blob((CodeBlob*)p1);
+  dump_vtable(adr);
+  nm(ip);
+  disnm(ip);
+  printnm(ip);
+  universe();
+  verify();
+  pp(p1);
+  ps();
+  pfl();
+  psf();
+  threads();
+  psd();
+  pss();
+  debug();
+  ndebug();
+  flush();
+  events();
+  findm(ip);
+  findnm(ip);
+  find(ip);
+  findpc(ip);
+  findclass("", 0);
+  findmethod("", "", 0);
+  findbcp(ip, ip);
+  u5decode(ip);
+  u5p(ip, ip, 0);
+  pp(ip);
+  pp(oh);
+  help();
+#ifndef PRODUCT
+  pns(p1, p2, p3);
+  pns2();
+#endif
+}
 
 
 // Returns true iff the address p is readable and *(intptr_t*)p != errvalue

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -699,7 +699,6 @@ extern "C" JNIEXPORT void JVM_debug_helpers_keeper(void* p1, void* p2, void* p3,
 #endif
 }
 
-
 // Returns true iff the address p is readable and *(intptr_t*)p != errvalue
 extern "C" bool dbg_is_safe(const void* p, intptr_t errvalue) {
   return p != nullptr && SafeFetchN((intptr_t*)const_cast<void*>(p), errvalue) != errvalue;


### PR DESCRIPTION
Backport of 8379516

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8379516](https://bugs.openjdk.org/browse/JDK-8379516) needs maintainer approval

### Issue
 * [JDK-8379516](https://bugs.openjdk.org/browse/JDK-8379516): Adjust JVM debug helper exports (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3008/head:pull/3008` \
`$ git checkout pull/3008`

Update a local copy of the PR: \
`$ git checkout pull/3008` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3008`

View PR using the GUI difftool: \
`$ git pr show -t 3008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3008.diff">https://git.openjdk.org/jdk21u-dev/pull/3008.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3008#issuecomment-5282545052)
</details>
