### PR TITLE
8331695: Serial: DefNewGeneration:_promotion_failed used without being initialized

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -330,6 +330,7 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
                                    size_t max_size,
                                    const char* policy)
   : Generation(rs, initial_size),
+    _promotion_failed(false),
     _preserved_marks_set(false /* in_c_heap */),
     _promo_failure_drain_in_progress(false),
     _should_allocate_from_space(false),


### PR DESCRIPTION
backport of 8331695. The same issue occurs when running binary files with --enable-ubsan.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8331695](https://bugs.openjdk.org/browse/JDK-8331695) needs maintainer approval

### Issue
 * [JDK-8331695](https://bugs.openjdk.org/browse/JDK-8331695): Serial: DefNewGeneration:_promotion_failed used without being initialized (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3025/head:pull/3025` \
`$ git checkout pull/3025`

Update a local copy of the PR: \
`$ git checkout pull/3025` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3025`

View PR using the GUI difftool: \
`$ git pr show -t 3025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3025.diff">https://git.openjdk.org/jdk21u-dev/pull/3025.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3025#issuecomment-5435936625)
</details>
