### PR TITLE
8349759: Add unit test for CertificateBuilder and SimpleOCSPServer test utilities

### DIFF
--- a/test/lib-test/jdk/test/lib/security/CPVAlgTestWithOCSP.java
+++ b/test/lib-test/jdk/test/lib/security/CPVAlgTestWithOCSP.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8349759
+ * @summary Test the CertificateBuilder and SimpleOCSPServer test utility
+ *          classes using a range of signature algorithms and parameters.
+ *          The goal is to test with both no-parameter and parameterized
+ *          signature algorithms and use the CertPathValidator to validate
+ *          the correctness of the certificate and OCSP server-side structures.
+ * @modules java.base/sun.security.x509
+ *          java.base/sun.security.provider.certpath
+ *          java.base/sun.security.util
+ * @library /test/lib
+ * @run main/othervm CPVAlgTestWithOCSP RSA
+ * @run main/othervm CPVAlgTestWithOCSP RSA:3072
+ * @run main/othervm CPVAlgTestWithOCSP DSA
+ * @run main/othervm CPVAlgTestWithOCSP DSA:3072
+ * @run main/othervm CPVAlgTestWithOCSP RSASSA-PSS
+ * @run main/othervm CPVAlgTestWithOCSP RSASSA-PSS:3072
+ * @run main/othervm CPVAlgTestWithOCSP RSASSA-PSS:4096:SHA-512:SHA3-384:128:1
+ * @run main/othervm CPVAlgTestWithOCSP EC
+ * @run main/othervm CPVAlgTestWithOCSP EC:secp521r1
+ * @run main/othervm CPVAlgTestWithOCSP Ed25519
+ * @run main/othervm CPVAlgTestWithOCSP ML-DSA-65
+ */
+
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.*;
+import java.security.cert.Certificate;
+import java.security.spec.*;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import jdk.test.lib.security.SimpleOCSPServer;
+import jdk.test.lib.security.CertificateBuilder;
+
+import static java.security.cert.PKIXRevocationChecker.Option.NO_FALLBACK;
+
+public class CPVAlgTestWithOCSP {
+
+    static final String passwd = "passphrase";
+    static final String ROOT_ALIAS = "root";
+    static final boolean[] CA_KU_FLAGS = {true, false, false, false, false,
+            true, true, false, false};
+    static final boolean[] EE_KU_FLAGS = {true, false, false, false, false,
+            false, false, false, false};
+    static final List<String> EE_EKU_OIDS = List.of("1.3.6.1.5.5.7.3.1",
+            "1.3.6.1.5.5.7.3.2");
+
+    public static void main(String[] args) throws Exception {
+        if (args == null || args.length < 1) {
+            throw new RuntimeException(
+                    "Usage: CPVAlgTestWithOCSP <IssKeyAlg>");
+        }
+        String keyGenAlg = args[0];
+
+        // Generate Root and EE keys
+        KeyPairGenerator keyGen = getKpGen(keyGenAlg);
+        KeyPair rootCaKP = keyGen.genKeyPair();
+        KeyPair eeKp = keyGen.genKeyPair();
+
+        // Set up the Root CA Cert
+        // Make a 3 year validity starting from 60 days ago
+        long start = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+        long end = start + TimeUnit.DAYS.toMillis(1085);
+        CertificateBuilder cbld = new CertificateBuilder();
+        cbld.setSubjectName("CN=Root CA Cert, O=SomeCompany").
+                setPublicKey(rootCaKP.getPublic()).
+                setSerialNumber(new BigInteger("1")).
+                setValidity(new Date(start), new Date(end)).
+                addSubjectKeyIdExt(rootCaKP.getPublic()).
+                addAuthorityKeyIdExt(rootCaKP.getPublic()).
+                addBasicConstraintsExt(true, true, -1).
+                addKeyUsageExt(CA_KU_FLAGS);
+
+        // Make our Root CA Cert!
+        X509Certificate rootCert = cbld.build(null, rootCaKP.getPrivate());
+        log("Root CA Created:\n%s", rootCert);
+
+        // Now build a keystore and add the keys and cert
+        KeyStore.Builder keyStoreBuilder =
+                KeyStore.Builder.newInstance("PKCS12", null,
+                new KeyStore.PasswordProtection("adminadmin0".toCharArray()));
+        KeyStore rootKeystore = keyStoreBuilder.getKeyStore();
+        Certificate[] rootChain = {rootCert};
+        rootKeystore.setKeyEntry(ROOT_ALIAS, rootCaKP.getPrivate(),
+                passwd.toCharArray(), rootChain);
+
+        // Now fire up the OCSP responder
+        SimpleOCSPServer rootOcsp = new SimpleOCSPServer(rootKeystore,
+                passwd, ROOT_ALIAS, null);
+        rootOcsp.enableLog(true);
+        rootOcsp.setNextUpdateInterval(3600);
+        rootOcsp.start();
+
+        // Wait 60 seconds for server ready
+        boolean readyStatus = rootOcsp.awaitServerReady(60, TimeUnit.SECONDS);
+        if (!readyStatus) {
+            throw new RuntimeException("Server not ready");
+        }
+        int rootOcspPort = rootOcsp.getPort();
+        String rootRespURI = "http://localhost:" + rootOcspPort;
+        log("Root OCSP Responder URI is %s", rootRespURI);
+
+        // Let's make an EE cert
+        // Make a 1 year validity starting from 60 days ago
+        start = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+        end = start + TimeUnit.DAYS.toMillis(365);
+        cbld.reset().setSubjectName("CN=Brave Sir Robin, O=SomeCompany").
+                setPublicKey(eeKp.getPublic()).
+                setValidity(new Date(start), new Date(end)).
+                addSubjectKeyIdExt(eeKp.getPublic()).
+                addAuthorityKeyIdExt(rootCaKP.getPublic()).
+                addKeyUsageExt(EE_KU_FLAGS).
+                addExtendedKeyUsageExt(EE_EKU_OIDS).
+                addSubjectAltNameDNSExt(Collections.singletonList("localhost")).
+                addAIAExt(Collections.singletonList(rootRespURI));
+        X509Certificate eeCert = cbld.build(rootCert, rootCaKP.getPrivate());
+        log("EE CA Created:\n%s", eeCert);
+
+        // Provide end entity cert revocation info to the Root CA
+        // OCSP responder.
+        Map<BigInteger, SimpleOCSPServer.CertStatusInfo> revInfo =
+                new HashMap<>();
+        revInfo.put(eeCert.getSerialNumber(),
+                new SimpleOCSPServer.CertStatusInfo(
+                        SimpleOCSPServer.CertStatus.CERT_STATUS_GOOD));
+        rootOcsp.updateStatusDb(revInfo);
+
+        // validate chain
+        CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
+        PKIXRevocationChecker prc =
+                (PKIXRevocationChecker) cpv.getRevocationChecker();
+        prc.setOptions(EnumSet.of(NO_FALLBACK));
+        PKIXParameters params =
+                new PKIXParameters(Set.of(new TrustAnchor(rootCert, null)));
+        params.addCertPathChecker(prc);
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        CertPath cp = cf.generateCertPath(List.of(eeCert));
+        cpv.validate(cp, params);
+    }
+
+    private static KeyPairGenerator getKpGen(String keyGenAlg)
+            throws GeneralSecurityException {
+        String[] algComps = keyGenAlg.split(":");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(algComps[0]);
+        int bitLen;
+
+        // Handle any parameters in additional tokenized fields
+        switch (algComps[0].toUpperCase()) {
+            case "EC":
+                // The curve name will be the second token, or secp256r1
+                // if not provided.
+                String curveName = (algComps.length >= 2) ? algComps[1] :
+                        "secp256r1";
+                kpg.initialize(new ECGenParameterSpec(curveName));
+                break;
+            case "RSA":
+            case "DSA":
+                // Form is RSA|DSA[:<KeyBitLen>]
+                bitLen = (algComps.length >= 2) ?
+                        Integer.parseInt(algComps[1]) : 2048;
+                kpg.initialize(bitLen);
+                break;
+            case "RSASSA-PSS":
+                // Form is RSASSA-PSS[:<KeyBitLen>[:HASH:MGFHASH:SALTLEN:TR]]
+                switch (algComps.length) {
+                    case 1:     // Default key length and parameters
+                        kpg.initialize(2048);
+                        break;
+                    case 2:     // Specified key length, default params
+                        kpg.initialize(Integer.parseInt(algComps[1]));
+                        break;
+                    default:    // len > 2, key length and specified parameters
+                        bitLen = Integer.parseInt(algComps[1]);
+                        String hashAlg = algComps[2];
+                        MGF1ParameterSpec mSpec = (algComps.length >= 4) ?
+                                new MGF1ParameterSpec(algComps[3]) :
+                                MGF1ParameterSpec.SHA256;
+                        int saltLen = (algComps.length >= 5) ?
+                                Integer.parseInt(algComps[4]) : 32;
+                        int trail = (algComps.length >= 6) ?
+                                Integer.parseInt(algComps[5]) :
+                                PSSParameterSpec.TRAILER_FIELD_BC;
+                        PSSParameterSpec pSpec = new PSSParameterSpec(hashAlg,
+                                "MGF1", mSpec, saltLen, trail);
+                        kpg.initialize(new RSAKeyGenParameterSpec(bitLen,
+                                RSAKeyGenParameterSpec.F4, pSpec));
+                        break;
+                }
+
+            // Default: just use the KPG as-is, no additional init needed.
+    }
+
+        return kpg;
+    }
+
+    /**
+     * Log a message on stdout
+     *
+     * @param format the format string for the log entry
+     * @param args zero or more arguments corresponding to the format string
+     */
+    private static void log(String format, Object ... args) {
+        System.out.format(format + "\n", args);
+    }
+}

