### PR TITLE
8331159: VM build without C2 fails after JDK-8180450

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -11138,6 +11138,7 @@ class StubGenerator: public StubCodeGenerator {
 
 #endif // LINUX
 
+#ifdef COMPILER2
     if (UseSecondarySupersTable) {
       StubRoutines::_lookup_secondary_supers_table_slow_path_stub = generate_lookup_secondary_supers_table_slow_path_stub();
       if (! InlineSecondarySupersTest) {
@@ -11147,6 +11148,7 @@ class StubGenerator: public StubCodeGenerator {
         }
       }
     }
+#endif
 
     StubRoutines::aarch64::set_completed(); // Inidicate that arraycopy and zero_blocks stubs are generated
   }


### PR DESCRIPTION
Clean backport.   Fixed a build failure on Linux aarch64 when disabling C2 via `--disable-jvm-feature-compiler2`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8331159](https://bugs.openjdk.org/browse/JDK-8331159) needs maintainer approval

### Issue
 * [JDK-8331159](https://bugs.openjdk.org/browse/JDK-8331159): VM build without C2 fails after JDK-8180450 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3015/head:pull/3015` \
`$ git checkout pull/3015`

Update a local copy of the PR: \
`$ git checkout pull/3015` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3015`

View PR using the GUI difftool: \
`$ git pr show -t 3015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3015.diff">https://git.openjdk.org/jdk21u-dev/pull/3015.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3015#issuecomment-5350662234)
</details>
