### PR TITLE
8316391: (zipfs) ZipFileSystem.readFullyAt does not tolerate short reads

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipInfo.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,12 +65,12 @@ public class ZipInfo {
                 // loc.extra is bigger than the cen.extra, try to avoid to read
                 // twice
                 long len = LOCHDR + CENNAM(cen, pos) + CENEXT(cen, pos) + CENHDR;
-                if (zfs.readFullyAt(buf, 0, len, locoff(cen, pos)) != len)
+                if (zfs.readNBytesAt(buf, 0, len, locoff(cen, pos)) != len)
                     throw new ZipException("read loc header failed");
                 if (LOCEXT(buf) > CENEXT(cen, pos) + CENHDR) {
                     // have to read the second time;
                     len = LOCHDR + LOCNAM(buf) + LOCEXT(buf);
-                    if (zfs.readFullyAt(buf, 0, len, locoff(cen, pos)) != len)
+                    if (zfs.readNBytesAt(buf, 0, len, locoff(cen, pos)) != len)
                         throw new ZipException("read loc header failed");
                 }
                 printLOC(buf);

--- a/test/jdk/java/nio/channels/FileChannel/LargeGatheringWrite.java
+++ b/test/jdk/java/nio/channels/FileChannel/LargeGatheringWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,18 +92,19 @@ public class LargeGatheringWrite {
 
         // Write the data to a temporary file
         Path tempFile = Files.createTempFile("LargeGatheringWrite", ".dat");
-
-        printTime("before writing");
-        System.out.printf("Writing %d bytes of data...%n", totalLength);
-        try (FileChannel fcw = FileChannel.open(tempFile, CREATE, WRITE);) {
-            // Print size of individual writes and total number written
-            long bytesWritten = 0;
-            long n;
-            while ((n = fcw.write(bigBuffers)) > 0) {
-                System.out.printf("Wrote %d bytes\n", n);
-                bytesWritten += n;
+        try {
+            printTime("before writing");
+            System.out.printf("Writing %d bytes of data...%n", totalLength);
+            try (FileChannel fcw = FileChannel.open(tempFile, CREATE, WRITE);) {
+                // Print size of individual writes and total number written
+                long bytesWritten = 0;
+                long n;
+                while ((n = fcw.write(bigBuffers)) > 0) {
+                    System.out.printf("Wrote %d bytes\n", n);
+                    bytesWritten += n;
+                }
+                System.out.printf("Total of %d bytes written\n", bytesWritten);
             }
-            System.out.printf("Total of %d bytes written\n", bytesWritten);
             printTime("after writing");
 
             // Verify the content written
@@ -121,8 +122,13 @@ public class LargeGatheringWrite {
                     ByteBuffer dst = ByteBuffer.wrap(bytes).slice(0, length);
                     if (dst.remaining() != length)
                         throw new RuntimeException("remaining");
-                    if (fcr.read(dst) != length)
-                        throw new RuntimeException("length");
+                    long totalRead = 0;
+                    while (totalRead < length) {
+                        int bytesRead = fcr.read(dst);
+                        if (bytesRead < 0)
+                            throw new RuntimeException("premature EOF");
+                        totalRead += bytesRead;
+                    }
                     dst.rewind();
 
                     // Verify that the bytes read from the file match the buffer


### PR DESCRIPTION
I backport this as prereq of https://bugs.openjdk.org/browse/JDK-8377983

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8316391](https://bugs.openjdk.org/browse/JDK-8316391) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8316391](https://bugs.openjdk.org/browse/JDK-8316391): (zipfs) ZipFileSystem.readFullyAt does not tolerate short reads (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3019/head:pull/3019` \
`$ git checkout pull/3019`

Update a local copy of the PR: \
`$ git checkout pull/3019` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3019`

View PR using the GUI difftool: \
`$ git pr show -t 3019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3019.diff">https://git.openjdk.org/jdk21u-dev/pull/3019.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3019#issuecomment-5392503296)
</details>
