### PR TITLE
8386474: Aarch64: Correct static_assert((N & (N - 1)) == 0

### DIFF
--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -27,6 +27,7 @@
 #define CPU_AARCH64_REGISTER_AARCH64_HPP
 
 #include "asm/register.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 class VMRegImpl;
@@ -509,25 +510,25 @@ template<int N> bool vs_write_before_read(const VSeq<N>& vout, const VSeq<N>& vi
 
 template<int N>
 VSeq<N/2> vs_front(const VSeq<N>& v) {
-  static_assert(N > 0 && ((N & 1) == 0), "sequence length must be even");
+  static_assert(N > 0 && is_even(N), "sequence length must be even");
   return VSeq<N/2>(v.base(), v.delta());
 }
 
 template<int N>
 VSeq<N/2> vs_back(const VSeq<N>& v) {
-  static_assert(N > 0 && ((N & 1) == 0), "sequence length must be even");
+  static_assert(N > 0 && is_even(N), "sequence length must be even");
   return VSeq<N/2>(v.base() + N / 2 * v.delta(), v.delta());
 }
 
 template<int N>
 VSeq<N/2> vs_even(const VSeq<N>& v) {
-  static_assert(N > 0 && ((N & 1) == 0), "sequence length must be even");
+  static_assert(N > 0 && is_even(N), "sequence length must be even");
   return VSeq<N/2>(v.base(), v.delta() * 2);
 }
 
 template<int N>
 VSeq<N/2> vs_odd(const VSeq<N>& v) {
-  static_assert(N > 0 && ((N & 1) == 0), "sequence length must be even");
+  static_assert(N > 0 && is_even(N), "sequence length must be even");
   return VSeq<N/2>(v.base() + v.delta(), v.delta() * 2);
 }
 

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -4609,6 +4609,7 @@ class StubGenerator: public StubCodeGenerator {
   // address supplied in base.
   template<int N>
   void vs_ldpq(const VSeq<N>& v, Register base) {
+    static_assert(N > 0 && is_even(N), "sequence length must be even");
     for (int i = 0; i < N; i += 2) {
       __ ldpq(v[i], v[i+1], Address(base, 32 * i));
     }
@@ -4619,7 +4620,7 @@ class StubGenerator: public StubCodeGenerator {
   // in base using post-increment addressing
   template<int N>
   void vs_ldpq_post(const VSeq<N>& v, Register base) {
-    static_assert((N & (N - 1)) == 0, "sequence length must be even");
+    static_assert(N > 0 && is_even(N), "sequence length must be even");
     for (int i = 0; i < N; i += 2) {
       __ ldpq(v[i], v[i+1], __ post(base, 32));
     }
@@ -4630,7 +4631,7 @@ class StubGenerator: public StubCodeGenerator {
   // supplied in base using post-increment addressing
   template<int N>
   void vs_stpq_post(const VSeq<N>& v, Register base) {
-    static_assert((N & (N - 1)) == 0, "sequence length must be even");
+    static_assert(N > 0 && is_even(N), "sequence length must be even");
     for (int i = 0; i < N; i += 2) {
       __ stpq(v[i], v[i+1], __ post(base, 32));
     }
@@ -4641,7 +4642,7 @@ class StubGenerator: public StubCodeGenerator {
   // using post-increment addressing.
   template<int N>
   void vs_ld2_post(const VSeq<N>& v, Assembler::SIMD_Arrangement T, Register base) {
-    static_assert((N & (N - 1)) == 0, "sequence length must be even");
+    static_assert(N > 0 && is_even(N), "sequence length must be even");
     for (int i = 0; i < N; i += 2) {
       __ ld2(v[i], v[i+1], T, __ post(base, 32));
     }
@@ -4652,7 +4653,7 @@ class StubGenerator: public StubCodeGenerator {
   // post-increment addressing.
   template<int N>
   void vs_st2_post(const VSeq<N>& v, Assembler::SIMD_Arrangement T, Register base) {
-    static_assert((N & (N - 1)) == 0, "sequence length must be even");
+    static_assert(N > 0 && is_even(N), "sequence length must be even");
     for (int i = 0; i < N; i += 2) {
       __ st2(v[i], v[i+1], T, __ post(base, 32));
     }
@@ -4685,6 +4686,7 @@ class StubGenerator: public StubCodeGenerator {
   // offsets array
   template<int N>
   void vs_ldpq_indexed(const VSeq<N>& v, Register base, int start, int (&offsets)[N/2]) {
+    static_assert(N > 0 && is_even(N), "sequence length must be even");
     for (int i = 0; i < N/2; i++) {
       __ ldpq(v[2*i], v[2*i+1], Address(base, start + offsets[i]));
     }
@@ -4732,6 +4734,7 @@ class StubGenerator: public StubCodeGenerator {
   template<int N>
   void vs_ld2_indexed(const VSeq<N>& v, Assembler::SIMD_Arrangement T, Register base,
                       Register tmp, int start, int (&offsets)[N/2]) {
+    static_assert(N > 0 && is_even(N), "sequence length must be even");
     for (int i = 0; i < N/2; i++) {
       __ add(tmp, base, start + offsets[i]);
       __ ld2(v[2*i], v[2*i+1], T, tmp);
@@ -4745,6 +4748,7 @@ class StubGenerator: public StubCodeGenerator {
   template<int N>
   void vs_st2_indexed(const VSeq<N>& v, Assembler::SIMD_Arrangement T, Register base,
                       Register tmp, int start, int (&offsets)[N/2]) {
+    static_assert(N > 0 && is_even(N), "sequence length must be even");
     for (int i = 0; i < N/2; i++) {
       __ add(tmp, base, start + offsets[i]);
       __ st2(v[2*i], v[2*i+1], T, tmp);

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1167,8 +1167,8 @@ inline T clamp(T value, T min, T max) {
   return MIN2(MAX2(value, min), max);
 }
 
-inline bool is_odd (intx x) { return x & 1;      }
-inline bool is_even(intx x) { return !is_odd(x); }
+constexpr bool is_odd (intx x) { return x & 1;      }
+constexpr bool is_even(intx x) { return !is_odd(x); }
 
 // abs methods which cannot overflow and so are well-defined across
 // the entire domain of integer types.


### PR DESCRIPTION
Backporting JDK-8386474: Aarch64: Correct static_assert((N & (N - 1)) == 0.

This PR fixes compile time static_assert checks in the aarch64.

For parity with Oracle JDK. Already backported to 25.

The PR compiles on linux-x64, linux-aarch64, macos-aarch64 and windows-x64.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=compiler/intrinsics/sha
make test TEST=compiler/intrinsics/chacha

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/31555027/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/31555028/windows-x64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/31555030/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/31555031/macos-aarch64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/31555032/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/31555033/linux-x64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/31555034/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/31555035/linux-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8386474](https://bugs.openjdk.org/browse/JDK-8386474) needs maintainer approval

### Issue
 * [JDK-8386474](https://bugs.openjdk.org/browse/JDK-8386474): Aarch64: Correct static_assert((N &amp; (N - 1)) == 0 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3033/head:pull/3033` \
`$ git checkout pull/3033`

Update a local copy of the PR: \
`$ git checkout pull/3033` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3033`

View PR using the GUI difftool: \
`$ git pr show -t 3033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3033.diff">https://git.openjdk.org/jdk21u-dev/pull/3033.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3033#issuecomment-5452895747)
</details>
