### PR TITLE
8377983: (zipfs) ZipFileSystem.initCEN needlessly reads END header

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1202,7 +1202,7 @@ class ZipFileSystem extends FileSystem {
 
     private volatile boolean isOpen = true;
     private final SeekableByteChannel ch; // channel to the zipfile
-    final byte[]  cen;     // CEN & ENDHDR
+    final byte[]  cen;     // CEN
     private END  end;
     private long locpos;   // position of first LOC header (usually 0)
 
@@ -1566,15 +1566,15 @@ class ZipFileSystem extends FileSystem {
         if (locpos < 0)
             throw new ZipException("invalid END header (bad central directory offset)");
 
-        // read in the CEN and END
-        byte[] cen = new byte[(int)(end.cenlen + ENDHDR)];
-        if (readNBytesAt(cen, 0, cen.length, cenpos) != end.cenlen + ENDHDR) {
+        // read in the CEN
+        byte[] cen = new byte[(int)(end.cenlen)];
+        if (readNBytesAt(cen, 0, cen.length, cenpos) != end.cenlen) {
             throw new ZipException("read CEN tables failed");
         }
         // Iterate through the entries in the central directory
         inodes = LinkedHashMap.newLinkedHashMap(end.centot + 1);
         int pos = 0;
-        int limit = cen.length - ENDHDR;
+        int limit = cen.length;
         while (pos < limit) {
             if (!cenSigAt(cen, pos))
                 throw new ZipException("invalid CEN header (bad signature)");
@@ -1606,7 +1606,7 @@ class ZipFileSystem extends FileSystem {
             // skip ext and comment
             pos += (CENHDR + nlen + elen + clen);
         }
-        if (pos + ENDHDR != cen.length) {
+        if (pos != cen.length) {
             throw new ZipException("invalid CEN header (bad header size)");
         }
         buildNodeTree();


### PR DESCRIPTION
I backport this for parity with 21.0.13-oracle.

Omitted patch to checkExtraFields( ) in ZipFileSystem.java.
This was added by https://bugs.openjdk.org/browse/JDK-8314891: Additional Zip64 extra header validation 



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8377983](https://bugs.openjdk.org/browse/JDK-8377983) needs maintainer approval

### Issue
 * [JDK-8377983](https://bugs.openjdk.org/browse/JDK-8377983): (zipfs) ZipFileSystem.initCEN needlessly reads END header (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3020/head:pull/3020` \
`$ git checkout pull/3020`

Update a local copy of the PR: \
`$ git checkout pull/3020` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3020`

View PR using the GUI difftool: \
`$ git pr show -t 3020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3020.diff">https://git.openjdk.org/jdk21u-dev/pull/3020.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3020#issuecomment-5410667056)
</details>
