### PR TITLE
8373676: Test javax/net/ssl/HttpsURLConnection/SubjectAltNameIP.java fails on a machine without IPV6

### DIFF
--- a/test/jdk/javax/net/ssl/HttpsURLConnection/SubjectAltNameIP.java
+++ b/test/jdk/javax/net/ssl/HttpsURLConnection/SubjectAltNameIP.java
@@ -30,7 +30,7 @@
  * @modules java.base/sun.net.util
  * @comment Insert -Djavax.net.debug=all into the following lines to enable SSL debugging
  * @run main/othervm SubjectAltNameIP 127.0.0.1
- * @run main/othervm SubjectAltNameIP [::1]
+ * @run main/othervm SubjectAltNameIP ::1
  */
 
 import javax.net.ssl.HandshakeCompletedListener;
@@ -166,14 +166,19 @@ public class SubjectAltNameIP {
     }
 
     public static void main(String[] args) throws Exception {
+        boolean isIpv6Addr = IPAddressUtil.isIPv6LiteralAddress(args[0]);
 
-        if (IPAddressUtil.isIPv6LiteralAddress(args[0]) && !IPSupport.hasIPv6()) {
+        if (isIpv6Addr && !IPSupport.hasIPv6()) {
             throw new SkippedException("Skipping test - IPv6 is not supported");
         }
         /*
          * Start the tests.
          */
-        new SubjectAltNameIP(args[0]);
+        if (isIpv6Addr) { // use the URL notion wrapper
+            new SubjectAltNameIP("[" + args[0] + "]");
+        } else {
+            new SubjectAltNameIP(args[0]);
+        }
     }
 
     Thread serverThread = null;


### PR DESCRIPTION
Backporting JDK-8373676: Test javax/net/ssl/HttpsURLConnection/SubjectAltNameIP.java fails on a machine without IPV6.

This PR fixes SubjectAltNameIP.java failing on IPv6-disabled machines by passing the raw address ::1 instead of [::1] on the command line. The brackets caused isIPv6LiteralAddress() to fail, bypassing the IPv6 skip check and leading to a SocketException: Protocol family unavailable. Brackets are now added programmatically only for URL construction.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8373676](https://bugs.openjdk.org/browse/JDK-8373676) needs maintainer approval

### Issue
 * [JDK-8373676](https://bugs.openjdk.org/browse/JDK-8373676): Test javax/net/ssl/HttpsURLConnection/SubjectAltNameIP.java fails on a machine without IPV6 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21u-dev.git pull/3055/head:pull/3055` \
`$ git checkout pull/3055`

Update a local copy of the PR: \
`$ git checkout pull/3055` \
`$ git pull https://git.openjdk.org/jdk21u-dev.git pull/3055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3055`

View PR using the GUI difftool: \
`$ git pr show -t 3055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21u-dev/pull/3055.diff">https://git.openjdk.org/jdk21u-dev/pull/3055.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk21u-dev/pull/3055#issuecomment-5608058632)
</details>
