### PR TITLE
8356085: AArch64: compiler stub buffer size wrongly depends on ZGC

### DIFF
--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -38,7 +38,7 @@ enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 53000 ZGC_ONLY(+10000),
+  _compiler_stubs_code_size     = 63000,
   _final_stubs_code_size        = 20000 ZGC_ONLY(+100000)
 };
 


### PR DESCRIPTION
I backport this as requested in https://github.com/openjdk/jdk17u-dev/pull/4614

Needed to be adapted to 21. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8356085](https://bugs.openjdk.org/browse/JDK-8356085) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8356085](https://bugs.openjdk.org/browse/JDK-8356085): AArch64: compiler stub buffer size wrongly depends on ZGC (**Bug** - P3 - Approved)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3013/head:pull/3013` \
`$ git checkout pull/3013`

Update a local copy of the PR: \
`$ git checkout pull/3013` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3013`

View PR using the GUI difftool: \
`$ git pr show -t 3013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3013.diff">https://git.openjdk.org/jdk21u-dev/pull/3013.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3013#issuecomment-5342066160)
</details>
