### PR TITLE
8381379: Support std/dstOffset attributes in CLDR's metazone definitions

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -87,6 +87,7 @@ public class CLDRConverter {
     static final String EXEMPLAR_CITY_PREFIX = "timezone.excity.";
     static final String ZONE_NAME_PREFIX = "timezone.displayname.";
     static final String METAZONE_ID_PREFIX = "metazone.id.";
+    static final String METAZONE_DSTOFFSET_PREFIX = "metazone.dstoffset.";
     static final String PARENT_LOCALE_PREFIX = "parentLocale.";
     static final String META_EMPTY_ZONE_NAME = "EMPTY_ZONE";
     static final String[] EMPTY_ZONE = {"", "", "", "", "", ""};
@@ -121,6 +122,11 @@ public class CLDRConverter {
     // rules maps
     static Map<String, String> pluralRules;
     static Map<String, String> dayPeriodRules;
+
+    // Map of explicit dst offsets for metazones
+    // key: time zone ID
+    // value: explicit dstOffset for the corresponding metazone name
+    static final Map<String, String> explicitDstOffsets = HashMap.newHashMap(32);
 
     static enum DraftType {
         UNCONFIRMED,
@@ -771,6 +777,12 @@ public class CLDRConverter {
             .filter(e -> e.getKey().startsWith(CLDRConverter.EXEMPLAR_CITY_PREFIX))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         names.putAll(exCities);
+
+        // Explicit metazone offsets
+        if (id.equals("root")) {
+            explicitDstOffsets.forEach((k, v) ->
+                names.put(METAZONE_DSTOFFSET_PREFIX + k, v));
+        }
 
         // If there's no UTC entry at this point, add an empty one
         if (!names.isEmpty() && !names.containsKey("UTC")) {

--- a/make/jdk/src/classes/build/tools/cldrconverter/MetaZonesParseHandler.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/MetaZonesParseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,15 @@ class MetaZonesParseHandler extends AbstractLDMLHandler<String> {
 
             if (fromLDT.isBefore(now) && toLDT.isAfter(now)) {
                 metazone = attributes.getValue("mzone");
+
+                // Explicit metazone DST offsets. Only the "dst" offset is needed,
+                // as "std" is used by default when it doesn't match.
+                String dstOffset = attributes.getValue("dstOffset");
+                if (dstOffset != null) {
+                    CLDRConverter.explicitDstOffsets.put(tzid, dstOffset);
+                }
             }
+
             pushIgnoredContainer(qName);
             break;
 

--- a/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
@@ -197,7 +197,8 @@ class ResourceBundleGenerator implements BundleGenerator {
                     } else if (value instanceof String) {
                         String valStr = (String)value;
                         if (type == BundleType.TIMEZONE &&
-                            !key.startsWith(CLDRConverter.EXEMPLAR_CITY_PREFIX) ||
+                            !(key.startsWith(CLDRConverter.EXEMPLAR_CITY_PREFIX) ||
+                              key.startsWith(CLDRConverter.METAZONE_DSTOFFSET_PREFIX)) ||
                             valStr.startsWith(META_VALUE_PREFIX)) {
                             out.printf("            { \"%s\", %s },\n", key, CLDRConverter.saveConvert(valStr, useJava));
                         } else {

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -41,7 +41,7 @@ package java.text;
 import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
-import static java.text.DateFormatSymbols.*;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -56,6 +56,8 @@ import sun.util.calendar.CalendarUtils;
 import sun.util.calendar.ZoneInfoFile;
 import sun.util.locale.provider.LocaleProviderAdapter;
 import sun.util.locale.provider.TimeZoneNameUtility;
+
+import static java.text.DateFormatSymbols.*;
 
 /**
  * {@code SimpleDateFormat} is a concrete class for formatting and
@@ -1283,15 +1285,22 @@ public class SimpleDateFormat extends DateFormat {
 
         case PATTERN_ZONE_NAME: // 'z'
             if (current == null) {
+                TimeZone tz = calendar.getTimeZone();
+                String tzid = tz.getID();
+                int zoneOffset = calendar.get(Calendar.ZONE_OFFSET);
+                int dstOffset = calendar.get(Calendar.DST_OFFSET) + zoneOffset;
+
+                // Check if an explicit metazone DST offset exists
+                String explicitDstOffset = TimeZoneNameUtility.explicitDstOffset(tzid);
+                boolean daylight = explicitDstOffset != null ?
+                    dstOffset == ZoneOffset.of(explicitDstOffset).getTotalSeconds() * 1_000 :
+                    dstOffset != zoneOffset;
                 if (formatData.locale == null || formatData.isZoneStringsSet) {
-                    int zoneIndex =
-                        formatData.getZoneIndex(calendar.getTimeZone().getID());
+                    int zoneIndex = formatData.getZoneIndex(tzid);
                     if (zoneIndex == -1) {
-                        value = calendar.get(Calendar.ZONE_OFFSET) +
-                            calendar.get(Calendar.DST_OFFSET);
-                        buffer.append(ZoneInfoFile.toCustomID(value));
+                        buffer.append(ZoneInfoFile.toCustomID(dstOffset));
                     } else {
-                        int index = (calendar.get(Calendar.DST_OFFSET) == 0) ? 1: 3;
+                        int index = daylight ? 3 : 1;
                         if (count < 4) {
                             // Use the short name
                             index++;
@@ -1300,8 +1309,6 @@ public class SimpleDateFormat extends DateFormat {
                         buffer.append(zoneStrings[zoneIndex][index]);
                     }
                 } else {
-                    TimeZone tz = calendar.getTimeZone();
-                    boolean daylight = (calendar.get(Calendar.DST_OFFSET) != 0);
                     int tzstyle = (count < 4 ? TimeZone.SHORT : TimeZone.LONG);
                     buffer.append(tz.getDisplayName(daylight, tzstyle, formatData.locale));
                 }

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -4503,7 +4503,11 @@ public final class DateTimeFormatterBuilder {
                 TemporalAccessor dt = context.getTemporal();
                 int type = GENERIC;
                 if (!isGeneric) {
-                    if (dt.isSupported(ChronoField.INSTANT_SECONDS)) {
+                    // Check if an explicit metazone DST offset exists
+                    String dstOffset = TimeZoneNameUtility.explicitDstOffset(zname);
+                    if (dt.isSupported(OFFSET_SECONDS) && dstOffset != null) {
+                        type = ZoneOffset.from(dt).equals(ZoneOffset.of(dstOffset)) ? DST : STD;
+                    } else if (dt.isSupported(ChronoField.INSTANT_SECONDS)) {
                         type = zone.getRules().isDaylightSavings(Instant.from(dt)) ? DST : STD;
                     } else if (dt.isSupported(ChronoField.EPOCH_DAY) &&
                                dt.isSupported(ChronoField.NANO_OF_DAY)) {

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -105,6 +105,9 @@ public class LocaleResources {
     // TimeZoneNamesBundle exemplar city prefix
     private static final String TZNB_EXCITY_PREFIX = "timezone.excity.";
 
+    // TimeZoneNamesBundle explicit metazone dst offset prefix
+    private static final String TZNB_METAZONE_DSTOFFSET_PREFIX = "metazone.dstoffset.";
+
     // null singleton cache value
     private static final Object NULLOBJECT = new Object();
 
@@ -321,7 +324,8 @@ public class LocaleResources {
 
         if (Objects.isNull(data) || Objects.isNull(val = data.get())) {
             TimeZoneNamesBundle tznb = localeData.getTimeZoneNames(locale);
-            if (key.startsWith(TZNB_EXCITY_PREFIX)) {
+            if (key.startsWith(TZNB_EXCITY_PREFIX) ||
+                key.startsWith(TZNB_METAZONE_DSTOFFSET_PREFIX)) {
                 if (tznb.containsKey(key)) {
                     val = tznb.getString(key);
                     assert val instanceof String;
@@ -378,7 +382,8 @@ public class LocaleResources {
         Set<String[]> value = new LinkedHashSet<>();
         Set<String> tzIds = new HashSet<>(Arrays.asList(TimeZone.getAvailableIDs()));
         for (String key : keyset) {
-            if (!key.startsWith(TZNB_EXCITY_PREFIX)) {
+            if (!key.startsWith(TZNB_EXCITY_PREFIX) &&
+                !key.startsWith(TZNB_METAZONE_DSTOFFSET_PREFIX)) {
                 value.add(rb.getStringArray(key));
                 tzIds.remove(key);
             }

--- a/src/java.base/share/classes/sun/util/locale/provider/TimeZoneNameUtility.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/TimeZoneNameUtility.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.spi.TimeZoneNameProvider;
 import sun.util.calendar.ZoneInfo;
 import sun.util.cldr.CLDRLocaleProviderAdapter;
-import static sun.util.locale.provider.LocaleProviderAdapter.Type;
+import static sun.util.locale.provider.LocaleProviderAdapter.Type.CLDR;
 
 /**
  * Utility class that deals with the localized time zone names
@@ -169,8 +169,20 @@ public final class TimeZoneNameUtility {
      * Returns the canonical ID for the given ID
      */
     public static Optional<String> canonicalTZID(String id) {
-        return ((CLDRLocaleProviderAdapter)LocaleProviderAdapter.forType(Type.CLDR))
+        return ((CLDRLocaleProviderAdapter)LocaleProviderAdapter.forType(CLDR))
                     .canonicalTZID(id);
+    }
+
+    /**
+     * {@return the explicit metazone DST offset for the specified time zone ID, if exists}
+     * @param tzid the time zone ID
+     */
+    public static String explicitDstOffset(String tzid) {
+        return (String) (LocaleProviderAdapter.forType(CLDR) instanceof CLDRLocaleProviderAdapter ca ?
+            ca.getLocaleResources(Locale.ROOT)
+                .getTimeZoneNames("metazone.dstoffset." +
+                    ca.canonicalTZID(tzid).orElse(tzid)) :
+            null);
     }
 
     private static String[] retrieveDisplayNamesImpl(String id, Locale locale) {

--- a/src/java.base/share/classes/sun/util/resources/TimeZoneNamesBundle.java
+++ b/src/java.base/share/classes/sun/util/resources/TimeZoneNamesBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,8 +43,6 @@ package sun.util.resources;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.MissingResourceException;
-import java.util.Objects;
 import java.util.Set;
 
 /**

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -24,6 +24,7 @@
  /*
  * @test
  * @bug 8181157 8202537 8234347 8236548 8261279
+ *      8381379
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at runtime
  * @run junit/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -30,15 +30,21 @@
  */
 
 import java.text.DateFormatSymbols;
+import java.text.SimpleDateFormat;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -176,6 +182,18 @@ public class TimeZoneNamesTest {
         };
     }
 
+    private static Stream<Arguments> explicitDstOffsets() {
+        return Stream.of(
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Irish Standard Time"),
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Europe/Dublin")), "Greenwich Mean Time"),
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Irish Standard Time"),
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Greenwich Mean Time"),
+            Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time"),
+            // This needs to change once TZDB adopts -7 offset year round, and CLDR uses explicit dst offset
+            // namely, "Pacific Standard Time" -> "Pacific Daylight Time"
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Standard Time")
+        );
+    }
 
     @ParameterizedTest
     @MethodSource("data")
@@ -208,5 +226,20 @@ public class TimeZoneNamesTest {
                 .findAny()
                 .isPresent(),
             "getZoneStrings() returned array containing non-empty string element(s)");
+    }
+
+    // Explicit metazone dst offset test. As of CLDR v48, only Europe/Dublin utilizes
+    // this attribute, but will be used for America/Vancouver once CLDR adopts the
+    // explicit offset for that zone, which warrants the test data modification.
+    @ParameterizedTest
+    @MethodSource("explicitDstOffsets")
+    public void test_ExplicitMetazoneOffsets(ZonedDateTime zdt, String expected) {
+        // java.time
+        assertEquals(expected, DateTimeFormatter.ofPattern("zzzz").format(zdt));
+
+        // java.text/util
+        var sdf = new SimpleDateFormat("zzzz");
+        sdf.setTimeZone(TimeZone.getTimeZone(zdt.getZone()));
+        assertEquals(expected, sdf.format(Date.from(zdt.toInstant())));
     }
 }


### PR DESCRIPTION
I backport this as prereq of the next time zone change.  Based on the change in 25.

Resolved Copyrights and bugid in TimeZoneNamesTest.java.

jdk/sun/util/resources/cldr/ tests pass.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8381379](https://bugs.openjdk.org/browse/JDK-8381379) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8381379](https://bugs.openjdk.org/browse/JDK-8381379): Support std/dstOffset attributes in CLDR's metazone definitions (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3037/head:pull/3037` \
`$ git checkout pull/3037`

Update a local copy of the PR: \
`$ git checkout pull/3037` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3037`

View PR using the GUI difftool: \
`$ git pr show -t 3037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3037.diff">https://git.openjdk.org/jdk21u-dev/pull/3037.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3037#issuecomment-5480538592)
</details>
