### PR TITLE
8339711: ZipFile.Source.initCEN needlessly reads END header

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -63,6 +63,7 @@ import java.util.stream.StreamSupport;
 import jdk.internal.access.JavaUtilZipFileAccess;
 import jdk.internal.access.JavaUtilJarAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.util.ArraysSupport;
 import jdk.internal.util.OperatingSystem;
 import jdk.internal.perf.PerfCounter;
 import jdk.internal.ref.CleanerFactory;
@@ -1164,6 +1165,8 @@ public class ZipFile implements ZipConstants, Closeable {
         // "META-INF/".length()
         private static final int META_INF_LEN = 9;
         private static final int[] EMPTY_META_VERSIONS = new int[0];
+        // CEN size is limited to the maximum array size in the JDK
+        private static final int MAX_CEN_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
         private final Key key;               // the key in files
         private final @Stable ZipCoder zc;   // zip coder used to decode/encode
@@ -1708,7 +1711,7 @@ public class ZipFile implements ZipConstants, Closeable {
             int idx = 0; // Index into the entries array
             int pos = 0;
             int entryPos = CENHDR;
-            int limit = cen.length - ENDHDR;
+            int limit = cen.length;
             manifestNum = 0;
             while (entryPos <= limit) {
                 if (idx >= entriesLength) {
@@ -1771,7 +1774,7 @@ public class ZipFile implements ZipConstants, Closeable {
             } else {
                 metaVersions = EMPTY_META_VERSIONS;
             }
-            if (pos + ENDHDR != cen.length) {
+            if (pos != cen.length) {
                 zerror("invalid CEN header (bad header size)");
             }
         }

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1174,7 +1174,7 @@ public class ZipFile implements ZipConstants, Closeable {
         private int refs = 1;
 
         private RandomAccessFile zfile;      // zfile of the underlying zip file
-        private byte[] cen;                  // CEN & ENDHDR
+        private byte[] cen;                  // CEN
         private long locpos;                 // position of first LOC header (usually 0)
         private byte[] comment;              // zip file comment
                                              // list of meta entries in META-INF dir
@@ -1223,7 +1223,7 @@ public class ZipFile implements ZipConstants, Closeable {
             }
             int entryPos = pos + CENHDR;
             int nlen = CENNAM(cen, pos);
-            if (entryPos + nlen > cen.length - ENDHDR) {
+            if (entryPos + nlen > cen.length) {
                 zerror("invalid CEN header (bad header size)");
             }
 
@@ -1674,15 +1674,15 @@ public class ZipFile implements ZipConstants, Closeable {
                 if (locpos < 0) {
                     zerror("invalid END header (bad central directory offset)");
                 }
-                // read in the CEN and END
-                if (end.cenlen + ENDHDR >= Integer.MAX_VALUE) {
+                // read in the CEN
+                if (end.cenlen > MAX_CEN_SIZE) {
                     zerror("invalid END header (central directory size too large)");
                 }
                 if (end.centot < 0 || end.centot > end.cenlen / CENHDR) {
                     zerror("invalid END header (total entries count too large)");
                 }
-                cen = this.cen = new byte[(int)(end.cenlen + ENDHDR)];
-                if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen + ENDHDR) {
+                cen = this.cen = new byte[(int)(end.cenlen)];
+                if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen) {
                     zerror("read CEN tables failed");
                 }
                 this.total = Math.toIntExact(end.centot);

--- a/test/jdk/java/util/zip/ZipFile/CenSizeTooLarge.java
+++ b/test/jdk/java/util/zip/ZipFile/CenSizeTooLarge.java
@@ -23,10 +23,12 @@
 
 /* @test
  * @bug 8272746
+ * @modules java.base/jdk.internal.util
  * @summary Verify that ZipFile rejects a ZIP with a CEN size which does not fit in a Java byte array
  * @run junit CenSizeTooLarge
  */
 
+import jdk.internal.util.ArraysSupport;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CenSizeTooLarge {
     // Maximum allowed CEN size allowed by the ZipFile implementation
-    static final int MAX_CEN_SIZE = Integer.MAX_VALUE - ZipFile.ENDHDR - 1;
+    static final int MAX_CEN_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
     /**
      * From the APPNOTE.txt specification:

--- a/test/jdk/java/util/zip/ZipFile/EndOfCenValidation.java
+++ b/test/jdk/java/util/zip/ZipFile/EndOfCenValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/zip/ZipFile/EndOfCenValidation.java
+++ b/test/jdk/java/util/zip/ZipFile/EndOfCenValidation.java
@@ -23,10 +23,12 @@
 
 /* @test
  * @bug 8272746
+ * @modules java.base/jdk.internal.util
  * @summary Verify that ZipFile rejects files with CEN sizes exceeding the implementation limit
  * @run junit/othervm EndOfCenValidation
  */
 
+import jdk.internal.util.ArraysSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +73,7 @@ public class EndOfCenValidation {
     private static final int ENDSIZ = ZipFile.ENDSIZ; // Offset of CEN size field within ENDHDR
     private static final int ENDOFF = ZipFile.ENDOFF; // Offset of CEN offset field within ENDHDR
     // Maximum allowed CEN size allowed by ZipFile
-    private static final int MAX_CEN_SIZE = Integer.MAX_VALUE - ENDHDR - 1;
+    private static final int MAX_CEN_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
     // Expected message when CEN size does not match file size
     private static final String INVALID_CEN_BAD_SIZE = "invalid END header (bad central directory size)";


### PR DESCRIPTION
I backport this to simplify the backport of 8377992.  It also seems strange to only backport [8377983](https://bugs.openjdk.org/browse/JDK-8377983): (zipfs) ZipFileSystem.initCEN needlessly reads END header
but not this one.

Resolved a few places, see extra commit. Code looks different, so not straight forward.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8339711](https://bugs.openjdk.org/browse/JDK-8339711) needs maintainer approval

### Issue
 * [JDK-8339711](https://bugs.openjdk.org/browse/JDK-8339711): ZipFile.Source.initCEN needlessly reads END header (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3028/head:pull/3028` \
`$ git checkout pull/3028`

Update a local copy of the PR: \
`$ git checkout pull/3028` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3028`

View PR using the GUI difftool: \
`$ git pr show -t 3028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3028.diff">https://git.openjdk.org/jdk21u-dev/pull/3028.diff</a>

</details>
