### PR TITLE
8390388: Cherry-pick tz attributes from newer CLDR data for jdk25u and earlier

### DIFF
--- a/make/data/cldr/common/dtd/ldmlSupplemental.dtd
+++ b/make/data/cldr/common/dtd/ldmlSupplemental.dtd
@@ -953,6 +953,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST usesMetazone mzone NMTOKEN #REQUIRED >
     <!--@MATCH:metazone-->
     <!--@VALUE-->
+<!ATTLIST usesMetazone stdOffset CDATA #IMPLIED >
+    <!--@MATCH:regex/[+-][0-9]{2}(:[0-9]{2})?-->
+    <!--@VALUE-->
+<!ATTLIST usesMetazone dstOffset CDATA #IMPLIED >
+    <!--@MATCH:regex/[+-][0-9]{2}(:[0-9]{2})?-->
+    <!--@VALUE-->
 
 <!ELEMENT plurals ( pluralRules*, pluralRanges* ) >
 <!ATTLIST plurals type (ordinal | cardinal) #IMPLIED >

--- a/make/data/cldr/common/supplemental/metaZones.xml
+++ b/make/data/cldr/common/supplemental/metaZones.xml
@@ -187,7 +187,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<timezone type="Africa/Windhoek">
 				<usesMetazone to="1990-03-20 22:00" mzone="Africa_Southern"/>
 				<usesMetazone to="1994-03-20 22:00" from="1990-03-20 22:00" mzone="Africa_Central"/>
-				<usesMetazone to="2017-10-23 22:00" from="1994-03-20 22:00" mzone="Africa_Western"/>
+				<usesMetazone to="2017-10-23 22:00" from="1994-03-20 22:00" mzone="Africa_Western" stdOffset="+01" dstOffset="+02"/>
 				<usesMetazone from="2017-10-23 22:00" mzone="Africa_Central"/>
 			</timezone>
 			<timezone type="America/Adak">
@@ -747,7 +747,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone mzone="Atlantic"/>
 			</timezone>
 			<timezone type="America/Vancouver">
-				<usesMetazone mzone="America_Pacific"/>
+				<usesMetazone mzone="America_Pacific" stdOffset="-08" dstOffset="-07"/>
 			</timezone>
 			<timezone type="America/Whitehorse">
 				<usesMetazone to="2020-11-01 07:00" mzone="America_Pacific"/>
@@ -1234,8 +1234,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone mzone="Europe_Central"/>
 			</timezone>
 			<timezone type="Europe/Dublin">
-				<usesMetazone mzone="Irish" to="1971-10-31 02:00"/>
-				<usesMetazone mzone="GMT" from="1971-10-31 02:00"/>
+				<usesMetazone mzone="Irish" to="1971-10-31 02:00" stdOffset="+00" dstOffset="+01"/>
+				<usesMetazone mzone="GMT" from="1971-10-31 02:00" stdOffset="+00" dstOffset="+01"/>
 			</timezone>
 			<timezone type="Europe/Gibraltar">
 				<usesMetazone mzone="Europe_Central"/>

--- a/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
+++ b/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ import org.testng.annotations.Test;
 /*
  * @test
  * @bug 8081022 8151876 8166875 8177819 8189784 8206980 8277049 8278434
+ *      8390388
  * @key randomness
  */
 
@@ -88,10 +89,16 @@ public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
                 }
                 zdt = zdt.withZoneSameLocal(ZoneId.of(zid));
                 TimeZone tz = TimeZone.getTimeZone(zid);
