### PR TITLE
8387273: Enhance httpserver logging to log when maxConnections is reached

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -544,6 +544,8 @@ class ServerImpl {
                                 if (MAX_CONNECTIONS > 0 && allConnections.size() >= MAX_CONNECTIONS) {
                                     // we've hit max limit of current open connections, so we go
                                     // ahead and close this connection without processing it
+                                    logger.log(Level.DEBUG, "connection limit reached, " +
+                                            "closing accepted connection " + chan);
                                     try {
                                         chan.close();
                                     } catch (IOException ignore) {


### PR DESCRIPTION
Backporting JDK-8387273: Enhance httpserver logging to log when maxConnections is reached.

This PR adds an new debug logging statement to ServerImpl.java.

JBS ticket labeled as trivial no regression test needed.

For parity with Oracle JDK. Already backported to 25.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8387273](https://bugs.openjdk.org/browse/JDK-8387273) needs maintainer approval

### Issue
 * [JDK-8387273](https://bugs.openjdk.org/browse/JDK-8387273): Enhance httpserver logging to log when maxConnections is reached (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3036/head:pull/3036` \
`$ git checkout pull/3036`

Update a local copy of the PR: \
`$ git checkout pull/3036` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3036`

View PR using the GUI difftool: \
`$ git pr show -t 3036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3036.diff">https://git.openjdk.org/jdk21u-dev/pull/3036.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3036#issuecomment-5479434744)
</details>