--- a/test/lib-test/jdk/test/lib/security/CPVAlgTestWithOCSP.java
+++ b/test/lib-test/jdk/test/lib/security/CPVAlgTestWithOCSP.java
@@ -43,7 +43,7 @@
  * @run main/othervm CPVAlgTestWithOCSP EC
  * @run main/othervm CPVAlgTestWithOCSP EC:secp521r1
  * @run main/othervm CPVAlgTestWithOCSP Ed25519
- * @run main/othervm CPVAlgTestWithOCSP ML-DSA-65
+ * //@run main/othervm CPVAlgTestWithOCSP ML-DSA-65 // requires JDK-8317431
  */
 
 import java.math.BigInteger;

--- a/test/lib-test/jdk/test/lib/security/CPVAlgTestWithOCSP.java
+++ b/test/lib-test/jdk/test/lib/security/CPVAlgTestWithOCSP.java
@@ -43,7 +43,6 @@
  * @run main/othervm CPVAlgTestWithOCSP EC
  * @run main/othervm CPVAlgTestWithOCSP EC:secp521r1
  * @run main/othervm CPVAlgTestWithOCSP Ed25519
- * //@run main/othervm CPVAlgTestWithOCSP ML-DSA-65 // requires JDK-8317431
  */
 
 import java.math.BigInteger;