-                boolean isDST = tz.inDaylightTime(new Date(zdt.toInstant().toEpochMilli()));
+                long epochMilli = zdt.toInstant().toEpochMilli();
+                boolean isDST = tz.inDaylightTime(new Date(epochMilli));
+                // Some zones now use an explicit daylight offset in CLDR without java.util.TimeZone
+                // reporting DST for the instant, so prefer the daylight name when the effective
+                // offset is greater than the raw standard offset.
+                boolean useDaylightName = isDST
+                        || (tz.getDSTSavings() == 0 && tz.getOffset(epochMilli) > tz.getRawOffset());
                 for (Locale locale : SAMPLE_LOCALES) {
-                    String longDisplayName = tz.getDisplayName(isDST, TimeZone.LONG, locale);
-                    String shortDisplayName = tz.getDisplayName(isDST, TimeZone.SHORT, locale);
+                    String longDisplayName = tz.getDisplayName(useDaylightName, TimeZone.LONG, locale);
+                    String shortDisplayName = tz.getDisplayName(useDaylightName, TimeZone.SHORT, locale);
                     if ((longDisplayName.startsWith("GMT+") && shortDisplayName.startsWith("GMT+"))
                             || (longDisplayName.startsWith("GMT-") && shortDisplayName.startsWith("GMT-"))) {
                         printText(locale, zdt, TextStyle.FULL, tz, tz.getID());
@@ -99,9 +106,9 @@ public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
                         continue;
                     }
                     printText(locale, zdt, TextStyle.FULL, tz,
-                            tz.getDisplayName(isDST, TimeZone.LONG, locale));
+                            tz.getDisplayName(useDaylightName, TimeZone.LONG, locale));
                     printText(locale, zdt, TextStyle.SHORT, tz,
-                            tz.getDisplayName(isDST, TimeZone.SHORT, locale));
+                            tz.getDisplayName(useDaylightName, TimeZone.SHORT, locale));
                 }
             }
         }

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -24,7 +24,7 @@
  /*
  * @test
  * @bug 8181157 8202537 8234347 8236548 8261279
- *      8381379
+ *      8381379 8390388
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at runtime
  * @run junit/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
@@ -190,9 +190,7 @@ public class TimeZoneNamesTest {
             Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Irish Standard Time"),
             Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("Eire")), "Greenwich Mean Time"),
             Arguments.of(ZonedDateTime.of(2026, 4, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time"),
-            // This needs to change once TZDB adopts -7 offset year round, and CLDR uses explicit dst offset
-            // namely, "Pacific Standard Time" -> "Pacific Daylight Time"
-            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Standard Time")
+            Arguments.of(ZonedDateTime.of(2026, 12, 5, 0, 0, 0, 0, ZoneId.of("America/Vancouver")), "Pacific Daylight Time")
         );
     }
 


### PR DESCRIPTION
Backporting from https://github.com/openjdk/jdk25u-dev/commit/838e26c2c10b308ebfe9f317714e930b32d112c0

This is the first of 4 changes required for the JDK 21 tzdata2026c update. 

The backport was not clean because JDK 21 uses an older CLDR baseline:

* `ldmlSupplemental.xsd` does not exist in the JDK 21 CLDR build, so that change was omitted. The required attributes were added to `ldmlSupplemental.dtd`.
* Conflicts in `TestZoneTextPrinterParser.java` and `TimeZoneNamesTest.java` were resolved by preserving JDK 21's existing test metadata and CLDR-provider configuration while applying the new display-name logic and Vancouver expectation.

#### Testing
* `make images`
* `make run-test TEST="test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java"`

tzdata2026c chain:
#3043 
#3044 
#3045 
#3046

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] [JDK-8390388](https://bugs.openjdk.org/browse/JDK-8390388) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390388](https://bugs.openjdk.org/browse/JDK-8390388): Cherry-pick tz attributes from newer CLDR data for jdk25u and earlier (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3043/head:pull/3043` \
`$ git checkout pull/3043`

Update a local copy of the PR: \
`$ git checkout pull/3043` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3043`

View PR using the GUI difftool: \
`$ git pr show -t 3043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3043.diff">https://git.openjdk.org/jdk21u-dev/pull/3043.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3043#issuecomment-5530552468)
</details>
