### PR TITLE
8336912: G1: Undefined behavior for G1ConfidencePercent=0

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -115,7 +115,7 @@
                                                                             \
   product(uintx, G1ConfidencePercent, 50,                                   \
           "Confidence level for MMU/pause predictions")                     \
-          range(0, 100)                                                     \
+          range(1, 100)                                                     \
                                                                             \
   product(intx, G1SummarizeRSetStatsPeriod, 0, DIAGNOSTIC,                  \
           "The period (in number of GCs) at which we will generate "        \

--- a/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
@@ -51,14 +51,14 @@ public class TestG1PercentageOptions {
         }
     }
 
-    private static final String[] defaultValid = new String[] {
-        "0", "1", "50", "95", "100" };
-    private static final String[] defaultInvalid = new String[] {
-        "-10", "110", "bad" };
+    private static final String[] rangeOneToHundredValid = new String[] {
+        "1", "50", "95", "100" };
+    private static final String[] rangeOneToHundredInvalid = new String[] {
+        "0", "-10", "110", "bad" };
 
     // All of the G1 product arguments that are percentages.
     private static final OptionDescription[] percentOptions = new OptionDescription[] {
-        new OptionDescription("G1ConfidencePercent", defaultValid, defaultInvalid)
+        new OptionDescription("G1ConfidencePercent", rangeOneToHundredValid, rangeOneToHundredInvalid)
         // Other percentage options are not yet validated by argument processing.
     };
 


### PR DESCRIPTION
backport of 8336912. The same issue occurs when running binary files with --enable-ubsan.
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change requires a CSR request matching fixVersion 21.0.14 to be approved (needs to be created)
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8336912](https://bugs.openjdk.org/browse/JDK-8336912) needs maintainer approval

### Issue
 * [JDK-8336912](https://bugs.openjdk.org/browse/JDK-8336912): G1: Undefined behavior for G1ConfidencePercent=0 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3031/head:pull/3031` \
`$ git checkout pull/3031`

Update a local copy of the PR: \
`$ git checkout pull/3031` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3031`

View PR using the GUI difftool: \
`$ git pr show -t 3031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3031.diff">https://git.openjdk.org/jdk21u-dev/pull/3031.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3031#issuecomment-5448728708)
</details>
