### PR TITLE
8300800: UB: Shift exponent 32 is too large for 32-bit type 'int'

### DIFF
--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -295,7 +295,7 @@ int expandLogicalImmediate(uint32_t immN, uint32_t immr,
     uint64_t and_bits_sub = replicate(and_bit, 1, nbits);
     uint64_t or_bits_sub = replicate(or_bit, 1, nbits);
     uint64_t and_bits_top = (and_bits_sub << nbits) | ones(nbits);
-    uint64_t or_bits_top = (0 << nbits) | or_bits_sub;
+    uint64_t or_bits_top = (UCONST64(0) << nbits) | or_bits_sub;
 
     tmask = ((tmask
               & (replicate(and_bits_top, 2 * nbits, 32 / nbits)))


### PR DESCRIPTION
backport of 8300800. The same issue occurs when running binary files with --enable-ubsan.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8300800](https://bugs.openjdk.org/browse/JDK-8300800) needs maintainer approval

### Issue
 * [JDK-8300800](https://bugs.openjdk.org/browse/JDK-8300800): UB: Shift exponent 32 is too large for 32-bit type 'int' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3030/head:pull/3030` \
`$ git checkout pull/3030`

Update a local copy of the PR: \
`$ git checkout pull/3030` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3030`

View PR using the GUI difftool: \
`$ git pr show -t 3030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3030.diff">https://git.openjdk.org/jdk21u-dev/pull/3030.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3030#issuecomment-5448028394)
</details>
