### PR TITLE
8368677: acvp test should throw SkippedException when no ACVP-Server available

### DIFF
--- a/test/jdk/sun/security/provider/acvp/Launcher.java
+++ b/test/jdk/sun/security/provider/acvp/Launcher.java
@@ -23,10 +23,10 @@
 
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
-import jdk.test.lib.artifacts.ArtifactResolverException;
 import jdk.test.lib.json.JSONValue;
 import jtreg.SkippedException;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.Provider;
@@ -116,7 +116,14 @@ public class Launcher {
 
     public static void main(String[] args) throws Exception {
 
-        Path archivePath = fetchACVPServerTests(ACVP_SERVER_TESTS.class);
+        Path archivePath = null;
+        try {
+            archivePath = ArtifactResolver.fetchOne(ACVP_SERVER_TESTS.class);
+        } catch (IOException e) {
+            if (e.getMessage().contains("Cannot find the artifact ACVP-Server")) {
+                throw new SkippedException("ACVP-Server not available.");
+            }
+        }
         System.out.println("Data path: " + archivePath);
 
         if (PROVIDER != null) {
@@ -185,21 +192,6 @@ public class Launcher {
             throw re;
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private static Path fetchACVPServerTests(Class<?> clazz) {
-        try {
-            return ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue();
-        } catch (ArtifactResolverException e) {
-            Throwable cause = e.getCause();
-            if (cause == null) {
-                throw new SkippedException("Cannot resolve artifact, "
-                        + "please check if JIB jar is present in classpath.", e);
-            }
-
-            throw new SkippedException("Fetch artifact failed: " + clazz, e);
         }
     }
 


### PR DESCRIPTION
I want to backport this to improve testing of the recent ML backports. 

A previous change to Launcher.java, 
[8350964: Add an ArtifactResolver.fetch(clazz) method](https://bugs.openjdk.org/browse/JDK-8350964) was 
backported in the past, but the part touching Launcher.java was omitted. I include it in this change, here.

Test passes.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8368677](https://bugs.openjdk.org/browse/JDK-8368677) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8368677: acvp test should throw SkippedException when no ACVP-Server available`

### Issue
 * [JDK-8368677](https://bugs.openjdk.org/browse/JDK-8368677): acvp test should throw SkippedException when no ACVP-Server available (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3009/head:pull/3009` \
`$ git checkout pull/3009`

Update a local copy of the PR: \
`$ git checkout pull/3009` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3009`

View PR using the GUI difftool: \
`$ git pr show -t 3009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3009.diff">https://git.openjdk.org/jdk21u-dev/pull/3009.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3009#issuecomment-5297989101)
</details>
