### PR TITLE
8391757: [PPC64] C1 runs into assertion with -XX:+VerifyOops

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -748,7 +748,7 @@ int LIR_Assembler::store(LIR_Opr from_reg, Register base, int offset, BasicType 
           if (UseCompressedOops && !wide) {
             // Encoding done in caller
             __ stw(from_reg->as_register(), offset, base);
-            __ verify_coop(from_reg->as_register(), FILE_AND_LINE);
+            __ verify_oop(from_reg->as_register(), FILE_AND_LINE, /*compressed*/ true); // kills R0
           } else {
             __ std(from_reg->as_register(), offset, base);
             if (VerifyOops) {
@@ -792,7 +792,7 @@ int LIR_Assembler::store(LIR_Opr from_reg, Register base, Register disp, BasicTy
         if (UseCompressedOops && !wide) {
           // Encoding done in caller.
           __ stwx(from_reg->as_register(), base, disp);
-          __ verify_coop(from_reg->as_register(), FILE_AND_LINE); // kills R0
+          __ verify_oop(from_reg->as_register(), FILE_AND_LINE, /*compressed*/ true); // kills R0
         } else {
           __ stdx(from_reg->as_register(), base, disp);
           if (VerifyOops) {

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -4278,15 +4278,8 @@ void MacroAssembler::asm_assert_mems_zero(bool check_equal, int size, int mem_of
 #endif // ASSERT
 }
 
-void MacroAssembler::verify_coop(Register coop, const char* msg) {
-  if (!VerifyOops) { return; }
-  if (UseCompressedOops) { decode_heap_oop(coop); }
-  verify_oop(coop, msg);
-  if (UseCompressedOops) { encode_heap_oop(coop, coop); }
-}
-
 // READ: oop. KILL: R0. Volatile floats perhaps.
-void MacroAssembler::verify_oop(Register oop, const char* msg) {
+void MacroAssembler::verify_oop(Register oop, const char* msg, bool compressed) {
   if (!VerifyOops) {
     return;
   }
@@ -4300,6 +4293,9 @@ void MacroAssembler::verify_oop(Register oop, const char* msg) {
   save_volatile_gprs(R1_SP, -nbytes_save); // except R0
 
   mr_if_needed(R4_ARG2, oop);
+  if (compressed) {
+    decode_heap_oop(R4_ARG2);
+  }
   save_LR_CR(tmp); // save in old frame
   push_frame_reg_args(nbytes_save, tmp);
   // load FunctionDescriptor** / entry_address *

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -901,11 +901,8 @@ class MacroAssembler: public Assembler {
     asm_assert_mems_zero(false, 8, mem_offset, mem_base, msg);
   }
 
-  // Calls verify_oop. If UseCompressedOops is on, decodes the oop.
-  // Preserves reg.
-  void verify_coop(Register reg, const char*);
   // Emit code to verify that reg contains a valid oop if +VerifyOops is set.
-  void verify_oop(Register reg, const char* s = "broken oop");
+  void verify_oop(Register reg, const char* s = "broken oop", bool compressed = false);
   void verify_oop_addr(RegisterOrConstant offs, Register base, const char* s = "contains broken oop");
 
   // TODO: verify method and klass metadata (compare against vptr?)

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4778,7 +4778,7 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::_throw_NullPointerException_at_call_entry= generate_throw_exception("NullPointerException at call throw_exception", CAST_FROM_FN_PTR(address, SharedRuntime::throw_NullPointerException_at_call), false);
 
     // support for verify_oop (must happen after universe_init)
-    StubRoutines::_verify_oop_subroutine_entry             = generate_verify_oop();
+    StubRoutines::_verify_oop_subroutine_entry = generate_verify_oop();
 
     // nmethod entry barriers for concurrent class unloading
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();


### PR DESCRIPTION
Clean backport of [JDK-8391757](https://bugs.openjdk.org/browse/JDK-8391757).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8391757](https://bugs.openjdk.org/browse/JDK-8391757) needs maintainer approval

### Issue
 * [JDK-8391757](https://bugs.openjdk.org/browse/JDK-8391757): [PPC64] C1 runs into assertion with -XX:+VerifyOops (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3051/head:pull/3051` \
`$ git checkout pull/3051`

Update a local copy of the PR: \
`$ git checkout pull/3051` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3051`

View PR using the GUI difftool: \
`$ git pr show -t 3051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3051.diff">https://git.openjdk.org/jdk21u-dev/pull/3051.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3051#issuecomment-5571940196)
</details>
