### PR TITLE
8390521: RISC-V: Clean up vector register dispatch in MachSpillCopyNode::implementation

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1596,12 +1596,16 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
   // address also needs t0 to materialize an offset outside the 12-bit range.
   if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
     int last_dst_offset = dst_offset;
-    if (bottom_type()->isa_vectmask()) {
-      int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
-      last_dst_offset += vmask_size_in_bytes - 4;
-    } else if (ideal_reg() == Op_VecA) {
-      int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
-      last_dst_offset += vector_reg_size_in_bytes - 8;
+    if (bottom_type()->isa_vect() != NULL) {
+      if (!bottom_type()->isa_vectmask()) {
+        assert(ideal_reg() == Op_VecA, "Must be Op_VecA");
+        int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
+        last_dst_offset += vector_reg_size_in_bytes - 8;
+      } else {
+        assert(ideal_reg() == Op_RegVectMask, "Must be Op_RegVectMask");
+        int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
+        last_dst_offset += vmask_size_in_bytes - 4;
+      }
     }
 
     if (cbuf != NULL && !Assembler::is_simm12(last_dst_offset)) {
@@ -1613,9 +1617,9 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
     }
   }
 
-  if (bottom_type()->isa_vect() != NULL) {
-    uint ireg = ideal_reg();
-    if (ireg == Op_VecA && cbuf) {
+  if (bottom_type()->isa_vect() != NULL && cbuf != NULL) {
+    if (!bottom_type()->isa_vectmask()) {
+      assert(ideal_reg() == Op_VecA, "Must be Op_VecA");
       C2_MacroAssembler _masm(cbuf);
       int vector_reg_size_in_bytes = Matcher::scalable_vector_reg_size(T_BYTE);
       if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
@@ -1634,7 +1638,8 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
       } else {
         ShouldNotReachHere();
       }
-    } else if (bottom_type()->isa_vectmask() && cbuf) {
+    } else {
+      assert(ideal_reg() == Op_RegVectMask, "Must be Op_RegVectMask");
       C2_MacroAssembler _masm(cbuf);
       int vmask_size_in_bytes = Matcher::scalable_predicate_reg_slots() * 32 / 8;
       if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
@@ -1738,14 +1743,11 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
       st->print("%s", Matcher::regName[dst_lo]);
     }
     if (bottom_type()->isa_vect() && !bottom_type()->isa_vectmask()) {
-      int vsize = 0;
-      if (ideal_reg() == Op_VecA) {
-        vsize = Matcher::scalable_vector_reg_size(T_BYTE) * 8;
-      } else {
-        ShouldNotReachHere();
-      }
+      assert(ideal_reg() == Op_VecA, "Must be Op_VecA");
+      int vsize = Matcher::scalable_vector_reg_size(T_BYTE) * 8;
       st->print("\t# vector spill size = %d", vsize);
-    } else if (ideal_reg() == Op_RegVectMask) {
+    } else if (bottom_type()->isa_vectmask()) {
+      assert(ideal_reg() == Op_RegVectMask, "Must be Op_RegVectMask");
       assert(Matcher::supports_scalable_vector(), "bad register type for spill");
       int vsize = Matcher::scalable_predicate_reg_slots() * 32;
       st->print("\t# vmask spill size = %d", vsize);


### PR DESCRIPTION
Hi, this patch is a backport of https://github.com/openjdk/jdk/pull/32416
Because JDK-8379867 hasn't been backported to jdk21u-dev yet, this has been adjusted compared to the original https://github.com/openjdk/jdk/pull/32416 (bottom_type()->isa_pvectmask() → bottom_type()->isa_vectmask()).
The main purposes of this backport are: 1. to eliminate some unnecessary type checks. 2. With this backport, readability and maintainability are also improved.

### Testing
- [x] `make test TEST="hotspot:tier1 hotspot:tier2 hotspot:tier3"` with fastdebug

This is a risc-v specific change. risk is low.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8390521](https://bugs.openjdk.org/browse/JDK-8390521) needs maintainer approval

### Issue
 * [JDK-8390521](https://bugs.openjdk.org/browse/JDK-8390521): RISC-V: Clean up vector register dispatch in MachSpillCopyNode::implementation (**Enhancement** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3040/head:pull/3040` \
`$ git checkout pull/3040`

Update a local copy of the PR: \
`$ git checkout pull/3040` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3040`

View PR using the GUI difftool: \
`$ git pr show -t 3040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3040.diff">https://git.openjdk.org/jdk21u-dev/pull/3040.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3040#issuecomment-5521128392)
</details>
