### PR TITLE
8391881: RISC-V: jni_fast_Get<Primitive>Field registers the wrong pc for the speculative load

### DIFF
--- a/src/hotspot/cpu/riscv/jniFastGetField_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jniFastGetField_riscv.cpp
@@ -116,10 +116,10 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   bs->try_resolve_jobject_in_native(masm, c_rarg0, robj, t0, slow);
 
   __ srli(roffset, c_rarg2, 2);                // offset
+  __ add(roffset, robj, roffset);
 
   assert(count < LIST_CAPACITY, "LIST_CAPACITY too small");
   speculative_load_pclist[count] = __ pc();   // Used by the segfault handler
-  __ add(roffset, robj, roffset);
 
   switch (type) {
     case T_BOOLEAN: __ lbu(result, Address(roffset, 0)); break;


### PR DESCRIPTION
Hi, this patch is a backport of https://github.com/openjdk/jdk/pull/32720 , same issue is there in jdk21u-dev repo. this is a risc-v specific change. Backport is clean, risk is low.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8391881](https://bugs.openjdk.org/browse/JDK-8391881) needs maintainer approval

### Issue
 * [JDK-8391881](https://bugs.openjdk.org/browse/JDK-8391881): RISC-V: jni_fast_Get&lt;Primitive&gt;Field registers the wrong pc for the speculative load (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3052/head:pull/3052` \
`$ git checkout pull/3052`

Update a local copy of the PR: \
`$ git checkout pull/3052` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3052`

View PR using the GUI difftool: \
`$ git pr show -t 3052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3052.diff">https://git.openjdk.org/jdk21u-dev/pull/3052.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3052#issuecomment-5587186290)
</details>
