### PR TITLE
8375367: vmTestbase tests reported variable uninitialized by clang23

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ static int prepare(JNIEnv* jni) {
 /** Agent algorithm. */
 static void JNICALL
 agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
-    jint dummy;
+    jint dummy = 0;
 
     if (!nsk_jvmti_waitForSync(timeout))
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002a.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ static int prepare(JNIEnv* jni) {
 /** Agent algorithm. */
 static void JNICALL
 agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
-    jint dummy;
+    jint dummy = 0;
 
     if (!nsk_jvmti_waitForSync(timeout))
         return;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e4474ad8](https://github.com/openjdk/jdk/commit/e4474ad8ae250771e031b8c18809d3e461970365) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 16 Jan 2026 and was reviewed by Serguei Spitsyn, Alex Menkov and Leonid Mesnik.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8375367](https://bugs.openjdk.org/browse/JDK-8375367) needs maintainer approval

### Issue
 * [JDK-8375367](https://bugs.openjdk.org/browse/JDK-8375367): vmTestbase tests reported variable uninitialized by clang23 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3042/head:pull/3042` \
`$ git checkout pull/3042`

Update a local copy of the PR: \
`$ git checkout pull/3042` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3042`

View PR using the GUI difftool: \
`$ git pr show -t 3042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3042.diff">https://git.openjdk.org/jdk21u-dev/pull/3042.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3042#issuecomment-5521631531)
</details>
