### PR TITLE
8391256: TestZoneTextPrinterParser.java assertion fails with expected: <Mountain Standard Time> but was: <Mountain Daylight Time>

### DIFF
--- a/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
+++ b/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
@@ -64,10 +64,13 @@ import org.testng.annotations.Test;
 @Test
 public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
 
-    // Explicit dstOffset attributes from CLDR v48.2 metazone data.
+    // Explicit dstOffset attributes from CLDR pre-release v49 metazone data.
     private static final Map<String, ZoneOffset> CLDR_EXPLICIT_DST_OFFSETS = Map.of(
             "Africa/Windhoek", ZoneOffset.of("+02:00"),
+            "America/Edmonton", ZoneOffset.of("-06:00"),
+            "America/Yellowknife", ZoneOffset.of("-06:00"),
             "America/Vancouver", ZoneOffset.of("-07:00"),
+            "Canada/Mountain", ZoneOffset.of("-06:00"),
             "Canada/Pacific", ZoneOffset.of("-07:00"),
             "Europe/Dublin", ZoneOffset.of("+01:00"),
             "Eire", ZoneOffset.of("+01:00"));


### PR DESCRIPTION
Backporting from https://github.com/openjdk/jdk25u/commit/1fac148c2dcc5c2f065999ff3562a76e3c699d0f

This is the final PR in the JDK 21 tzdata2026c stack and depends on PR #3045. It updates the randomized parser test's explicit daylight-offset map for `America/Edmonton`, `America/Yellowknife`, and `Canada/Mountain`.

This was a clean cherry-pick. 

tzdata2026c chain:
#3043 
#3044 
#3045 
#3046

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8391256](https://bugs.openjdk.org/browse/JDK-8391256) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #3045 must be integrated first

### Issue
 * [JDK-8391256](https://bugs.openjdk.org/browse/JDK-8391256): TestZoneTextPrinterParser.java assertion fails with expected: &lt;Mountain Standard Time&gt; but was: &lt;Mountain Daylight Time&gt; (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3046/head:pull/3046` \
`$ git checkout pull/3046`

Update a local copy of the PR: \
`$ git checkout pull/3046` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3046`

View PR using the GUI difftool: \
`$ git pr show -t 3046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3046.diff">https://git.openjdk.org/jdk21u-dev/pull/3046.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3046#issuecomment-5531730009)
</details>
