### PR TITLE
8388872: Avoid unused variables warnings in libj2pkcs11

### DIFF
--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -79,10 +79,6 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     jstring jGetFunctionList)
 {
     HINSTANCE hModule;
-    int i = 0;
-    CK_ULONG ulCount = 0;
-    CK_C_GetInterfaceList C_GetInterfaceList = NULL;
-    CK_INTERFACE_PTR iList = NULL;
     CK_C_GetInterface C_GetInterface = NULL;
     CK_INTERFACE_PTR interface = NULL;
     CK_C_GetFunctionList C_GetFunctionList = NULL;
@@ -129,22 +125,27 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
     /*
      * Get function pointer to C_GetInterfaceList
      */
-    C_GetInterfaceList = (CK_C_GetInterfaceList) GetProcAddress(hModule,
+    CK_C_GetInterfaceList C_GetInterfaceList = (CK_C_GetInterfaceList) GetProcAddress(hModule,
             "C_GetInterfaceList");
     if (C_GetInterfaceList != NULL) {
+        CK_ULONG ulCount = 0;
         TRACE0("Found C_GetInterfaceList func\n");
         rv = (C_GetInterfaceList)(NULL, &ulCount);
         if (rv == CKR_OK) {
             /* get copy of interfaces */
-            iList = (CK_INTERFACE_PTR)
-                    malloc(ulCount*sizeof(CK_INTERFACE));
-            rv = C_GetInterfaceList(iList, &ulCount);
-            for (i=0; i < (int)ulCount; i++) {
-                printf("interface %s version %d.%d funcs %p flags 0x%lu\n",
-                        iList[i].pInterfaceName,
-                        ((CK_VERSION *)iList[i].pFunctionList)->major,
-                        ((CK_VERSION *)iList[i].pFunctionList)->minor,
-                        iList[i].pFunctionList, iList[i].flags);
+            CK_INTERFACE_PTR iList = (CK_INTERFACE_PTR) malloc(ulCount*sizeof(CK_INTERFACE));
+            if (iList == NULL) {
+                TRACE0("Connect: error allocating interface list\n");
+            } else {
+                rv = C_GetInterfaceList(iList, &ulCount);
+                for (int i=0; i < (int)ulCount; i++) {
+                    printf("interface %s version %d.%d funcs %p flags 0x%lu\n",
+                            iList[i].pInterfaceName,
+                            ((CK_VERSION *)iList[i].pFunctionList)->major,
+                            ((CK_VERSION *)iList[i].pFunctionList)->minor,
+                            iList[i].pFunctionList, iList[i].flags);
+                }
+                free(iList);
             }
         } else {
             TRACE0("Connect: error polling interface list size\n");


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8388872](https://bugs.openjdk.org/browse/JDK-8388872) needs maintainer approval

### Issue
 * [JDK-8388872](https://bugs.openjdk.org/browse/JDK-8388872): Avoid unused variables warnings in libj2pkcs11 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3039/head:pull/3039` \
`$ git checkout pull/3039`

Update a local copy of the PR: \
`$ git checkout pull/3039` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3039`

View PR using the GUI difftool: \
`$ git pr show -t 3039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3039.diff">https://git.openjdk.org/jdk21u-dev/pull/3039.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3039#issuecomment-5540113239)
</details>