--- a/test/lib/jdk/test/lib/security/CertificateBuilder.java
+++ b/test/lib/jdk/test/lib/security/CertificateBuilder.java
@@ -48,6 +48,7 @@ import sun.security.x509.IPAddressName;
 import sun.security.x509.NameConstraintsExtension;
 import sun.security.x509.SubjectKeyIdentifierExtension;
 import sun.security.x509.BasicConstraintsExtension;
+import sun.security.x509.CertificateSerialNumber;
 import sun.security.x509.ExtendedKeyUsageExtension;
 import sun.security.x509.DistributionPoint;
 import sun.security.x509.DNSName;
@@ -677,7 +678,9 @@ public class CertificateBuilder {
         }
 
         // Serial Number
-        SerialNumber sn = new SerialNumber(serialNumber);
+        CertificateSerialNumber sn = (serialNumber != null) ?
+            new CertificateSerialNumber(serialNumber) :
+            CertificateSerialNumber.newRandom64bit(new SecureRandom());
         sn.encode(tbsCertItems);
 
         // Algorithm ID
@@ -694,8 +697,12 @@ public class CertificateBuilder {
 
         // Validity period (set as UTCTime)
         DerOutputStream valSeq = new DerOutputStream();
-        valSeq.putUTCTime(notBefore);
-        valSeq.putUTCTime(notAfter);
+        Instant now = Instant.now();
+        Date startDate = (notBefore != null) ? notBefore : Date.from(now);
+        valSeq.putUTCTime(startDate);
+        Date endDate = (notAfter != null) ? notAfter :
+            Date.from(now.plus(90, ChronoUnit.DAYS));
+        valSeq.putUTCTime(endDate);
         tbsCertItems.write(DerValue.tag_Sequence, valSeq);
 
         // Subject Name
@@ -735,6 +742,10 @@ public class CertificateBuilder {
      */
     private void encodeExtensions(DerOutputStream tbsStream)
             throws IOException {
+
+        if (extensions.isEmpty()) {
+            return;
+        }
         DerOutputStream extSequence = new DerOutputStream();
         DerOutputStream extItems = new DerOutputStream();
 

--- a/test/lib/jdk/test/lib/security/CertificateBuilder.java
+++ b/test/lib/jdk/test/lib/security/CertificateBuilder.java
@@ -55,7 +55,6 @@ import sun.security.x509.DNSName;
 import sun.security.x509.GeneralName;
 import sun.security.x509.GeneralNames;
 import sun.security.x509.KeyUsageExtension;
-import sun.security.x509.SerialNumber;
 import sun.security.x509.SubjectAlternativeNameExtension;
 import sun.security.x509.URIName;
 import sun.security.x509.KeyIdentifier;
@@ -453,11 +452,8 @@ public class CertificateBuilder {
      *
      * @param bitSettings Boolean array for all nine bit settings in the order
      * documented in RFC 5280 section 4.2.1.3.
-     *
-     * @throws IOException if an encoding error occurs.
      */
-    public CertificateBuilder addKeyUsageExt(boolean[] bitSettings)
-            throws IOException {
+    public CertificateBuilder addKeyUsageExt(boolean[] bitSettings) {
         return addExtension(new KeyUsageExtension(bitSettings));
     }
 
@@ -470,11 +466,9 @@ public class CertificateBuilder {
      * @param maxPathLen The maximum path length issued by this CA.  Values
      * less than zero will omit this field from the resulting extension and
      * no path length constraint will be asserted.
-     *
-     * @throws IOException if an encoding error occurs.
      */
     public CertificateBuilder addBasicConstraintsExt(boolean crit, boolean isCA,
-            int maxPathLen) throws IOException {
+            int maxPathLen) {
         return addExtension(new BasicConstraintsExtension(crit, isCA,
                 maxPathLen));
     }
@@ -565,7 +559,27 @@ public class CertificateBuilder {
     }
 
     /**
-     * Build the certificate.
+     * Build the certificate using the default algorithm for the provided
+     * signing key.
+     *
+     * @param issuerCert The certificate of the issuing authority, or
+     * {@code null} if the resulting certificate is self-signed.
+     * @param issuerKey The private key of the issuing authority
+     *
+     * @return The resulting {@link X509Certificate}
+     *
+     * @throws IOException if an encoding error occurs.
+     * @throws CertificateException If the certificate cannot be generated
+     * by the underlying {@link CertificateFactory}
+     */
+    public X509Certificate build(X509Certificate issuerCert,
+            PrivateKey issuerKey) throws IOException, CertificateException {
+        return build(issuerCert, issuerKey,
+                SignatureUtil.getDefaultSigAlgForKey(issuerKey));
+    }
+
+    /**
+     * Build the certificate using the key and specified signing algorithm.
      *
      * @param issuerCert The certificate of the issuing authority, or
      * {@code null} if the resulting certificate is self-signed.
@@ -577,14 +591,10 @@ public class CertificateBuilder {
      * @throws IOException if an encoding error occurs.
      * @throws CertificateException If the certificate cannot be generated
      * by the underlying {@link CertificateFactory}
-     * @throws NoSuchAlgorithmException If an invalid signature algorithm
-     * is provided.
      */
     public X509Certificate build(X509Certificate issuerCert,
             PrivateKey issuerKey, String algName)
-            throws IOException, CertificateException, NoSuchAlgorithmException {
-        // TODO: add some basic checks (key usage, basic constraints maybe)
-
+            throws IOException, CertificateException {
         byte[] encodedCert = encodeTopLevel(issuerCert, issuerKey, algName);
         ByteArrayInputStream bais = new ByteArrayInputStream(encodedCert);
         return (X509Certificate)factory.generateCertificate(bais);
@@ -613,15 +623,14 @@ public class CertificateBuilder {
      */
     private byte[] encodeTopLevel(X509Certificate issuerCert,
             PrivateKey issuerKey, String algName)
-            throws CertificateException, IOException, NoSuchAlgorithmException {
+            throws CertificateException, IOException {
 
-        AlgorithmId signAlg = AlgorithmId.get(algName);
+        AlgorithmId signAlg;
         DerOutputStream outerSeq = new DerOutputStream();
         DerOutputStream topLevelItems = new DerOutputStream();
 
         try {
-            Signature sig = SignatureUtil.fromKey(signAlg.getName(), issuerKey, (Provider)null);
-            // Rewrite signAlg, RSASSA-PSS needs some parameters.
+            Signature sig = SignatureUtil.fromKey(algName, issuerKey, "");
             signAlg = SignatureUtil.fromSignature(sig, issuerKey);
             tbsCertBytes = encodeTbsCert(issuerCert, signAlg);
             sig.update(tbsCertBytes);
@@ -742,7 +751,6 @@ public class CertificateBuilder {
      */
     private void encodeExtensions(DerOutputStream tbsStream)
             throws IOException {
-
         if (extensions.isEmpty()) {
             return;
         }


### PR DESCRIPTION
I backport this for parity with 21.0.13-oracle.


I include changes to CertificateBuildser.java from 8317431: "Implement simpler Comparator when building certification paths".
Without that, CPVAlgTestWithOCSP does not work.  I could also adapt that test, but I think it's better to keep the
helper files up-to-date, later backports might depend on these.  See first commit.

The change itself applies clean on top of this.

I exclude a subtest of CPVAlgTestWithOCSP as it depends on 8302233: "HSS/LMS: keytool and jarsigner changes" which only came in 22, see third commit.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8349759](https://bugs.openjdk.org/browse/JDK-8349759) needs maintainer approval

### Issue
 * [JDK-8349759](https://bugs.openjdk.org/browse/JDK-8349759): Add unit test for CertificateBuilder and SimpleOCSPServer test utilities (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) Review applies to [e668d92f](https://git.openjdk.org/jdk21u-dev/pull/3022/files/e668d92ffdc3dc07721374a063f9c8dd9c86231a)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3022/head:pull/3022` \
`$ git checkout pull/3022`

Update a local copy of the PR: \
`$ git checkout pull/3022` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3022`

View PR using the GUI difftool: \
`$ git pr show -t 3022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3022.diff">https://git.openjdk.org/jdk21u-dev/pull/3022.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3022#issuecomment-5436043130)
</details>
