### PR TITLE
8390441: RISC-V: Fix C2 stack-to-stack spill copies with large offsets

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1592,6 +1592,27 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
   int src_offset = ra_->reg2offset(src_lo);
   int dst_offset = ra_->reg2offset(dst_lo);
 
+  // Stack-to-stack copies use t0 for the value. Bail out if a destination
+  // address also needs t0 to materialize an offset outside the 12-bit range.
+  if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
+    int last_dst_offset = dst_offset;
+    if (bottom_type()->isa_vectmask()) {
+      int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
+      last_dst_offset += vmask_size_in_bytes - 4;
+    } else if (ideal_reg() == Op_VecA) {
+      int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
+      last_dst_offset += vector_reg_size_in_bytes - 8;
+    }
+
+    if (cbuf != NULL && !Assembler::is_simm12(last_dst_offset)) {
+      // size() emits into a scratch buffer where recording a failure is not allowed.
+      if (!C->output()->in_scratch_emit_size()) {
+        C->record_method_not_compilable("unsupported large stack-to-stack spill copy");
+      }
+      return 0;
+    }
+  }
+
   if (bottom_type()->isa_vect() != NULL) {
     uint ireg = ideal_reg();
     if (ireg == Op_VecA && cbuf) {


### PR DESCRIPTION
Hi, this patch is a backport of https://github.com/openjdk/jdk/pull/32387 . this is a risc-v specific change. risk is low.

The origin backport PR is clean, but it fails to compile. The issue is that TypeVectMask was renamed to TypePVectMask (isa_vectmask -> isa_pvectmask) here: https://bugs.openjdk.org/browse/JDK-8379867.

### Testing: 
- [x] The test TestRiscvLargeStackToStack.java[1], which previously had test failures, has now passed.
- [x] make test TEST="hotspot:tier1 hotspot:tier2 hotspot:tier3" with fastdebug/release
- [x] make test TEST="hotspot_vector_1 hotspot_vector_2 jdk_vector jdk_vector_sanity" with fastdebug

[1] https://bugs.openjdk.org/secure/attachment/121298/TestRiscvLargeStackToStack.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8390441](https://bugs.openjdk.org/browse/JDK-8390441) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390441](https://bugs.openjdk.org/browse/JDK-8390441): RISC-V: Fix C2 stack-to-stack spill copies with large offsets (**Bug** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3018/head:pull/3018` \
`$ git checkout pull/3018`

Update a local copy of the PR: \
`$ git checkout pull/3018` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3018`

View PR using the GUI difftool: \
`$ git pr show -t 3018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3018.diff">https://git.openjdk.org/jdk21u-dev/pull/3018.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3018#issuecomment-5381115388)
</details>
