### PR TITLE
8390212: (dc) On AIX, DatagramChannel.join can join IPv4 multicast group with IPv6 socket

### DIFF
--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -91,6 +91,11 @@ static void initGroupSourceReq(JNIEnv* env, jbyteArray group, jint index,
 
 #ifdef _AIX
 
+static jboolean isIPv4MappedGroup(struct group_source_req *req) {
+    struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&req->gsr_group;
+    return IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr) ? JNI_TRUE : JNI_FALSE;
+}
+
 /*
  * Checks whether or not "socket extensions for multicast source filters" is supported.
  * Returns JNI_TRUE if it is supported, JNI_FALSE otherwise
@@ -220,7 +225,7 @@ Java_sun_nio_ch_Net_shouldSetBothIPv4AndIPv6Options0(JNIEnv* env, jclass cl)
 JNIEXPORT jboolean JNICALL
 Java_sun_nio_ch_Net_canIPv6SocketJoinIPv4Group0(JNIEnv* env, jclass cl)
 {
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(_AIX)
     /* IPv6 sockets can join IPv4 multicast groups */
     return JNI_TRUE;
 #else
@@ -232,7 +237,7 @@ Java_sun_nio_ch_Net_canIPv6SocketJoinIPv4Group0(JNIEnv* env, jclass cl)
 JNIEXPORT jboolean JNICALL
 Java_sun_nio_ch_Net_canJoin6WithIPv4Group0(JNIEnv* env, jclass cl)
 {
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_AIX)
     /* IPV6_ADD_MEMBERSHIP can be used to join IPv4 multicast groups */
     return JNI_TRUE;
 #else
@@ -751,6 +756,11 @@ Java_sun_nio_ch_Net_joinOrDrop6(JNIEnv *env, jobject this, jboolean join, jobjec
     if (n < 0) {
         if (join && (errno == ENOPROTOOPT || errno == EOPNOTSUPP))
             return IOS_UNAVAILABLE;
+#ifdef _AIX
+        // AIX rejects MCAST_*_SOURCE_GROUP for IPv4-mapped groups with EINVAL
+        if (source != NULL && errno == EINVAL && isIPv4MappedGroup(&req))
+            return IOS_UNAVAILABLE;
+#endif
         handleSocketErrorWithMessage(env, errno, "setsockopt failed");
     }
     return 0;
@@ -775,6 +785,11 @@ Java_sun_nio_ch_Net_blockOrUnblock6(JNIEnv *env, jobject this, jboolean block, j
     if (n < 0) {
         if (block && (errno == ENOPROTOOPT || errno == EOPNOTSUPP))
             return IOS_UNAVAILABLE;
+#ifdef _AIX
+        // AIX rejects MCAST_BLOCK/UNBLOCK_SOURCE for IPv4-mapped groups with EINVAL
+        if (errno == EINVAL && isIPv4MappedGroup(&req))
+            return IOS_UNAVAILABLE;
+#endif
         handleSocketError(env, errno);
     }
     return 0;
@@ -971,4 +986,3 @@ Java_sun_nio_ch_Net_sendOOB(JNIEnv* env, jclass this, jobject fdo, jbyte b)
     int n = send(fdval(env, fdo), (const void*)&b, 1, MSG_OOB);
     return convertReturnVal(env, n, JNI_FALSE);
 }
-

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -573,17 +573,14 @@ javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java 
 java/net/DatagramSocket/DatagramSocketExample.java              8144003,8308807 macosx-all,aix-ppc64
 java/net/DatagramSocket/DatagramSocketMulticasting.java         8144003,8308807 macosx-all,aix-ppc64
 
-java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
 java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
 java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc64
-java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc64
 java/net/MulticastSocket/NoLoopbackPackets.java                 7122846,8308807 macosx-all,aix-ppc64
 java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
-java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc64
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
 java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 macosx-all,aix-ppc64
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
-java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/Test.java                              7145658 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
This pull request contains a backport of commit [05eaf783](https://github.com/openjdk/jdk/commit/05eaf783b270ec5cd901704c5e16b6201de7a9e4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by David Briemann on 20 Aug 2026 and was reviewed by Alan Bateman, Matthias Baesken and Martin Doerr.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8390212](https://bugs.openjdk.org/browse/JDK-8390212) needs maintainer approval

### Issue
 * [JDK-8390212](https://bugs.openjdk.org/browse/JDK-8390212): (dc) On AIX, DatagramChannel.join can join IPv4 multicast group with IPv6 socket (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3021/head:pull/3021` \
`$ git checkout pull/3021`

Update a local copy of the PR: \
`$ git checkout pull/3021` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3021`

View PR using the GUI difftool: \
`$ git pr show -t 3021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3021.diff">https://git.openjdk.org/jdk21u-dev/pull/3021.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3021#issuecomment-5426089030)
</details>
